### PR TITLE
merge: #9 Provider selection fails closed on macOS

### DIFF
--- a/src/manifest.test.ts
+++ b/src/manifest.test.ts
@@ -41,6 +41,13 @@ const WINDOWS = platform({
   version: null,
   caps: { apt: false, gui: true, systemd: false, winget: true, flatpak: false },
 });
+const DARWIN = platform({
+  os: "darwin",
+  env: "desktop",
+  distro: null,
+  version: null,
+  caps: { apt: false, gui: true, systemd: false, winget: false, flatpak: false },
+});
 
 describe("applicableScopes", () => {
   test("WSL gets core and wsl, never desktop", () => {
@@ -85,6 +92,12 @@ describe("providerFor", () => {
   test("falls back to u24 when u26 is omitted", () => {
     const same: Tool = { ...tool, u26: undefined };
     expect(providerFor(same, WSL26)).toEqual({ kind: "apt", pkg: "example" });
+  });
+
+  test("rejects Darwin before selecting a Linux provider", () => {
+    expect(() => providerFor(tool, DARWIN)).toThrow(
+      "unsupported platform: darwin. macOS support is planned in Phase 5 as an adapter of the platform contracts; this is not a broken Ubuntu install.",
+    );
   });
 });
 

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -8,6 +8,7 @@
  */
 
 import { existsSync } from "node:fs";
+import { RedError } from "./log.ts";
 import { commandExists, versionAtLeast, type Platform } from "./platform.ts";
 
 export type Scope =
@@ -772,6 +773,12 @@ export const TOOLS: Tool[] = [
 
 /** Pick the provider column that applies to this machine. */
 export function providerFor(tool: Tool, p: Platform): Provider {
+  if (p.os === "darwin") {
+    throw new RedError(
+      "unsupported platform: darwin. macOS support is planned in Phase 5 as an adapter of the platform contracts; this is not a broken Ubuntu install.",
+    );
+  }
+
   // Docker is the one tool whose right answer depends on what the host
   // is already doing, not on which platform this is. Docker Desktop
   // shares one daemon with Windows and every integrated distro;


### PR DESCRIPTION
<!-- afk:reseed-trail v1 issue=9 -->
🤖 **Re-seed trail** — #9 on `afk/9-provider-selection-fails-closed-on-macos`, lane `/afk`.

Rounds spent: 4/4. A Re-seed re-instructs the implementer in place —
same Worker, same Worktree, same branch — after a gate stage blocked the work.

| round | trigger | what it was asked to fix |
| --- | --- | --- |
| 1/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE; correction retry 1/3. |
| 2/4 | `tier-escalation` (tier) | 🤖 /afk: complex-tier feedback failed for #9; re-seeding on the think tier before terminal validation routing. |
| 3/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE; correction retry 2/3. |
| 4/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE; correction retry 3/3. |

The Worker's branch and iteration log are the source of truth; this is a derived projection.

Closes #9