### PR TITLE
chore: #11 Themes declare explicit light/dark appearance; Rose Pine renders light

### DIFF
--- a/src/theme-apply.ts
+++ b/src/theme-apply.ts
@@ -245,7 +245,7 @@ export async function applyThemeEverywhere(
           ["neovim", () => applyNeovim(theme)],
           ["vscode", () => applyVsCodeTheme(theme, p, key)],
           ...cliSurfaces(theme, p, key),
-          ["gnome", () => applyGnomeTheme(p, key)],
+          ["gnome", () => applyGnomeTheme(p, theme, key)],
         ];
 
   for (const [name, fn] of surfaces) {

--- a/src/theme-editors.test.ts
+++ b/src/theme-editors.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { codeArgv } from "./theme-editors.ts";
+import { codeArgv, gnomeColorScheme } from "./theme-editors.ts";
+import { THEMES } from "./themes.ts";
 
 describe("codeArgv", () => {
   test("wraps a .cmd on Windows, because CreateProcess cannot run one", () => {
@@ -30,5 +31,12 @@ describe("codeArgv", () => {
 
   test("does not wrap a path that merely contains .cmd", () => {
     expect(codeArgv(["C:\\cmd.tools\\code.exe"], "win32")).toEqual(["C:\\cmd.tools\\code.exe"]);
+  });
+});
+
+describe("gnomeColorScheme", () => {
+  test("uses Rose Pine's explicit light appearance", () => {
+    const theme = THEMES["rose-pine"]!;
+    expect(gnomeColorScheme(theme)).toBe("prefer-light");
   });
 });

--- a/src/theme-editors.ts
+++ b/src/theme-editors.ts
@@ -194,7 +194,11 @@ const GNOME_ACCENTS: Record<string, string> = {
   "rose-pine": "pink",
 };
 
-export async function applyGnomeTheme(p: Platform, slug: string): Promise<boolean> {
+export function gnomeColorScheme(theme: Theme): "prefer-light" | "prefer-dark" {
+  return theme.appearance === "light" ? "prefer-light" : "prefer-dark";
+}
+
+export async function applyGnomeTheme(p: Platform, theme: Theme, slug: string): Promise<boolean> {
   if (!p.caps.gui || !Bun.which("gsettings")) {
     log.skip("no GNOME session here");
     return false;
@@ -208,9 +212,7 @@ export async function applyGnomeTheme(p: Platform, slug: string): Promise<boolea
     return (await proc.exited) === 0;
   };
 
-  // Every palette shipped here is dark; when a light one lands this
-  // should read the background's luminance rather than assume.
-  await run("org.gnome.desktop.interface", "color-scheme", "prefer-dark");
+  await run("org.gnome.desktop.interface", "color-scheme", gnomeColorScheme(theme));
 
   const accent = GNOME_ACCENTS[slug];
   if (accent) {

--- a/src/themes.test.ts
+++ b/src/themes.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "bun:test";
+import { THEMES } from "./themes.ts";
+
+describe("themes", () => {
+  test("every theme declares its desktop appearance explicitly", () => {
+    for (const [slug, theme] of Object.entries(THEMES)) {
+      expect(["light", "dark"], slug).toContain(theme.appearance);
+    }
+  });
+
+  test("rose-pine is the light Rose Pine Dawn palette", () => {
+    expect(THEMES["rose-pine"]?.appearance).toBe("light");
+  });
+});

--- a/src/themes.ts
+++ b/src/themes.ts
@@ -33,6 +33,7 @@ export interface TerminalPalette {
 
 export interface Theme {
   name: string;
+  appearance: "light" | "dark";
   /** Neovim colorscheme name, for the LazyVim config. */
   neovim: string;
   terminal: TerminalPalette;
@@ -41,6 +42,7 @@ export interface Theme {
 export const THEMES: Record<string, Theme> = {
   "tokyo-night": {
     name: "Tokyo Night",
+    appearance: "dark",
     neovim: "tokyonight",
     terminal: {
       background: "#1A1B26",
@@ -68,6 +70,7 @@ export const THEMES: Record<string, Theme> = {
 
   catppuccin: {
     name: "Catppuccin Macchiato",
+    appearance: "dark",
     neovim: "catppuccin-macchiato",
     terminal: {
       background: "#24273A",
@@ -95,6 +98,7 @@ export const THEMES: Record<string, Theme> = {
 
   gruvbox: {
     name: "Gruvbox Dark",
+    appearance: "dark",
     neovim: "gruvbox",
     terminal: {
       background: "#282828",
@@ -126,6 +130,7 @@ export const THEMES: Record<string, Theme> = {
   // notices their terminal's blue is slightly off.
   "everforest": {
     name: "Everforest",
+    appearance: "dark",
     neovim: "everforest",
     terminal: {
       background: "#2D353B",
@@ -152,6 +157,7 @@ export const THEMES: Record<string, Theme> = {
   },
   "kanagawa": {
     name: "Kanagawa",
+    appearance: "dark",
     neovim: "kanagawa",
     terminal: {
       background: "#1F1F28",
@@ -178,6 +184,7 @@ export const THEMES: Record<string, Theme> = {
   },
   "matte-black": {
     name: "Matte Black",
+    appearance: "dark",
     neovim: "matteblack",
     terminal: {
       background: "#121212",
@@ -204,6 +211,7 @@ export const THEMES: Record<string, Theme> = {
   },
   "nord": {
     name: "Nord",
+    appearance: "dark",
     neovim: "nordfox",
     terminal: {
       background: "#2E3440",
@@ -230,6 +238,7 @@ export const THEMES: Record<string, Theme> = {
   },
   "osaka-jade": {
     name: "Osaka Jade",
+    appearance: "dark",
     neovim: "bamboo",
     terminal: {
       background: "#111C18",
@@ -256,6 +265,7 @@ export const THEMES: Record<string, Theme> = {
   },
   "ristretto": {
     name: "Ristretto",
+    appearance: "dark",
     neovim: "monokai-pro",
     terminal: {
       background: "#2C2525",
@@ -282,6 +292,7 @@ export const THEMES: Record<string, Theme> = {
   },
   "rose-pine": {
     name: "Rose Pine",
+    appearance: "light",
     neovim: "rose-pine-dawn",
     terminal: {
       background: "#FAF4ED",

--- a/src/windows-theme.test.ts
+++ b/src/windows-theme.test.ts
@@ -12,7 +12,8 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import { accentDword } from "./windows-theme.ts";
+import { THEMES } from "./themes.ts";
+import { accentDword, windowsLightThemeValue } from "./windows-theme.ts";
 
 describe("accentDword", () => {
   test("Windows' own default round-trips", () => {
@@ -34,5 +35,12 @@ describe("accentDword", () => {
     // The first version produced -7830203 and PowerShell refused it.
     expect(accentDword("#458588")).toBeGreaterThan(0);
     expect(accentDword("#000000")).toBe(0xff000000);
+  });
+});
+
+describe("windowsLightThemeValue", () => {
+  test("uses Rose Pine's explicit light appearance", () => {
+    const theme = THEMES["rose-pine"]!;
+    expect(windowsLightThemeValue(theme)).toBe(1);
   });
 });

--- a/src/windows-theme.ts
+++ b/src/windows-theme.ts
@@ -64,12 +64,12 @@ export function accentDword(hex: string): number {
   return ((0xff << 24) >>> 0) + (b << 16) + (g << 8) + r;
 }
 
+export function windowsLightThemeValue(theme: Theme): 0 | 1 {
+  return theme.appearance === "light" ? 1 : 0;
+}
+
 /**
  * Apply the desktop half of a theme on Windows.
- *
- * Every palette this project ships is dark, so dark mode is not a
- * question — light mode with a dark terminal is the seam omakub's GNOME
- * step exists to close.
  */
 export async function applyWindowsDesktopTheme(
   theme: Theme,
@@ -80,6 +80,7 @@ export async function applyWindowsDesktopTheme(
 
   const accent = accentOf(theme, slug);
   const dword = accentDword(accent);
+  const lightTheme = windowsLightThemeValue(theme);
 
   const script = [
     `$pers = 'HKCU:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize'`,
@@ -87,8 +88,8 @@ export async function applyWindowsDesktopTheme(
     // Apps and shell together: setting only one leaves a light taskbar
     // over dark windows, which looks like a half-applied theme because
     // it is one.
-    `Set-ItemProperty $pers -Name AppsUseLightTheme -Value 0 -Type DWord`,
-    `Set-ItemProperty $pers -Name SystemUsesLightTheme -Value 0 -Type DWord`,
+    `Set-ItemProperty $pers -Name AppsUseLightTheme -Value ${lightTheme} -Type DWord`,
+    `Set-ItemProperty $pers -Name SystemUsesLightTheme -Value ${lightTheme} -Type DWord`,
     `Set-ItemProperty $dwm -Name AccentColor -Value ${dword} -Type DWord`,
     // Without this the accent is stored and never shown: it only reaches
     // title bars and the taskbar when prevalence is on.
@@ -108,7 +109,8 @@ export async function applyWindowsDesktopTheme(
     return false;
   }
 
-  log.plain(`       accent ${accent}, dark mode, accent on title bars`);
+  const mode = theme.appearance === "light" ? "light mode" : "dark mode";
+  log.plain(`       accent ${accent}, ${mode}, accent on title bars`);
   log.plain(`       already-open windows keep their colour until reopened`);
   return true;
 }


### PR DESCRIPTION
Automated AFK landing for #11. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #11

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788374211&installation_model_id=20659&pr_number=25&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F25&signature=16c9fd118ddb550cc2014f745d4d2e6f5f3e99bce4feefbabe9e73ea9bbb0c78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->