### PR TITLE
docs: land AFK boot docs sweep

### DIFF
--- a/.red/CONTEXT.md
+++ b/.red/CONTEXT.md
@@ -1,0 +1,23 @@
+# Contexto — red-dev
+
+Glossário do domínio. Termos resolvidos em sessões de grilling; livre de detalhes de implementação.
+
+## Perfil
+
+Declaração versionada de intenção de máquina: o conjunto de itens que uma instalação deve convergir. O mecanismo de perfis é neutro; o gosto (quais itens) mora em cada perfil, não no core.
+
+## reddb-employee
+
+O único perfil com usuário conhecido e critério de pronto cobrável. Baseline em camadas: um núcleo **obrigatório** (stack RedDB completo — `red`, `tq`, red-request, `dit`, red-ui, RedSkills — mais Docker, runtimes mise e um agent host padrão), e todo item adicional do catálogo marcado explicitamente como **recomendado** ou **experimental**.
+
+## Camadas de obrigatoriedade
+
+Todo item de um perfil pertence a exatamente uma camada: **obrigatório** (readiness cobra 100%), **recomendado** (instalado por padrão, pode ser recusado) ou **experimental** (opt-in, nunca conta contra o readiness).
+
+## Agent host
+
+Programa cliente de agentes que consome RedSkills numa máquina provisionada. Conjunto suportado decidido: Claude Code, Codex, OpenCode, Gemini, Pi e Hermes — os seis com skills compartilhadas e verificação no doctor. Hermes depende de suporte oficial no RedSkills upstream.
+
+## Readiness report
+
+Resultado que encerra uma convergência de perfil. Distingue por item: `healthy`, `auth-required` (ação humana pendente, não é falha), `unsupported-with-reason`, `failed` e `not-chosen`. "Pronto" = 100% dos obrigatórios em `healthy` ou `auth-required`.


### PR DESCRIPTION
Automated Docs Sweep landing for stranded .red documentation.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788362448&installation_model_id=20659&pr_number=3&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F3&signature=92bcbccfb6869712b36e8b35bdd008c6f0700c3b2b4a49182d5de6c7e96e04d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->