### PR TITLE
fix(afk): commit pnpm lockfile so the feedback gate can materialize

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,73 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      cli-args-parser:
+        specifier: ^1.0.6
+        version: 1.0.6
+      tuiuiu.js:
+        specifier: 1.0.75
+        version: 1.0.75
+    devDependencies:
+      '@types/bun':
+        specifier: latest
+        version: 1.3.14
+      typescript:
+        specifier: ^5.6.0
+        version: 5.9.3
+
+packages:
+
+  '@types/bun@1.3.14':
+    resolution: {integrity: sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw==}
+
+  '@types/node@26.1.2':
+    resolution: {integrity: sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==}
+
+  bun-types@1.3.14:
+    resolution: {integrity: sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ==}
+
+  cli-args-parser@1.0.6:
+    resolution: {integrity: sha512-c6dKqF8mo2Vq1gw9OUoYoEGnGi9uatHLJWEzbzBn55kXMJdWIFMfRld9NprOF02oco9+SU9E2AgobmdjXxLlBw==}
+    engines: {node: '>=18.0.0'}
+
+  tuiuiu.js@1.0.75:
+    resolution: {integrity: sha512-QQCbz22sDi12OV/CMxMutn7eJ2IwS3eJFbW3nQTQqwsgjD5bbHX2NRT+Insu56p8WbpJLWnerADhEnsQxlIa5A==}
+    engines: {node: '>=22.12'}
+    hasBin: true
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@8.3.0:
+    resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
+
+snapshots:
+
+  '@types/bun@1.3.14':
+    dependencies:
+      bun-types: 1.3.14
+
+  '@types/node@26.1.2':
+    dependencies:
+      undici-types: 8.3.0
+
+  bun-types@1.3.14:
+    dependencies:
+      '@types/node': 26.1.2
+
+  cli-args-parser@1.0.6: {}
+
+  tuiuiu.js@1.0.75: {}
+
+  typescript@5.9.3: {}
+
+  undici-types@8.3.0: {}


### PR DESCRIPTION
The AFK feedback gate materializes its worktree with `pnpm install --frozen-lockfile`. Without a pnpm lockfile every validation failed in <5ms as `suspect-infra`, so every worker conceded — three generations of claim/concede churn on issues #7–#10 with zero drained. The lockfile mirrors `package.json`; bun stays the dev runtime and `bun.lock` stays authoritative.

Upstream gap to file separately: the engine hardcodes pnpm for feedback-worktree installs; bun-only repos break invisibly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0172iFcxJFvKcyTSHmgejY89

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788371334&installation_model_id=20659&pr_number=21&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F21&signature=b5148fb555d430f322692825f9a461fb6f8d2c9642bfd540fef7467d80b3976e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->