### PR TITLE
docs: context map, bounded-context glossaries, and ADR 0001

### DIFF
--- a/.red/CONTEXT-MAP.md
+++ b/.red/CONTEXT-MAP.md
@@ -1,0 +1,18 @@
+# Context Map — red-dev
+
+Bounded contexts split by **subject** (language boundary), never by OS nor by implementation layer — OS is an adapter, layer is a stratum (see ADR 0001).
+
+| Context | Subject | Glossary |
+|---|---|---|
+| `provisioning` | Convergence engine: manifest, providers, plan/apply, clean-machine proof | `.red/contexts/provisioning/CONTEXT.md` |
+| `profiles` | Machine intent: profiles, requirement tiers, readiness | `.red/contexts/profiles/CONTEXT.md` |
+| `interaction` | Semantic actions: hotkeys, tiling, workspaces, launcher | `.red/contexts/interaction/CONTEXT.md` |
+| `visual` | Visual system: themes, fonts, wallpapers, config ownership | `.red/contexts/visual/CONTEXT.md` |
+| `agents` | Agent hosts, RedSkills, MCPs, and agent accessibility | `.red/contexts/agents/CONTEXT.md` |
+| `lifecycle` | Self-update of the binary, channels, rollback, origin verification | *(no resolved terms yet)* |
+
+## Relationships
+
+- `profiles` **consumes** `provisioning`: a profile is intent; the engine is what converges it.
+- `interaction`, `visual`, and `agents` define **platform-neutral contracts**; each OS joins as an adapter inside the context, never as a context of its own.
+- `lifecycle` is cross-cutting and runs on its own track (decision from the 2026-08-03 session).

--- a/.red/adr/0001-cross-platform-phased-not-a-distro.md
+++ b/.red/adr/0001-cross-platform-phased-not-a-distro.md
@@ -1,0 +1,34 @@
+# 0001 — red-dev stays cross-platform and absorbs Omarchy/Omakub in phases, via contracts and adapters
+
+- Status: accepted
+- Date: 2026-08-03
+- Sources: `.red/researches/2026-08-03-omarchy-deep-dive-and-red-dev-opportunities.md`, `.red/researches/2026-08-03-red-dev-vs-omakub-gap-analysis.md`, `.red/researches/2026-08-03-red-dev-vs-omakub-gap-analysis-2.md`
+
+## Context
+
+Three studies compared red-dev with Omakub, Omarchy, and the 37signals ecosystem. Each proposed a different, mutually incompatible prioritization philosophy as the starting point:
+
+- **Doc 1 (Omarchy):** contracts-first — a semantic action registry, an atomic theme contract, and graphical E2E as the foundation (P0) before any feature work.
+- **Doc 2 (Omakub v1):** honesty/profile-first — self-update, macOS fail-closed, and the `reddb-employee` Day-One profile as the product goal.
+- **Doc 3 (Omakub v2, correcting Doc 2):** defects-first — 8+ concrete defects found (7 broken Neovim theme adapters, Rose Pine forced to dark, preferences not hydrated into `ApplyContext`, stale red-ui Windows provider, fonts not installed outside WSL, missing implicit dependencies) make any new promise dishonest while they exist.
+
+There was also the implicit temptation to follow Omarchy's path (become an opinionated Linux distribution/environment) or to port Omakub's scripts directly.
+
+## Decision
+
+red-dev **stays cross-platform** (Linux, Windows/WSL, and eventually macOS) and absorbs Omarchy/Omakub ideas **via semantic contracts + per-platform adapters + profiles**, never becoming a distro nor porting ad-hoc scripts. All three philosophies from the studies are adopted, **phased** in this order:
+
+1. **Phase 1 — Defects:** only Doc 3's mechanical correctness fixes (Neovim themes, explicit light/dark, preference hydration, fonts on Ubuntu/native Windows, `wl-clipboard`, red-ui Windows, macOS fail-closed, dead code). Atomic self-update + SHA256 verification of bootstraps move to a dedicated update/security track.
+2. **Phase 2 — Profile:** profile mechanism + **only** `reddb-employee`, with required/recommended/experimental tiers and a readiness report born as `doctor --json`. Wires all 6 agent hosts (Claude, Codex, OpenCode, Gemini, Pi, Hermes — the latter assumes upstream delivery in RedSkills). The agent-accessibility contract for the other RedDB products is a separate program, outside this phasing.
+3. **Phase 3 — Desktop parity:** the Omakub layer (Chrome as default browser, adoptable editor starter, GNOME extensions, web apps, screenshots), covering Linux and Windows together. The semantic action schema is **pulled forward** into this phase and is born with two adapters — GNOME and PowerToys/FancyZones — to prove portability. No databases module: RedDB (`red`) + Docker suffice.
+4. **Phase 4 — Contracts:** the remaining contracts (atomic per-surface theme contract, lifecycle/transactions, asset provenance, full command registry).
+5. **Phase 5 — macOS:** Darwin is born as an adapter of the Phase 4 contracts, never as a third ad-hoc implementation.
+
+Cross-cutting: an **incremental** clean-machine E2E fleet — each phase only closes with lanes covering what it shipped. MCP is **optional-with-fallback**: every required capability has a stable CLI path.
+
+## Consequences
+
+- No contract is designed in the abstract: the profile and the desktop act as forcing functions, except the action schema (deliberately pulled forward to avoid rewriting GNOME hotkeys in Phase 4).
+- Phase 2 is coupled to one upstream RedSkills release (Hermes) — accepted consciously, and limited to that single external dependency.
+- Visible product value lands before the full architecture; the cost is potential rework on Phase 3 surfaces not covered by the action schema.
+- Study items explicitly **not adopted**: the Omakub-style databases module, DHH personal taste in the neutral core, and everything on Doc 1's "do not copy" list (permission-bypass defaults, unsigned channels, etc.).

--- a/.red/contexts/agents/CONTEXT.md
+++ b/.red/contexts/agents/CONTEXT.md
@@ -1,0 +1,11 @@
+# Context: agents
+
+Agent hosts, RedSkills, MCPs, and RedDB products' accessibility to agents.
+
+## Agent host
+
+An agent client program that consumes RedSkills on a provisioned machine. Decided supported set: Claude Code, Codex, OpenCode, Gemini, Pi, and Hermes — all six with shared skills and doctor verification. Hermes depends on official upstream RedSkills support.
+
+## MCP posture
+
+CLI-first: every required capability has a stable CLI path; MCP is optional acceleration. An MCP failure never brings down a required item's readiness — the item stays `healthy` with a `degraded(reason, fallback, remediation)` state pointing at the CLI fallback.

--- a/.red/contexts/interaction/CONTEXT.md
+++ b/.red/contexts/interaction/CONTEXT.md
@@ -1,0 +1,7 @@
+# Context: interaction
+
+Interacting with the machine — actions, hotkeys, tiling, workspaces, launcher.
+
+## Semantic action
+
+A portable unit of interaction (`terminal.new`, `window.tile.left`, `workspace.goto.N`…): identity and meaning are defined platform-neutrally; each platform provides a bindings adapter — GNOME and PowerToys/FancyZones are the first two, born together to prove the contract's portability. Hotkeys, cheat sheets, and conflict detection derive from the schema, never the other way around.

--- a/.red/contexts/profiles/CONTEXT.md
+++ b/.red/contexts/profiles/CONTEXT.md
@@ -1,0 +1,23 @@
+# Context: profiles
+
+Machine intent — what an installation must contain and how "ready" is enforced.
+
+## Profile
+
+A versioned declaration of machine intent: the set of items an installation must converge. The profile mechanism is neutral; taste (which items) lives in each profile, not in the core.
+
+## reddb-employee
+
+The only profile with a known user and an enforceable definition of done. Tiered baseline: a **required** core (the full RedDB stack — `red`, `tq`, red-request, `dit`, red-ui, RedSkills — plus Docker, mise runtimes, and a default agent host), with every additional catalog item explicitly marked **recommended** or **experimental**.
+
+## Requirement tiers
+
+Every profile item belongs to exactly one tier: **required** (readiness enforces 100%), **recommended** (installed by default, can be declined), or **experimental** (opt-in, never counts against readiness).
+
+## Readiness report
+
+The result that closes a profile convergence. Distinguishes per item: `healthy`, `auth-required` (pending human action, not a failure), `unsupported-with-reason`, `failed`, and `not-chosen`. "Ready" = 100% of required items in `healthy` or `auth-required`. Born machine-readable (`doctor --json`).
+
+## Development databases
+
+red-dev installs no databases and no database containers — an explicit decision against the Omakub-style module. The required stack already contains RedDB (the `red` binary) and Docker; any additional service is the developer's responsibility, via Docker.

--- a/.red/contexts/provisioning/CONTEXT.md
+++ b/.red/contexts/provisioning/CONTEXT.md
@@ -1,0 +1,7 @@
+# Context: provisioning
+
+Convergence engine — manifest, providers, plan/apply, and the proof discipline.
+
+## E2E lane
+
+A clean machine (VM) for one target platform that walks the full journey — install → second convergence with zero drift → theme/font switch → N-1 update → rollback → uninstall. Incremental definition of done: each phase only closes with lanes covering what it shipped; no item is ever declared ready by mere file existence.

--- a/.red/contexts/visual/CONTEXT.md
+++ b/.red/contexts/visual/CONTEXT.md
@@ -1,0 +1,7 @@
+# Context: visual
+
+Visual system — themes, fonts, wallpapers, and the ownership of the configs that apply them.
+
+## Config ownership modes
+
+Every configuration file touched by an adapter declares a mode: `owned` (red-dev owns and converges it), `merged` (red-dev manages only explicitly-owned fields), `adopted` (pre-existing; red-dev took over management with consent and a plan), or `external` (red-dev never touches it; at most themes it when present). Editors follow the *adoptable starter* model: install when absent, never overwrite what exists.


### PR DESCRIPTION
Lands the documentation produced by the 2026-08-03 grilling session over the three researches in `.red/researches/` (red-dev vs Omakub v1/v2, Omarchy deep-dive):

- `.red/CONTEXT-MAP.md` — six bounded contexts split by subject (provisioning, profiles, interaction, visual, agents, lifecycle), never by OS or layer.
- Five context glossaries under `.red/contexts/**` with the terms resolved in session: profile, reddb-employee, requirement tiers, readiness report, semantic action, MCP posture, config ownership modes, E2E lane, and the no-databases decision.
- `.red/adr/0001-cross-platform-phased-not-a-distro.md` — the phased adoption decision: defects → `reddb-employee` profile → desktop parity (Linux + Windows, action schema pulled forward) → contracts → macOS as contract adapter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0172iFcxJFvKcyTSHmgejY89

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788367816&installation_model_id=20659&pr_number=4&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F4&signature=9b01a67f80ef1298526e8438ff86241914c074e4c4c4bd083252070cebdfe9dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->