### PR TITLE
feat: WSL clipboard bridge, Windows output encoding, and provisioning fixes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*]
+charset = utf-8
+insert_final_newline = true

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules/
 dist/
 *.log
 .DS_Store
+.red/tmp/
+.red/state/

--- a/README.md
+++ b/README.md
@@ -188,6 +188,16 @@ Because zellij is now always on, its own keybindings would be taking `Ctrl-p`,
 unlocks, every binding returns to locked, and `Alt` plus arrows or `hjkl` moves
 between panes without leaving it.
 
+Clipboard text stays Unicode across WSL: zellij sends UTF-8, and red-dev's
+low-latency bridge converts it to BOM-less UTF-16LE before `clip.exe` reads it.
+That avoids both `clip.exe`'s OEM-code-page mojibake and zellij's one-second
+timeout for clipboard commands. Mouse selection copies automatically. In
+Alacritty, paste is `Ctrl+V` or `Ctrl+Shift+V`; `Ctrl+Shift+C` copies an
+Alacritty selection, while plain `Ctrl+C` remains the application's interrupt
+key. Inside a mouse-capturing TUI such as herdr, normal drag selection belongs
+to herdr and is copied automatically; hold `Shift` while dragging to select in
+Alacritty instead, or use herdr's copy mode (`Ctrl+B`, then `[`).
+
 ### The tools
 
 `git` · `curl` · `ripgrep` · `fd` · `bat` · `eza` · `zoxide` · `fzf` · `btop` ·
@@ -297,7 +307,7 @@ red-dev agents               # choose coding agents, wire in red-skills
 red-dev share [path]         # one directory both WSL and Windows read
 red-dev share adopt <tool>   # move that tool's configuration into it
 red-dev uninstall            # remove tools, or red-dev's own config
-red-dev wsl                  # Windows: set up WSL
+red-dev wsl                  # Windows: set up or verify WSL 2
 red-dev ui                   # fullscreen, with live theme preview
 red-dev doctor               # report tool and configuration drift
 ```
@@ -522,6 +532,14 @@ run natively, and the wallpaper goes through `gsettings`.
 ```bash
 curl -fsSL https://raw.githubusercontent.com/reddb-io/red-dev/main/boot.sh | sh
 ```
+
+WSL 2 is an explicit invariant, not an assumption. From Windows, red-dev sets
+version 2 as the default for every future distro and reads `wsl --list
+--verbose` before entering the selected distro. An existing WSL 1 distro is
+never used silently: `red-dev wsl` offers to convert it after warning that the
+conversion can take time, while `red-dev doctor` reports the architecture in
+use. From inside a distro, `red-dev wsl` verifies it and prints the PowerShell
+conversion commands when Windows does not report version 2.
 
 Scopes: `core` + `wsl`. The `core` half installs inside the distro; the `wsl`
 half deliberately reaches **out to Windows**, because that is where the terminal

--- a/config/bash/prompt.sh
+++ b/config/bash/prompt.sh
@@ -10,6 +10,14 @@
 # the wsl scope installs one on the Windows host before this ever
 # matters — under WSL the font belongs to the terminal, not the distro.
 
+# Login shells used by agents and automation still pass through
+# ~/.profile -> ~/.bashrc -> this file. They have no prompt to render,
+# and the tool runner deliberately advertises that fact as TERM=dumb.
+# Initialising starship there only emits an error before every command.
+if [[ $- != *i* ]] || [ "${TERM:-dumb}" = "dumb" ]; then
+  return 0
+fi
+
 if command -v starship >/dev/null 2>&1; then
   # starship owns the prompt when present. It has to win outright, not
   # merge: two things writing PS1 produce a prompt that is neither.

--- a/config/bash/windows-clipboard.sh
+++ b/config/bash/windows-clipboard.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Zellij writes UTF-8 to copy_command. clip.exe reads redirected input as
+# UTF-16LE, so bridge the encodings without starting PowerShell: Zellij kills
+# clipboard commands that are still running after one second.
+
+set -o pipefail
+
+if ! command -v iconv >/dev/null 2>&1; then
+  printf 'red-dev clipboard: iconv is unavailable\n' >&2
+  exit 127
+fi
+
+if ! command -v clip.exe >/dev/null 2>&1; then
+  printf 'red-dev clipboard: clip.exe is unavailable (WSL interop is disabled)\n' >&2
+  exit 127
+fi
+
+# No BOM: clip.exe already treats redirected UTF-16LE as Unicode, while a BOM
+# becomes a literal U+FEFF at the start of the Windows clipboard contents.
+iconv -f UTF-8 -t UTF-16LE | clip.exe

--- a/src/alacritty.ts
+++ b/src/alacritty.ts
@@ -20,6 +20,7 @@ import { existsSync, mkdirSync } from "node:fs";
 import { log, RedError } from "./log.ts";
 import type { Platform } from "./platform.ts";
 import type { Theme, TerminalPalette } from "./themes.ts";
+import { readWindowsOutput } from "./windows-output.ts";
 
 async function capture(cmd: string[]): Promise<string> {
   const proc = Bun.spawn(cmd, { stdout: "pipe", stderr: "pipe" });
@@ -228,14 +229,13 @@ async function shellToml(p: Platform): Promise<string> {
 /**
  * The distro WSL would open by default.
  *
- * `wsl -l -q` writes UTF-16, so the output arrives with NUL bytes
- * between characters; stripping them is the difference between parsing
- * a name and parsing nothing.
+ * `wsl -l -q` writes UTF-16LE when redirected, so decode the Windows
+ * boundary before treating the result as normal text.
  */
 async function defaultWslDistro(): Promise<string | null> {
   try {
     const proc = Bun.spawn(["wsl.exe", "-l", "-q"], { stdout: "pipe", stderr: "ignore" });
-    const out = (await new Response(proc.stdout).text()).replace(/\0/g, "");
+    const out = await readWindowsOutput(proc.stdout);
     if ((await proc.exited) !== 0) return null;
     return out.split(/\r?\n/).map((l) => l.trim()).find(Boolean) ?? null;
   } catch {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -139,7 +139,7 @@ export function buildCli(): CLI {
         description: "remove tools or red-dev's own configuration",
       },
       wsl: {
-        description: "set up WSL on this Windows machine",
+        description: "set up or verify WSL 2 on this Windows machine",
       },
       ui: {
         description: "fullscreen interface, with live theme preview",

--- a/src/clipboard.test.ts
+++ b/src/clipboard.test.ts
@@ -12,8 +12,9 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import { readFileSync } from "node:fs";
-import { zellijConfigFor } from "./dotfiles.ts";
+import { chmodSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { zellijConfigAction, zellijConfigFor } from "./dotfiles.ts";
 import { repairedImports } from "./alacritty.ts";
 import type { Platform } from "./platform.ts";
 
@@ -31,16 +32,44 @@ function platform(over: Partial<Platform>): Platform {
 }
 
 describe("where zellij puts a copied selection", () => {
-  test("goes through clip.exe under WSL", () => {
-    // Verified from a distro before this was written: piping into
-    // clip.exe and reading Get-Clipboard back returns the same text.
+  test("uses the fast UTF-8 bridge under WSL", () => {
     const config = zellijConfigFor(platform({ env: "wsl" }));
-    expect(config).toContain('copy_command "clip.exe"');
+    expect(config).toContain("windows-clipboard.sh");
+    expect(config).not.toContain("powershell.exe");
+    expect(config).not.toContain('copy_command "clip.exe"');
   });
 
-  test("goes through clip.exe on native Windows too", () => {
+  test("uses the same Unicode-safe bridge on native Windows", () => {
     const config = zellijConfigFor(platform({ os: "windows", env: "windows" }));
-    expect(config).toContain('copy_command "clip.exe"');
+    expect(config).toContain("powershell.exe");
+    expect(config).not.toContain('copy_command "clip.exe"');
+  });
+
+  test("converts Zellij UTF-8 to BOM-less UTF-16LE within its timeout", async () => {
+    const dir = mkdtempSync(`${tmpdir()}/red-clipboard-`);
+    const capture = `${dir}/clipboard.bin`;
+    const fakeClip = `${dir}/clip.exe`;
+    writeFileSync(fakeClip, '#!/bin/sh\nexec tee "$CLIP_CAPTURE" >/dev/null\n');
+    chmodSync(fakeClip, 0o755);
+
+    const input = "copiar e colar: ação — 🧪";
+    const started = performance.now();
+    const proc = Bun.spawn(["bash", "config/bash/windows-clipboard.sh"], {
+      env: {
+        ...process.env,
+        PATH: `${dir}:${process.env["PATH"] ?? ""}`,
+        CLIP_CAPTURE: capture,
+      },
+      stdin: "pipe",
+      stdout: "ignore",
+      stderr: "pipe",
+    });
+    proc.stdin.write(input);
+    proc.stdin.end();
+
+    expect(await proc.exited).toBe(0);
+    expect(performance.now() - started).toBeLessThan(1_000);
+    expect(readFileSync(capture).toString("utf16le")).toBe(input);
   });
 
   test("uses the Wayland tool on a Linux desktop", () => {
@@ -94,6 +123,43 @@ describe("paste", () => {
 });
 
 describe("reaching a machine that already has a config", () => {
+  test("upgrades the generated clip.exe config that corrupts UTF-8", () => {
+    const base = readFileSync("config/zellij/config.kdl", "utf8");
+    const old = `${base}
+// Generated for this target by red-dev.
+//
+// The clipboard zellij should write to. Without it zellij uses OSC 52,
+// which asks the terminal to do the copying and cannot tell whether it
+// did — so a selection reports success and the clipboard keeps whatever
+// was in it.
+copy_command "clip.exe"
+`;
+    const next = zellijConfigFor(platform({ env: "wsl" }));
+    expect(zellijConfigAction(old, next)).toBe("upgrade");
+  });
+
+  test("upgrades the generated PowerShell bridge that Zellij times out", () => {
+    const base = readFileSync("config/zellij/config.kdl", "utf8");
+    const script =
+      "$ProgressPreference='SilentlyContinue';" +
+      "$s=[Console]::OpenStandardInput();" +
+      "$m=New-Object IO.MemoryStream;" +
+      "$s.CopyTo($m);" +
+      "Set-Clipboard -Value ([Text.Encoding]::UTF8.GetString($m.ToArray()))";
+    const encoded = Buffer.from(script, "utf16le").toString("base64");
+    const old = `${base}
+// Generated for this target by red-dev.
+//
+// The clipboard zellij should write to. Without it zellij uses OSC 52,
+// which asks the terminal to do the copying and cannot tell whether it
+// did — so a selection reports success and the clipboard keeps whatever
+// was in it.
+copy_command "powershell.exe -NoProfile -EncodedCommand ${encoded}"
+`;
+    const next = zellijConfigFor(platform({ env: "wsl" }));
+    expect(zellijConfigAction(old, next)).toBe("upgrade");
+  });
+
   test("the config being shipped is registered as shipped", () => {
     // The upgrade only fires for a file that hashes to something
     // red-dev is known to have written. Leaving the current one out is

--- a/src/dotfiles.ts
+++ b/src/dotfiles.ts
@@ -24,6 +24,7 @@ import functionsSh from "../config/bash/functions.sh" with { type: "text" };
 import promptSh from "../config/bash/prompt.sh" with { type: "text" };
 import sharedSh from "../config/bash/shared.sh" with { type: "text" };
 import zellijSh from "../config/bash/zellij.sh" with { type: "text" };
+import windowsClipboardSh from "../config/bash/windows-clipboard.sh" with { type: "text" };
 import inputrc from "../config/bash/inputrc.conf" with { type: "text" };
 import zellijBase from "../config/zellij/config.kdl" with { type: "text" };
 
@@ -39,6 +40,7 @@ export const FILES: Record<string, string> = {
   "prompt.sh": promptSh,
   "shared.sh": sharedSh,
   "zellij.sh": zellijSh,
+  "windows-clipboard.sh": windowsClipboardSh,
   // Deployed without the .conf suffix: the repo needs an extension for
   // the text import to resolve, readline does not care what it is
   // called, and INPUTRC points straight at it.
@@ -221,7 +223,42 @@ const SHIPPED_ZELLIJ_CONFIGS = new Set([
   // that took 0.11.0 could never be given one, because "written once"
   // has no exception for a file that is still exactly ours.
   "df96577497a13f992edf36e3ffcb89717472e83c841809eea1a789bed20ae34b",
+  // 0.15.0 through 0.19.0 on WSL/Windows: the base above plus a
+  // generated `copy_command "clip.exe"`. clip.exe decodes redirected
+  // stdin with the Windows OEM code page, so UTF-8 became mojibake.
+  "2210c40109a5f89c9acb30baa0cc3f67072eed998ac3c7569c19866aa8a2efb8",
+  // 0.19.0 on WSL/Windows: the UTF-8-safe PowerShell bridge. Correct in
+  // isolation, but Zellij kills copy commands after one second and Windows
+  // PowerShell startup can exceed that from WSL, leaving the old clipboard.
+  "386a88423e2c91e3af3341ac82f9402d0cf81ae2ed325859236e1dbfa400db12",
 ]);
+
+/**
+ * WSL's low-latency clipboard bridge.
+ *
+ * Zellij gives copy_command UTF-8 on stdin and terminates it after one
+ * second. Starting powershell.exe is too slow on some WSL machines, while
+ * iconv + clip.exe completes in tens of milliseconds. clip.exe accepts
+ * redirected UTF-16LE without a BOM, preserving accents and supplementary
+ * Unicode characters in the Windows clipboard.
+ */
+export function wslClipboardCommand(): string {
+  return `bash ${home()}/.local/share/red-dev/config/bash/windows-clipboard.sh`;
+}
+
+/** Native Windows fallback. WSL uses the faster helper above because Zellij
+ * terminates commands after one second; PowerShell startup inside WSL can
+ * exceed that deadline. */
+export function windowsClipboardCommand(): string {
+  const script =
+    "$ProgressPreference='SilentlyContinue';" +
+    "$s=[Console]::OpenStandardInput();" +
+    "$m=New-Object IO.MemoryStream;" +
+    "$s.CopyTo($m);" +
+    "Set-Clipboard -Value ([Text.Encoding]::UTF8.GetString($m.ToArray()))";
+  const encoded = Buffer.from(script, "utf16le").toString("base64");
+  return `powershell.exe -NoProfile -EncodedCommand ${encoded}`;
+}
 
 /**
  * The zellij config for this machine, which is the shipped one plus the
@@ -231,9 +268,10 @@ const SHIPPED_ZELLIJ_CONFIGS = new Set([
  * terminal to set the clipboard and reports success either way. On
  * Windows that ask goes unanswered often enough that selecting text
  * shows "Copied!" and pastes the previous contents, which is worse than
- * failing. clip.exe is the Windows clipboard itself, reachable from WSL
- * through interop and from Git Bash as a normal program; verified from
- * this side with a round trip through Get-Clipboard.
+ * failing. On WSL the helper converts Zellij's UTF-8 to BOM-less UTF-16LE
+ * before clip.exe reads it. This both preserves Unicode and finishes before
+ * Zellij's one-second copy-command deadline. Native Windows uses the same
+ * explicit UTF-8 decoding through the PowerShell clipboard API.
  *
  * Per platform rather than shipped, because a copy_command naming a
  * program that does not exist is the same silent failure pointed the
@@ -241,11 +279,13 @@ const SHIPPED_ZELLIJ_CONFIGS = new Set([
  */
 export function zellijConfigFor(p: Platform): string {
   const command =
-    p.os === "windows" || p.env === "wsl"
-      ? "clip.exe"
-      : p.env === "desktop"
-        ? "wl-copy"
-        : null;
+    p.env === "wsl"
+      ? wslClipboardCommand()
+      : p.os === "windows"
+        ? windowsClipboardCommand()
+        : p.env === "desktop"
+          ? "wl-copy"
+          : null;
 
   if (!command) return zellijBase;
 

--- a/src/drift.ts
+++ b/src/drift.ts
@@ -199,6 +199,49 @@ function checkWslInterop(p: Platform): DriftCheck {
       };
 }
 
+/** WSL is a product name; this check makes the required architecture explicit. */
+async function checkWslArchitecture(p: Platform): Promise<DriftCheck> {
+  if (p.env !== "wsl" && p.os !== "windows") {
+    return { name: "wsl architecture", status: "n/a", detail: "not WSL or Windows" };
+  }
+
+  try {
+    const { detectWsl } = await import("./wsl-provision.ts");
+    const state = await detectWsl();
+    const currentName = p.env === "wsl" ? process.env["WSL_DISTRO_NAME"] : undefined;
+    const distro =
+      state.distributions.find((item) => item.name === currentName) ??
+      state.distributions.find((item) => item.default) ??
+      state.distributions[0];
+
+    if (!distro) {
+      return { name: "wsl architecture", status: "n/a", detail: "no distro installed" };
+    }
+    if (distro.version === 2) {
+      return { name: "wsl architecture", status: "ok", detail: `${distro.name} uses WSL 2` };
+    }
+    if (distro.version === 1) {
+      return {
+        name: "wsl architecture",
+        status: "drift",
+        detail: `${distro.name} uses WSL 1; red-dev requires WSL 2`,
+        fix:
+          p.os === "windows"
+            ? "red-dev wsl"
+            : `from PowerShell: wsl --set-version ${distro.name} 2`,
+      };
+    }
+    return {
+      name: "wsl architecture",
+      status: "drift",
+      detail: `cannot verify whether ${distro.name} uses WSL 2`,
+      fix: "wsl --update, then red-dev doctor",
+    };
+  } catch (err) {
+    return { name: "wsl architecture", status: "n/a", detail: (err as Error).message };
+  }
+}
+
 async function checkDelta(): Promise<DriftCheck> {
   if (!Bun.which("delta")) {
     return { name: "git pager", status: "n/a", detail: "delta not installed" };
@@ -413,6 +456,7 @@ export async function collectDrift(p: Platform): Promise<DriftCheck[]> {
   checks.push(await checkShellWiring());
   checks.push(...(await checkTheme(p)));
   checks.push(await checkWallpaper(p));
+  checks.push(await checkWslArchitecture(p));
   checks.push(checkWslInterop(p));
   checks.push(await checkFont(p));
   checks.push(await checkWslDistro(p));

--- a/src/main.ts
+++ b/src/main.ts
@@ -551,13 +551,33 @@ async function cmdUi(p: Platform, inv: Invocation): Promise<number> {
 }
 
 /**
- * Set WSL up from the Windows side, on demand rather than only during a
+ * Set WSL 2 up from the Windows side, on demand rather than only during a
  * first run — someone who declined at setup should not have to reset
  * their preferences to change their mind.
  */
 async function cmdWsl(p: Platform): Promise<number> {
+  if (p.env === "wsl") {
+    const { detectWsl } = await import("./wsl-provision.ts");
+    const state = await detectWsl();
+    const name = process.env["WSL_DISTRO_NAME"];
+    const distro = state.distributions.find((item) => item.name === name);
+    if (distro?.version === 2) {
+      log.ok(`${distro.name} is using WSL 2`);
+      return 0;
+    }
+
+    const label = name ?? "this distro";
+    const commandName = name ?? "<distro>";
+    log.err(`${label} is not confirmed as WSL 2`);
+    log.plain("     A running distro cannot safely convert itself. In PowerShell run:");
+    log.plain(`       wsl --shutdown`);
+    log.plain(`       wsl --set-default-version 2`);
+    log.plain(`       wsl --set-version ${commandName} 2`);
+    return 1;
+  }
+
   if (p.os !== "windows") {
-    log.skip("this sets WSL up from the Windows side; you are already inside a distro");
+    log.skip("this sets WSL 2 up from the Windows side");
     return 0;
   }
   const { offerWsl } = await import("./wsl-provision.ts");

--- a/src/prompt-noninteractive.test.ts
+++ b/src/prompt-noninteractive.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from "bun:test";
+
+const PROMPT = `${import.meta.dir}/../config/bash/prompt.sh`;
+
+test("a non-interactive dumb shell never initializes starship", () => {
+  const script = `
+    starship() {
+      printf 'STARSHIP_CALLED\\n' >&2
+      printf ':'
+    }
+    export TERM=dumb
+    . '${PROMPT}'
+  `;
+  const proc = Bun.spawnSync(["bash", "--noprofile", "--norc", "-c", script], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const stderr = new TextDecoder().decode(proc.stderr);
+
+  expect(proc.exitCode).toBe(0);
+  expect(stderr).not.toContain("STARSHIP_CALLED");
+});

--- a/src/windows-output.test.ts
+++ b/src/windows-output.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test";
+import { decodeWindowsOutput } from "./windows-output.ts";
+
+describe("native Windows output", () => {
+  test("keeps UTF-8 as UTF-8", () => {
+    const bytes = new TextEncoder().encode("“WSL” é configuração rápida");
+    expect(decodeWindowsOutput(bytes)).toBe("“WSL” é configuração rápida");
+  });
+
+  test("decodes redirected wsl.exe UTF-16LE without losing accents", () => {
+    const bytes = Buffer.from("* Distribuição  Running  2\r\n", "utf16le");
+    expect(decodeWindowsOutput(bytes)).toBe("* Distribuição  Running  2\r\n");
+  });
+
+  test("recognises an explicit UTF-16LE byte-order mark", () => {
+    const bytes = Buffer.concat([Buffer.from([0xff, 0xfe]), Buffer.from("ação", "utf16le")]);
+    expect(decodeWindowsOutput(bytes)).toBe("ação");
+  });
+});

--- a/src/windows-output.ts
+++ b/src/windows-output.ts
@@ -1,0 +1,32 @@
+/**
+ * Decode output crossing from a native Windows process into Bun.
+ *
+ * Most commands emit UTF-8, while WSL's own CLI emits UTF-16LE when
+ * stdout is redirected. Treating those bytes as UTF-8 leaves a NUL
+ * after every ASCII character and corrupts every non-ASCII character.
+ */
+export function decodeWindowsOutput(bytes: Uint8Array): string {
+  if (bytes.length === 0) return "";
+
+  const hasUtf16LeBom = bytes.length >= 2 && bytes[0] === 0xff && bytes[1] === 0xfe;
+  let oddNuls = 0;
+  let evenNuls = 0;
+  for (let i = 0; i < bytes.length; i++) {
+    if (bytes[i] !== 0) continue;
+    if (i % 2 === 0) evenNuls++;
+    else oddNuls++;
+  }
+
+  // ASCII-heavy UTF-16LE has NUL in most odd byte positions. Requiring
+  // both a useful ratio and a strong odd/even bias avoids guessing from
+  // an incidental NUL in otherwise normal UTF-8 output.
+  const pairs = Math.floor(bytes.length / 2);
+  const looksUtf16Le = pairs > 0 && oddNuls / pairs >= 0.25 && oddNuls > evenNuls * 2;
+  const decoder = hasUtf16LeBom || looksUtf16Le ? new TextDecoder("utf-16") : new TextDecoder();
+  return decoder.decode(bytes);
+}
+
+export async function readWindowsOutput(stream: ReadableStream<Uint8Array>): Promise<string> {
+  const bytes = new Uint8Array(await new Response(stream).arrayBuffer());
+  return decodeWindowsOutput(bytes);
+}

--- a/src/wsl-provision.test.ts
+++ b/src/wsl-provision.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+import { parseWslVerbose } from "./wsl-provision.ts";
+
+describe("WSL architecture detection", () => {
+  test("parses the default marker and WSL version", () => {
+    const output = [
+      "  NAME              STATE           VERSION",
+      "* Ubuntu-24.04      Running         2",
+      "  legacy            Stopped         1",
+    ].join("\r\n");
+
+    expect(parseWslVerbose(output)).toEqual([
+      { name: "Ubuntu-24.04", default: true, version: 2 },
+      { name: "legacy", default: false, version: 1 },
+    ]);
+  });
+
+  test("tolerates the legacy NUL-separated representation", () => {
+    const utf16Looking =
+      "*\0 \0U\0b\0u\0n\0t\0u\0 \0 \0R\0u\0n\0n\0i\0n\0g\0 \0 \0" +
+      "2\0\r\0\n\0";
+    expect(parseWslVerbose(utf16Looking)).toEqual([
+      { name: "Ubuntu", default: true, version: 2 },
+    ]);
+  });
+
+  test("does not invent a version from quiet or malformed output", () => {
+    expect(parseWslVerbose("Ubuntu-24.04\r\n")).toEqual([]);
+  });
+});

--- a/src/wsl-provision.ts
+++ b/src/wsl-provision.ts
@@ -18,37 +18,88 @@
 
 import { log } from "./log.ts";
 import type { Platform } from "./platform.ts";
+import { readWindowsOutput } from "./windows-output.ts";
 
 export interface WslState {
   /** The WSL feature is present and usable. */
   available: boolean;
   /** Distro names already installed. */
   distros: string[];
+  /** Installed distros, including the WSL architecture when Windows reports it. */
+  distributions: WslDistribution[];
   detail: string;
+}
+
+export interface WslDistribution {
+  name: string;
+  default: boolean;
+  /** Null only on an old WSL build that cannot report verbose state. */
+  version: 1 | 2 | null;
 }
 
 async function capture(cmd: string[]): Promise<{ out: string; code: number }> {
   const proc = Bun.spawn(cmd, { stdout: "pipe", stderr: "pipe" });
-  const out = await new Response(proc.stdout).text();
+  const out = await readWindowsOutput(proc.stdout);
   const code = await proc.exited;
   return { out, code };
+}
+
+/** Parse decoded `wsl -l -v` output, tolerating the old NUL-separated form too. */
+export function parseWslVerbose(out: string): WslDistribution[] {
+  const lines = out
+    .replace(/\0/g, "")
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  const distributions: WslDistribution[] = [];
+  for (const line of lines) {
+    const isDefault = line.startsWith("*");
+    const columns = line.replace(/^\*\s*/, "").split(/\s{2,}/);
+    const version = Number(columns.at(-1));
+    if ((version !== 1 && version !== 2) || columns.length < 3) continue;
+    distributions.push({
+      name: columns.slice(0, -2).join("  ").trim(),
+      default: isDefault,
+      version,
+    });
+  }
+  return distributions;
 }
 
 /**
  * What WSL looks like right now.
  *
- * `wsl -l -q` writes UTF-16 on Windows, so the output arrives with NUL
- * bytes between characters — stripping them is not cosmetic, it is the
- * difference between parsing distro names and parsing nothing.
+ * `wsl -l -v` writes UTF-16LE when redirected. `capture` decodes that
+ * Windows boundary before this function parses the architecture column.
  */
 export async function detectWsl(): Promise<WslState> {
   const wsl = process.platform === "win32" ? "wsl.exe" : "wsl.exe";
+  const verbose = await capture([wsl, "-l", "-v"]);
+
+  if (verbose.code === 0) {
+    const distributions = parseWslVerbose(verbose.out);
+    return {
+      available: true,
+      distros: distributions.map((distro) => distro.name),
+      distributions,
+      detail:
+        distributions.length > 0
+          ? `${distributions.length} distro(s) installed`
+          : "WSL is enabled but has no distro",
+    };
+  }
+
+  // Old inbox WSL builds do not support `--verbose`. They can still be
+  // detected, but the architecture stays unknown and red-dev will not
+  // silently claim they are WSL 2.
   const { out, code } = await capture([wsl, "-l", "-q"]);
 
   if (code !== 0) {
     return {
       available: false,
       distros: [],
+      distributions: [],
       detail: "the WSL feature is not enabled on this machine",
     };
   }
@@ -62,8 +113,53 @@ export async function detectWsl(): Promise<WslState> {
   return {
     available: true,
     distros,
+    distributions: distros.map((name, index) => ({
+      name,
+      default: index === 0,
+      version: null,
+    })),
     detail: distros.length > 0 ? `${distros.length} distro(s) installed` : "WSL is enabled but has no distro",
   };
+}
+
+/** Make every future distro choose the WSL 2 architecture. */
+export async function setWsl2Default(): Promise<boolean> {
+  log.step("WSL 2: setting the default architecture for new distros");
+  const proc = Bun.spawn(["wsl.exe", "--set-default-version", "2"], {
+    stdout: "inherit",
+    stderr: "inherit",
+    stdin: "ignore",
+  });
+  const code = await proc.exited;
+  if (code !== 0) {
+    log.err(`wsl --set-default-version 2 exited ${code}`);
+    return false;
+  }
+  log.ok("WSL 2 is the default for new distros");
+  return true;
+}
+
+/** Convert one stopped distro after the user has accepted the migration cost. */
+export async function convertDistroToWsl2(distro: string): Promise<boolean> {
+  log.step(`WSL 2: converting ${distro}`);
+  const proc = Bun.spawn(["wsl.exe", "--set-version", distro, "2"], {
+    stdout: "inherit",
+    stderr: "inherit",
+    stdin: "inherit",
+  });
+  const code = await proc.exited;
+  if (code !== 0) {
+    log.err(`wsl --set-version ${distro} 2 exited ${code}`);
+    return false;
+  }
+
+  const observed = (await detectWsl()).distributions.find((item) => item.name === distro);
+  if (observed?.version !== 2) {
+    log.err(`Windows did not report ${distro} as WSL 2 after conversion`);
+    return false;
+  }
+  log.ok(`${distro} now uses WSL 2`);
+  return true;
 }
 
 /** Is this process elevated? `wsl --install` will not work without it. */
@@ -91,6 +187,14 @@ export async function installWsl(distro = "Ubuntu-24.04"): Promise<boolean> {
     log.plain("     Open PowerShell as Administrator and run:");
     log.plain(`       wsl --install -d ${distro}`);
     log.plain("     Then re-run red-dev. It will pick up from there.");
+    return false;
+  }
+
+  // `wsl --install` defaults to WSL 2 on current Windows releases, but
+  // make the invariant explicit so an older machine or previous user
+  // preference cannot silently create a WSL 1 distro.
+  if (!(await setWsl2Default())) {
+    log.err("refusing to install a distro without confirming WSL 2 as the default");
     return false;
   }
 
@@ -148,8 +252,24 @@ export async function offerWsl(p: Platform): Promise<boolean> {
   const state = await detectWsl();
 
   if (state.distros.length > 0) {
-    log.skip(`WSL already set up: ${state.distros.join(", ")}`);
-    return false;
+    const preferred = state.distributions.find((distro) => distro.default) ?? state.distributions[0]!;
+    await setWsl2Default();
+
+    if (preferred.version === 2) {
+      log.skip(`WSL 2 already set up: ${preferred.name}`);
+      return false;
+    }
+
+    if (preferred.version === null) {
+      log.warn(`cannot verify the WSL version for ${preferred.name}`);
+      log.plain("     Update WSL, then run `red-dev wsl` again. red-dev will not assume WSL 2.");
+      return false;
+    }
+
+    log.warn(`${preferred.name} is using WSL 1; red-dev targets WSL 2`);
+    log.plain("     Conversion can take time. Back up important distro files first.");
+    if (!(await confirm(`Convert ${preferred.name} to WSL 2 now?`, false))) return false;
+    return await convertDistroToWsl2(preferred.name);
   }
 
   log.plain("");

--- a/src/wsl-sync.ts
+++ b/src/wsl-sync.ts
@@ -28,7 +28,8 @@ import { VERSION } from "./cli.ts";
 import { log, RedError } from "./log.ts";
 import type { Platform } from "./platform.ts";
 import { spawnLogged } from "./providers.ts";
-import { detectWsl } from "./wsl-provision.ts";
+import { detectWsl, setWsl2Default, type WslDistribution } from "./wsl-provision.ts";
+import { readWindowsOutput } from "./windows-output.ts";
 
 const BOOT_URL = "https://raw.githubusercontent.com/reddb-io/red-dev/main/boot.sh";
 
@@ -39,24 +40,29 @@ async function inDistro(distro: string, script: string): Promise<{ out: string; 
     stderr: "pipe",
     stdin: "ignore",
   });
-  const out = await new Response(proc.stdout).text();
+  const out = await readWindowsOutput(proc.stdout);
   const code = await proc.exited;
-  // WSL writes UTF-16 for its own messages; a distro's stdout is plain,
-  // but a failure notice from wsl.exe itself arrives NUL-separated.
-  return { out: out.replace(/\0/g, "").trim(), code };
+  // A distro's stdout is UTF-8, but a failure notice from wsl.exe itself
+  // is UTF-16LE. The boundary decoder handles both without losing text.
+  return { out: out.trim(), code };
 }
 
 /**
  * Which distro to converge.
  *
  * The default one, which is what `wsl.exe` with no `-d` opens and
- * therefore what the terminal red-dev configures will land in. `wsl -l
- * -q` lists the default first, which is the only ordering guarantee
- * there is — and the only one needed.
+ * therefore what the terminal red-dev configures will land in. The
+ * verbose listing marks it with `*`, which also lets us verify that it
+ * is actually WSL 2 before executing anything inside it.
  */
 export async function defaultDistro(): Promise<string | null> {
+  return (await defaultDistroInfo())?.name ?? null;
+}
+
+/** The default distro and, unlike the legacy quiet listing, its architecture. */
+export async function defaultDistroInfo(): Promise<WslDistribution | null> {
   const state = await detectWsl();
-  return state.distros[0] ?? null;
+  return state.distributions.find((distro) => distro.default) ?? state.distributions[0] ?? null;
 }
 
 /** What red-dev the distro has, or null when it has none. */
@@ -114,13 +120,27 @@ export async function syncWslDistro(p: Platform): Promise<void> {
     return;
   }
 
-  const distro = await defaultDistro();
-  if (!distro) {
+  // Keep future installs on WSL 2 even when there is no distro yet.
+  // A failed preference is visible but does not hide the more specific
+  // architecture diagnosis below.
+  await setWsl2Default();
+
+  const selected = await defaultDistroInfo();
+  if (!selected) {
     // Loudly, because "no distro" and "distro left alone" are different
     // states and only one of them is fine.
     log.skip("wsl sync: no WSL distro on this machine");
     return;
   }
+
+  if (selected.version !== 2) {
+    const observed = selected.version === 1 ? "WSL 1" : "an unknown WSL version";
+    throw new RedError(
+      `${selected.name} uses ${observed}; run \`red-dev wsl\` from Windows to migrate it to WSL 2`,
+    );
+  }
+
+  const distro = selected.name;
 
   const plan = planFor(await distroVersion(distro));
   log.step(`wsl sync: ${distro} — ${plan.reason}`);


### PR DESCRIPTION
Lands the locally validated working-tree work (+379/−41 across 11 files, plus 5 new source/test files and .editorconfig):

- **WSL clipboard bridge**: `iconv` UTF-8 → UTF-16LE into `clip.exe`, no BOM, no PowerShell — fits Zellij 0.44.3's one-second `copy_command` kill window (measured 24–57 ms) and preserves `Ctrl+C` as interrupt. Verified vertical: Herdr drag autocopy, Alacritty native selection via Shift, `Ctrl+Shift+C`/`Ctrl+V`, Herdr copy mode.
- **Windows output encoding helpers** with tests.
- **WSL provisioning repairs** with tests, non-interactive prompt guard, drift detection additions.

Validation: 279 tests passing, typecheck clean, Linux/Windows builds green.

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0172iFcxJFvKcyTSHmgejY89

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788369320&installation_model_id=20659&pr_number=19&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F19&signature=f9dad5fe02b17758f0b4fa8925524ac1180aa89691a6751f316f72f6a2aa270e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->