### PR TITLE
merge: #7 Every theme installs and activates its exact Neovim colorscheme

### DIFF
--- a/src/theme-apply.ts
+++ b/src/theme-apply.ts
@@ -163,8 +163,16 @@ export async function applyNeovim(theme: Theme): Promise<boolean> {
     tokyonight: '"folke/tokyonight.nvim"',
     "catppuccin-macchiato": '"catppuccin/nvim", name = "catppuccin"',
     gruvbox: '"ellisonleao/gruvbox.nvim"',
+    everforest: '"neanias/everforest-nvim"',
+    kanagawa: '"rebelot/kanagawa.nvim"',
+    matteblack: '"tahayvr/matteblack.nvim"',
+    nordfox: '"EdenEast/nightfox.nvim"',
+    bamboo: '"ribru17/bamboo.nvim"',
+    "monokai-pro": '"gthelding/monokai-pro.nvim"',
+    "rose-pine-dawn": '"rose-pine/neovim", name = "rose-pine"',
   };
-  const spec = PLUGIN[theme.neovim] ?? '"folke/tokyonight.nvim"';
+  const spec = PLUGIN[theme.neovim];
+  if (!spec) throw new Error(`no Neovim plugin mapped for ${theme.neovim}`);
 
   const lua = `-- ${GENERATED}
 return {

--- a/src/theme-neovim.test.ts
+++ b/src/theme-neovim.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { applyNeovim } from "./theme-apply.ts";
+import { THEMES } from "./themes.ts";
+
+const savedHome = process.env["HOME"];
+
+afterEach(() => {
+  if (savedHome === undefined) delete process.env["HOME"];
+  else process.env["HOME"] = savedHome;
+});
+
+const EXPECTED: Record<string, { plugin: string; colorscheme: string }> = {
+  "tokyo-night": { plugin: "folke/tokyonight.nvim", colorscheme: "tokyonight" },
+  catppuccin: { plugin: "catppuccin/nvim", colorscheme: "catppuccin-macchiato" },
+  gruvbox: { plugin: "ellisonleao/gruvbox.nvim", colorscheme: "gruvbox" },
+  everforest: { plugin: "neanias/everforest-nvim", colorscheme: "everforest" },
+  kanagawa: { plugin: "rebelot/kanagawa.nvim", colorscheme: "kanagawa" },
+  "matte-black": { plugin: "tahayvr/matteblack.nvim", colorscheme: "matteblack" },
+  nord: { plugin: "EdenEast/nightfox.nvim", colorscheme: "nordfox" },
+  "osaka-jade": { plugin: "ribru17/bamboo.nvim", colorscheme: "bamboo" },
+  ristretto: { plugin: "gthelding/monokai-pro.nvim", colorscheme: "monokai-pro" },
+  "rose-pine": { plugin: "rose-pine/neovim", colorscheme: "rose-pine-dawn" },
+};
+
+async function generatedNeovimConfig(slug: string): Promise<string> {
+  const root = mkdtempSync(`${tmpdir()}/red-neovim-theme-`);
+  process.env["HOME"] = root;
+  mkdirSync(`${root}/.config/nvim`, { recursive: true });
+
+  const theme = THEMES[slug];
+  if (!theme) throw new Error(`missing fixture theme ${slug}`);
+  expect(await applyNeovim(theme)).toBe(true);
+
+  return readFileSync(`${root}/.config/nvim/lua/plugins/red-dev-theme.lua`, "utf8");
+}
+
+describe("neovim theme generation", () => {
+  test("pins every theme to its colorscheme plugin and LazyVim colorscheme", async () => {
+    expect(Object.keys(EXPECTED)).toEqual(Object.keys(THEMES));
+
+    for (const [slug, spec] of Object.entries(EXPECTED)) {
+      const lua = await generatedNeovimConfig(slug);
+      expect(lua).toContain(`"${spec.plugin}"`);
+      expect(lua).toContain(`colorscheme = "${spec.colorscheme}"`);
+    }
+  });
+
+  test("only Tokyo Night generates a tokyonight reference", async () => {
+    for (const slug of Object.keys(THEMES)) {
+      const lua = await generatedNeovimConfig(slug);
+      expect(lua.includes("tokyonight")).toBe(slug === "tokyo-night");
+    }
+  });
+});

--- a/src/themes.ts
+++ b/src/themes.ts
@@ -178,7 +178,7 @@ export const THEMES: Record<string, Theme> = {
   },
   "matte-black": {
     name: "Matte Black",
-    neovim: "matte-black",
+    neovim: "matteblack",
     terminal: {
       background: "#121212",
       foreground: "#BEBEBE",
@@ -204,7 +204,7 @@ export const THEMES: Record<string, Theme> = {
   },
   "nord": {
     name: "Nord",
-    neovim: "nord",
+    neovim: "nordfox",
     terminal: {
       background: "#2E3440",
       foreground: "#D8DEE9",
@@ -230,7 +230,7 @@ export const THEMES: Record<string, Theme> = {
   },
   "osaka-jade": {
     name: "Osaka Jade",
-    neovim: "osaka-jade",
+    neovim: "bamboo",
     terminal: {
       background: "#111C18",
       foreground: "#C1C497",
@@ -256,7 +256,7 @@ export const THEMES: Record<string, Theme> = {
   },
   "ristretto": {
     name: "Ristretto",
-    neovim: "ristretto",
+    neovim: "monokai-pro",
     terminal: {
       background: "#2C2525",
       foreground: "#E6D9DB",
@@ -282,7 +282,7 @@ export const THEMES: Record<string, Theme> = {
   },
   "rose-pine": {
     name: "Rose Pine",
-    neovim: "rose-pine",
+    neovim: "rose-pine-dawn",
     terminal: {
       background: "#FAF4ED",
       foreground: "#575279",


### PR DESCRIPTION
<!-- afk:reseed-trail v1 issue=7 -->
🤖 **Re-seed trail** — #7 on `afk/7-every-theme-installs-and-activates-its-e`, lane `/afk`.

Rounds spent: 5/4. A Re-seed re-instructs the implementer in place —
same Worker, same Worktree, same branch — after a gate stage blocked the work.

| round | trigger | what it was asked to fix |
| --- | --- | --- |
| 1/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE, but the base gained 2 commits under this attempt; the gate ran on a tree merged with that newer base, so the failure is attributed to stale-base drift, not the branch; granting a free stale-base correction (1/2), budget untouched at 0/3. |
| 2/4 | `tier-escalation` (tier) | 🤖 /afk: complex-tier feedback failed for #7; re-seeding on the think tier before terminal validation routing. |
| 3/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE, but the base gained 2 commits under this attempt; the gate ran on a tree merged with that newer base, so the failure is attributed to stale-base drift, not the branch; granting a free stale-base correction (2/2), budget untouched at 0/3. |
| 4/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE; correction retry 1/3. |
| 5/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE; correction retry 2/3. |

The Worker's branch and iteration log are the source of truth; this is a derived projection.

Closes #7