### PR TITLE
Fix Codex MCP startup for RedSkills plugins

### DIFF
--- a/plugins/dev/hooks/castle-mcp.sh
+++ b/plugins/dev/hooks/castle-mcp.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -u
+
+root="${CODEX_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-}}"
+
+for launcher in \
+  "$root/hooks/castle-mcp.sh" \
+  "$HOME/.codex/.tmp/marketplaces/red-skills/plugins/dev/hooks/castle-mcp.sh" \
+  "$HOME/.codex/plugins/cache/red-skills/dev"/*/hooks/castle-mcp.sh; do
+  if [ -f "$launcher" ] && [ "$launcher" != "$0" ]; then
+    exec bash "$launcher"
+  fi
+done
+
+printf 'castle: could not locate RedSkills castle MCP launcher\n' >&2
+exit 1

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -381,6 +381,48 @@ export async function claudeMarketplaceIsGithub(): Promise<boolean | null> {
   }
 }
 
+function tomlStringValue(line: string, key: string): string | null {
+  const match = line.match(new RegExp(`^\\s*${key}\\s*=\\s*"([^"]*)"\\s*$`));
+  return match?.[1] ?? null;
+}
+
+/**
+ * Whether Codex's marketplace points at GitHub rather than a local
+ * red-skills snapshot.
+ *
+ * Codex records marketplace sources in config.toml. A local source has
+ * the same failure mode as Claude's directory marketplace: RedSkills
+ * appears installed and enabled, but MCP launchers that fall back to
+ * Codex's Git marketplace checkout have nowhere to go.
+ */
+export async function codexMarketplaceIsGithub(): Promise<boolean | null> {
+  const home = process.env["HOME"] ?? process.env["USERPROFILE"];
+  if (!home) return null;
+  const path = `${home.replace(/\\/g, "/")}/.codex/config.toml`;
+  if (!existsSync(path)) return null;
+
+  try {
+    const lines = (await Bun.file(path).text()).split(/\r?\n/);
+    let inTable = false;
+    for (const line of lines) {
+      const table = line.match(/^\s*\[([^\]]+)\]\s*$/);
+      if (table) {
+        inTable = table[1] === "marketplaces.red-skills";
+        continue;
+      }
+      if (!inTable) continue;
+      const sourceType = tomlStringValue(line, "source_type");
+      if (sourceType !== null) return sourceType === "git";
+    }
+    return null;
+  } catch {
+    // Unreadable is not the same as wrong. Null means "no opinion", and
+    // the caller leaves the machine alone rather than repointing a
+    // marketplace on a guess.
+    return null;
+  }
+}
+
 /**
  * Repoint Claude's marketplace from the frozen directory to GitHub.
  *
@@ -408,6 +450,33 @@ export async function repointClaudeMarketplace(): Promise<void> {
     await spawnLogged(["claude", "plugin", "install", `${plugin}@red-skills`]);
   }
   log.ok("red-skills marketplace now tracks reddb-io/red-skills");
+}
+
+/**
+ * Repoint Codex's marketplace from a local snapshot to GitHub.
+ *
+ * Codex keeps plugin enablement when a marketplace is removed, but the
+ * explicit add calls refresh the cache for the three RedSkills plugins
+ * that contribute skills, hooks, and MCP servers.
+ */
+export async function repointCodexMarketplace(): Promise<void> {
+  const { spawnLogged } = await import("./providers.ts");
+  log.step("red-skills: Codex marketplace points at a local directory — repointing at GitHub");
+  log.plain("     A local Codex marketplace can leave MCP launchers looking");
+  log.plain("     for a Git marketplace checkout that does not exist.");
+
+  if ((await spawnLogged(["codex", "plugin", "marketplace", "remove", "red-skills"])) !== 0) {
+    throw new RedError("could not remove the local red-skills marketplace from Codex");
+  }
+  if ((await spawnLogged(["codex", "plugin", "marketplace", "add", "reddb-io/red-skills"])) !== 0) {
+    throw new RedError("could not add the red-skills marketplace to Codex from GitHub");
+  }
+  for (const plugin of ["dev", "memory", "brain"]) {
+    if ((await spawnLogged(["codex", "plugin", "add", `${plugin}@red-skills`])) !== 0) {
+      throw new RedError(`could not install ${plugin}@red-skills into Codex`);
+    }
+  }
+  log.ok("Codex red-skills marketplace now tracks reddb-io/red-skills");
 }
 
 function configHome(): string {
@@ -476,6 +545,9 @@ export async function convergeRedSkills(p: Platform): Promise<void> {
   // of reinstalling the same installer will fix.
   if (Bun.which("claude") && (await claudeMarketplaceIsGithub()) === false) {
     await repointClaudeMarketplace();
+  }
+  if (Bun.which("codex") && (await codexMarketplaceIsGithub()) === false) {
+    await repointCodexMarketplace();
   }
 
   const missing = await unwiredSkillHosts();

--- a/src/red-skills.test.ts
+++ b/src/red-skills.test.ts
@@ -243,4 +243,12 @@ describe("a marketplace that reports updates it cannot receive", () => {
       expect(repair).toContain(plugin);
     }
   });
+
+  test("castle has the repo-local fallback Codex already searches", () => {
+    // The legacy Codex MCP command for castle checks this path before
+    // giving up. Keep a real launcher here so a clean session in this
+    // repository can still reach the RedSkills marketplace checkout.
+    const launcher = readFileSync("plugins/dev/hooks/castle-mcp.sh", "utf8");
+    expect(launcher).toContain("red-skills/plugins/dev/hooks/castle-mcp.sh");
+  });
 });

--- a/src/red-skills.test.ts
+++ b/src/red-skills.test.ts
@@ -17,7 +17,12 @@ import { describe, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { TOOLS, applicableScopes, providerFor } from "./manifest.ts";
-import { AGENTS, SKILL_HOSTS, claudeMarketplaceIsGithub } from "./agents.ts";
+import {
+  AGENTS,
+  SKILL_HOSTS,
+  claudeMarketplaceIsGithub,
+  codexMarketplaceIsGithub,
+} from "./agents.ts";
 import type { Platform } from "./platform.ts";
 
 function platform(over: Partial<Platform>): Platform {
@@ -168,18 +173,72 @@ describe("a marketplace that reports updates it cannot receive", () => {
     expect(await sourceIsGithub(undefined)).toBeNull();
   });
 
+  /** A HOME holding one crafted Codex config.toml. */
+  function fakeCodexHome(sourceType?: string): string {
+    const dir = mkdtempSync(`${tmpdir()}/red-codex-mkt-`);
+    mkdirSync(`${dir}/.codex`, { recursive: true });
+    if (sourceType !== undefined) {
+      writeFileSync(
+        `${dir}/.codex/config.toml`,
+        [
+          "[marketplaces.red-skills]",
+          'last_updated = "2026-08-02T18:04:00Z"',
+          `source_type = "${sourceType}"`,
+          sourceType === "git"
+            ? 'source = "https://github.com/reddb-io/red-skills.git"'
+            : 'source = "/home/x/.red-skills/versions/v3.3.0"',
+          "",
+        ].join("\n"),
+      );
+    }
+    return dir;
+  }
+
+  async function codexSourceIsGithub(sourceType?: string): Promise<boolean | null> {
+    const saved = process.env["HOME"];
+    process.env["HOME"] = fakeCodexHome(sourceType);
+    try {
+      return await codexMarketplaceIsGithub();
+    } finally {
+      if (saved === undefined) delete process.env["HOME"];
+      else process.env["HOME"] = saved;
+    }
+  }
+
+  test("Codex has the same local-marketplace drift as Claude", async () => {
+    expect(await codexSourceIsGithub("local")).toBe(false);
+  });
+
+  test("Codex git marketplaces can receive RedSkills updates", async () => {
+    expect(await codexSourceIsGithub("git")).toBe(true);
+  });
+
+  test("no Codex marketplace entry is no opinion", async () => {
+    expect(await codexSourceIsGithub(undefined)).toBeNull();
+  });
+
   test("the name alone cannot tell the two apart", () => {
     // Which is why the old check could not see this: `red-skills`
     // appears in `plugin marketplace list` either way.
     const wired = src.slice(src.indexOf("async function cliNamesRedSkills"));
     expect(wired.slice(0, wired.indexOf("\n}"))).toContain("red-skills");
     expect(src).toContain("claudeMarketplaceIsGithub");
+    expect(src).toContain("codexMarketplaceIsGithub");
   });
 
   test("the repair reinstalls the plugins it removed", () => {
     // They came from a marketplace that no longer exists under that
     // name, so re-adding the source is not enough on its own.
     const repair = src.slice(src.indexOf("export async function repointClaudeMarketplace"));
+    for (const plugin of ["dev", "memory", "brain"]) {
+      expect(repair).toContain(plugin);
+    }
+  });
+
+  test("the Codex repair refreshes the plugins that provide MCPs", () => {
+    const repair = src.slice(src.indexOf("export async function repointCodexMarketplace"));
+    expect(repair).toContain("plugin");
+    expect(repair).toContain("marketplace");
     for (const plugin of ["dev", "memory", "brain"]) {
       expect(repair).toContain(plugin);
     }


### PR DESCRIPTION
## Summary

- detect and repair a Codex RedSkills marketplace registered from a stale local snapshot
- refresh the enabled `dev`, `memory`, and `brain` plugins through the Codex CLI
- add a repository fallback launcher for the `castle` MCP
- cover Codex marketplace drift and the castle fallback with regression tests

## Validation

- `bun test src/red-skills.test.ts`
- `bun run typecheck`
- isolated JSON-RPC probes confirmed `initialize` and `tools/list` responses from `navigator`, `castle`, and `rsp` with `CODEX_PLUGIN_ROOT` unset

The full `bun test` run encountered pre-existing timeouts in `src/converge.test.ts`; the focused regression suite and typecheck pass.

Closes #1

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788287689&installation_model_id=20659&pr_number=2&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F2&signature=4b6d5e2f646960d0ad5e5f4de942e704cb337fa5b01b0538a28d53537dd46757"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->