### PR TITLE
chore: land research docs and project statusline settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,7 @@
+{
+  "statusLine": {
+    "type": "command",
+    "command": "sh -c 'N=$(command -v node 2>/dev/null || ls -1 /usr/local/bin/node /opt/homebrew/bin/node /usr/bin/node \"$HOME\"/.volta/bin/node \"$HOME\"/.asdf/shims/node \"$HOME\"/.nodenv/shims/node \"$HOME\"/.nvm/versions/node/*/bin/node \"$HOME\"/.local/share/fnm/node-versions/*/installation/bin/node \"$HOME\"/.fnm/node-versions/*/installation/bin/node 2>/dev/null | sort -V | tail -1); [ -z \"$N\" ] && exit 0; b=$(ls -1 \"$HOME\"/.cache/red-skills/bundles/dev-*.bundle.min.mjs 2>/dev/null | sort -V | tail -1); [ -z \"$b\" ] && b=$(ls -1 \"$HOME\"/.claude/plugins/cache/red-skills/dev/*/skills/engineering/afk/bin/afk.mjs 2>/dev/null | sort -V | tail -1); [ -n \"$b\" ] && \"$N\" \"$b\" statusline --no-workers; r=$(ls -1 \"$HOME\"/.cache/red-skills/bundles/redskilled*.bundle.min.mjs 2>/dev/null | sort -V | tail -1); [ -n \"$r\" ] && \"$N\" \"$r\" statusline 2>/dev/null'",
+    "refreshInterval": 60
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 .DS_Store
 .red/tmp/
 .red/state/
+.claude/settings.local.json

--- a/.red/researches/2026-08-03-omarchy-deep-dive-and-red-dev-opportunities.md
+++ b/.red/researches/2026-08-03-omarchy-deep-dive-and-red-dev-opportunities.md
@@ -1,0 +1,1146 @@
+# Omarchy Deep Dive — Product, UX, Agents, Assets, Hotkeys and red-dev Opportunities
+
+**Research date:** 2026-08-03
+
+**Scope:** Omarchy as a Linux distribution and desktop product, its stable 3.8.4 release, the in-development 4.0 “Quattro” branch, its ISO/package delivery chain, and the ideas red-dev should adapt or reject.
+
+**Method:** official-source-only audit of the repositories, release artifacts, product site and manual. File counts and inventories were recomputed from pinned checkouts rather than copied from marketing copy.
+
+## Executive Summary
+
+Omarchy is not simply “Omakub for Arch”. Omakub configures an existing Ubuntu installation; Omarchy owns nearly the entire workstation experience: bootable ISO, installer, partitioning, encryption, package repositories, update channels, boot loader, snapshots, recovery, hardware adaptation, login, compositor, desktop shell, launcher, panels, themes, hotkeys, default applications, web apps, developer tools and agent tooling.
+
+That larger ownership produces the most coherent keyboard-first Linux workstation examined in this study. The coherence is built from a few strong product decisions:
+
+1. One discoverable action system connects hotkeys, a hierarchical menu, a machine-readable CLI and shell IPC.
+2. Themes are semantic token sets rendered into application-specific templates, staged atomically and applied across the desktop.
+3. Installation, removal, updates, migrations and recovery are treated as product surfaces rather than isolated scripts.
+4. Hardware differences are represented as detected capabilities and adapters.
+5. AI agents are part of the standard workstation: Omarchy installs several agent CLIs, ships an Agent Skill describing safe customization, themes agent interfaces and exposes command metadata agents can inspect.
+6. The distribution is validated through a real graphical clean-machine installation harness using VM keystrokes, OCR, screenshots and post-install acceptance checks.
+
+The highest-value lesson for red-dev is not to turn into an Arch distribution. It is to define an equivalent **cross-platform workstation contract**: semantic actions, capability-driven adapters, an atomic theme pipeline, a manifest-backed control center, command metadata for humans and agents, lifecycle symmetry and clean-machine graphical acceptance tests.
+
+The audit also found important limits that must not be copied:
+
+- Omarchy’s default aliases deliberately start Claude and Codex with permission bypasses.
+- Secure Boot is not currently delivered; users are instructed to disable it.
+- Omarchy package repositories are configured with permissive signature policies even though packages are signed.
+- The stable ISO’s documented detached-signature URL returned 404 during this audit.
+- Documentation, stable 3.8.4 and the future 4.0 alpha disagree on themes, terminal, networking, workspaces and firewall behavior.
+- The 4.0 branch is a large architectural rewrite and must not be represented as stable functionality.
+- Omarchy’s opinionated personal app/hotkey choices are excellent for a single “omakase” product but unsuitable as an unconditional enterprise default.
+
+The recommended direction is therefore: **adapt Omarchy’s contracts and testing discipline; do not clone its package list, security compromises or Linux-only implementation.**
+
+## Official Sources
+
+### Pinned repositories and releases
+
+| Source | Pinned state | Purpose in this audit |
+|---|---|---|
+| [basecamp/omarchy](https://github.com/basecamp/omarchy) | stable tag [`v3.8.4`](https://github.com/basecamp/omarchy/tree/v3.8.4), commit `8fcc9d6048af4cb0e3af8512c78049857a3b53dd`; Quattro commit [`12af188304793b65551b5c43d20f02961dc938a9`](https://github.com/basecamp/omarchy/tree/12af188304793b65551b5c43d20f02961dc938a9) | Runtime, commands, configuration, themes, shell, packages, migrations and tests |
+| [Omarchy releases](https://github.com/basecamp/omarchy/releases) | latest stable `v3.8.4`, published 2026-07-21 | Stable product boundary and ISO checksum |
+| [omacom-io/omarchy-iso](https://github.com/omacom-io/omarchy-iso) | commit [`17532793fdccea862b6c9a080b55b85c7a4b5321`](https://github.com/omacom-io/omarchy-iso/tree/17532793fdccea862b6c9a080b55b85c7a4b5321) | ISO build, signing, installer and graphical acceptance harness |
+| [omacom-io/omarchy-pkgs](https://github.com/omacom-io/omarchy-pkgs) | commit [`7a5f347a8b95639de8b3a79b67b0bc197caeb21a`](https://github.com/omacom-io/omarchy-pkgs/tree/7a5f347a8b95639de8b3a79b67b0bc197caeb21a) | Custom package source, build, signing and promotion |
+| [omacom-io/omarchy-site](https://github.com/omacom-io/omarchy-site) | commit [`2844c11632b0a48ab1339c062a89a13087a03274`](https://github.com/omacom-io/omarchy-site/tree/2844c11632b0a48ab1339c062a89a13087a03274) | Download experience and public positioning |
+| [omacom-io/omarchy-mirror](https://github.com/omacom-io/omarchy-mirror) | current official repository | Mirror tooling and package delivery context |
+
+### Product and manual
+
+- [Omarchy product site](https://omarchy.org)
+- [The Omarchy Manual](https://learn.omacom.io/2/the-omarchy-manual/)
+- [Welcome to Omarchy](https://learn.omacom.io/2/the-omarchy-manual/91/welcome-to-omarchy)
+- [Getting started](https://learn.omacom.io/books/2/pages/50)
+- [Navigation](https://learn.omacom.io/2/the-omarchy-manual/51/navigation)
+- [Hotkeys](https://learn.omacom.io/books/2/pages/53)
+- [Updates](https://learn.omacom.io/2/the-omarchy-manual/68/updates)
+- [Extra themes](https://learn.omacom.io/books/2/pages/90)
+- [Making a theme](https://learn.omacom.io/2/the-omarchy-manual/92/making-your-own-theme)
+- [Security](https://learn.omacom.io/2/the-omarchy-manual/93/security)
+- [System snapshots](https://learn.omacom.io/2/the-omarchy-manual/101/system-snapshots)
+- [Fingerprint and FIDO2 authentication](https://learn.omacom.io/2/the-omarchy-manual/77/fingerprint-fido2-authentication)
+- [Mac support](https://learn.omacom.io/2/the-omarchy-manual/97/mac-support)
+- [Manual installation](https://learn.omacom.io/2/the-omarchy-manual/96/manual-insta)
+- [Troubleshooting](https://learn.omacom.io/2/the-omarchy-manual/88/troubleshooting)
+
+## Hotlinks
+
+- Stable package manifest: [`install/omarchy-base.packages`](https://github.com/basecamp/omarchy/blob/v3.8.4/install/omarchy-base.packages)
+- Quattro package manifest: [`install/omarchy-base.packages`](https://github.com/basecamp/omarchy/blob/12af188304793b65551b5c43d20f02961dc938a9/install/omarchy-base.packages)
+- Quattro AI/tool installation: [`install/user/mise.sh`](https://github.com/basecamp/omarchy/blob/12af188304793b65551b5c43d20f02961dc938a9/install/user/mise.sh)
+- Agent aliases: [`default/bash/aliases`](https://github.com/basecamp/omarchy/blob/12af188304793b65551b5c43d20f02961dc938a9/default/bash/aliases)
+- Omarchy Agent Skill: [`default/omarchy-skill/SKILL.md`](https://github.com/basecamp/omarchy/blob/12af188304793b65551b5c43d20f02961dc938a9/default/omarchy-skill/SKILL.md)
+- Application bindings: [`default/hypr/bindings/applications.lua`](https://github.com/basecamp/omarchy/blob/12af188304793b65551b5c43d20f02961dc938a9/default/hypr/bindings/applications.lua)
+- Tiling bindings: [`default/hypr/bindings/tiling.lua`](https://github.com/basecamp/omarchy/blob/12af188304793b65551b5c43d20f02961dc938a9/default/hypr/bindings/tiling.lua)
+- Utility bindings: [`default/hypr/bindings/utilities.lua`](https://github.com/basecamp/omarchy/blob/12af188304793b65551b5c43d20f02961dc938a9/default/hypr/bindings/utilities.lua)
+- Universal clipboard: [`default/hypr/bindings/clipboard.lua`](https://github.com/basecamp/omarchy/blob/12af188304793b65551b5c43d20f02961dc938a9/default/hypr/bindings/clipboard.lua)
+- Atomic theme application: [`bin/omarchy-theme-set`](https://github.com/basecamp/omarchy/blob/12af188304793b65551b5c43d20f02961dc938a9/bin/omarchy-theme-set)
+- Update orchestration: [`bin/omarchy-update`](https://github.com/basecamp/omarchy/blob/12af188304793b65551b5c43d20f02961dc938a9/bin/omarchy-update)
+- ISO configurator: [`configs/airootfs/root/configurator`](https://github.com/omacom-io/omarchy-iso/blob/17532793fdccea862b6c9a080b55b85c7a4b5321/configs/airootfs/root/configurator)
+- ISO test architecture: [`README.md`](https://github.com/omacom-io/omarchy-iso/blob/17532793fdccea862b6c9a080b55b85c7a4b5321/README.md)
+
+## Version Discipline: Stable Product vs Quattro
+
+This distinction is essential because the default GitHub branch is not the stable release.
+
+| Dimension | Stable 3.8.4 | Quattro checkout audited |
+|---|---|---|
+| Product status | released 2026-07-21 | `4.0.0.alpha` in repository version file |
+| Desktop shell | Hyprland plus Waybar, Walker, Mako, SwayOSD and related processes | one Quickshell-based Omarchy shell with a plugin/IPC architecture |
+| Terminal in package manifest | Alacritty | Foot |
+| Network stack | iwd/Impala-oriented stable manifest | NetworkManager plus integrated shell panel |
+| Lock/idle | Hyprlock/Hypridle | shell/service integration |
+| Themes found in source | 19 | 22 |
+| Command files | 283 | 397 |
+| Legacy/current migrations | 330 | 54 current migrations after rewrite/consolidation |
+| Tests found | one older test file | 150 files across shell and acceptance areas |
+| Base package entries | 149 | 144 |
+| Other/ISO-support entries | 60 | 60 |
+
+Additional version notes:
+
+- The stable tag and GitHub release are named `v3.8.4`, but the `version` file at that tag contains `3.8.3`. This is a release-engineering inconsistency, not evidence that the tag is unofficial.
+- Manual pages lag both source lines. Examples include theme count, workspace count, default terminal and SSH/firewall behavior.
+- Any Quattro capability in this document is labeled as such and is an architectural preview, not a promise that stable users receive it today.
+
+## Key Findings
+
+The detailed audit supports five conclusions that should guide the red-dev roadmap:
+
+1. Omarchy’s advantage comes from shared contracts—actions, capabilities, themes and lifecycle—not from any single package.
+2. Its Quattro architecture makes the operating system unusually legible to both people and agents through one CLI/menu/hotkey/Skill vocabulary.
+3. Its semantic theme engine, user-overlay model and graphical acceptance harness are mature patterns worth adapting almost directly.
+4. Its strongest implementation choices depend on owning Arch, Wayland and Hyprland; red-dev must preserve the intent through platform adapters rather than copy the mechanism.
+5. Omarchy’s security compromises are meaningful enough that a RedDB implementation needs stricter artifact verification, safer agent defaults and clearer data-loss metadata.
+
+### What Omarchy Actually Delivers
+
+The useful unit of analysis is a product stack, not a dotfiles repository:
+
+```text
+Product site + manual
+        ↓
+Signed bootable ISO + interactive configurator
+        ↓
+Arch base + Omarchy stable/RC/edge/dev package channels
+        ↓
+LUKS2 + Btrfs + Limine + Snapper + system services
+        ↓
+Hyprland + Omarchy shell/menu/panels/plugins
+        ↓
+Themes + assets + semantic hotkeys + default apps
+        ↓
+Developer tools + AI agents + Agent Skill + command metadata
+        ↓
+Updates + migrations + snapshots + rollback + reinstall
+        ↓
+QMP/OCR clean-machine graphical acceptance testing
+```
+
+Omarchy can make stronger coherence guarantees than red-dev or Omakub because it owns every layer. The cost is equally real: it assumes Arch Linux, Wayland, Hyprland, a rolling package base and a specific opinionated workflow.
+
+## Installation and First-Run Experience
+
+### Supported delivery path
+
+The ISO repository now states that the bootable ISO is the only supported installation path. The manual-install page remains an advanced fallback, not the normal product funnel. This removes a large class of “unknown starting state” failures.
+
+The stable 3.8.4 release publishes an externally hosted ISO of 7,957,577,728 bytes, approximately 7.96 GB, with SHA-256:
+
+```text
+7bc1dc7d98f3d088e57dc06581a494ea441fb15f3edd191360fd1696931bd895
+```
+
+The size reflects an unusually complete offline payload: the installer can carry the Omarchy runtime, settings and a package mirror rather than depending on a fragile live network bootstrap.
+
+### Configurator flow
+
+The current configurator asks for and validates:
+
+1. Keyboard layout, including Brazilian Portuguese (`br-abnt2`) and many international layouts.
+2. Username, with syntax validation and rejection of reserved system accounts.
+3. A password, confirmation and yescrypt hash.
+4. Optional full name and email for Git identity.
+5. Hostname.
+6. Timezone, with a geolocation-assisted default when available.
+7. Target disk and a visible partition summary.
+8. Full-disk or free-space installation mode when the machine supports it.
+9. Encrypted-by-default confirmation; the unencrypted path is intentionally less prominent.
+
+The password is explicitly reused for the user, root and LUKS encryption when encryption is enabled. That reduces cognitive load but couples three security boundaries to one secret.
+
+### Disk behavior
+
+Stable documentation emphasizes a dedicated drive and destructive full-disk installation. Quattro’s current ISO configurator adds a protected free-space mode:
+
+- Selects the largest contiguous unallocated region.
+- Requires at least 32 GB total allocation.
+- Creates a dedicated 2 GB `OMARCHY_EFI` partition and an `OMARCHY_ROOT` partition.
+- Leaves an existing Windows ESP untouched.
+- Detects the `-FVE-FS-` BitLocker signature and refuses to proceed.
+- Creates LUKS2 encryption by default.
+- Creates Btrfs subvolumes `@`, `@home`, `@log` and `@pkg`.
+- Uses `/boot` as the dedicated ESP mount for encrypted installs and `/efi` for unencrypted installs.
+- Does not automatically shrink an existing filesystem; the user must create free space first.
+
+This is careful engineering, but it belongs to the unreleased Quattro line. The repository also contains detailed **plans** for dual boot, protected recovery partitions, OEM installation, factory reset, AArch64 and consumer Secure Boot. Those plan documents are not delivered product features.
+
+### Authentication and login
+
+Encrypted installations can auto-login through SDDM because disk unlock is treated as the physical authentication boundary. Unencrypted installs retain the visible login prompt. This is a deliberate reduction of duplicate authentication rather than an accidental bypass.
+
+The tradeoff should be documented clearly: possession of an already-unlocked machine grants the local session, and the single password has unusually broad impact.
+
+### First-run integrations
+
+The user setup path applies:
+
+- Wi-Fi/network checks.
+- Hardware-specific fixes.
+- Matching speaker tuning.
+- User systemd units.
+- User theme and agent theme activation.
+- Omarchy Skill installation for supported agents.
+- Git identity when supplied.
+- Desktop and application defaults.
+
+The product does not attempt to configure every account. 1Password, GitHub, Signal, Spotify, browser sync and agent-provider credentials remain user-owned authentication steps.
+
+## Installed Programs and Packages
+
+### Stable 3.8.4: what users receive today
+
+The stable base manifest contains 149 packages. Its major end-user programs and tools include:
+
+| Area | Stable packages/programs |
+|---|---|
+| Browser and credentials | Chromium, 1Password beta, 1Password CLI |
+| Communication/media | Signal Desktop, Spotify, LocalSend, OBS Studio, Kdenlive, mpv |
+| Documents/creation | LibreOffice Fresh, Obsidian, Typora, Pinta, Xournal++, Evince |
+| Files/system | Nautilus, GNOME Disk Utility, Sushi, GNOME calculator, system-config-printer |
+| Terminal/dev | Alacritty, Neovim, tmux, GitHub CLI, Docker/Buildx/Compose, Ruby, Rust, LLVM/Clang, mise |
+| Terminal utilities | bat, eza, fd, fzf, ripgrep, jq, lazygit, lazydocker, btop, fastfetch, dust, zoxide, tldr |
+| Desktop | Hyprland, Waybar, Omarchy Walker, Mako, Hyprlock, Hypridle, SwayOSD, SDDM |
+| Capture/input | grim, slurp, Satty, GPU Screen Recorder, Hyprpicker, Tesseract OCR, wl-clipboard |
+| Connectivity | iwd, Impala, Bluetui, Wiremix, Avahi, GVFS SMB/NFS/MTP |
+| AI | Claude Code as a package, plus user-level agent tools installed separately |
+
+### Quattro base manifest: complete 144-package inventory
+
+This is the exact non-comment inventory from the pinned `install/omarchy-base.packages`, grouped here only for readability:
+
+**Desktop, session and system integration:** `aether`, `alsa-utils`, `asdcontrol`, `avahi`, `bluez`, `bluez-tools`, `bluez-utils`, `bolt`, `brightnessctl`, `cups`, `cups-browsed`, `cups-filters`, `cups-pdf`, `ddcutil`, `dosfstools`, `exfatprogs`, `fcitx5`, `fcitx5-gtk`, `fcitx5-qt`, `fontconfig`, `gnome-keyring`, `gnome-themes-extra`, `gvfs-mtp`, `gvfs-nfs`, `gvfs-smb`, `hyprland`, `hyprland-guiutils`, `hyprland-preview-share-picker`, `hyprsunset`, `kernel-modules-hook`, `networkmanager`, `nss-mdns`, `pacman-contrib`, `pamixer`, `plocate`, `plymouth`, `power-profiles-daemon`, `python-gobject`, `quickshell-git`, `sddm`, `socat`, `system-config-printer`, `tzupdate`, `udiskie`, `ufw`, `ufw-docker`, `usage`, `uwsm`, `wireless-regdb`, `wireplumber`, `wl-clipboard`, `wtype`, `xdg-desktop-portal-gtk`, `xdg-desktop-portal-hyprland`, `xdg-terminal-exec`, `yaru-icon-theme`.
+
+**Desktop applications and media:** `chromium`, `evince`, `imv`, `kdenlive`, `libreoffice-fresh`, `localsend`, `moonlight-qt`, `mpv`, `mpv-mpris`, `nautilus`, `nautilus-python`, `gnome-disk-utility`, `obs-studio`, `obsidian`, `omacalc`, `omacut`, `omawrite`, `pinta`, `sushi`, `xournalpp`.
+
+**Development and terminal:** `bash-completion`, `bat`, `btop`, `clang`, `cliamp`, `docker`, `docker-buildx`, `docker-compose`, `dotnet-runtime`, `dua-cli`, `expac`, `eza`, `fakeroot`, `fastfetch`, `fd`, `foot`, `fzf`, `git`, `gum`, `inetutils`, `inotify-tools`, `inxi`, `jq`, `lazydocker`, `lazygit`, `less`, `libsecret`, `libyaml`, `llvm`, `lua51`, `luarocks`, `man-db`, `mariadb-libs`, `mise`, `nvim`, `omarchy-nvim`, `postgresql-libs`, `python-poetry-core`, `python-terminaltexteffects`, `qemu-user-static-binfmt`, `qrencode`, `ripgrep`, `ruby`, `starship`, `tensaku`, `tldr`, `tree-sitter-cli`, `tmux`, `tobi-try`, `unzip`, `whois`, `yay`, `yt-dlp`, `zoxide`.
+
+**Capture and transformation:** `ffmpegthumbnailer`, `grim`, `gpu-screen-recorder`, `hyprpicker`, `imagemagick`, `slurp`, `tesseract`, `tesseract-data-eng`.
+
+**Fonts and icons:** `noto-fonts`, `noto-fonts-cjk`, `noto-fonts-emoji`, `ttf-ia-writer`, `ttf-jetbrains-mono-nerd-basic`, `woff2-font-awesome`.
+
+### Quattro ISO/hardware support: complete 60-entry inventory
+
+The secondary manifest makes the ISO and hardware breadth explicit:
+
+`autoconf-archive`, `asusctl`, `base`, `base-devel`, `broadcom-wl`, `btrfs-progs`, `dkms`, `egl-wayland`, `gst-plugin-pipewire`, `gtk4-layer-shell`, `libpulse`, `intel-ipu7-camera`, `intel-lpmd`, `intel-media-driver`, `libva-intel-driver`, `libva-nvidia-driver`, `limine`, `limine-mkinitcpio-hook`, `limine-snapper-sync`, `linux`, `linux-firmware`, `linux-headers`, `linux-ptl`, `linux-ptl-headers`, `macbook12-spi-driver-dkms`, `nvidia-580xx-dkms`, `nvidia-dkms`, `nvidia-open-dkms`, `nvidia-580xx-utils`, `nvidia-utils`, `lib32-nvidia-580xx-utils`, `lib32-nvidia-utils`, `pipewire`, `pipewire-alsa`, `pipewire-jack`, `pipewire-pulse`, `qt6-wayland`, `snapper`, `sof-firmware`, `thermald`, `webp-pixbuf-loader`, `yay-debug`, `tuxedo-drivers-nocompatcheck-dkms`, `yt6801-dkms`, `zram-generator`, `libvpl`, `vpl-gpu-rt`, `vulkan-intel`, `vulkan-radeon`, `vulkan-asahi`, `linux-firmware-marvell`, `dell-xps-touchpad-haptics`, `lsp-plugins-lv2`, `apple-bcm-firmware`, `apple-t2-audio-config`, `linux-t2`, `linux-t2-headers`, `t2fanrd`, `tiny-dfr`, `qmk-hid`.
+
+### Stable-to-Quattro program changes
+
+The rewrite is not just a package refresh:
+
+- Alacritty moves to Foot as the base terminal, while multiple terminals remain optional and themeable.
+- Waybar, Walker, Mako, SwayOSD, Swaybg, Hyprlock and Hypridle give way to the integrated Quickshell architecture.
+- iwd/Impala move toward NetworkManager and an integrated network panel.
+- Stable packages such as 1Password, Signal, Spotify, Typora, Rust, GitHub CLI and Claude Code are no longer all system-base entries; several move to optional or user-managed installation.
+- New first-party programs appear: Omawrite, Omacut and Omacalc.
+- `dust` becomes `dua-cli`; `neovim` becomes the custom `nvim` package; the Nerd Font package is narrowed to the basic variant.
+- Moonlight, yt-dlp, QR generation, ddcutil, udiskie, inotify tools and Quickshell enter the core.
+
+This is a positive ownership shift: the immutable/base layer gets smaller while personal and fast-moving developer tools move to user-level management. red-dev should use the same separation explicitly.
+
+## AI and Developer Tooling
+
+### Installed agent surface in Quattro
+
+`install/user/mise.sh` installs the following user-level tools:
+
+- Codex
+- Claude Code
+- Gemini CLI
+- GitHub CLI
+- GitHub Copilot CLI
+- OpenCode
+- Playwright
+- Pi
+- Oh My Pi (`omp`)
+- `ghui`
+- Hunk
+
+Stable Omarchy also installs a comparable agent/tool set, though some packaging locations differ. The important product decision is that agent readiness is not an optional afterthought.
+
+### Opinionated aliases
+
+Omarchy makes autonomous agent execution a one-letter workflow:
+
+```bash
+alias c='opencode --auto'
+alias cx='claude --permission-mode bypassPermissions'
+alias cy='codex -s danger-full-access -a never'
+```
+
+It also provides `tdl`/`tdlm` tmux layouts for one or two agent panes and an editor/diff/terminal/agent workspace.
+
+This is extremely efficient for DHH’s trusted personal machine model. It is not an acceptable corporate default. red-dev can ship ergonomic aliases or profiles, but permission bypass must be explicit, visible, scoped and preferably time-limited.
+
+### The Omarchy Agent Skill
+
+Quattro ships an extensive host-agnostic Skill and symlinks it into agent-specific locations for Codex, Claude and Pi, plus the general `.agents` convention. The Skill teaches an agent to:
+
+- Inspect the packaged source under `/usr/share/omarchy`.
+- Write user changes under `~/.config` rather than mutating managed defaults.
+- Prefer the stable `omarchy` CLI.
+- Back up existing configuration.
+- Validate changes.
+- Respect trust boundaries and privilege escalation.
+- Discover supported customization paths for hotkeys, themes, plugins and system behavior.
+
+This is one of Omarchy’s strongest contributions. It turns undocumented “dotfile folklore” into an agent-operable public contract. It is directly compatible with the earlier DHH/37signals finding: products should expose API/CLI primitives and teach agents how to compose them safely, instead of making MCP the only access route.
+
+### Agent-aware visual integration
+
+The theme engine includes templates or hooks for Claude and Pi, while OpenCode is restarted on theme changes. The Quattro bar includes a `model-usage` plugin. AI is therefore integrated into both operation and presentation.
+
+### Implication for MCP reliability
+
+Omarchy suggests a useful hierarchy for red-dev and RedDB:
+
+1. Stable local CLI with structured output.
+2. Product-owned Agent Skill explaining safe workflows.
+3. Optional MCP for richer discovery and UI integration.
+4. Health/readiness commands and a CLI fallback when MCP startup fails.
+
+That structure would have reduced the severity of the original `castle`, `navigator` and `rsp` startup failures: the agent could still inspect health and execute supported actions through a stable command surface.
+
+## CLI, Menu and Discoverability
+
+### Machine-readable command system
+
+The Quattro checkout contains 397 command files. Its command registry successfully described 393 commands, including 339 public commands, 54 hidden implementation commands and 73 commands requiring sudo. It supports:
+
+- Hierarchical command groups.
+- Summaries, arguments, examples and aliases embedded as source metadata.
+- `omarchy commands --all --json` for machine-readable discovery.
+- Metadata validation through `omarchy commands --check`.
+- Group-level help.
+- A distinction between public product surface and internal plumbing.
+
+The largest command families cover installation, hardware, Hyprland, launch, removal, themes, restart, update, menus, refresh, toggles, developer tooling, audio, packages and plugins.
+
+red-dev should adopt this exact concept: every action should carry stable ID, human label, description, platform availability, privilege level, destructive flag, arguments, result schema and health dependencies. The CLI, menus, hotkey help and Agent Skill should all derive from the same registry.
+
+### Hierarchical control center
+
+Quattro’s root menu is data-driven JSONC with nested routes and runtime predicates. Its top-level areas are:
+
+- Apps
+- Learn
+- Trigger
+- Style
+- Setup
+- Install
+- Remove
+- Update
+- About
+- System
+
+Entries can have `when` conditions and `checked` state, so the menu is both launcher and control surface. User extensions live outside packaged defaults. This is a much more scalable model than independent install scripts and undocumented shortcuts.
+
+### Install surface
+
+The current CLI exposes optional installation for:
+
+- **Browsers:** Chrome, Brave, Brave Origin, Edge, Firefox and Zen.
+- **Developer environments:** Ruby, Node, Bun, Deno, Go, Laravel, Symfony, PHP, Python, Elixir, Phoenix, Rust, Java, Zig, OCaml, .NET, Clojure and Scala.
+- **Databases:** containerized database setup.
+- **Editors:** Emacs, Helix, VS Code and Zed, with related menu variants in the product line.
+- **Gaming:** Battle.net, GeForce Now, Heroic, Lutris, RetroArch, Steam, Xbox Cloud and Xbox controllers.
+- **Services:** 1Password, Dropbox, NordVPN, ONCE, Signal, Spotify, Sunshine and Tailscale.
+- **Terminals:** Alacritty, Foot, Ghostty and Kitty.
+- **Fonts:** Cascadia Mono, Meslo LG, Fira Code, Victor Code, Bitstream Vera and Iosevka.
+- **Chromium helpers:** Copy URL native integration, Google account integration and yt-dlp.
+
+### Removal symmetry
+
+Omarchy exposes matching removal flows for browsers, development environments, gaming, services, security features, web apps, TUIs and preinstalls. This matters more than it first appears: a workstation product must know what it owns and how to unwind it.
+
+Some removal operations can delete substantial state. A red-dev action registry should explicitly tag:
+
+- package-only removal;
+- configuration removal;
+- credential/session removal;
+- user-data deletion;
+- reversible vs irreversible operations;
+- confirmation phrase and dry-run requirements.
+
+## Default Apps and Web Apps
+
+Quattro’s default web-app surface includes Basecamp, ChatGPT, Discord, Google Contacts, Google Maps, Google Messages, Google Photos, HEY, WhatsApp, X, YouTube and Zoom, with launch aliases for compose/new-message variants. Stable packaging also includes items such as GitHub, Figma and Fizzy in parts of its web-app inventory.
+
+Web apps are not crude bookmarks. Omarchy creates app launchers, retrieves high-resolution icons where possible, assigns matching/focus behavior and integrates hotkeys. It also exposes user-managed creation and removal.
+
+This model is useful for red-dev if separated into profiles:
+
+- A neutral core should provide the web-app mechanism.
+- An employee profile can provide RedDB-approved defaults.
+- A personal/DHH-inspired profile can include HEY, Basecamp and opinionated shortcuts.
+- User-created apps must remain first-class and removable.
+
+## Hotkeys — Complete Interaction Model
+
+The Quattro bindings are split into semantic Lua modules rather than one opaque compositor file. They feed a built-in keybinding help surface (`Super+K`), making the keyboard model learnable.
+
+### Application launchers
+
+| Hotkey | Action |
+|---|---|
+| `Super+Enter` | Terminal |
+| `Super+Shift+Enter` | Browser |
+| `Super+Shift+F` | File manager |
+| `Super+Alt+Shift+F` | File manager at current working directory |
+| `Super+Shift+B` | Browser alternate binding |
+| `Super+Alt+Shift+B` | Private browser |
+| `Super+Shift+N` | Editor |
+| `Super+Alt+Enter` | tmux terminal |
+| `Super+Shift+M` | Spotify/music |
+| `Super+Alt+Shift+M` | CLI music player |
+| `Super+Shift+D` | Docker/lazydocker |
+| `Super+Shift+G` | Signal |
+| `Super+Shift+O` | Obsidian |
+| `Super+Shift+W` | Omawrite |
+| `Super+Shift+/` | Password manager |
+
+Opinionated preinstalled web-app bindings include ChatGPT, Grok, HEY calendar/email/new email, YouTube, WhatsApp, Google Messages, Google Photos, Google Maps and X/new post. The source allows the preinstalled binding layer to be disabled.
+
+### Universal clipboard
+
+| Hotkey | Behavior |
+|---|---|
+| `Super+C` | Copy; emits `Ctrl+C` in GUI apps and `Ctrl+Insert` in terminals |
+| `Super+V` | Paste; emits `Ctrl+V` in GUI apps and `Shift+Insert` in terminals |
+| `Super+X` | Cut |
+| `Super+Ctrl+V` | Clipboard manager |
+
+This is a subtle but excellent usability layer. It gives Linux a macOS-like universal convention without breaking terminal interrupt semantics.
+
+### Tiling and workspaces
+
+| Area | Hotkeys and behavior |
+|---|---|
+| Close | `Super+W`; `Ctrl+Alt+Delete` closes all windows |
+| Layout | `Super+J` split, `Super+P` pseudo, `Super+T` float/tile, `Super+L` dwindle/scrolling |
+| Fullscreen | `Super+F` full screen, `Super+Ctrl+F` tiled full screen, `Super+Alt+F` full width |
+| Pop/pin | `Super+O` floats and pins; width save/restore on `Super+Alt+Home`/`Super+Home` |
+| Focus | `Super+Arrow` directional focus; `Alt+Tab` cycles windows |
+| Swap | `Super+Shift+Arrow` swaps windows |
+| Workspaces | `Super+1…0` selects 1–10; add Shift to move window; add Shift+Alt for silent move |
+| Workspace history | `Super+Tab`, `Super+Shift+Tab`, `Super+Ctrl+Tab` |
+| Scratchpad | `Super+S` toggle; `Super+Alt+S` move window |
+| Monitors | `Ctrl+Alt+Tab`; directional monitor/workspace movement variants |
+| Resize | three increments: 25, 100 and 300 pixels through modifier variants |
+| Mouse | `Super+left-drag` moves; `Super+right-drag` resizes; wheel changes workspace |
+| Groups | `Super+G` groups; directional group insertion, group cycling and direct positions 1–5 |
+| Scaling | `Super+/` up; `Super+Alt+/` down |
+
+The manual describes fewer workspaces in places, but the audited Quattro source binds all ten.
+
+### System, style and capture
+
+| Hotkey | Action |
+|---|---|
+| `Super+Space` | Omarchy menu |
+| `Super+Escape` | System menu |
+| `Super+K` | Keybinding reference |
+| `Super+Alt+K` | tmux keybinding reference |
+| `Super+Ctrl+E` | Emoji picker |
+| `Super+Ctrl+C` | Capture menu |
+| `Super+Ctrl+O` | Toggle menu |
+| `Super+Ctrl+H` | Hardware menu |
+| `Super+Shift+Space` | Top bar |
+| `Super+Ctrl+Space` | Background switcher |
+| `Super+Ctrl+Shift+Space` | Theme menu |
+| `Super+Backspace` | Window transparency |
+| `Super+Shift+Backspace` | Gaps |
+| `Print` | Screenshot |
+| `Alt+Print` | Screen recording menu/stop |
+| `Super+Print` | Color picker |
+| `Super+Ctrl+Print` | OCR selection to clipboard |
+| `Super+Ctrl+S` | Share menu |
+| `Super+Ctrl+.` | Transcode |
+| `Super+Ctrl+R` | Reminder creation |
+| `Super+Ctrl+L` | Lock |
+
+There are dedicated panels for audio, Bluetooth, display, calendar, network, power and activity, plus notification dismissal/history/silencing, nightlight, idle locking, internal-monitor control, mirror mode, zoom, battery, weather and time.
+
+### Hardware media keys
+
+Omarchy handles volume, mute, microphone mute, display brightness, keyboard backlight, touchpad on/off, media next/play/pause/previous, output switching and source switching. `Alt` variants provide one-unit precision instead of the normal larger step.
+
+### Dictation
+
+When VoiceType is present, `Super+Ctrl+X` toggles dictation and `F9` works as push-to-talk. Conditional binding prevents a dead shortcut when the capability is absent.
+
+### red-dev lesson
+
+Do not copy this key map literally across Windows, WSL, Linux and macOS. Define semantic actions such as `window.focus.left`, `app.terminal`, `capture.ocr`, `clipboard.history` and `theme.next`, then provide platform bindings, collision detection, a searchable overlay and an exportable machine-readable registry.
+
+## Themes, Fonts and Assets
+
+### Built-in theme inventory
+
+Stable 3.8.4 contains 19 themes:
+
+`catppuccin`, `catppuccin-latte`, `ethereal`, `everforest`, `flexoki-light`, `gruvbox`, `hackerman`, `kanagawa`, `lumon`, `matte-black`, `miasma`, `nord`, `osaka-jade`, `retro-82`, `ristretto`, `rose-pine`, `tokyo-night`, `vantablack`, `white`.
+
+Quattro contains 22, adding:
+
+`last-horizon`, `lupine`, `solitude`.
+
+The manual’s smaller advertised theme count is therefore stale.
+
+### Asset inventory
+
+The pinned Quattro repository contains:
+
+- 91 theme background images.
+- 131 PNG files overall.
+- 60 JPG/JPEG files overall.
+- 5 SVG files overall.
+- Per-theme preview and lock-preview imagery.
+- Plymouth boot graphics and scripts.
+- App/extension icons.
+- Font packages for Noto Latin/CJK/emoji, JetBrains Mono Nerd Basic and iA Writer.
+- Optional font installers for Cascadia Mono, Meslo LG, Fira Code, Victor Code, Bitstream Vera and Iosevka.
+
+Licensing/provenance is not obvious for every bundled wallpaper and derivative theme asset. red-dev should require an asset manifest with origin, author, license, checksum, intended surfaces and redistribution status.
+
+### Semantic color architecture
+
+Each Quattro theme centers on `colors.toml`, not a pile of unrelated app fragments. It describes:
+
+- dark or light mode;
+- background and foreground;
+- accent color;
+- semantic red, orange, yellow, green, cyan, blue, purple and magenta;
+- neutral ramps;
+- gradients;
+- optional per-surface overrides.
+
+Theme-specific files can override generated output for Chromium, btop, Hyprland, Neovim, VS Code and icons.
+
+### Generated surfaces
+
+Quattro carries 17 default theme templates:
+
+- Alacritty
+- btop
+- Chromium
+- Claude
+- Foot
+- Ghostty
+- Gum
+- Helix
+- Hyprland preview picker CSS
+- Hyprland
+- keyboard RGB
+- Kitty
+- Neovim
+- Obsidian
+- Pi
+- Omarchy shell
+- VS Code
+
+Additional apply hooks cover tmux, GNOME/GTK and application restarts. Theme changes therefore propagate far beyond the terminal.
+
+### Atomic theme application
+
+The theme setter:
+
+1. Resolves the selected official or user theme.
+2. Builds a clean `next-theme` staging directory.
+3. Copies explicit theme files first.
+4. Renders default templates only where an explicit file did not already win.
+5. Atomically swaps the completed theme directory into place.
+6. Tells the live shell to adopt the palette immediately.
+7. Runs application-specific hooks in parallel.
+8. Refreshes tmux, terminal, GNOME, browser/editor and agent surfaces as appropriate.
+
+This avoids half-applied themes and establishes a clear precedence rule: packaged semantic default → selected theme override → user override.
+
+### Theme extension model
+
+Themes can be installed from Git repositories, updated and removed. Aether provides a GUI path for creation. Community themes are documented separately from first-party themes.
+
+For red-dev, the missing contract should be:
+
+```text
+semantic tokens
+  → generated per-app configuration
+  → user override
+  → staged validation
+  → atomic activation
+  → restart/reload only affected surfaces
+  → visual acceptance screenshot
+```
+
+## Quattro Desktop Shell and Plugin Platform
+
+Quattro replaces a collection of independent desktop processes with a long-running Quickshell application. The checkout contains 102 QML files and 26 first-party plugin manifests, including nested panel/service plugins.
+
+First-party plugin capabilities include:
+
+- background and transitions;
+- top bar;
+- active window;
+- workspaces;
+- system tray;
+- keyboard layout;
+- microphone;
+- update status;
+- clipboard;
+- emoji and image pickers;
+- lock screen;
+- launcher/menu;
+- model usage;
+- notifications and history;
+- on-screen display;
+- audio, Bluetooth, network, monitor, power and weather panels;
+- Dropbox and Tailscale panels;
+- polkit prompts;
+- reminders;
+- battery, idle, media and nightlight services;
+- developer gallery.
+
+The default shell configuration places menu/workspaces on the left, clock/weather/update in the center and model usage/connectivity/audio/display/power on the right. Default idle timings observed were 150 seconds to screensaver and 300 seconds to lock.
+
+### Plugin ownership model
+
+Third-party and cloned plugins live under `~/.config/omarchy/plugins/<id>` with a manifest schema. Commands support add, clone, enable, disable, update, validate, list and remove. A user can clone a built-in plugin before modifying it rather than patching `/usr/share/omarchy`.
+
+This packaged-default/user-overlay split is highly reusable. The Quickshell implementation is not portable, but the manifest and IPC contracts can be.
+
+## Updates, Migrations and Recovery
+
+### Channels
+
+Omarchy exposes four operating postures:
+
+- **stable:** curated Omarchy packages and an Arch base intentionally delayed by roughly a month according to the manual;
+- **RC:** release-candidate validation;
+- **edge:** newer Arch/package content;
+- **dev:** source checkout plus edge-like dependencies.
+
+The stable delay is a risk-control mechanism for rolling release, not a conventional fixed release branch.
+
+### Update transaction
+
+Quattro’s `omarchy update` sequence is explicit:
+
+1. Capture terminal output in `/tmp/omarchy-update.log`.
+2. Acquire a per-user runtime lock so two updates cannot run concurrently.
+3. Require sufficient free space.
+4. Ask for confirmation unless `-y` is supplied.
+5. Create a Snapper snapshot when available.
+6. Inhibit sleep during the transaction.
+7. Update a dev checkout if applicable.
+8. Update signing keyring.
+9. Update system packages.
+10. Run migrations.
+11. Run post-update hooks.
+12. Update AUR and mise-managed packages.
+13. identify/remove or retain orphan packages through the product flow.
+14. Analyze logs and update status.
+15. Release the sleep inhibitor.
+16. Offer or perform the appropriate restart.
+
+An ALPM pre-transaction guard blocks an ordinary direct `pacman -Syu` path and instructs the user to use `omarchy update`, with an escape mechanism for deliberate bypass. This protects lifecycle hooks but reduces standard Arch autonomy.
+
+### Migration model
+
+Stable history contains 330 migration scripts; Quattro’s reorganized branch has 54 current migrations. Fresh installs mark shipped migrations as already applied, while upgrades run only pending items. Multi-user handling can notify another user when system updates advanced migrations outside their session.
+
+The design is good, but configuration migration remains difficult. The manual acknowledges incomplete `.pacnew`/`.pacsave` handling, and the refresh command’s path validation is not strong enough to reject every `..` traversal into locations outside the intended `~/.config` subtree.
+
+### Recovery
+
+Omarchy combines:
+
+- Btrfs subvolumes;
+- Snapper snapshots;
+- Limine boot integration;
+- pre-update snapshots;
+- rollback documentation;
+- a reinstall command for restoring managed packages/configuration.
+
+Reinstall and some removal flows are intentionally destructive. A future internal recovery-partition/factory-reset design exists in plan documents, but it is not current product functionality.
+
+## Hardware and Platform Adaptation
+
+### Delivered adapters
+
+The Quattro source contains detection or setup paths for:
+
+- NVIDIA open/proprietary/legacy and hybrid GPU configurations.
+- Intel Panther Lake kernels, Wi-Fi 7, IPU7 cameras, SOF audio, media drivers, thermald and low-power behavior.
+- AMD and Intel Vulkan drivers.
+- ASUS ROG, Zenbook, ExpertBook and Flow Z13 behaviors.
+- Framework 16/QMK input.
+- Dell XPS haptic touchpads, OLED/text scaling and speaker behavior.
+- Microsoft Surface firmware/kernel support.
+- Lenovo Yoga speaker tuning.
+- Apple T1/T2 keyboard, NVMe, Wi-Fi, audio, fan and display support.
+- Broadcom Wi-Fi.
+- Tuxedo keyboard/backlight hardware.
+- Synaptics input devices.
+- YT6801 Ethernet.
+- Laptop touchpad, touchscreen, webcam, lid and internal display behavior.
+
+### Audio tuning
+
+Audio deserves separate mention. Omarchy matches hardware against tuning data and launches an LV2 PipeWire filter chain in a separate user service. A malformed speaker profile therefore does not have to crash or poison the main PipeWire graph. Matching profiles can be enabled, disabled and changed independently.
+
+This is a model for red-dev adapters: isolate fragile vendor tuning from the core service and expose deterministic match/explain/disable commands.
+
+### Mac support
+
+The manual supports Intel Macs, including significant T1/T2 accommodations. Apple Silicon direct installation is not a currently delivered mainstream path. Although the package repository has x86_64 and AArch64 capabilities and `vulkan-asahi` appears in the support manifest, the existence of an AArch64 plan must not be confused with an official M-series ISO.
+
+### Input caveat
+
+Full-disk encryption requires input before the normal Bluetooth stack is running. The manual recommends a wired or 2.4 GHz keyboard for the LUKS prompt. That is an important first-run compatibility constraint.
+
+## Security and Supply Chain Assessment
+
+### Positive controls
+
+- LUKS2 encryption is the default path.
+- Btrfs/Snapper snapshots protect update recovery.
+- UFW defaults to deny incoming and allow outgoing.
+- LocalSend receives narrow TCP/UDP rules on port 53317.
+- Docker receives dedicated firewall handling.
+- SSH setup is opt-in in the current source, uses key-oriented setup and opens a rate-limited port only when enabled.
+- FIDO2 and fingerprint authentication are supported as optional setup flows.
+- The ISO release process computes SHA-256 and uses a GPG signing key stored through the team’s 1Password vault.
+- Omarchy’s package build system supports signed packages and promotion of tested artifacts between channels.
+- Managed defaults and user customization are separated.
+
+### Material gaps and contradictions
+
+#### Secure Boot and TPM
+
+Current installation guidance instructs users to disable Secure Boot and TPM-related protections. The ISO repository contains a thorough consumer Secure Boot plan, but no delivered implementation was found. This is acceptable as a clearly documented alpha/enthusiast limitation, not as a long-term enterprise baseline.
+
+#### Package signature enforcement
+
+Official stable/RC/edge pacman configurations use `SigLevel = Optional TrustAll` for the Omarchy repository. The Mac-specific repository path uses `SigLevel = Never`; the offline ISO mirror also trusts ISO integrity instead of enforcing package signatures. The package project says artifacts are signed and imports the key, but the client configuration does not require valid signatures.
+
+Signed-but-optional is weaker than signature enforcement. red-dev should require signatures for all network-delivered managed artifacts and treat an offline bundle’s signed manifest as a separate verified root.
+
+#### ISO detached signature availability
+
+The release pipeline signs and uploads both ISO and `.sig`, and the manual tells users to append `.sig` to the ISO URL. During this audit, the exact stable 3.8.4 `.sig` URL returned HTTP 404. The SHA-256 in the release notes remains available, but a checksum shown on the same delivery channel is not equivalent to an independently verified signature.
+
+#### Firewall documentation drift
+
+The current source makes SSH opt-in. The Security manual says port 22 is allowed by default. The implementation should be treated as ground truth, and the documentation needs correction.
+
+#### Unrestricted agents
+
+The `cx` and `cy` aliases explicitly bypass normal approval/sandbox controls. This is intentional but high-risk, especially when combined with an agent Skill that can execute system configuration commands.
+
+#### Shared secret
+
+One password protects user, root and encrypted disk. A compromised or shoulder-surfed secret crosses all three boundaries.
+
+#### Configuration path containment
+
+The config refresh path check confirms existence but is not a complete canonical-path containment check. A crafted relative path containing `..` can escape the intended user config subtree. This is especially relevant once agents compose commands automatically.
+
+#### Asset provenance
+
+Wallpaper and theme origin/license metadata is not consistently obvious from the asset directories. A corporate distribution needs machine-readable provenance.
+
+## Services and Runtime Behavior
+
+System setup enables or configures:
+
+- CUPS and CUPS browsing;
+- Avahi/mDNS;
+- Docker socket activation;
+- systemd-resolved;
+- NetworkManager in Quattro;
+- power-profiles-daemon;
+- SDDM;
+- systemd-oomd;
+- kernel cleanup hooks;
+- PipeWire/WirePlumber;
+- zram;
+- UFW.
+
+`NetworkManager-wait-online` is masked to avoid delaying boot on a workstation. The shell and user services handle idle, lock, notifications, media, nightlight, model usage and hardware panels.
+
+## Testing and Quality Strategy
+
+Quattro represents a major increase in test ambition. The checkout contains 150 files in test areas, including CLI/shell tests and graphical acceptance coverage.
+
+The ISO harness is especially valuable:
+
+1. Boots a real ISO in a headless VM.
+2. Reads installer screens through QMP screendumps and OCR.
+3. Responds with virtual keystrokes, exercising the actual wizard.
+4. Validates install progress, reboot and SDDM login.
+5. Boots the installed workstation.
+6. Sends real keyboard shortcuts.
+7. Runs the in-guest acceptance suite.
+8. Checks package manifest, services, defaults, launchers, menus, panels, live weather, notifications, clipboard and interactive shell behavior.
+9. Saves ordered `success-*` or `failure-*` screenshots plus serial/install logs.
+10. Continues independent checks after a failure so one defect does not hide the rest.
+11. Supports a reusable base disk for faster local iteration.
+12. Can test the encrypted boot flow, including the LUKS password.
+
+This is the most directly reusable Omarchy idea for red-dev. Unit tests cannot prove a theme rendered correctly, a shortcut reached the intended app, an MCP error was legible, or an installer survived an actual clean machine.
+
+## Omarchy vs Omakub vs red-dev
+
+| Dimension | Omakub | Omarchy | red-dev opportunity |
+|---|---|---|---|
+| Starting point | Existing Ubuntu/GNOME | Owned Arch ISO/distribution | Existing Windows/WSL/Linux/macOS hosts with explicit capability detection |
+| Desktop ownership | GNOME customization and apps | Boot-to-desktop ownership with Hyprland/Quickshell | Cross-platform semantic action layer and native adapters |
+| Package lifecycle | install scripts and Ubuntu packages | custom repos, channels, updates, migrations, removal, snapshots | signed manifests, transactional steps, rollback and ownership registry |
+| Themes | coherent app configs/assets | semantic tokens, templates, previews, atomic swap, plugins | one portable token schema with per-platform renderers |
+| Hotkeys | opinionated GNOME shortcuts | comprehensive discoverable keyboard OS | semantic actions, collision detection and searchable overlay |
+| Apps | strong curated bundle | base/optional/web-app/TUI layers | profiles: neutral, employee, creator, DHH-inspired |
+| Agents | not the main product layer | installed agents, Skill, themed interfaces and model-usage panel | CLI-first product contract, Agent Skill and MCP as optional adapter |
+| Testing | script-oriented | clean-ISO graphical acceptance | clean Windows/WSL/Linux/macOS VM matrix plus screenshots |
+| Hardware | relies heavily on Ubuntu | explicit hardware adapter catalogue | capability manifest and explainable adapter selection |
+| Recovery | reinstall/script rerun | snapshot, rollback, reinstall | checkpointed reversible provisioning and repair |
+
+## Opportunities for red-dev
+
+### P0 — foundational contracts
+
+#### 1. Semantic action registry
+
+Create one registry for every user/system action:
+
+```yaml
+id: capture.ocr
+label: Copy text from screen
+platforms: [windows, linux, macos]
+capabilities: [screen_capture, ocr, clipboard]
+privilege: user
+destructive: false
+bindings:
+  linux: Super+Ctrl+Print
+  windows: Win+Ctrl+Shift+O
+result_schema: clipboard-text
+```
+
+Generate CLI help, control-center entries, hotkey overlays, conflict checks, docs and agent metadata from it.
+
+#### 2. Command metadata and structured health
+
+Every red-dev command should advertise summary, arguments, examples, supported hosts, privilege, mutations, destructive effects, prerequisites, fallback and structured result. Add:
+
+- `red-dev commands --json`
+- `red-dev commands --check`
+- `red-dev doctor --json`
+- `red-dev mcp status --json`
+- CLI fallbacks for core MCP actions
+
+#### 3. Product-owned Agent Skill
+
+Ship a RedDB/red-dev Skill that teaches agents:
+
+- managed vs user-owned paths;
+- platform capability discovery;
+- safe use of package/theme/hotkey APIs;
+- backup and rollback expectations;
+- how to diagnose unavailable MCPs;
+- when privilege is required;
+- how to avoid unrestricted mode by default.
+
+This should complement RedSkills rather than duplicate its process skills.
+
+#### 4. Atomic theme contract
+
+Replace disconnected terminal/editor themes with semantic tokens, generated adapters, asset provenance, staging, validation and atomic activation. Add a completeness check that fails when a required surface has no renderer.
+
+#### 5. Clean-machine graphical acceptance
+
+Build VM fixtures for Windows, WSL and Linux first. Exercise first run, terminal, clipboard, menus, themes, hotkeys, MCP failure/recovery and uninstall using actual UI input and screenshot artifacts.
+
+### P1 — product coherence
+
+#### 6. Manifest-backed control center
+
+Generate a searchable control center from the same action/capability manifest. Support conditional availability, installed/checked state, install/remove symmetry and a Learn section.
+
+#### 7. Lifecycle transaction engine
+
+Provisioning and updates should have:
+
+- global/per-host lock;
+- free-space and dependency preflight;
+- checkpoint/snapshot where supported;
+- ordered migrations;
+- captured log;
+- rollback/repair;
+- post-update validation;
+- restart classification;
+- dry run;
+- explicit bypass with audit trail.
+
+#### 8. Capability-driven hardware adapters
+
+Represent host facts independently from actions: GPU, display, audio codec, laptop model, input devices, package manager, compositor, WSL version and corporate policy. Every adapter should support `match`, `explain`, `apply`, `validate`, `disable` and `rollback`.
+
+#### 9. Profile architecture
+
+Recommended profiles:
+
+- `core`: shell, terminal, Git, clipboard, fonts, common CLI.
+- `reddb-employee`: company apps, credentials, policies and approved agents.
+- `linux-workstation`: Omarchy-inspired interaction layer where Hyprland/Wayland is available.
+- `creator`: OBS, capture, video/image/document tools.
+- `dhh-inspired`: HEY/Basecamp-style apps, keyboard map and optional autonomous-agent ergonomics.
+
+The mechanism belongs in core; the personal taste belongs in profiles.
+
+#### 10. Plugin/overlay ownership
+
+Use immutable packaged defaults plus user-owned overlays. Never require users or agents to patch managed source. Provide clone/fork, validate, enable, disable, update and reset flows.
+
+### P2 — differentiators
+
+#### 11. Cross-platform universal clipboard behavior
+
+Map a consistent copy/paste/cut/history convention while preserving terminal interrupt semantics. This is small, visible and high-frequency.
+
+#### 12. Web-app product surface
+
+Provide installable web apps with icons, app IDs, isolated profiles where possible, hotkeys, focus matching and complete uninstall.
+
+#### 13. Model-usage/status integration
+
+Expose local agent availability, authentication state, quota/usage where supported and MCP readiness through a neutral status provider. Avoid binding the core UX to any one agent vendor.
+
+#### 14. Theme and hardware galleries
+
+Use preview screenshots and golden images for themes; use explainable detected-card views for hardware adapters. A visual tool should be generated from the same contracts used by automation.
+
+## What red-dev Should Not Copy
+
+1. Permission-bypassing agent aliases as the default.
+2. `Optional TrustAll` or unsigned package channels.
+3. Permanent Secure Boot disablement as the product posture.
+4. The 7.96 GB all-in-one ISO model for a cross-platform bootstrapper.
+5. Personal HEY/Basecamp/Spotify/Signal choices in the neutral core.
+6. Linux/Hyprland key combinations as the portable abstraction.
+7. Blocking the native package manager without excellent escape, diagnostics and documentation.
+8. A shared user/root/disk password as the only enterprise option.
+9. Treating default-branch alpha code as released product.
+10. Shipping backgrounds without explicit provenance metadata.
+11. A rolling-distribution operational burden unless red-dev explicitly becomes an OS product.
+12. Reinstall/remove commands whose data-loss scope is not machine-readable before execution.
+
+## Proposed red-dev Architecture
+
+```text
+                        ┌─────────────────────┐
+                        │ Workstation Manifest│
+                        │ actions/capabilities│
+                        └──────────┬──────────┘
+                                   │
+          ┌────────────────────────┼────────────────────────┐
+          │                        │                        │
+ ┌────────▼────────┐      ┌────────▼────────┐      ┌────────▼────────┐
+ │ Human surfaces  │      │ Agent surfaces  │      │ Lifecycle       │
+ │ menu/help/keys  │      │ CLI/Skill/MCP   │      │ install/update  │
+ └────────┬────────┘      └────────┬────────┘      └────────┬────────┘
+          │                        │                        │
+          └────────────────────────┼────────────────────────┘
+                                   │
+                        ┌──────────▼──────────┐
+                        │ Platform adapters   │
+                        │ Win/WSL/Linux/macOS │
+                        └──────────┬──────────┘
+                                   │
+                     ┌─────────────┼─────────────┐
+                     │             │             │
+               themes/assets   apps/packages  hardware/services
+```
+
+The manifest is the source of truth. Menus, help, shortcuts, CLI, Skill and MCP describe the same actions. Platform adapters decide what is possible. The lifecycle engine owns mutation and rollback. Tests operate through the same public surfaces users and agents use.
+
+## API / CLI / Config Details
+
+### Proposed command examples
+
+```bash
+red-dev commands --json
+red-dev capabilities --json
+red-dev doctor --json
+red-dev mcp status --json
+red-dev action run capture.ocr --json
+red-dev action explain theme.activate
+red-dev theme validate tokyo-night
+red-dev theme preview tokyo-night
+red-dev theme activate tokyo-night --atomic
+red-dev profile plan reddb-employee
+red-dev profile apply reddb-employee
+red-dev profile remove reddb-employee --keep-user-data
+red-dev update plan --json
+red-dev update apply
+red-dev rollback latest
+```
+
+### Proposed action metadata
+
+```json
+{
+  "id": "profile.remove",
+  "summary": "Remove managed profile components",
+  "platforms": ["windows", "wsl", "linux", "macos"],
+  "requiresPrivilege": "conditional",
+  "mutates": true,
+  "destructive": "configuration",
+  "supportsDryRun": true,
+  "supportsRollback": true,
+  "userDataPolicy": "preserve-by-default",
+  "healthDependencies": ["package-manager", "state-store"]
+}
+```
+
+### Proposed theme metadata
+
+```toml
+id = "tokyo-night"
+mode = "dark"
+license = "MIT"
+source = "https://example.invalid/theme"
+
+[colors]
+background = "#1a1b26"
+foreground = "#c0caf5"
+accent = "#7aa2f7"
+red = "#f7768e"
+green = "#9ece6a"
+yellow = "#e0af68"
+blue = "#7aa2f7"
+
+[assets.wallpaper]
+path = "backgrounds/main.jpg"
+author = "..."
+license = "..."
+sha256 = "..."
+```
+
+## Version Notes
+
+- Stable version audited: GitHub release/tag `v3.8.4`, released 2026-07-21.
+- Stable tag commit: `8fcc9d6048af4cb0e3af8512c78049857a3b53dd`.
+- Stable version-file mismatch: `3.8.3`.
+- Quattro source version: `4.0.0.alpha`.
+- Quattro commit: `12af188304793b65551b5c43d20f02961dc938a9`, dated 2026-08-01.
+- ISO commit: `17532793fdccea862b6c9a080b55b85c7a4b5321`, dated 2026-08-01.
+- Package commit: `7a5f347a8b95639de8b3a79b67b0bc197caeb21a`.
+- Site commit: `2844c11632b0a48ab1339c062a89a13087a03274`.
+- Counts are snapshots of those commits and will change.
+
+## Gotchas
+
+1. Default branch `quattro` is alpha; stable behavior must be checked at the release tag.
+2. The manual is not a reliable source for exact package, theme, workspace or firewall counts.
+3. Secure Boot documents in `plans/` are designs, not features.
+4. Apple Silicon-related packages/plans do not mean a supported M-series ISO exists.
+5. The stable ISO is externally hosted; GitHub release entries do not contain the binary as a release asset.
+6. The detached `.sig` URL was unavailable during the audit.
+7. Encrypted boot cannot rely on an ordinary Bluetooth keyboard.
+8. Stable and Quattro use materially different shell architectures.
+9. Omarchy’s package-manager guard is intentional and can surprise experienced Arch users.
+10. Optional AUR software has a different trust/support profile from first-party packages.
+11. Theme switching may need application restart/reload even though the shell updates immediately.
+12. Removal/reinstall flows need close inspection before automation because their state-deletion scope differs.
+13. Agent aliases assume a trusted personal workstation and deliberately weaken interactive safety.
+14. The web-app list reflects DHH/Basecamp taste, not a universal productivity baseline.
+15. `omarchy refresh config` needs stronger canonical path containment before being treated as safe for arbitrary agent-generated input.
+
+## Open Questions
+
+1. Will Quattro 4.0 enforce package signatures before stable release?
+2. Will the public ISO delivery page expose a working detached signature and public-key verification instructions beside the checksum?
+3. What is the final Secure Boot and TPM posture for consumer and enterprise machines?
+4. Which Quattro install modes will ship in 4.0, and which will remain plans?
+5. Will user/root/LUKS credentials become separable in an advanced or managed profile?
+6. What compatibility guarantee exists for third-party shell plugins and command metadata?
+7. Are all bundled wallpaper/theme assets licensed for redistribution, and where is that recorded?
+8. How are automatic update notifications balanced with the need for explicit migration/reboot control?
+9. Will the manual be versioned per stable release instead of tracking a mixed product state?
+10. Can the Agent Skill expose a safer default mode while preserving DHH’s optional “YOLO” workflow?
+11. Which Omarchy ideas belong in red-dev core versus a separate Linux-workstation profile?
+12. Should red-dev’s action manifest become the source of MCP tool schemas as well as CLI/menu/hotkey documentation?
+
+## Source Notes
+
+### Omarchy runtime
+
+- Package counts came from non-empty, non-comment lines of the pinned manifests.
+- Theme and asset counts came from the Git tree, not the manual.
+- Command counts came from the repository’s own JSON command registry.
+- Hotkeys were read from the Quattro Lua binding modules because they are more precise than the manual.
+- Quattro shell/plugin claims came from QML and plugin manifest files.
+- Update sequencing came from the actual `bin/omarchy-update` orchestration.
+
+### ISO
+
+- Install-mode and encryption behavior came from the current configurator source.
+- The ISO repository’s `plans/` directory was used only to distinguish future intentions from delivered behavior.
+- Test behavior came from the ISO README and harness source.
+- ISO size/checksum came from the stable release metadata and hosted artifact response.
+
+### Packages and mirror
+
+- Signing and promotion claims came from the official package repository.
+- Client signature-policy findings came from official pacman configuration in the ISO source.
+- The distinction between “package is signed” and “client requires a valid signature” is intentional and security-relevant.
+
+## Recommended Next Steps
+
+### Immediate study outputs
+
+1. Add this report as the Omarchy companion layer to the existing red-dev/Omakub/DHH study.
+2. Create a decision record: red-dev remains cross-platform and adopts Omarchy patterns through adapters/profiles rather than becoming an OS distribution.
+3. Convert the P0 contracts into separate design tickets before implementation.
+
+### Suggested implementation sequence
+
+1. **Action registry spike:** model 20 existing red-dev actions and generate JSON/help from it.
+2. **MCP resilience spike:** expose MCP readiness and CLI fallbacks through that registry.
+3. **Theme spike:** render one semantic theme to Alacritty, shell prompt and one editor with atomic staging.
+4. **Hotkey spike:** generate a platform-specific overlay and detect collisions.
+5. **Lifecycle spike:** add plan/apply/validate/rollback around one reversible package group.
+6. **Agent Skill:** document safe red-dev customization and CLI discovery.
+7. **Clean-machine E2E:** automate one Windows+WSL fixture and one Linux fixture with screenshots.
+8. **Profiles:** separate core, RedDB employee and Omarchy-inspired Linux workstation choices.
+9. **Asset manifest:** record provenance/license/checksum and visual golden image for every bundled theme asset.
+10. **Security gates:** require signatures, contain paths canonically and prohibit permission-bypass defaults.
+
+## Final Assessment
+
+Omarchy’s deepest contribution is not Arch, Hyprland or a particular theme. It is the demonstration that a workstation can behave like a coherent product when actions, appearance, packages, hardware, updates, recovery and agents are designed as one system.
+
+For red-dev, the strategic opportunity is to reproduce that coherence **without** inheriting the Linux-only boundary. A semantic manifest, platform adapters, atomic themes, profile-based curation, lifecycle transactions, an Agent Skill and real clean-machine UI tests would give Windows/WSL/Linux/macOS users the same feeling of deliberate integration while preserving RedDB’s portability and security needs.
+
+Omarchy should therefore be treated as a high-quality reference implementation and a source of product contracts—not as a package list to copy wholesale.

--- a/.red/researches/2026-08-03-red-dev-vs-omakub-gap-analysis-2.md
+++ b/.red/researches/2026-08-03-red-dev-vs-omakub-gap-analysis-2.md
@@ -1,0 +1,1630 @@
+# red-dev vs. Omakub — auditoria técnica aprofundada
+
+Date: 2026-08-03
+
+Query: investigar profundamente o red-dev e o Omakub, comparar tudo o que cada produto instala e configura, cobrir programas, assets, temas, fontes, hotkeys, tiling, agentes, ferramentas RedDB e upgrades, e encontrar gaps e oportunidades para que o red-dev entregue uma experiência de workstation superior em Linux, WSL, Windows e macOS.
+
+Scope: código e assets do red-dev no commit `e7757978783fc96ec8871e5efdeddc93ee8adc06`; código e assets do Omakub no commit `c873902f1a5d8b0f54e2e52d565a77274a5941ff`; releases oficiais vigentes em 2026-08-03; inventários completos dos manifests e scripts; comportamento por plataforma; experiência de instalação, configuração e atualização. Não foram executadas instalações destrutivas em máquinas limpas. Quando o código e a documentação divergiram, o código fixado por commit foi tratado como comportamento de produto e a divergência foi registrada.
+
+## Executive Summary
+
+O red-dev já é uma evolução arquitetural do Omakub, mas ainda não é uma evolução completa da experiência do Omakub.
+
+Ele possui uma base melhor para um produto corporativo multiplataforma: manifesto tipado com 56 itens, providers explícitos, binários compilados, convergência reexecutável, falhas isoladas por item, `plan`, `doctor`, migrações ledgered, configuração compartilhada WSL/Windows, canais stable/next, ferramentas RedDB e onboarding de agentes. O Omakub é mais estreito: Ubuntu GNOME x86, checkout Git e scripts Bash imperativos.
+
+Entretanto, o Omakub ainda ganha com folga naquilo que o usuário vê e sente no primeiro dia:
+
+- instala um workstation desktop completo, não somente ferramentas de desenvolvimento;
+- instala e configura Chrome, VS Code, LazyVim, launcher, screenshots, comunicação, escritório e utilidades;
+- entrega tiling de janelas via GNOME/Tactile e tiling de terminal via Zellij;
+- configura seis workspaces, dock, app grid, extensões e dezenas de atalhos úteis;
+- possui dez bundles de tema completos, cada um com Alacritty, Zellij, btop, Neovim, VS Code, GNOME, TopHat e wallpaper;
+- inclui dez wallpapers e nove ícones de aplicação no checkout;
+- oferece bancos Docker e linguagens durante o primeiro run;
+- atualiza o próprio produto e executa migrações.
+
+O red-dev tem dez temas e alcança mais superfícies CLI, mas a auditoria encontrou defeitos relevantes:
+
+1. Sete temas não instalam o plugin Neovim correspondente; alguns também usam o nome de colorscheme errado.
+2. Rose Pine é uma paleta clara, mas GNOME e Windows são forçados para dark mode.
+3. Osaka Jade não tem integração VS Code; o Omakub usa Ocean Green como aproximação explícita.
+4. Apenas três dos dez wallpapers gerados estão versionados, apesar dos comentários dizerem que todos estão.
+5. `fzfColors()` existe, mas não é conectado a nenhuma configuração.
+6. No Windows nativo, o ramo de tema ignora Zellij, btop, bat, delta, lazygit, OpenCode e Herdr.
+7. A fonte escolhida não é instalada no Ubuntu desktop nem no Windows nativo.
+8. Trocar tema ou convergir novamente pode voltar a fonte para FiraCode e tamanho 11 porque preferências persistidas não alimentam o `ApplyContext`.
+
+Também há gaps de catálogo e assets que mudam a prioridade do roadmap:
+
+- red-ui já publica Windows x64 e macOS Intel/ARM, mas o manifesto ainda declara que não existe build Windows;
+- todas as ferramentas RedDB principais já possuem assets macOS; `red`, `tq` e `dit` também possuem Linux ARM;
+- RedSkills v2 já suporta Pi, mas red-dev não instala Pi e seu `doctor` só reconhece Claude, Codex e OpenCode;
+- RedSkills v3 adiciona Gemini, enquanto red-dev continua chamando o instalador v2;
+- Hermes ainda não é um host oficial RedSkills, embora suporte skills externas e MCP nativamente;
+- macOS é reconhecido como `darwin`, mas cai no provider Ubuntu 24 e não possui bootstrap nem release asset.
+
+A ordem recomendada é:
+
+1. corrigir as falsas promessas e os defeitos de tema/fonte/provider;
+2. completar um perfil `reddb-employee` verificável;
+3. entregar desktop Linux no nível de acabamento do Omakub;
+4. adicionar macOS como plataforma real, aproveitando Homebrew e os assets RedDB já existentes;
+5. transformar hotkeys, temas, fontes, apps e agentes em contratos declarativos com testes E2E.
+
+## Official Sources
+
+### red-dev
+
+- [README no commit auditado](https://github.com/reddb-io/red-dev/blob/e7757978783fc96ec8871e5efdeddc93ee8adc06/README.md) — promessa de produto, comandos e limitações declaradas.
+- [Manifesto completo](https://github.com/reddb-io/red-dev/blob/e7757978783fc96ec8871e5efdeddc93ee8adc06/src/manifest.ts) — fonte de verdade dos 56 itens e seus providers.
+- [Plataformas e capacidades](https://github.com/reddb-io/red-dev/blob/e7757978783fc96ec8871e5efdeddc93ee8adc06/src/platform.ts) — detecção de Linux, Windows, Darwin, WSL e desktop/server.
+- [Agentes e integração RedSkills](https://github.com/reddb-io/red-dev/blob/e7757978783fc96ec8871e5efdeddc93ee8adc06/src/agents.ts) — catálogo, installers e hosts reconhecidos.
+- [Paletas de tema](https://github.com/reddb-io/red-dev/blob/e7757978783fc96ec8871e5efdeddc93ee8adc06/src/themes.ts) — dez temas e paletas ANSI.
+- [Aplicação de temas](https://github.com/reddb-io/red-dev/blob/e7757978783fc96ec8871e5efdeddc93ee8adc06/src/theme-apply.ts) — superfícies e diferenças por plataforma.
+- [Temas de VS Code e GNOME](https://github.com/reddb-io/red-dev/blob/e7757978783fc96ec8871e5efdeddc93ee8adc06/src/theme-editors.ts) — extensions, labels, accents e política de merge.
+- [Temas de CLI e agentes](https://github.com/reddb-io/red-dev/blob/e7757978783fc96ec8871e5efdeddc93ee8adc06/src/theme-cli.ts) — bat, delta, lazygit, OpenCode, Herdr e função fzf não conectada.
+- [Wallpapers](https://github.com/reddb-io/red-dev/blob/e7757978783fc96ec8871e5efdeddc93ee8adc06/src/wallpaper.ts) — geração 2560×1440 e aplicação GNOME/Windows.
+- [Fontes e Windows Terminal](https://github.com/reddb-io/red-dev/blob/e7757978783fc96ec8871e5efdeddc93ee8adc06/src/wsl.ts) — famílias Nerd Font, registro Windows e config do terminal.
+- [Hotkeys Windows](https://github.com/reddb-io/red-dev/blob/e7757978783fc96ec8871e5efdeddc93ee8adc06/src/hotkeys.ts) — dois atalhos globais.
+- [Config Zellij](https://github.com/reddb-io/red-dev/blob/e7757978783fc96ec8871e5efdeddc93ee8adc06/config/zellij/config.kdl) — tabela de teclas, sessão e clipboard.
+- [Web apps](https://github.com/reddb-io/red-dev/blob/e7757978783fc96ec8871e5efdeddc93ee8adc06/src/webapps.ts) — catálogo existente, mas não roteado no CLI.
+- [Providers e update](https://github.com/reddb-io/red-dev/blob/e7757978783fc96ec8871e5efdeddc93ee8adc06/src/providers.ts) — downloads, unpack, apt/winget e upgrade do sistema.
+- [Release pipeline](https://github.com/reddb-io/red-dev/blob/e7757978783fc96ec8871e5efdeddc93ee8adc06/.github/workflows/release.yml) — Linux/Windows x64, checksums e attestations.
+- [Release v0.17.1](https://github.com/reddb-io/red-dev/releases/tag/v0.17.1) — última stable no momento da pesquisa.
+
+### Omakub
+
+- [Repositório oficial](https://github.com/basecamp/omakub) — fonte primária do produto.
+- [README no commit auditado](https://github.com/basecamp/omakub/blob/c873902f1a5d8b0f54e2e52d565a77274a5941ff/README.md) — escopo Ubuntu e instalação.
+- [Bootstrap](https://github.com/basecamp/omakub/blob/c873902f1a5d8b0f54e2e52d565a77274a5941ff/boot.sh) — clone do checkout e seleção de ref.
+- [Instalador principal](https://github.com/basecamp/omakub/blob/c873902f1a5d8b0f54e2e52d565a77274a5941ff/install.sh) — fluxo terminal/desktop e política `set -e`.
+- [Programas de terminal](https://github.com/basecamp/omakub/tree/c873902f1a5d8b0f54e2e52d565a77274a5941ff/install/terminal) — bibliotecas, CLIs, runtimes e bancos.
+- [Programas de desktop](https://github.com/basecamp/omakub/tree/c873902f1a5d8b0f54e2e52d565a77274a5941ff/install/desktop) — apps, optional apps e configuração GNOME.
+- [Hotkeys GNOME](https://github.com/basecamp/omakub/blob/c873902f1a5d8b0f54e2e52d565a77274a5941ff/install/desktop/set-gnome-hotkeys.sh) — bindings de workspaces, apps, launcher e utilidades.
+- [Extensões GNOME e Tactile](https://github.com/basecamp/omakub/blob/c873902f1a5d8b0f54e2e52d565a77274a5941ff/install/desktop/set-gnome-extensions.sh) — sete extensões e layout de tiling.
+- [Dock](https://github.com/basecamp/omakub/blob/c873902f1a5d8b0f54e2e52d565a77274a5941ff/install/desktop/set-dock.sh) — favoritos curados.
+- [Bundles de tema](https://github.com/basecamp/omakub/tree/c873902f1a5d8b0f54e2e52d565a77274a5941ff/themes) — dez temas com oito assets cada.
+- [Mudança de tema](https://github.com/basecamp/omakub/blob/c873902f1a5d8b0f54e2e52d565a77274a5941ff/bin/omakub-sub/theme.sh) — aplicação coordenada das superfícies.
+- [Fontes](https://github.com/basecamp/omakub/blob/c873902f1a5d8b0f54e2e52d565a77274a5941ff/bin/omakub-sub/font.sh) — quatro famílias e integração GNOME/Alacritty/VS Code.
+- [Update](https://github.com/basecamp/omakub/blob/c873902f1a5d8b0f54e2e52d565a77274a5941ff/bin/omakub-sub/update.sh) e [migração](https://github.com/basecamp/omakub/blob/c873902f1a5d8b0f54e2e52d565a77274a5941ff/bin/omakub-sub/migrate.sh) — self-update Git e migrations.
+- [Manual de hotkeys](https://learn.omacom.io/1/read/29/hotkeys) — referência de uso oficial.
+- [Manual de tiling](https://learn.omacom.io/1/read/39/tiling) — modelo de janelas e Tactile.
+- [Manual de temas](https://learn.omacom.io/1/read/6/themes) — intenção de experiência; contém inventário desatualizado.
+- [Manual de fontes](https://learn.omacom.io/1/read/16/fonts) — famílias e comportamento de tamanho.
+- [Manual de update](https://learn.omacom.io/1/read/32/updating) — fluxo esperado pelo usuário.
+- [Release v1.5.0](https://github.com/basecamp/omakub/releases/tag/v1.5.0) — última stable no momento da pesquisa.
+
+### Iniciativa de agentes da 37signals/DHH
+
+- [house-skills no commit auditado](https://github.com/basecamp/house-skills/tree/d2d85abe034b0e6d4bfc3dbef646c427b05a385f) — conjunto opinionado de práticas, skills e plugins internos da 37signals.
+- [README do house-skills](https://github.com/basecamp/house-skills/blob/d2d85abe034b0e6d4bfc3dbef646c427b05a385f/README.md) — canais de distribuição e catálogo público.
+- [Skill agents-md](https://github.com/basecamp/house-skills/blob/d2d85abe034b0e6d4bfc3dbef646c427b05a385f/plugins/ai/skills/agents-md/SKILL.md) — política para contexto always-on, auditoria e progressive disclosure.
+- [Skill skill-crafting](https://github.com/basecamp/house-skills/blob/d2d85abe034b0e6d4bfc3dbef646c427b05a385f/plugins/ai/skills/skill-crafting/references/guide.md) — flywheel de co-desenvolvimento, exemplares e evals.
+- [Ralph–Lisa loop](https://github.com/basecamp/house-skills/blob/d2d85abe034b0e6d4bfc3dbef646c427b05a385f/plugins/dev/skills/ralph-lisa-loop/references/guide.md) — loop planner/implementer/self-review/Codex, rope length e close gate.
+- [Trust boundaries do repositório](https://github.com/basecamp/house-skills/blob/d2d85abe034b0e6d4bfc3dbef646c427b05a385f/AGENTS.md) — output externo é evidência, não instrução executável.
+- [basecamp-cli no commit auditado](https://github.com/basecamp/basecamp-cli/tree/3e86a0f0f50772eddbe0a607a5fc5c9c3809d7cf) — exemplo concreto de produto tornado agent-accessible por CLI estruturado.
+- [Basecamp Agent Skill publicada](https://github.com/basecamp/skills/blob/024f56a8e058c9fecdeea6aef9eb5e02c6f10022/skills/basecamp/SKILL.md) — superfície operacional gerada junto ao CLI.
+- [Install document para agentes](https://github.com/basecamp/skills/blob/024f56a8e058c9fecdeea6aef9eb5e02c6f10022/install.md) — instalação autônoma com objetivo, critérios de conclusão e verificações.
+- [Marketplace oficial 37signals](https://github.com/basecamp/claude-plugins) — plugins de Basecamp, HEY, Fizzy e house-skills.
+- [DHH: Promoting AI agents](https://world.hey.com/dhh/promoting-ai-agents-3ee04945) — posição sobre agentes autônomos com supervisão e revisão humana.
+- [DHH: Basecamp becomes agent accessible](https://world.hey.com/dhh/basecamp-becomes-agent-accessible-3ae6b949) — estratégia API + CLI + skill, sem exigir um harness específico.
+
+### RedSkills, agentes, macOS e assets RedDB
+
+- [RedSkills atual no commit auditado](https://github.com/reddb-io/red-skills/tree/0cfe62c5185f0b1c82292de880111087b4266e11) — hosts e instalador v3.
+- [RedSkills README](https://github.com/reddb-io/red-skills/blob/0cfe62c5185f0b1c82292de880111087b4266e11/README.md) — Claude, Codex, Gemini, OpenCode e Pi.
+- [Pi Coding Agent](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/README.md) e [Pi packages](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/packages.md) — instalação e extensibilidade oficiais.
+- [Hermes skills](https://github.com/NousResearch/hermes-agent/blob/main/website/docs/user-guide/features/skills.md) e [Hermes MCP](https://github.com/NousResearch/hermes-agent/blob/main/website/docs/user-guide/features/mcp.md) — diretórios externos e servidores MCP.
+- [Homebrew formula API](https://formulae.brew.sh/api/formula.json) e [cask API](https://formulae.brew.sh/api/cask.json) — disponibilidade oficial do catálogo macOS.
+- Releases: [toon/tq v0.13.0](https://github.com/reddb-io/toon/releases/tag/v0.13.0), [RedDB v1.23.2](https://github.com/reddb-io/reddb/releases/tag/v1.23.2), [red-request v0.65.1](https://github.com/reddb-io/red-request/releases/tag/v0.65.1), [dit v0.3.2](https://github.com/reddb-io/dit/releases/tag/v0.3.2), [red-ui v0.3.2](https://github.com/reddb-io/red-ui/releases/tag/v0.3.2), [RedSkills v3.3.18](https://github.com/reddb-io/red-skills/releases/tag/v3.3.18).
+
+## Hotlinks
+
+- [Manifesto local](../../src/manifest.ts)
+- [Temas locais](../../src/themes.ts)
+- [Aplicação de temas local](../../src/theme-apply.ts)
+- [Integrações editor/GNOME locais](../../src/theme-editors.ts)
+- [Hotkeys locais](../../src/hotkeys.ts)
+- [Zellij local](../../config/zellij/config.kdl)
+- [Agentes locais](../../src/agents.ts)
+- [Runtimes locais](../../src/runtimes.ts)
+- [Web apps locais](../../src/webapps.ts)
+- [Preferências locais](../../src/preferences.ts)
+- [Release workflow local](../../.github/workflows/release.yml)
+
+## Methodology and evidence model
+
+Esta auditoria não inferiu o produto apenas pelo README.
+
+1. O array `TOOLS` foi importado e serializado; foram encontrados 56 itens: 35 `core`, 7 `desktop`, 4 `wsl` e 10 `optional`.
+2. `AGENTS`, `OFFERED_RUNTIMES`, `THEMES`, `VSCODE_THEMES`, `WEB_APPS` e `NERD_FONTS` foram lidos diretamente do código.
+3. Todos os scripts de instalação do Omakub foram enumerados e agrupados por execução automática, escolha inicial e menu posterior.
+4. Os dez diretórios de tema do Omakub foram inspecionados arquivo por arquivo.
+5. Hotkeys foram derivadas do `gsettings`, Alacritty, Zellij, Readline e manual oficial.
+6. Assets de release RedDB foram consultados na API oficial do GitHub.
+7. Disponibilidade macOS foi consultada nas APIs oficiais Homebrew formula/cask.
+8. Funções sem call site foram classificadas como implementação desconectada, não como entrega de produto.
+9. `house-skills`, `basecamp-cli` e a skill publicada do Basecamp foram clonados, enumerados e lidos no commit atual; a análise separa método de desenvolvimento, distribuição de skills e acesso operacional ao produto.
+
+Legenda usada nas matrizes:
+
+- **default**: ocorre no caminho feliz sem o usuário adicionar o item;
+- **preselected**: aparece marcado, mas pode ser desmarcado;
+- **optional**: requer escolha deliberada;
+- **configured**: não apenas instalado; recebe integração ou baseline;
+- **present-only**: o produto detecta ou tematiza se já existir, mas não instala;
+- **dead path**: há código, mas não existe comando/menu/call site que o alcance.
+
+## Key Findings
+
+Os achados centrais desta auditoria são:
+
+1. Omakub continua muito à frente como workstation pronta: apps, GNOME, tiling, hotkeys, fontes e assets são uma experiência integrada, não apenas uma lista de pacotes.
+2. red-dev possui uma engine de convergência mais geral e um catálogo CLI maior, mas há promessas quebradas em temas, fontes, preferências, web apps, providers e assets de release.
+3. Os dez temas existem nominalmente nos dois produtos, porém sete temas red-dev têm integração Neovim incorreta; Rose Pine mistura paleta clara com política dark forçada.
+4. O inventário real do red-dev contém 56 itens, mas dependências implícitas ausentes (`wl-clipboard`, browser, FFmpeg, VS Code) impedem partes do produto de funcionar como descritas.
+5. A integração de agentes está à frente do Omakub em amplitude, mas red-dev chama RedSkills v2, não oferece Pi e não verifica Gemini/Pi/Hermes de ponta a ponta.
+6. A iniciativa 37signals adiciona um benchmark diferente: não só instalar agentes, mas tornar produtos e workflows agent-accessible por CLIs estruturados, skills portáveis, evals e trust boundaries.
+7. Para resolver a fragilidade de MCPs, a lição mais útil da 37signals é CLI-first com MCP opcional: JSON, introspecção, non-interactive mode, `doctor` e fallback explícito devem existir antes de o MCP ser considerado parte do caminho crítico.
+
+## Product scorecard
+
+| Dimensão | Omakub | red-dev | Resultado atual |
+|---|---|---|---|
+| Escopo de OS | Ubuntu 24.04+ GNOME, x86 | Ubuntu, WSL e Windows x64; Darwin apenas detectado | red-dev em ambição; Omakub em honestidade do suporte |
+| Distribuição | clone Git completo | binários compilados Linux/Windows, stable/next | red-dev |
+| Instalação | scripts lineares, aborta no primeiro erro | convergência por item, falha isolada | red-dev |
+| Self-update | `git pull` + migrations | ausente | Omakub |
+| Preview e diagnóstico | nenhum equivalente estrutural | `plan`, `doctor`, drift checks | red-dev |
+| Desktop Linux | GNOME inteiro configurado | tema/accent/wallpaper, poucos apps | Omakub |
+| Windows/WSL | fora de escopo | integração real e configuração compartilhada | red-dev |
+| macOS | fora de escopo | fora de escopo, com fallback perigoso para apt | nenhum; red-dev tem obrigação pela própria promessa |
+| Programas CLI | bom baseline Ubuntu | baseline maior e multiplataforma | red-dev |
+| Programas desktop | workstation amplo | essencialmente RedDB + terminal | Omakub |
+| Editor | VS Code baseline + LazyVim pronto | Neovim/VS Code são present-only | Omakub |
+| Temas | 10 bundles completos, 8 superfícies | 10 paletas, mais superfícies CLI, bugs de integração | empate conceitual; Omakub mais correto hoje |
+| Fontes | instala e sincroniza GNOME/Alacritty/VS Code | instala somente no host Windows via WSL | Omakub |
+| Hotkeys | sistema, apps, workspaces, tiling, terminal, emojis | 2 globais Windows + terminal/Zellij | Omakub |
+| Tiling | janelas via Tactile + terminal via Zellij | terminal via Zellij; PowerToys sem config | Omakub |
+| Linguagens | 8 escolhas; Ruby/Node preselected | 8 escolhas; Node preselected | equivalente, catálogos diferentes |
+| Bancos | MySQL/Redis preselected, Postgres opcional | nenhum | Omakub |
+| Agentes | não é o foco | 10 entradas, 3 preselected | red-dev |
+| Método agentic | house-skills/basecamp-cli ficam fora do Omakub, mas pertencem ao mesmo ecossistema 37signals | RedSkills é mais amplo; falta contrato CLI-first e fallback uniforme para MCP | vantagem distribuída; padrões complementares |
+| Ferramentas RedDB | não se aplica | `red`, `tq`, red-request, dit, red-ui, RedSkills | red-dev |
+| Ownership de config | frequentemente substitui arquivos | tenta preservar/mesclar e mantém backups | red-dev |
+| Validação real | produto maduro em Ubuntu, pouca automação | muitos testes unitários, pouca E2E por OS real | lacuna nos dois, mais crítica no red-dev |
+
+## Complete red-dev installation inventory
+
+Fonte: [`src/manifest.ts`](https://github.com/reddb-io/red-dev/blob/e7757978783fc96ec8871e5efdeddc93ee8adc06/src/manifest.ts).
+
+### Core — 35 items
+
+| Item | Ubuntu/WSL provider ou asset | Windows provider ou asset | Observação |
+|---|---|---|---|
+| git | `apt:git` | `winget:Git.Git` | default |
+| curl | `apt:curl` | `winget:cURL.cURL` | default |
+| unzip | `apt:unzip` | skip, expansão nativa | default onde necessário |
+| ripgrep | `apt:ripgrep` | `winget:BurntSushi.ripgrep.MSVC` | comando `rg` |
+| fd | `apt:fd-find` | `winget:sharkdp.fd` | normaliza `fdfind`/`fd` |
+| bat | `apt:bat` | `winget:sharkdp.bat` | normaliza `batcat`/`bat` |
+| eza | `apt:eza` | `winget:eza-community.eza` | aliases `ls`, `lt` |
+| zoxide | `apt:zoxide` | `winget:ajeetdsouza.zoxide` | ativado no shell |
+| fzf | `apt:fzf` | `winget:junegunn.fzf` | keybindings ativados |
+| btop | `apt:btop` | `winget:aristocratos.btop4win` | tema só aplicado no ramo não Windows |
+| jq | `apt:jq` | `winget:jqlang.jq` | default |
+| tq | `reddb-io/toon:tq-linux-x86_64` | `tq-windows-x86_64.exe` | RedDB, bare binary |
+| red | `reddb-io/reddb:red-linux-x86_64` | `red-windows-x86_64.exe` | valida assinatura para não confundir com GNU ed |
+| starship | release `starship-x86_64-unknown-linux-gnu.tar.gz` | `winget:Starship.Starship` | prompt principal |
+| atuin | release `atuin-x86_64-unknown-linux-musl.tar.gz` | `winget:Atuinsh.Atuin` | histórico/Ctrl-R |
+| carapace | release `carapace-bin_*_linux_amd64.deb` | `winget:rsteube.Carapace` | completions |
+| direnv | `apt:direnv` | `winget:direnv.direnv` | hook ativado |
+| delta | `apt:git-delta` | `winget:dandavison.delta` | configurado como pager Git |
+| yazi | release `yazi-x86_64-unknown-linux-gnu.zip` | `winget:sxyazi.yazi` | função shell `y` integrada |
+| tldr | release `tealdeer-linux-x86_64-musl` | `winget:dbrgn.tealdeer` | cache inicial baixado |
+| fastfetch | PPA `zhangsongcui3371/fastfetch` | `winget:Fastfetch-cli.Fastfetch` | PPA ainda não validado em Ubuntu 26 |
+| gh | repositório apt oficial | `winget:GitHub.cli` | default |
+| lazygit | release `lazygit_*_Linux_x86_64.tar.gz` | `winget:JesseDuffield.lazygit` | default |
+| lazydocker | release `lazydocker_*_Linux_x86_64.tar.gz` | `winget:JesseDuffield.Lazydocker` | default |
+| zellij | release `zellij-x86_64-unknown-linux-musl.tar.gz` | `winget:Zellij.Zellij` | sessão automática e tiling de terminal |
+| mise | repositório apt oficial | `winget:jdx.mise` | owner dos runtimes |
+| neovim | PPA `neovim-ppa/unstable` | `winget:Neovim.Neovim` | binário apenas; sem starter config |
+| docker | repo apt + CE/CLI/containerd/buildx/compose | `winget:Docker.DockerDesktop` | adiciona grupo no Linux |
+| dotfiles | builtin | builtin | 9 arquivos Bash + config Zellij |
+| alacritty-config | builtin | builtin | theme/font/shell/keys e arquivo principal |
+| runtimes | builtin | builtin | Node LTS default |
+| blesh | builtin | builtin | instalado, desabilitado por default |
+| shared-root | builtin | builtin | config WSL/Windows compartilhável |
+| hotkeys | builtin, skip fora de Windows/WSL | builtin | dois atalhos globais Windows |
+| red-skills | builtin, instalador RedSkills v2 | builtin | só roda se encontrar host suportado conhecido |
+
+### Desktop — 7 items
+
+| Item | Ubuntu desktop | Windows desktop | Observação |
+|---|---|---|---|
+| gnome-tweaks | `apt:gnome-tweaks` | skip | único utilitário GNOME instalado |
+| alacritty | `apt:alacritty` | `winget:Alacritty.Alacritty` | terminal padrão conceitual |
+| flatpak | `apt:flatpak` | skip | não adiciona Flathub nem plugin GNOME Software |
+| red-request | installer oficial `--no-color` | asset `red-request-windows-x86_64-setup.exe /S` | configurado pelo vendor |
+| red-ui | asset `red-ui_*_amd64.deb` | **skip stale: “não há Windows build”** | release atual já possui EXE/MSI Windows |
+| dit | installer oficial `--yes --no-service` | asset `dit-windows-x86_64.exe` | serviço Linux deliberadamente desativado |
+| wsl-sync | skip em Linux | builtin em Windows | instala/sincroniza red-dev dentro da distro |
+
+### WSL — 4 items
+
+| Item | Provider | Entrega |
+|---|---|---|
+| wsl-interop | builtin | preserva execução de `.exe` quando systemd-binfmt limpa o registro |
+| nerd-font | builtin | instala a fonte no host Windows, onde o terminal renderiza |
+| alacritty-host | winget através do host | instala Alacritty Windows a partir do WSL |
+| windows-terminal | builtin | escreve perfil, esquema, fonte e shell no Windows Terminal |
+
+### Optional — 10 items
+
+No primeiro run, todos os disponíveis são preselected, exceto os marcados “off”.
+
+| Item | Ubuntu | Windows | Default da seleção |
+|---|---|---|---|
+| PowerToys | skip | `winget:Microsoft.PowerToys` | preselected no Windows |
+| Blender | builtin release oficial | `winget:BlenderFoundation.Blender` | off, aproximadamente 1.2 GB |
+| RedSkills VS Code | build/install builtin | build/install builtin | off |
+| RedSkills Herdr | build/install builtin | skip | off |
+| just | `apt:just` | `winget:Casey.Just` | preselected |
+| duf | `apt:duf` | `winget:muesli.duf` | preselected |
+| dust | release `dust-*-x86_64-unknown-linux-musl.tar.gz` | `winget:bootandy.dust` | preselected |
+| hyperfine | `apt:hyperfine` | `winget:sharkdp.hyperfine` | preselected |
+| glow | release `glow_*_Linux_x86_64.tar.gz` | `winget:charmbracelet.glow` | preselected |
+| gitui | release `gitui-linux-x86_64.tar.gz` | `winget:StephanDilly.gitui` | preselected |
+
+### Agents — 10 catalog entries
+
+Fonte: [`src/agents.ts`](https://github.com/reddb-io/red-dev/blob/e7757978783fc96ec8871e5efdeddc93ee8adc06/src/agents.ts).
+
+| Agent | Linux/WSL | Windows | First run | RedSkills verificado pelo red-dev |
+|---|---|---|---|---|
+| Claude Code | `https://claude.ai/install.sh` | `Anthropic.ClaudeCode` | preselected | sim |
+| Codex CLI | npm `@openai/codex` | `OpenAI.Codex` | preselected | sim |
+| OpenCode | installer oficial | `SST.opencode` | preselected | sim |
+| Gemini CLI | npm `@google/gemini-cli` | npm | optional | não; v3 suporta, red-dev chama v2 |
+| T3 Code | desktop-only | `T3Tools.T3Code` | optional Windows | não aplicável |
+| Herdr | `https://herdr.dev/install.sh` | indisponível | optional | plugin RedSkills separado, optional/off |
+| OpenClaw | installer oficial | npm `openclaw` | optional | não |
+| Hermes Agent | installer oficial | npm `hermes-agent` | optional | não |
+| Claude Desktop | indisponível neste catálogo Linux | `Anthropic.Claude` | optional Windows | não aplicável |
+| Codex Desktop | indisponível neste catálogo Linux | Microsoft Store `9PLM9XGG6VKS` | optional Windows | não aplicável |
+
+**Ausência crítica:** Pi não está no catálogo, embora o instalador RedSkills v2 chamado pelo próprio red-dev já saiba instalar packages no Pi quando o comando `pi` existe.
+
+### Runtimes — 8 choices
+
+| Runtime | Versão escolhida pelo red-dev | Default |
+|---|---|---|
+| Node.js | `node@lts` | sim |
+| Bun | `bun@latest` | não |
+| Deno | `deno@latest` | não |
+| Python | `python@3.13` | não |
+| Go | `go@latest` | não |
+| Rust | `rust@stable` | não |
+| Ruby | `ruby@3.4` | não |
+| Java | `java@lts` | não |
+
+Todos são geridos por mise, exceto Rust, cuja semântica interna do mise pode usar rustup. Node habilita corepack quando possível.
+
+### Web apps — 6 entries, currently a dead path
+
+| Web app | URL | O que existe |
+|---|---|---|
+| ChatGPT | `chatgpt.com` | `.desktop` Linux + icon CDN |
+| Claude | `claude.ai` | `.desktop` Linux + icon CDN |
+| Google Photos | `photos.google.com` | `.desktop` Linux + icon CDN |
+| Google Contacts | `contacts.google.com` | `.desktop` Linux + icon CDN |
+| Tailscale | admin web | `.desktop` Linux + icon CDN |
+| GitHub | `github.com` | `.desktop` Linux + icon CDN |
+
+O módulo exige Chrome/Chromium/Brave/Edge, mas o red-dev não instala nenhum browser. Também não há referência a `WEB_APPS` fora de `src/webapps.ts`; portanto, nenhuma entrada de CLI ou TUI permite chegar a essa funcionalidade. Windows e macOS não têm adapters.
+
+## Complete Omakub installation inventory
+
+Fonte: árvore oficial [`install/`](https://github.com/basecamp/omakub/tree/c873902f1a5d8b0f54e2e52d565a77274a5941ff/install).
+
+### Bootstrap and terminal base
+
+O caminho padrão faz `apt update`, `apt upgrade`, instala `curl`, `git`, `unzip` e depois executa todos os scripts em `install/terminal/*.sh`.
+
+#### Development libraries and clients
+
+| Grupo | Pacotes default |
+|---|---|
+| Build | build-essential, pkg-config, autoconf, bison, clang, rustc, pipx |
+| Runtime headers | libssl-dev, libreadline-dev, zlib1g-dev, libyaml-dev, libncurses5-dev, libffi-dev, libgdbm-dev, libjemalloc2 |
+| Images/PDF | libvips, imagemagick, libmagickwand-dev, mupdf, mupdf-tools |
+| Data clients | redis-tools, sqlite3, libsqlite3-0, libmysqlclient-dev, libpq-dev, postgresql-client, postgresql-client-common |
+
+#### Default terminal tools
+
+| Tool | Provider/asset | Configuration |
+|---|---|---|
+| fzf | apt | Bash completion/keybindings |
+| ripgrep | apt | none |
+| bat | apt | alias `batcat` → `bat` |
+| eza | apt | aliases `ls`, `lt` |
+| zoxide | apt | `cd` aliased to `z` |
+| plocate | apt | none |
+| apache2-utils | apt | none |
+| fd-find | apt | alias `fd` |
+| btop | apt | config + Tokyo Night theme |
+| fastfetch | PPA | config if absent |
+| GitHub CLI | repo apt oficial | none |
+| LazyDocker | latest GitHub tarball | `/usr/local/bin` |
+| LazyGit | latest GitHub tarball | config directory |
+| Neovim | stable x86_64 tarball | LazyVim starter completo quando ausente |
+| luarocks | apt | suporte LazyVim |
+| tree-sitter-cli | apt | suporte LazyVim |
+| Zellij | latest GitHub tarball | config + Tokyo Night |
+| Docker Engine | repo oficial | daemon config, group, buildx, compose, rootless extras |
+| mise | repo apt oficial | runtime owner |
+| gum 0.17.0 | GitHub `.deb` pinado | UI do Omakub |
+
+### Default desktop applications
+
+Executados automaticamente quando `XDG_CURRENT_DESKTOP` contém GNOME.
+
+| App/capability | Provider | Configuration adicional |
+|---|---|---|
+| Flatpak | apt | Flathub + GNOME Software plugin |
+| Alacritty | apt | config completa, theme/font/size, default terminal |
+| Google Chrome | `.deb` oficial | default browser |
+| Flameshot | apt | Ctrl+Print global |
+| GNOME Sushi | apt | Space preview no Files |
+| GNOME Tweaks | apt | instalado |
+| LibreOffice | apt | app grid folder |
+| LocalSend | GitHub `.deb` | dock quando presente |
+| Obsidian | GitHub `.deb` | dock quando presente |
+| Pinta | Flatpak | dock quando presente |
+| Signal | repo apt oficial | dock quando presente |
+| Typora | repo apt oficial | temas iA Writer claro/escuro |
+| VLC | apt | instalado |
+| VS Code | repo apt Microsoft | baseline settings + Tokyo Night extension |
+| wl-clipboard | apt | clipboard Neovim/Wayland |
+| Xournal++ | apt | PDFs/anotações |
+| Ulauncher | PPA | autostart, tema dark, Super+Space |
+| Fonts | Nerd Fonts + iA Writer Mono | fontconfig e integração GNOME |
+
+### First-run preselected options
+
+| Categoria | Preselected | Available but off |
+|---|---|---|
+| Apps | 1Password, Spotify, Zoom | Dropbox |
+| Languages | Ruby on Rails, Node.js | Go, PHP, Python, Elixir, Rust, Java |
+| Databases | MySQL 8.4, Redis 7 | PostgreSQL 16 |
+
+Os bancos são containers Docker com restart `unless-stopped`, binds somente em `127.0.0.1` e autenticação local simplificada para desenvolvimento.
+
+### Optional apps from the Omakub menu
+
+| Categoria | Apps/capabilities |
+|---|---|
+| Segurança/sync | 1Password + CLI, Dropbox, Tailscale |
+| Browser/comunicação | Brave, Discord, Zoom |
+| Áudio/vídeo | Audacity, OBS Studio, Spotify |
+| Imagem | Gimp |
+| Desenvolvimento/hardware | ASDControl, Geekbench, Mainline Kernels, Ollama |
+| Games/VM | Minecraft, RetroArch, Steam, VirtualBox |
+| Editors | Cursor, Doom Emacs, RubyMine, Windsurf, Zed |
+| Web apps | ChatGPT, Google Photos, Google Contacts, Tailscale |
+
+Há ainda um helper de Windows 11/virtio acessível pelo seletor de arquivos de installers, mas não aparece como entrada principal do menu.
+
+### Default desktop launchers and web apps
+
+Omakub cria oito `.desktop` próprios durante a instalação:
+
+| Launcher | Destino |
+|---|---|
+| About | Fastfetch dentro de Alacritty |
+| Activity | btop dentro de Alacritty |
+| Docker | LazyDocker dentro de Alacritty |
+| Neovim | nvim dentro de Alacritty |
+| Omakub | painel Omakub dentro de Alacritty |
+| Basecamp | Chrome app para 37signals Launchpad |
+| HEY | Chrome app para HEY |
+| WhatsApp | Chrome app para WhatsApp Web |
+
+Os quatro web apps opcionais usam o mesmo padrão `google-chrome --app`, baixam ícones e entram na pasta GNOME “Web Apps”.
+
+## Program-by-program gap analysis
+
+### Shared baseline
+
+Ambos instalam Git, curl, unzip, ripgrep, fd, bat, eza, zoxide, fzf, btop, fastfetch, GitHub CLI, LazyGit, LazyDocker, Zellij, mise, Neovim e Docker.
+
+### red-dev-only strengths
+
+| Capability | red-dev | Valor |
+|---|---|---|
+| Structured data | jq + tq | JSON e TOON como baseline |
+| RedDB CLI | `red` | stack interna no core |
+| Shell UX | Starship, Atuin, Carapace, direnv | prompt, history, completions, env por diretório |
+| Git UX | delta | pager e conflitos `zdiff3` configurados |
+| File navigation | yazi | file manager terminal integrado ao cwd |
+| Help | tealdeer/tldr | cache inicial preparado |
+| Optional CLI | just, duf, dust, hyperfine, glow, gitui | toolbox moderno |
+| Cross-platform | winget + WSL bridge | catálogo substancial em Windows |
+
+### Omakub-only strengths
+
+| Capability | Omakub | Gap red-dev |
+|---|---|---|
+| Toolchain native | compiladores, headers e libs de imagem/PDF/database | projetos podem falhar no build após “setup concluído” |
+| Database clients | Redis, SQLite, MySQL e PostgreSQL clients/dev libs | red-dev instala Docker, mas nenhum client/database profile |
+| Browser | Chrome default | web apps do red-dev não conseguem funcionar numa máquina realmente limpa |
+| Editor baseline | VS Code settings + LazyVim starter | red-dev tematiza apenas se já existir |
+| Clipboard Linux | wl-clipboard | red-dev configura Zellij para `wl-copy`, mas não instala o comando |
+| Launcher | Ulauncher | nenhum launcher no red-dev |
+| Screenshots | Flameshot + hotkey | nenhum fluxo equivalente |
+| Workstation | office, notes, media, communication, file transfer | perfil corporativo incompleto |
+| GNOME polish | extensions, dock, grid, six workspaces | quase ausente |
+| Databases | MySQL, Redis, Postgres Docker | ausente |
+
+### Concrete dependency mismatches in red-dev
+
+1. Zellij recebe `copy_command "wl-copy"` no desktop Linux, mas `wl-clipboard` não está no manifesto.
+2. A função `webm2mp4` chama `ffmpeg`, mas `ffmpeg` não é instalado.
+3. Web apps exigem browser Chromium-family, mas nenhum é instalado.
+4. A extensão RedSkills VS Code pode ser oferecida sem VS Code/Codium/Cursor; o código então apenas pula.
+5. A integração de tema VS Code também é present-only.
+6. `red-skills-herdr` exige Herdr, mas ambos são optional e off; não existe seleção dependente que marque o plugin ao escolher Herdr.
+
+## Themes — complete inventory
+
+### Bundle shape
+
+Cada tema Omakub contém exatamente oito assets funcionais:
+
+1. `alacritty.toml`
+2. `zellij.kdl`
+3. `btop.theme`
+4. `neovim.lua`
+5. `vscode.sh`
+6. `gnome.sh`
+7. `tophat.sh`
+8. `background.jpg` ou `background.png`
+
+O red-dev define cada tema como uma paleta central de 20 cores e um nome Neovim. A partir dela, gera Alacritty, Windows Terminal, Zellij, btop, lazygit, wallpaper e accents. Integrações que não aceitam uma paleta arbitrária usam mappings.
+
+O modelo central do red-dev reduz duplicação e favorece adapters multiplataforma. O bundle explícito do Omakub, porém, força cada tema a provar que todas as superfícies existem. O red-dev hoje permite que uma paleta seja adicionada sem um plugin Neovim, extension VS Code ou wallpaper versionado correspondente.
+
+### Theme-by-theme compatibility
+
+| Tema | Omakub GNOME/mode | Omakub Neovim | Omakub VS Code | red-dev Neovim | red-dev VS Code | red-dev wallpaper |
+|---|---|---|---|---|---|---|
+| Tokyo Night | purple/dark | `tokyonight` | `enkia.tokyo-night` | plugin correto | correto | committed + runtime |
+| Catppuccin | magenta/dark | `catppuccin` | `Catppuccin.catppuccin-vsc` | plugin correto | correto | committed + runtime |
+| Gruvbox | sage/dark | `ellisonleao/gruvbox.nvim` / `gruvbox` | `jdinhlife.gruvbox` | plugin correto | correto | committed + runtime |
+| Everforest | bark/dark | `neanias/everforest-nvim` | `sainnhe.everforest` | **não instala plugin; fallback declara Tokyo Night** | correto | runtime-only |
+| Kanagawa | purple/dark | `rebelot/kanagawa.nvim` | `qufiwefefwoyn.kanagawa` | **não instala plugin** | correto | runtime-only |
+| Matte Black | orange/dark | `tahayvr/matteblack.nvim` / `matteblack` | `CleanThemes.matte-black-theme` | **usa `matte-black`, nome divergente, e plugin errado** | correto | runtime-only |
+| Nord | blue/dark | `EdenEast/nightfox.nvim` / `nordfox` | `arcticicestudio.nord-visual-studio-code` | **usa `nord` e plugin errado** | correto | runtime-only |
+| Osaka Jade | green/dark | `ribru17/bamboo.nvim` / `bamboo` | Ocean Green approximation | **usa `osaka-jade` e plugin errado** | **sem mapping** | runtime-only |
+| Ristretto | grey/dark | `gthelding/monokai-pro.nvim` / filter Ristretto | Monokai Pro Ristretto | **usa `ristretto` e plugin errado** | correto | runtime-only |
+| Rose Pine | red/**light** | `rose-pine-dawn` | Rosé Pine Dawn | **usa `rose-pine`, plugin errado** | usa Rosé Pine, não Dawn | runtime-only; sistema forçado dark |
+
+“Plugin errado” significa: o arquivo que o red-dev gera declara `folke/tokyonight.nvim` como fallback e pede outro colorscheme. Se o usuário já tiver instalado o plugin necessário por conta própria, pode funcionar; o red-dev não garante isso. Em uma configuração nova, a integração não é autocontida.
+
+### Surface coverage by platform
+
+| Superfície | Omakub Ubuntu | red-dev Ubuntu | red-dev WSL | red-dev Windows |
+|---|---|---|---|---|
+| Alacritty | 10/10 | 10/10 | host Windows 10/10 | 10/10 |
+| Windows Terminal | n/a | n/a | 10/10 | 10/10 |
+| Zellij | 10/10 | 10/10 | 10/10 | **não chamado pelo ramo Windows** |
+| btop | 10/10 | 10/10 | 10/10 | **não chamado** |
+| Neovim | 10/10 autocontido | 3/10 garantidos | 3/10 garantidos | 3/10 garantidos |
+| VS Code | 10/10 | 9/10, present-only | 9/10, host-aware | 9/10, present-only |
+| GNOME mode/accent | 10/10 + GTK/icon/cursor | 10 aplicados, Rose incorreto | n/a | n/a |
+| Windows dark/accent | n/a | n/a | 10 aplicados, Rose incorreto | 10 aplicados, Rose incorreto |
+| TopHat | 10/10 | não instala nem tematiza | n/a | n/a |
+| Wallpaper | 10 imagens | 10 gerados runtime | 10 gerados no host | 10 gerados |
+| bat | não | 10 aproximações | 10 aproximações | **não chamado** |
+| delta | não | 10 aproximações | 10 aproximações | **não chamado** |
+| lazygit | não | 10 quando config é gerenciável | idem | **não chamado** |
+| OpenCode | não | segue `system` | segue `system` | **não chamado** |
+| Herdr | não | 4 temas nativos, 6 seguem terminal | idem | indisponível |
+| fzf | não | função de cores existe, sem call site | idem | idem |
+
+### Theme semantics and correctness gaps
+
+- Omakub muda GTK theme, icon theme, cursor theme, accent, light/dark, TopHat e wallpaper. red-dev no GNOME muda apenas `color-scheme` e `accent-color`.
+- Rose Pine é explicitamente light no Omakub. O background do red-dev é `#FAF4ED`, também claro, mas `applyGnomeTheme()` e `applyWindowsDesktopTheme()` afirmam que todos os temas são dark e forçam dark mode.
+- Omakub aproxima Osaka Jade no VS Code com Ocean Green. O red-dev prefere pular; essa honestidade é aceitável, mas a cobertura precisa aparecer na UI como 9/10, não como “tema aplicado everywhere”.
+- bat e delta não recebem a paleta exata; recebem o tema embutido mais próximo. A UI deve rotular isso como approximation.
+- lazygit recebe cores exatas, mas se o config já existir e não tiver o marker red-dev, é deixado intacto.
+- VS Code settings com comentários/trailing commas são válidos para o editor, mas o red-dev usa `JSON.parse` e não aplica nada. Omakub evita isso porque cria seu próprio baseline, embora seu `sed` também dependa da chave já existir.
+
+## Assets — complete comparison
+
+### Distribution assets
+
+#### red-dev v0.17.1
+
+| Asset | Bytes | Papel |
+|---|---:|---|
+| `red-dev-linux-x64` | 95,537,280 | Linux e WSL x86_64 |
+| `red-dev-windows-x64.exe` | 99,427,840 | Windows x86_64 |
+| `SHA256SUMS` | 174 | checksums canônicos |
+| `checksums.txt` | 174 | compatibilidade de naming |
+
+O release workflow também tenta publicar build provenance attestation. Os bootstraps, contudo, não validam o SHA256 nem a attestation: Linux baixa e move; Windows valida somente o tamanho retornado pela API.
+
+#### Omakub v1.5.0
+
+A release não publica binários ou bundles próprios. `boot.sh` remove `~/.local/share/omakub`, clona o repositório completo e faz checkout da ref stable/master. Os assets viajam no Git checkout.
+
+### Static/configuration assets
+
+#### red-dev repository
+
+- 3 wallpapers PNG committed: Tokyo Night, Catppuccin e Gruvbox, todos 2560×1440;
+- 3 SVGs de documentação: hero, stack e themes;
+- 9 arquivos Bash embedded: rc, path, init, aliases, functions, prompt, shared, zellij autostart e inputrc;
+- 1 config Zellij base com 287 linhas;
+- 1 hook Castle MCP;
+- configurações Alacritty/Windows Terminal/tema/wallpaper são geradas por código, não arquivos estáticos.
+
+O script `generate-wallpapers.ts` percorre dez temas, mas sete PNGs não estão versionados. Isso contradiz o comentário de `wallpaper.ts` e deixa a revisão visual incompleta. O runtime continua capaz de gerar os dez.
+
+#### Omakub repository
+
+- 80 assets de tema: 10 temas × 8 arquivos;
+- 10 wallpapers fotográficos/ilustrados, de 2912×1632 a 6930×3960;
+- 9 ícones PNG próprios para launchers;
+- configs estáticos de Alacritty, btop, fastfetch, inputrc, LazyVim, Typora, Ulauncher, VS Code, XCompose e Zellij;
+- 8 scripts de `.desktop` próprios;
+- 16 migrations timestamped no commit auditado.
+
+### Wallpaper strategy
+
+| Aspecto | Omakub | red-dev |
+|---|---|---|
+| Fonte | imagem curada por tema | gradiente determinístico da paleta |
+| Quantidade entregue no repo | 10 | 3 de 10 |
+| Dependência de rede ao aplicar | não | não |
+| Resolução | variável, majoritariamente alta | fixa 2560×1440 |
+| Identidade visual | forte e distinta | coerente, porém mais genérica |
+| Licenciamento/proveniência | não documentado por asset | geração própria evita dúvida |
+| Windows | não | sim |
+| macOS | não | não |
+
+Oportunidade: manter wallpapers gerados como fallback universal, mas permitir assets art-directed por tema com metadata de licença, autor, hash, aspect ratios e crop/focal point.
+
+### Current RedDB release assets by platform
+
+| Produto | Linux x64 | Linux ARM | Windows | macOS Intel | macOS ARM | Gap no manifesto red-dev |
+|---|---|---|---|---|---|---|
+| tq/toon v0.13.0 | sim | aarch64 | x64 | sim | sim | só Linux/Windows x64 |
+| RedDB `red` v1.23.2 | sim | aarch64 + armv7 | x64 | sim | sim | só Linux/Windows x64 |
+| red-request v0.65.1 | deb/AppImage | aarch64 | setup x64 | DMG | DMG | sem mac; Linux ARM ausente |
+| dit v0.3.2 | sim | aarch64 + armv7 | x64 + ARM | sim | sim | só Linux/Windows x64 |
+| red-ui v0.3.2 | deb/AppImage | aarch64 | EXE + MSI | DMG/universal | DMG/universal | Windows incorretamente marcado skip; mac ausente |
+| RedSkills v3.3.18 | scripts/assets JS | universal | via Bash/Git Bash | via shell | via shell | red-dev chama v2 e verifica somente 3 hosts |
+
+Isso muda a avaliação de viabilidade: a maior parte da stack RedDB já está pronta para macOS e ARM. O gargalo está no red-dev, não nos produtos dependentes.
+
+## Fonts — complete comparison
+
+| Produto | Família | Asset Nerd Fonts | Default |
+|---|---|---|---|
+| Omakub | Caskaydia Mono | CascadiaMono.zip | sim |
+| Omakub | Fira Mono | FiraMono.zip | não |
+| Omakub | JetBrains Mono | JetBrainsMono.zip | não |
+| Omakub | Meslo | Meslo.zip | não |
+| red-dev | FiraCode | FiraCode.zip | sim |
+| red-dev | JetBrains Mono | JetBrainsMono.zip | não |
+| red-dev | Hack | Hack.zip | não |
+| red-dev | Caskaydia Cove | CascadiaCode.zip | não |
+
+Ambos oferecem tamanho 7–14. Omakub começa em 9; o red-dev gera 11 quando nenhum tamanho é passado.
+
+### Omakub font behavior
+
+- instala arquivos em `~/.local/share/fonts` e executa `fc-cache`;
+- configura monospace do GNOME;
+- troca `font.toml` do Alacritty;
+- troca `editor.fontFamily` do VS Code;
+- tamanho afeta Alacritty e apps dentro do terminal, não VS Code.
+
+### red-dev font behavior and defects
+
+- a implementação real de instalação chama o font store Windows e só é executada no scope WSL;
+- Ubuntu desktop recebe Alacritty apontando para uma família que o red-dev não instalou;
+- Windows nativo não executa o scope WSL e também pode receber uma família ausente;
+- o `doctor` verifica fonte apenas em Windows/WSL e responde `n/a` no Ubuntu;
+- o menu salva `font` e `fontSize`, porém `ApplyContext` contém somente os defaults da invocação;
+- `configureAlacritty()` usa tamanho 11 quando `fontSize` não é passado;
+- mudar o tema ou rodar converge/update pode sobrescrever `font.toml` com FiraCode tamanho 11, mesmo que preferences registrem outra escolha.
+
+P0: transformar fonte em recurso por plataforma com `install`, `apply`, `verify` e `current`, e fazer todo comando ler a preferência persistida antes de montar o plano.
+
+## Hotkeys — complete comparison
+
+### Omakub system/navigation hotkeys
+
+Fonte: [código GNOME](https://github.com/basecamp/omakub/blob/c873902f1a5d8b0f54e2e52d565a77274a5941ff/install/desktop/set-gnome-hotkeys.sh) e [manual](https://learn.omacom.io/1/read/29/hotkeys).
+
+| Hotkey | Ação |
+|---|---|
+| Super+Space | Ulauncher |
+| Super+A | app grid GNOME |
+| Super+W | fechar janela |
+| Super+Up | maximizar |
+| Super+Backspace | iniciar resize |
+| Shift+F11 | fullscreen com chrome/título |
+| Super+1…6 | ir ao workspace 1…6 |
+| Shift+Super+1…4 | mover janela ao workspace; documentado no manual, mas não redefinido explicitamente pelo script auditado |
+| Alt+1…9 | abrir/focar app fixado no dock |
+| Shift+Alt+1 | nova janela Chrome |
+| Shift+Alt+2 | nova janela Alacritty |
+| Ctrl+Print | captura de região Flameshot |
+| Shift+AudioPlay | próxima faixa |
+| Ctrl+F1 | brilho Apple display para baixo |
+| Ctrl+F2 | brilho para cima |
+| Ctrl+Shift+F2 | brilho máximo |
+
+O manual ainda mostra Super+1…4, mas o código atual configura seis workspaces. Esta é uma divergência de documentação.
+
+### Omakub window tiling hotkeys
+
+| Hotkey | Ação |
+|---|---|
+| Super+Left | metade esquerda GNOME |
+| Super+Right | metade direita GNOME |
+| Super+Up | maximizar |
+| Super+T | overlay Tactile |
+| Super+Shift+T | settings Tactile |
+| Super+T, W, S | centro vertical |
+| Super+T, Q, A | coluna esquerda |
+| Super+T, E, D | coluna direita |
+| Super+T, Q, Q | superior esquerda |
+| Super+T, A, A | inferior esquerda |
+
+O Tactile é configurado como quatro colunas com pesos `1,2,1,0`, duas linhas `1,1` e gap 32. O modelo visual efetivo possui seis regiões úteis.
+
+### red-dev global hotkeys
+
+| Plataforma | Hotkey | Ação |
+|---|---|---|
+| Windows/WSL host | Ctrl+Alt+T | Alacritty quando disponível; fallback WSL |
+| Windows/WSL host | Ctrl+Alt+Shift+T | PowerShell elevado, com UAC |
+| Ubuntu | — | nenhum hotkey global configurado |
+| macOS | — | nenhum suporte |
+
+Os atalhos Windows são `.lnk` no Start Menu e não exigem AutoHotkey/PowerToys. É uma implementação elegante e pequena, mas cobre apenas abertura de terminal/admin.
+
+### Alacritty hotkeys
+
+| Ação | Omakub | red-dev |
+|---|---|---|
+| Fullscreen | F11 | F11 |
+| Paste Windows muscle memory | defaults do Alacritty | Ctrl+V e Ctrl+Shift+V |
+| Copy | defaults | Ctrl+Shift+C |
+| New terminal instance | GNOME Shift+Alt+2 | Ctrl+Shift+N dentro do terminal |
+| Increase font | não customizado | Ctrl+= |
+| Decrease font | não customizado | Ctrl+- |
+| Reset font | não customizado | Ctrl+0 |
+
+### Zellij terminal tiling
+
+Os dois projetos compartilham essencialmente a mesma tabela de bindings, em locked mode:
+
+| Hotkey/mode | Ação |
+|---|---|
+| Ctrl+G | desbloquear e entrar no modo normal |
+| Alt+Arrow ou Alt+H/J/K/L | navegar panes/tabs sem sair de locked |
+| Alt+N | novo pane |
+| Alt+= / Alt+- | aumentar/diminuir pane |
+| Alt+[ / Alt+] | trocar swap layout |
+| Alt+F | toggle floating panes |
+| Ctrl+G, P, R | novo pane à direita |
+| Ctrl+G, P, D | novo pane abaixo |
+| Ctrl+G, P, X | fechar pane |
+| Ctrl+G, P, F | fullscreen do pane |
+| Ctrl+G, T, N | nova tab |
+| Ctrl+G, T, R | renomear tab |
+| Ctrl+G, T, 1…9 | ir à tab |
+| Ctrl+G, O, D | detach |
+| Ctrl+G, O, W | session manager |
+| Ctrl+G, S, E | editar scrollback |
+| Ctrl+G, R, H/J/K/L | resize direcional |
+| Ctrl+Q em modo desbloqueado | sair do Zellij |
+
+O red-dev melhora a base com:
+
+- Zellij automático em qualquer shell interativo compatível, não só Alacritty;
+- exclusões para VS Code, JetBrains, Neovim, Emacs e tmux;
+- fallback para Bash se Zellij falhar;
+- session serialization e pane viewport serialization;
+- scrollback 50.000;
+- clipboard `clip.exe` em WSL/Windows e `wl-copy` no desktop Linux;
+- configuração compartilhável WSL/Windows.
+
+O problema é de framing: Zellij resolve tiling **dentro do terminal**. Ele não substitui tiling de janelas de browser, editor, Red Request e desktop apps. O comentário do manifesto usa Zellij como resposta multiplataforma ao Tactile/FancyZones, mas são camadas diferentes.
+
+### Readline, history and text input
+
+Ambos configuram Up/Down como prefix history search, completion case-insensitive, completions visíveis e comportamento melhor de symlinks/hidden files.
+
+- Omakub entrega Ctrl+R via fzf e um XCompose extenso, incluindo atalhos CapsLock para emojis.
+- red-dev entrega Ctrl+R via Atuin, Carapace completions, autocd/cdspell/globstar/direnv e não possui XCompose/emoji layer.
+
+### Hotkey product gap
+
+O red-dev precisa de um catálogo semântico, não de três arquivos independentes:
+
+```ts
+type ActionId =
+  | "launcher.open"
+  | "terminal.new"
+  | "terminal.admin"
+  | "window.close"
+  | "window.maximize"
+  | "window.tile.left"
+  | "window.tile.right"
+  | "window.tile.grid"
+  | "workspace.goto.1"
+  | "workspace.move.1"
+  | "app.focus.1"
+  | "screenshot.region";
+```
+
+Cada adapter GNOME, Windows e macOS deve declarar binding, dependency, conflict detection, apply e verify. A cheat sheet deve ser gerada desse mesmo schema.
+
+## Tiling and desktop coherence
+
+### Omakub model
+
+1. GNOME native split/maximize para laptop.
+2. Tactile para grids maiores.
+3. Seis workspaces fixos para isolamento de tarefas.
+4. Dock numerado via Alt+1…9.
+5. Zellij para panes/tabs/session dentro do terminal.
+6. Ulauncher para abrir qualquer aplicação sem navegação visual.
+
+### red-dev model today
+
+1. Zellij é o único tiling realmente configurado.
+2. PowerToys é preselected no Windows, mas FancyZones não recebe layout/config/hotkeys.
+3. Windows Snap Layouts ficam nos defaults do OS.
+4. GNOME não recebe Tactile, workspaces, dock ou launcher.
+5. macOS não tem adapter.
+
+### Recommended coherent model
+
+- **Terminal tiling:** Zellij em todas as plataformas.
+- **Window tiling:** Tactile ou equivalente GNOME; FancyZones/Snap no Windows; uma escolha oficial via ADR no macOS.
+- **Workspace semantics:** 1–6 com ações equivalentes, mesmo que o mecanismo varie.
+- **Launcher semantics:** Super/Win/Cmd+Space ou uma combinação sem conflito, adaptada por plataforma.
+- **Layout presets:** laptop 2-column, ultrawide 3-column, focus, presentation.
+- **Generated docs:** um único mapa visual de hotkeys por plataforma.
+
+## GNOME and desktop assets
+
+### Omakub GNOME extensions
+
+| Extension | Papel | Configuração principal |
+|---|---|---|
+| Tactile | tiling grid | 3 colunas úteis × 2 linhas, gap 32 |
+| Just Perfection | shell polish | animação, workspace, popup |
+| Blur My Shell | visual | blur no overview/dock |
+| Space Bar | workspaces | nomes e shortcuts |
+| Undecorate | remover title bars | menu de janela |
+| TopHat | métricas | cores por tema, network bits |
+| Alphabetical App Grid | organização | folders ao final |
+
+Omakub desabilita Tiling Assistant, AppIndicators, Ubuntu Dock e Desktop Icons NG antes de instalar sua camada.
+
+### red-dev GNOME behavior
+
+- instala `gnome-tweaks` e Flatpak;
+- ajusta light/dark e accent no theme switch;
+- aplica wallpaper;
+- não instala extensions, launcher, clipboard package, screenshots, dock, app grid ou workspace policy;
+- não registra hotkeys GNOME;
+- README admite ausência e falta de validação em hardware real.
+
+### Windows behavior
+
+red-dev é mais avançado que o Omakub por definição:
+
+- dark mode de apps e sistema;
+- accent DWM e prevalence;
+- wallpaper com refresh imediato via `SystemParametersInfo`;
+- Windows Terminal theme/font/profile;
+- Alacritty com Git Bash ou WSL escolhido;
+- PowerToys disponível;
+- shared config e distro sync.
+
+Mas a experiência ainda não é um desktop opinionado: não há FancyZones config, launcher/remapper config, dock/taskbar policy, workspace mapping ou equivalentes dos atalhos GNOME.
+
+## Shell, aliases and functions
+
+### Shared Omakub lineage
+
+Ambos fornecem aliases `ls/lsa/lt/lta`, navegação `../...`, `n`, `g`, `d`, `lzg`, `lzd`, `ff`, `compress/decompress` e funções `webm2mp4`, `iso2sd`, `web2app`.
+
+### red-dev additions
+
+- Git aliases completos: status, diff, staging, commits, switch, branches, push seguro, pull rebase, fetch prune, logs, stash, rebase e worktrees;
+- `gdm` para diff desde merge-base;
+- `mkcd`, `fe`, `fcd` e wrapper `y`;
+- `winopen` e `winpath` equivalentes em WSL/Git Bash;
+- PATH preservado/deduplicado, sem apagar interop WSL;
+- Starship, Atuin, Carapace, direnv e mise ativados;
+- config sharing para Starship, mise, Zellij, yazi, Atuin, bat e Git include.
+
+### Ownership difference
+
+Omakub move `~/.bashrc` para backup e o substitui integralmente. red-dev faz backup, adiciona uma linha de source e mantém seus próprios arquivos versionados em `~/.local/share/red-dev`. A política do red-dev é mais segura para uma ferramenta corporativa que será atualizada repetidamente.
+
+## Agents and RedSkills readiness
+
+### Current RedSkills host support
+
+| Host | RedSkills v2 called by red-dev | RedSkills v3 current | red-dev installs host | red-dev doctor verifies |
+|---|---|---|---|---|
+| Claude Code | sim | sim | sim | sim, source GitHub |
+| Codex | sim | sim | sim | sim, marketplace wiring |
+| OpenCode | sim | sim | sim | sim, manifest file |
+| Pi | sim | sim | **não** | não |
+| Gemini | não | sim | sim | não |
+| Hermes | não | não | sim | não |
+
+O primeiro relatório subestimou Pi: o instalador RedSkills v2 já suporta Pi packages. O gap está em `AGENTS` e em `SKILL_HOSTS`, não na inexistência de integração upstream.
+
+### What “ready” must mean
+
+Um host não está pronto apenas porque o executável responde:
+
+1. executável instalado;
+2. versão registrada;
+3. RedSkills wired no scope correto;
+4. skills `dev`, `memory`, `brain` visíveis;
+5. MCPs inicializam;
+6. hooks/plugins/statusline instalados quando suportados;
+7. source aponta para GitHub/canal atualizável, não snapshot congelado;
+8. smoke command por host passa;
+9. autenticação pendente é apresentada como HITL explícito.
+
+### Hermes path
+
+Hermes permite `skills.external_dirs` e MCPs em configuração. Um adapter inicial pode apontar para um diretório de skills compartilhadas. Isso não equivale automaticamente às superfícies completas de Claude/Codex/OpenCode; o caminho correto é adicionar suporte oficial no repositório RedSkills e consumir esse host adapter no red-dev.
+
+### Agent roadmap
+
+1. adicionar Pi ao `AGENTS` com installer oficial;
+2. mover red-dev para RedSkills v3;
+3. adicionar Pi e Gemini ao `SKILL_HOSTS`/doctor;
+4. criar contrato `SkillHostAdapter` com install/wire/verify/update/uninstall;
+5. implementar Hermes upstream em RedSkills;
+6. fazer a seleção de Herdr marcar/oferecer automaticamente o plugin RedSkills Herdr;
+7. garantir uma única versão RedSkills por máquina e reportar skew.
+
+## DHH/37signals agent initiative — deep comparison
+
+### Which repository the request refers to
+
+Há duas iniciativas oficiais próximas, mas com papéis diferentes:
+
+| Repositório | Papel | Unidade distribuída |
+|---|---|---|
+| [`basecamp/house-skills`](https://github.com/basecamp/house-skills) | método opinionado de trabalho com agentes | 11 skills em quatro plugins |
+| [`basecamp/basecamp-cli`](https://github.com/basecamp/basecamp-cli) + [`basecamp/skills`](https://github.com/basecamp/skills) | tornar o produto Basecamp operável por agentes | CLI versionado + skill publicada automaticamente |
+
+O primeiro é o repositório “super opinionated” sobre como configurar e conduzir agentes. O segundo é a materialização da tese pública do DHH: API abrangente, CLI amigável a máquina e skill que ensina qualquer harness a operar o produto.
+
+Commits auditados em 3 de agosto de 2026:
+
+- `house-skills`: `d2d85abe034b0e6d4bfc3dbef646c427b05a385f`;
+- `basecamp-cli`: `3e86a0f0f50772eddbe0a607a5fc5c9c3809d7cf`, release `v0.8.0`;
+- `basecamp/skills`: `024f56a8e058c9fecdeea6aef9eb5e02c6f10022`, sincronizado do `basecamp-cli v0.8.0`.
+
+### The 37signals stack is three layers, not one
+
+```text
+human intent
+  -> harness (Claude Code, Codex, OpenCode, Gemini, etc.)
+  -> house method (AGENTS.md + house-skills + hooks/evals)
+  -> product skill (Basecamp/HEY/Fizzy workflow knowledge)
+  -> structured CLI (JSON, introspection, auth, doctor, non-interactive mode)
+  -> product API
+```
+
+Essa separação é importante. A skill não implementa a API, o MCP não é o transporte obrigatório e o `AGENTS.md` não carrega o manual inteiro. Cada camada tem um contrato menor e verificável.
+
+### house-skills inventory
+
+O repositório contém quatro plugins Claude e uma visão unificada portável em `skills/`:
+
+| Plugin | Versão auditada | Skills | Função |
+|---|---:|---|---|
+| `ai` | 1.2.1 | `agents-md`, `install-md`, `skill-crafting` | contexto always-on, documentação executável e criação/evolução de skills |
+| `dev` | 1.1.1 | `address-pr-reviews`, `consult-outside-expert`, `ralph-lisa-loop` | review, consulta externa e execução iterativa |
+| `security` | 1.1.1 | `harden-github-actions` | pinning e hardening de GitHub Actions com `zizmor` |
+| `recap` | 0.1.1 | `basecamp-activity`, `git-activity`, `github-activity`, `recap` | coleta em átomos diários e síntese por período/audiência |
+
+Total: 11 skills. Os arquivos reais vivem em `plugins/<plugin>/skills`; `skills/` contém symlinks. Isso atende simultaneamente:
+
+- marketplace nativo Claude via `git-subdir`, incluindo hooks;
+- outros agentes via `npx skills add basecamp/house-skills`, que dereferencia a visão plana;
+- desenvolvimento sem duplicar o conteúdo das skills.
+
+O CI `bin/ci` valida essa topologia: todo symlink resolve, nenhum manifesto declara indevidamente um campo `skills` e nenhum arquivo real é criado na visão plana.
+
+### The opinionated AGENTS.md model
+
+A skill `agents-md` parte de uma premissa correta: instruções do repositório entram em toda sessão antes da primeira pergunta, portanto são o contexto mais caro. Cada linha é classificada:
+
+| Classe | Teste | Ação recomendada |
+|---|---|---|
+| `OBVIOUS` | derivável de `ls`, `--help` ou convenção do framework | remover |
+| `GOTCHA` | específico do repo e custaria uma rodada perdida | manter, começando pelo sintoma |
+| `TASTE` | preferência não recuperável pelo código | manter somente quando contraria o prior do modelo |
+| `POINTER` | profundidade necessária em alguns casos | apontar para arquivo canônico e quando abri-lo |
+
+Outras regras fortes:
+
+- alvo default de aproximadamente 100 linhas/2,5 mil tokens always-on;
+- não repetir README, help, scripts ou regras globais já carregadas;
+- preferir paths reais a exemplos inventados;
+- manter fora do arquivo estado efêmero de PR, branch, blocker ou tarefa;
+- mover profundidade para skills on-demand e regras path-scoped;
+- verificar todo comando, path, link, literal e contradição antes de publicar;
+- em repositório não confiável, fazer apenas auditoria estática e rejeitar symlinks/traversal;
+- `AGENTS.md` é o nome portável; Claude precisa de `CLAUDE.md`/`.claude/CLAUDE.md` importando ou apontando para ele.
+
+Esse modelo deve influenciar red-dev. Instalar RedSkills não basta se os projetos RedDB carregam instruções duplicadas, longas, contraditórias ou não verificadas.
+
+### Skill-crafting flywheel
+
+`skill-crafting` rejeita a ideia de escrever uma skill inteira em abstrato. O processo é:
+
+```text
+problema real
+  -> v0 mínima
+  -> executar em alvo real
+  -> observar falha/decisão repetida
+  -> atualizar guide/eval/exemplar
+  -> executar em outro alvo
+  -> repetir até passar cedo e com pouca intervenção
+```
+
+Os artefatos amadurecem por uso:
+
+- falha repetida vira eval;
+- decisão repetida vira regra;
+- output bom vira exemplar;
+- explicação grande sai de `SKILL.md` e vai para `references/`;
+- tradeoff de design pausa para decisão humana;
+- maturidade significa zero H/M aberto e duas rodadas consecutivas sem novos H/M no processo de revisão descrito.
+
+Há sobreposição direta com `dev:write-a-skill`, `dev:audit-skills` e `memory:improve-skills`. A oportunidade não é copiar outra skill de criação: é adotar o requisito de exemplares reais e evals executáveis como contrato comum do ecossistema RedSkills.
+
+### Ralph–Lisa: the strongest and most coupled idea
+
+O Ralph–Lisa loop é o elemento mais opinionado do repositório:
+
+```text
+implement
+  -> self-review independente
+  -> review externo por Codex
+  -> reconciliation
+  -> synthesis
+  -> derived close gate
+  -> nova rodada ou encerramento
+```
+
+Papéis:
+
+- Claude como orquestrador;
+- subagente planner/implementer;
+- subagente self-reviewer read-only;
+- Codex como reviewer externo independente;
+- humano como autoridade de steering e decisões obrigatórias.
+
+O usuário escolhe um `rope length` de 0 a 5. O número muda apenas quando o loop interrompe o humano; não reduz o padrão de qualidade. Mesmo em rope 5, autorização externa, mudança de escopo, ação destrutiva/irreversível, segurança/autenticação e ausência de convergência continuam sendo escaladas obrigatórias.
+
+O close gate é derivado dos registros de findings e disputes, não de contadores mutáveis:
+
+```text
+close = open_findings == 0
+     && open_disputes == 0
+     && implementation_complete
+     && eval_passed
+```
+
+Se cache e derivação divergem, o gate falha fechado. Findings recebem IDs, estado, evidência e cadeia `supersedes`; três rodadas sem resolver a mesma cadeia forçam intervenção humana. O log preserva as três rodadas mais recentes e compacta histórico antigo depois da oitava.
+
+O Codex é acessado preferencialmente por MCP, mantendo a thread entre rodadas. Porém o desenho exige fallback explícito:
+
+1. tentar MCP;
+2. repetir uma vez em erro/timeout;
+3. usar `codex exec` somente após opt-in;
+4. cair para self-review somente naquela rodada, registrar finding M e tentar restaurar MCP na próxima;
+5. nunca degradar silenciosamente.
+
+Esse é o padrão mais relevante para `castle`, `navigator` e `rsp`: um MCP quebrado deve reduzir capacidade de forma visível e recuperável, não impedir todo o ambiente de iniciar nem fingir readiness.
+
+### Product accessibility: API + CLI + skill, not MCP-first
+
+O Basecamp CLI mostra como a 37signals torna um produto acessível a agentes:
+
+| Capacidade | Contrato exposto |
+|---|---|
+| output | humano no TTY; JSON quando pipe; `--json`, `--quiet`, `--agent`, `--md` explícitos |
+| envelope | `{ok, data, summary, breadcrumbs, meta}` |
+| descoberta | todo comando suporta `--help --agent`; catálogo completo em `basecamp commands --json` |
+| navegação | `breadcrumbs` devolvem próximos comandos válidos |
+| não interação | `--agent` e `BASECAMP_NONINTERACTIVE=1` transformam prompts em erros acionáveis |
+| filtro | `--jq` embutido evita dependência/processo externo e opera sobre o envelope |
+| diagnóstico | `basecamp doctor --json` inclui saúde, auth, conectividade e integração Claude/Codex |
+| autenticação | OAuth 2.1, refresh, device flow/fallback e perfis isolados |
+| segurança de repo | authority keys em `.basecamp/config.json` são bloqueadas até `basecamp config trust` |
+| integração | plugins nativos Claude/Codex; skill genérica para qualquer agente que execute shell |
+
+A skill publicada cobre 155 endpoints e registra invariantes, decision trees, paginação, defaults, erros e workflows. Ela é sincronizada automaticamente do `basecamp-cli` em cada release. Isso evita o drift clássico em que o binário muda e a skill continua ensinando flags antigas.
+
+O `install.md` também é escrito para execução por agente: `OBJECTIVE`, `DONE WHEN`, checklist, steps, verificação após cada step e uma seção manual explicitamente proibida sem solicitação. É documentação como protocolo verificável, não tutorial narrativo.
+
+### How this changes the MCP diagnosis
+
+O modelo 37signals não prova que MCP seja ruim. Ele define melhor seu lugar:
+
+- CLI é o contrato universal e debuggable;
+- skill é progressive disclosure e conhecimento de workflow;
+- plugin adiciona ergonomia específica do host;
+- hook impõe comportamento quando o host suporta;
+- MCP é canal de alta integração, mas deve ter equivalente CLI ou degradação clara;
+- `doctor --json` mede readiness em vez de assumir que um processo iniciou corretamente.
+
+Para red-dev, todo MCP gerenciado deveria publicar a mesma máquina de estados:
+
+```text
+not_installed
+  -> installed
+  -> configured
+  -> transport_started
+  -> initialized
+  -> smoke_passed
+  -> ready
+
+qualquer falha
+  -> degraded(reason, fallback, remediation)
+```
+
+`process exists` ou `command found` não deve significar ready. O erro exibido no início desta pesquisa — broken pipe durante `initialize` — é exatamente uma falha entre `transport_started` e `initialized`.
+
+### Direct comparison with RedSkills
+
+| Dimensão | house-skills/37signals | RedSkills/red-dev | Leitura |
+|---|---|---|---|
+| amplitude | 11 skills muito focadas | coleção muito maior: engenharia, memória, brain e operação | RedSkills é plataforma mais ampla |
+| distribuição | quatro plugins Claude + Agent Skills genéricas | bundles/plugins para cinco hosts no v3 | RedSkills cobre mais hosts nativamente |
+| fonte única | arquivos reais por plugin, symlinks para visão plana | bundles próprios por host | ambos combatem duplicação, com mecanismos distintos |
+| instruções de repo | skill específica, budget e auditoria de literals/paths | `dev:context` e setup, sem o mesmo contrato editorial explícito | incorporar princípios `agents-md` |
+| criação de skills | flywheel por alvo real + exemplares + evals | write/audit/telemetry/improve | unir evals locais à telemetria RedSkills |
+| execução autônoma | Ralph–Lisa com rope 0–5 e close gate derivado | manager/implement/afk/code-review | RedSkills é mais operacional; Ralph–Lisa tem gate mais formal |
+| segunda opinião | Codex fixo como reviewer de Claude | multi-agent/review dependente do fluxo | evitar acoplamento fixo a vendors |
+| product tooling | CLI estruturado + skill gerada por release | ferramentas RedDB instaladas, mas sem contrato agent CLI uniforme | maior oportunidade prática |
+| MCP | opcional no review, `codex exec` fallback | MCPs centrais podem falhar no startup | adotar fallback e readiness estruturado |
+| trust boundaries | aparecem em AGENTS e skills que processam input externo | guardrails existem, mas variam por skill | normalizar no schema/auditoria |
+
+### Internal contradictions and limits in the 37signals design
+
+A iniciativa é forte, mas não deve ser copiada sem crítica:
+
+1. A própria referência `agents-md` afirma que `triggers:` não faz parte do Agent Skills spec nem da documentação Claude; várias skills do mesmo repositório ainda carregam listas extensas de `triggers`. Isso é drift interno documentável.
+2. Plugins completos são Claude-first. Outros agentes recebem standalone skills, mas não recebem automaticamente o stop hook nem toda a ergonomia do plugin.
+3. Ralph–Lisa fixa Claude como orquestrador, Codex como reviewer e `xhigh` como política. É uma boa implementação concreta, mas não um protocolo vendor-neutral.
+4. `house-skills` não publica tags/releases; instalar da branch principal reduz reprodutibilidade. Os manifests têm versões, porém o consumo genérico não está pinado.
+5. O loop gera estado em `tmp/ralph-lisa-loop-session.md`; o guia manda apagar ou ignorar, mas o repositório não consegue impor isso nos consumidores. Há risco de commit acidental de conteúdo sensível.
+6. O modo de auditoria não confiável é seguro, porém operacionalmente rígido: se o `AGENTS.md` alvo já influenciou a sessão, a skill exige recomeçar em cwd neutro.
+7. Evals estruturais detectam formato e estado, não garantem semântica. O próprio material reconhece que um exemplar existente pode deixar de exemplificar e que uma flag real pode estar descrita incorretamente.
+8. O Basecamp CLI continua exigindo autenticação humana e credenciais; “autônomo” não elimina HITL nem justifica ampliar scope de acesso.
+
+### What red-dev should adopt
+
+Adotar:
+
+1. `AGENTS.md` como contexto mínimo, auditável e portátil; CLAUDE bridge explícita.
+2. CLI-first para todas as capacidades RedDB, com `--json`, `--agent`, `--help --agent`, non-interactive e exit codes estáveis.
+3. `doctor --json` com estados de readiness completos para agentes, plugins, hooks e MCPs.
+4. Skills geradas/testadas junto à release do CLI, não mantidas manualmente em outro ritmo.
+5. `install.md` executável com objective/done-when/checkpoints para red-dev e produtos RedDB.
+6. Close gates derivados de registros reais, falhando fechados em inconsistência.
+7. Trust boundaries obrigatórias para skill que lê issue, PR, web, MCP, chat ou output de outro modelo.
+8. Fallback MCP → CLI registrado, testado e visível no doctor.
+9. Evals executáveis e exemplares reais como requisito de maturidade de skill.
+10. Um nível de autonomia simples, com escaladas obrigatórias invariantes.
+
+Não adotar literalmente:
+
+1. vendor lock Claude-orchestrator/Codex-reviewer;
+2. listas `triggers:` não portáveis como mecanismo de ativação;
+3. branch `main` mutável como canal padrão de produção;
+4. mais uma coleção paralela de skills que duplique RedSkills;
+5. MCP como requisito para um fluxo cuja operação básica cabe em CLI;
+6. logs de sessão dentro do repo sem lifecycle e política de dados.
+
+### Proposed RedDB agent-accessibility contract
+
+Cada CLI RedDB deveria satisfazer o mesmo contrato:
+
+```text
+<tool> commands --json
+<tool> <command> --help --agent
+<tool> doctor --json
+<tool> auth status --json        # quando aplicável
+<tool> ... --agent              # output estável, sem prompt
+<tool> ... --dry-run            # para mutações relevantes
+```
+
+Cada integração de host/MCP deveria declarar:
+
+```text
+install -> configure -> start -> initialize -> smoke -> ready
+                                          \-> degraded + fallback + remediation
+```
+
+E cada release deveria publicar, como uma unidade compatível:
+
+- binário;
+- schema/command catalog;
+- Agent Skill;
+- plugin adapters;
+- checksum/provenance;
+- testes de drift entre comandos e skill;
+- versão mínima do host/hook/MCP.
+
+Isso aproveita o melhor da iniciativa do DHH sem enfraquecer o diferencial do RedSkills: uma camada universal de engenharia, memória e conhecimento por cima de ferramentas RedDB realmente agent-accessible.
+
+## Update, migration and supply-chain comparison
+
+### Omakub
+
+- `Omakub > Update > Omakub` faz `git pull` no checkout;
+- compara timestamp do último commit anterior com nomes de migrations;
+- executa migrations novas em ordem;
+- menu oferece atualização manual de Ollama, LazyGit, LazyDocker, Neovim e Zellij;
+- packages apt/Flatpak continuam sob mecanismos Ubuntu;
+- migrations podem substituir configs e pedir interação/logout;
+- bootstrap remove o checkout anterior antes de clonar novamente.
+
+### red-dev
+
+- `update` executa `apt full-upgrade/autoremove` ou `winget upgrade --all`;
+- reexecuta instalador RedSkills;
+- converge o manifesto;
+- possui duas migrations de reparo de fonte com ledger em preferences;
+- não atualiza o próprio binário;
+- não mantém rollback do binário/config;
+- releases têm checksums e provenance, mas os installers não verificam checksum;
+- downloads `gh` de dependências também não validam checksums publicados.
+
+### Preference/state bug affecting upgrades
+
+O first run grava theme, font e fontSize. Depois dele:
+
+- `contextFor()` monta o contexto a partir dos defaults CLI, não de `readPreferences()`;
+- `red-dev update` chama converge com esses defaults;
+- `red-dev theme <outro>` usa o nome pedido, mas mantém fonte/tamanho defaults;
+- o estado declarado e o estado aplicado podem divergir silenciosamente.
+
+Isso precisa ser P0 porque torna update potencialmente regressivo para preferências visuais.
+
+### Required update contract
+
+```text
+resolve channel/version
+  -> download platform+arch asset
+  -> verify SHA256 + provenance/signature
+  -> stage next binary
+  -> run preflight
+  -> atomically swap
+  -> run migrations
+  -> converge persisted desired state
+  -> doctor/readiness
+  -> retain previous binary/config snapshot for rollback
+```
+
+## Platform matrix and macOS feasibility
+
+### Actual support today
+
+| Capability | Ubuntu 24 | Ubuntu 26 | WSL | Windows x64 | macOS Intel | macOS ARM |
+|---|---|---|---|---|---|---|
+| red-dev release binary | sim | mesmo asset, não validado | sim | sim | não | não |
+| bootstrap | sim | sim conceitual | sim | PowerShell | não | não |
+| provider package manager | apt | apt com gaps | apt + winget | winget | **cai em apt/u24** | **cai em apt/u24** |
+| desktop integration | parcial GNOME | não validada | host Windows | parcial | não | não |
+| architecture | x64 | x64 | x64 | x64 | — | — |
+| E2E clean-machine | parcial/manual | não | melhor exercitado | bootstrap não validado clean | não | não |
+
+### macOS is technically tractable
+
+A consulta oficial Homebrew encontrou formulas para todos estes itens do core/optional: Git, curl, unzip, ripgrep, fd, bat, eza, zoxide, fzf, btop, jq, Starship, Atuin, Carapace, direnv, git-delta, yazi, tealdeer, fastfetch, gh, LazyGit, LazyDocker, Zellij, mise, Neovim, just, duf, dust, hyperfine, glow e gitui.
+
+Há casks oficiais para Alacritty, Docker Desktop, VS Code, Blender e as quatro Nerd Fonts escolhidas pelo red-dev. As ferramentas RedDB já oferecem assets macOS Intel/ARM.
+
+Portanto, macOS não exige inventar distribuição da stack; exige implementar:
+
+- `Env = "macos"` e capacidades próprias;
+- providers `brew`, `cask`, `gh-dmg`, `gh-binary`, `builtin-macos`;
+- release targets Darwin x64/arm64;
+- bootstrap universal;
+- paths/config/shell;
+- instalação/registro de apps DMG;
+- hotkeys, tiling, launcher, dark/accent/wallpaper;
+- testes em Intel e Apple Silicon.
+
+### Immediate safety fix
+
+Antes de qualquer suporte macOS, `providerFor()` deve rejeitar Darwin. Tentar `apt` em macOS é pior que declarar unsupported.
+
+## First-run experience
+
+### Omakub sequence
+
+1. valida Ubuntu/arquitetura;
+2. pergunta apps opcionais;
+3. pergunta linguagens;
+4. pergunta bancos;
+5. coleta identificação Git;
+6. instala terminal;
+7. instala desktop e customiza GNOME;
+8. oferece reboot.
+
+O usuário termina com uma opinião forte aplicada. O custo é que uma falha aborta tudo e vários arquivos são substituídos.
+
+### red-dev sequence
+
+1. em Windows/WSL, oferece config compartilhada e shell destino;
+2. preselect Claude/Codex/OpenCode;
+3. preselect Node LTS;
+4. preselect optional CLI tools compatíveis;
+5. deixa ble.sh off;
+6. escolhe Nerd Font;
+7. escolhe tema com preview;
+8. converge core/desktop/WSL e escolhas.
+
+O fluxo é mais sofisticado para cross-platform e agentes, mas o resultado desktop é menor. Não pergunta workstation apps, browser, editor baseline, bancos, hotkey profile ou tiling profile.
+
+### Recommended profiles
+
+| Profile | Conteúdo |
+|---|---|
+| `minimal` | shell, Git, terminal, mise, Node, CLI essencial |
+| `desktop` | minimal + browser, editor baseline, fonts, themes, hotkeys, tiling, launcher, screenshots, web apps |
+| `reddb-employee` | desktop + `red`, `tq`, red-request, dit, red-ui, RedSkills e agentes corporativos |
+| `ai-heavy` | reddb-employee + conjunto amplo de agentes, Ollama e extensões |
+
+Perfis devem ser intenção persistida. Remover um item do perfil é uma escolha registrada, não drift. Itens pessoais continuam fora da propriedade do red-dev.
+
+## Critical gaps ranked
+
+### P0 — correctness and honesty
+
+1. Darwin não pode usar provider Ubuntu.
+2. Persisted theme/font/fontSize precisam alimentar todo `plan/install/update/theme`.
+3. Corrigir os sete adapters Neovim e seus nomes de colorscheme.
+4. Tratar Rose Pine como light no GNOME e Windows.
+5. Corrigir red-ui Windows de skip para asset real.
+6. Instalar e verificar Nerd Font no Ubuntu, Windows e futuro macOS.
+7. Instalar `wl-clipboard` antes de configurar `wl-copy`.
+8. Conectar ou remover funções mortas: web apps e fzf colors.
+9. Mostrar matriz real de superfície por tema na UI.
+10. Implementar self-update verificado e rollback.
+
+### P0 — RedDB employee readiness
+
+1. Adicionar Pi.
+2. Atualizar RedSkills v2 → v3.
+3. Verificar Pi e Gemini no doctor.
+4. Criar caminho oficial RedSkills para Hermes.
+5. Instalar todos os assets RedDB disponíveis por plataforma/arch.
+6. Adicionar smoke tests reais, inclusive MCP startup.
+7. Exibir auth-required separadamente de failed.
+
+### P1 — desktop parity with Omakub
+
+1. Browser Chromium-family.
+2. VS Code baseline seguro e LazyVim starter governado.
+3. GNOME extensions, Tactile, launcher, workspaces, dock e app grid.
+4. Screenshots e clipboard.
+5. Web apps integrados ao CLI/TUI.
+6. Bancos/serviços Docker selecionáveis.
+7. Catálogo workstation em profile, não no core.
+8. Templates/launchers RedDB próprios com ícones.
+
+### P1 — cross-platform interaction model
+
+1. Semantic hotkey schema.
+2. GNOME adapter.
+3. PowerToys/FancyZones adapter e export de configuração.
+4. macOS tiling/launcher ADR + adapter.
+5. Conflict detection e generated cheat sheet.
+
+### P2 — visual system and assets
+
+1. Theme manifest com status exact/approximate/follow-system/unsupported por superfície.
+2. CI exigindo adapter completeness para tema novo.
+3. Versionar os dez wallpapers gerados.
+4. Metadata de wallpaper e assets art-directed opcionais.
+5. Font manifest com install/apply/verify por OS.
+6. Ícones e launchers consistentes para red-dev e produtos RedDB.
+
+## Proposed internal contracts
+
+```ts
+interface DesiredProfile {
+  id: "minimal" | "desktop" | "reddb-employee" | "ai-heavy";
+  tools: string[];
+  agents: string[];
+  runtimes: string[];
+  services: string[];
+  theme: string;
+  font: { family: string; size: number };
+  hotkeyProfile: string;
+  tilingProfile: string;
+}
+
+interface Installable {
+  id: string;
+  supports(platform: Platform): Support;
+  plan(desired: DesiredState): Promise<PlanStep[]>;
+  apply(step: PlanStep): Promise<void>;
+  verify(desired: DesiredState): Promise<HealthResult>;
+  uninstall?(): Promise<void>;
+}
+
+interface ThemeSurface {
+  id: string;
+  support(theme: Theme, platform: Platform):
+    | "exact"
+    | "approximate"
+    | "follow-system"
+    | "unsupported";
+  apply(theme: Theme, platform: Platform): Promise<void>;
+  verify(theme: Theme, platform: Platform): Promise<HealthResult>;
+}
+
+interface SkillHostAdapter {
+  id: "claude" | "codex" | "opencode" | "gemini" | "pi" | "hermes";
+  install(): Promise<void>;
+  wireRedSkills(version: string): Promise<void>;
+  verifySkills(): Promise<HealthResult>;
+  verifyMcp(): Promise<HealthResult>;
+  update(): Promise<void>;
+}
+```
+
+## Acceptance criteria and E2E matrix
+
+### Per platform
+
+| Target | Required lane |
+|---|---|
+| Ubuntu 24 desktop x64 | clean VM + GNOME session |
+| Ubuntu 26 desktop x64 | clean VM + GNOME session |
+| Ubuntu server x64 | headless |
+| WSL Ubuntu 24 | Windows host crossing |
+| Windows 11 x64 | clean VM, no preinstalled Git/Bun |
+| macOS Intel | clean runner/hardware |
+| macOS ARM | Apple Silicon runner/hardware |
+
+### Test sequence
+
+1. bootstrap verified by checksum;
+2. apply `reddb-employee`;
+3. capture plan/result/readiness;
+4. run second converge and assert zero unexpected mutations;
+5. verify every binary/app/agent/MCP;
+6. change all ten themes and inspect declared surfaces;
+7. change all fonts and preserve size through theme/update;
+8. exercise semantic hotkeys;
+9. start selected databases;
+10. update N-1 → current;
+11. rollback;
+12. uninstall selected item without deleting unrelated configuration.
+
+### Agent accessibility and MCP sequence
+
+1. enumerar comandos e schemas sem executar mutações;
+2. executar cada CLI em `--agent`/non-interactive e validar JSON + exit code;
+3. instalar a skill da mesma versão do CLI e testar drift de comandos/flags;
+4. verificar `AGENTS.md`/Claude bridge e budget always-on;
+5. exercitar MCP até `initialize` e smoke funcional, não apenas spawn do processo;
+6. matar o MCP durante uma operação e confirmar estado `degraded` + fallback CLI;
+7. restaurar o MCP e confirmar reconexão sem reinstalar o ambiente;
+8. injetar conteúdo hostil por issue/PR/MCP e confirmar que é tratado como dado, não instrução;
+9. verificar que actions remotas, auth e mudanças destrutivas continuam exigindo autoridade adequada;
+10. executar N-1 CLI com skill N e vice-versa para provar que incompatibilidade falha com diagnóstico acionável.
+
+### SLOs
+
+- setup concluído em até 30 minutos, descontando autenticação humana;
+- no máximo um reboot/sign-out;
+- segundo converge sem drift;
+- 100% dos itens escolhidos em `healthy`, `auth-required` ou `unsupported-with-reason`;
+- nenhum “success” baseado somente em arquivo existente;
+- todo tema novo passa completeness checks;
+- N-1 update e rollback comprovados antes da stable.
+
+## API / CLI / Config Details
+
+```text
+red-dev profile list
+red-dev profile show reddb-employee
+red-dev profile apply reddb-employee --plan
+red-dev self-update --channel stable
+red-dev rollback
+red-dev theme matrix
+red-dev hotkeys list
+red-dev hotkeys conflicts
+red-dev services
+red-dev agents doctor
+red-dev agents doctor --json
+red-dev mcp doctor --json
+red-dev mcp status --json
+red-dev tools doctor
+red-dev doctor --readiness
+red-dev webapps
+```
+
+`red-dev update` deve continuar sendo o caminho feliz, orquestrando self-update, migrations, converge do desired profile e readiness.
+
+Config ownership deve ser explícito:
+
+| Mode | Significado |
+|---|---|
+| owned | arquivo inteiro gerado e atualizável |
+| merged | somente chaves declaradas pertencem ao red-dev |
+| adopted | config existente foi importada após consentimento |
+| external | red-dev apenas verifica/orienta |
+
+## Version Notes
+
+- O checkout red-dev declara `0.19.0`; a stable mais recente é `v0.17.1`, publicada em 2026-08-02.
+- Omakub master auditado continua em `1.5.0`; a release foi publicada em 2025-11-09.
+- O manual Omakub fala em sete temas, mas o código possui dez.
+- O manual Omakub fala em workspaces 1–4, mas o código configura 1–6.
+- RedSkills latest é `v3.3.18`; red-dev chama explicitamente o major tag v2.
+- `house-skills` foi auditado em `d2d85ab` e não possui tags/releases; seus manifests internos declaram `ai 1.2.1`, `dev 1.1.1`, `security 1.1.1` e `recap 0.1.1`.
+- `basecamp-cli v0.8.0` e `basecamp/skills` sincronizada dessa release foram auditados em 2026-08-03; a superfície muda rapidamente e precisa ser pinada por commit/release em qualquer adoção.
+- Os releases RedDB consultados são atuais na data do relatório e podem ganhar novos assets; o manifesto deveria consumir uma contract manifest publicada por cada produto, em vez de manter frases manuais como “não há Windows build”.
+
+## Gotchas
+
+- “Instalado” não significa configurado, autenticado ou saudável.
+- “Tema suporta Neovim” não significa que o plugin do colorscheme foi instalado.
+- “Zellij resolve tiling” só vale dentro do terminal.
+- Uma preference persistida que não alimenta o próximo converge é documentação, não desired state.
+- Dark/light deve ser propriedade do tema, não suposição global.
+- Um asset existir na release não garante silent install; DMG/MSI/NSIS precisam de adapters próprios.
+- O catálogo desktop deve ser profile-driven para não transformar o core em uma instalação de dezenas de GB.
+- Não sobrescrever VS Code/Neovim existentes silenciosamente.
+- Hotkeys globais precisam de conflict detection; uma tecla global pode quebrar browser/editor.
+- macOS deve falhar fechado até o provider existir.
+- Downloads devem verificar hash/proveniência antes de executar.
+- Plugin instalado não garante equivalência entre hosts: hooks e lifecycle Claude podem não existir no modo standalone Agent Skills.
+- MCP que deu spawn mas falhou no handshake não está ready; a granularidade precisa alcançar `initialize` e smoke.
+- `triggers:` extensos não são mecanismo portável de ativação segundo a própria referência `agents-md`; a description continua sendo o contrato interoperável.
+- Output de outro agente ou reviewer é input não confiável e não deve ser executado como instrução.
+
+## Open Questions
+
+1. Quais apps são obrigatórios no perfil `reddb-employee`?
+2. Chrome, Brave ou Edge será o browser padrão por plataforma?
+3. O baseline editor corporativo inclui VS Code, Neovim ou ambos?
+4. O template editorial será owned ou um starter adotável?
+5. Quais bancos são default para colaboradores RedDB?
+6. Quais agentes são mandatory, recommended e experimental?
+7. Hermes deve receber integração oficial dentro de RedSkills antes de entrar no perfil?
+8. Qual ferramenta macOS será padrão para tiling e launcher?
+9. O macOS usará Bash por paridade ou Zsh por natividade?
+10. Quais wallpapers podem ser distribuídos com licença/proveniência explícita?
+11. PowerToys será obrigatório no Windows ou apenas adapter optional?
+12. Como credenciais corporativas serão guiadas sem serem armazenadas pelo red-dev?
+13. Quais CLIs RedDB serão priorizados para o contrato `--agent`/`doctor --json`?
+14. MCP será obrigatório, preferred ou optional-with-fallback por capacidade?
+15. Qual matriz de compatibilidade vai pinçar CLI, skill, plugin, host e protocolo MCP?
+16. O nível de autonomia será global, por perfil ou por operação?
+
+## Source-by-Source Notes
+
+### red-dev source notes
+
+- `manifest.ts` é um bom source of truth, mas ainda mistura instalação, alcance de desktop e assumptions de asset que ficam stale.
+- `themes.ts` centraliza paletas, mas o schema não exige mode light/dark, plugin Neovim ou adapter coverage.
+- `theme-apply.ts` possui um ramo Windows que reduz indevidamente as superfícies.
+- `theme-editors.ts` tem mappings VS Code bons e host-aware, mas não suporta JSONC e força dark no GNOME.
+- `theme-cli.ts` melhora o Omakub em CLI, porém `fzfColors()` está morto.
+- `preferences.ts` persiste escolhas corretas; `main.ts/contextFor()` não as consome nos próximos comandos.
+- `webapps.ts` é uma implementação competente sem product route.
+- `agents.ts` tem catálogo amplo, porém usa RedSkills v2 e mantém doctor de apenas três hosts.
+- `providers.ts` tem bom matching de assets e timeout, mas não verifica checksums e não faz self-update.
+- release pipeline produz checksums/attestation e dois targets x64; os bootstraps não consomem a verificação.
+
+### Omakub source notes
+
+- Omakub maximiza coerência escolhendo um único OS/desktop.
+- O catálogo de workstation é muito mais amplo e aplicado automaticamente.
+- Cada tema é um bundle completo e autocontido.
+- GNOME/hotkeys/tiling/dock formam um interaction model, não uma lista de tweaks.
+- LazyVim e VS Code deixam o usuário produtivo imediatamente.
+- Scripts substituem configs e `set -e` aborta o restante; é menos resiliente que red-dev.
+- Self-update e migrations fecham um ciclo que o red-dev ainda não fecha.
+
+### DHH/37signals agent source notes
+
+- `house-skills` separa conteúdo físico por plugin e expõe uma visão plana por symlink; essa inversão existe porque o marketplace extrai subdiretórios.
+- `agents-md` é a contribuição mais universal: gastar contexto always-on somente com gotchas, counter-priors e pointers verificáveis.
+- `skill-crafting` conecta instrução, alvo real, exemplar e eval; a maturidade é evidenciada por execução, não por tamanho da documentação.
+- Ralph–Lisa formaliza autonomia sem relaxar o close gate, mas é deliberadamente acoplado a Claude + Codex.
+- O stop hook impede encerramento durante loop ativo somente no plugin Claude; standalone skills não herdam automaticamente essa garantia.
+- Trust boundaries são explícitas: PR comments, conteúdo externo e output de modelo permanecem dados não confiáveis.
+- `basecamp-cli` demonstra a arquitetura agent-accessible mais concreta: JSON estável, breadcrumbs, introspecção, non-interactive, auth profiles, config trust e doctor.
+- `basecamp/skills` é sincronizado a cada release do CLI, padrão que RedDB deveria adotar para evitar drift entre binário e skill.
+- A estratégia pública do DHH é supervised collaboration: agentes produzem contribuições reais, mas revisão, guidance e decisões continuam humanas.
+- Manual e código divergiram em temas e workspaces, mostrando a necessidade de docs geradas.
+
+### RedSkills source notes
+
+- v2 já suporta Claude, Codex, OpenCode e Pi.
+- v3 adiciona Gemini e mantém Pi packages publicados.
+- Hermes não aparece como host oficial.
+- O source atual possui release assets para OpenCode, Pi packages, VS Code e Herdr plugin.
+
+### RedDB release notes
+
+- Os cinco produtos principais já publicam cobertura maior que o red-dev consome.
+- red-ui Windows é o exemplo mais claro de provider stale.
+- assets macOS e ARM reduzem muito o custo de implementar o novo provider.
+
+## Recommended Next Steps
+
+### Immediate remediation tickets
+
+1. `fix(platform): reject darwin until a mac provider exists`
+2. `fix(preferences): hydrate ApplyContext from persisted theme/font/fontSize`
+3. `fix(theme): make light/dark explicit and correct Rose Pine`
+4. `fix(theme): install exact Neovim plugin/config for every theme`
+5. `fix(theme): restore CLI surfaces on native Windows`
+6. `fix(font): install and verify Nerd Fonts on Ubuntu and Windows native`
+7. `fix(clipboard): add wl-clipboard to desktop manifest`
+8. `fix(red-ui): consume current Windows release asset`
+9. `feat(agent): add Pi and RedSkills verification`
+10. `chore(red-skills): move universal installer from v2 to v3`
+11. `feat(webapps): wire catalog into CLI/TUI and add browser dependency`
+12. `feat(update): verified atomic self-update and rollback`
+13. `feat(mcp): model install/configure/initialize/smoke/readiness and explicit CLI fallback`
+14. `feat(agent-cli): standardize --agent, --help --agent, doctor --json and non-interactive behavior`
+15. `test(skills): generate/version product skills with their CLI releases and fail on command drift`
+16. `docs(agents): add verified minimal AGENTS.md plus Claude bridge and agent-executable install.md`
+
+### Product epics
+
+1. RedDB Employee Profile.
+2. Theme/Font Contract.
+3. Semantic Hotkeys and Cross-platform Tiling.
+4. Desktop Linux Parity.
+5. macOS Intel/ARM.
+6. Clean-machine E2E Fleet.
+7. Generated Capability and Asset Documentation.
+8. RedDB Agent Accessibility: CLI contracts, generated skills, host plugins, MCP fallback and readiness.
+
+## Final assessment
+
+O primeiro relatório estava errado em profundidade porque comparava intenções e arquitetura, não o produto que realmente chega à máquina. A inspeção completa muda a conclusão de forma importante.
+
+O red-dev é mais avançado como engine. Omakub é mais avançado como workstation. Hoje, dizer que o red-dev é a evolução espiritual do Omakub é uma direção de produto, não ainda uma descrição completa da experiência entregue.
+
+A boa notícia é que a base mais difícil já existe: providers, convergência, WSL/Windows, state, doctor, temas como dados, releases e produtos RedDB multiplataforma. Os gaps encontrados são concretos e planejáveis. Corrigir correctness primeiro, transformar o setup RedDB em profile verificável e depois portar o interaction model completo do Omakub permitirá ao red-dev superar o original sem perder seu diferencial: uma estação coerente, atualizável e recuperável em qualquer sistema suportado.

--- a/.red/researches/2026-08-03-red-dev-vs-omakub-gap-analysis.md
+++ b/.red/researches/2026-08-03-red-dev-vs-omakub-gap-analysis.md
@@ -1,0 +1,400 @@
+# red-dev vs. Omakub: análise comparativa e oportunidades
+
+## Data
+
+2026-08-03
+
+## Query
+
+Comparar o que o Omakub entrega hoje com o que o red-dev entrega, validar a tese de que o red-dev é uma evolução espiritual multiplataforma, identificar lacunas para o setup inicial dos colaboradores da RedDB.io e propor um caminho de produto para instalação, experiência de desktop, agentes, ferramentas internas e upgrades.
+
+## Escopo
+
+- red-dev no commit `e7757978783fc96ec8871e5efdeddc93ee8adc06`, versão de pacote `0.19.0`.
+- Última release estável publicada do red-dev no momento da pesquisa: `v0.17.1`.
+- Omakub no commit `c873902f1a5d8b0f54e2e52d565a77274a5941ff`, versão/release `1.5.0`.
+- Ubuntu, WSL, Windows e a aspiração de suporte a macOS.
+- Instalação inicial, convergência, atualização, temas, fontes, hotkeys, tiling, aplicativos, linguagens, bancos, agentes de IA e ferramentas RedDB.
+- Apenas documentação, repositórios e releases oficiais foram usados como fontes externas.
+
+Não fazem parte deste estudo testes manuais em hardware limpo, avaliação subjetiva de cada tema nem a escolha final de ferramentas nativas para tiling e launcher no macOS.
+
+## Resumo executivo
+
+A tese de “evolução espiritual do Omakub” é defensável, mas ainda está parcialmente realizada.
+
+O red-dev já tem uma fundação de engenharia mais ambiciosa: modelo tipado de plataforma e capacidades, binários compilados, providers por plataforma, instalação convergente e reexecutável, `plan`, `doctor`, isolamento de falhas, preferências persistentes, migrações, integração WSL/Windows e uma oferta muito mais orientada a agentes e ao ecossistema RedDB. Isso é uma evolução real do modelo de scripts Bash focados em Ubuntu do Omakub.
+
+O Omakub, porém, ainda entrega uma experiência de desktop Linux mais completa e coerente no primeiro dia. Ele configura GNOME, workspaces, tiling, launcher, dock, atalhos, aplicativos, LazyVim, VS Code, web apps, linguagens e bancos como uma experiência única. O red-dev tem ótimas peças, mas várias ainda não formam uma jornada ponta a ponta.
+
+Os cinco bloqueadores principais são:
+
+1. `red-dev update` não atualiza o próprio binário do red-dev.
+2. macOS não é suportado e hoje pode cair incorretamente em providers Ubuntu; deve falhar de forma explícita até existir um provider Darwin real.
+3. Pi não está no catálogo e Hermes é instalado sem receber a integração RedSkills; a promessa de ambiente de agentes uniforme ainda cobre efetivamente apenas Claude Code, Codex e OpenCode.
+4. O desktop Ubuntu não porta nem valida a camada que torna o Omakub memorável: hotkeys, tiling, workspaces, dock, launcher e extensões GNOME.
+5. A experiência editorial e de workstation está incompleta: não há bootstrap LazyVim, template completo de VS Code, seletor de bancos e o módulo de web apps não está conectado a nenhum comando ou menu.
+
+A recomendação não é copiar indiscriminadamente todos os aplicativos do Omakub. É preservar a arquitetura convergente do red-dev e organizar o produto em perfis declarativos — por exemplo `minimal`, `desktop`, `reddb-employee` e `ai-heavy` — com uma camada semântica comum para temas, fontes, hotkeys, ferramentas, agentes e verificações de prontidão.
+
+## Fontes oficiais
+
+### red-dev
+
+- [README e promessa de produto](https://github.com/reddb-io/red-dev/blob/e7757978783fc96ec8871e5efdeddc93ee8adc06/README.md)
+- [Detecção de plataforma e capacidades](https://github.com/reddb-io/red-dev/blob/e7757978783fc96ec8871e5efdeddc93ee8adc06/src/platform.ts)
+- [Manifesto de ferramentas e seleção de providers](https://github.com/reddb-io/red-dev/blob/e7757978783fc96ec8871e5efdeddc93ee8adc06/src/manifest.ts)
+- [Catálogo e instalação de agentes](https://github.com/reddb-io/red-dev/blob/e7757978783fc96ec8871e5efdeddc93ee8adc06/src/agents.ts)
+- [Providers de instalação e atualização](https://github.com/reddb-io/red-dev/blob/e7757978783fc96ec8871e5efdeddc93ee8adc06/src/providers.ts)
+- [CLI de atualização](https://github.com/reddb-io/red-dev/blob/e7757978783fc96ec8871e5efdeddc93ee8adc06/src/commands/update.ts)
+- [Migrações](https://github.com/reddb-io/red-dev/blob/e7757978783fc96ec8871e5efdeddc93ee8adc06/src/migrations.ts)
+- [Hotkeys](https://github.com/reddb-io/red-dev/blob/e7757978783fc96ec8871e5efdeddc93ee8adc06/src/hotkeys.ts)
+- [Web apps](https://github.com/reddb-io/red-dev/blob/e7757978783fc96ec8871e5efdeddc93ee8adc06/src/webapps.ts)
+- [Release estável v0.17.1](https://github.com/reddb-io/red-dev/releases/tag/v0.17.1)
+
+### Omakub
+
+- [Site oficial](https://omakub.org/)
+- [Manual oficial](https://learn.omacom.io/1/read)
+- [Repositório oficial](https://github.com/basecamp/omakub)
+- [Instalador principal](https://github.com/basecamp/omakub/blob/c873902f1a5d8b0f54e2e52d565a77274a5941ff/install.sh)
+- [Menu principal](https://github.com/basecamp/omakub/blob/c873902f1a5d8b0f54e2e52d565a77274a5941ff/bin/omakub)
+- [Configuração de GNOME e hotkeys](https://github.com/basecamp/omakub/tree/c873902f1a5d8b0f54e2e52d565a77274a5941ff/defaults)
+- [Catálogo de temas](https://github.com/basecamp/omakub/tree/c873902f1a5d8b0f54e2e52d565a77274a5941ff/themes)
+- [Atualização e migrações](https://github.com/basecamp/omakub/blob/c873902f1a5d8b0f54e2e52d565a77274a5941ff/bin/omakub-sub/update.sh)
+- [Release v1.5.0](https://github.com/basecamp/omakub/releases/tag/v1.5.0)
+
+### Pi e Hermes
+
+- [Pi Coding Agent — README oficial](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/README.md)
+- [Pi packages](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/packages.md)
+- [Hermes — instalação](https://github.com/NousResearch/hermes-agent/blob/main/website/docs/getting-started/installation.md)
+- [Hermes — skills](https://github.com/NousResearch/hermes-agent/blob/main/website/docs/user-guide/features/skills.md)
+- [Hermes — MCP](https://github.com/NousResearch/hermes-agent/blob/main/website/docs/user-guide/features/mcp.md)
+
+## Hotlinks
+
+- [README do red-dev](../../README.md)
+- [Plataformas](../../src/platform.ts)
+- [Manifesto](../../src/manifest.ts)
+- [Agentes](../../src/agents.ts)
+- [Providers](../../src/providers.ts)
+- [Hotkeys](../../src/hotkeys.ts)
+- [Web apps](../../src/webapps.ts)
+- [Migrações](../../src/migrations.ts)
+
+## Comparação de produto
+
+| Dimensão | Omakub | red-dev hoje | Veredito |
+|---|---|---|---|
+| Plataforma | Ubuntu GNOME x86_64; foco deliberadamente estreito | Ubuntu 24.04, caminho para 26.04, WSL e Windows x64; macOS aspiracional | red-dev tem a arquitetura mais ampla, mas ainda não entrega macOS/ARM |
+| Forma de distribuição | Checkout Git + scripts Bash | Binários compilados Linux/Windows e manifesto tipado | red-dev |
+| Reexecução | Instalação linear com `set -e` | Convergência idempotente, etapas independentes, `plan` e `doctor` | red-dev |
+| Atualização | Atualiza o próprio checkout e executa migrações | Atualiza sistema, ferramentas e RedSkills, mas não o próprio red-dev | Empate com lacuna crítica no red-dev |
+| Desktop Linux | GNOME completo: extensões, tiling, dock, launcher, workspaces e hotkeys | Apps, temas e fontes; configuração GNOME ainda não portada/validada | Omakub |
+| Windows/WSL | Não é objetivo | Integração de host, config compartilhada, winget e hotkeys básicos | red-dev |
+| Temas | Dez temas sobre terminal, editor e GNOME | Os mesmos dez, mais várias superfícies CLI e agentes | red-dev em cobertura; Omakub em acabamento GNOME |
+| Fontes | Quatro famílias, tamanhos configuráveis | Quatro famílias, tamanhos persistentes 7–14 | Equivalentes, com escolhas de família diferentes |
+| Editor | Neovim/LazyVim e VS Code configurados | Instala Neovim/VS Code e aplica temas, sem baseline completo | Omakub |
+| Linguagens | Ruby/Node e seleção de Go, PHP, Python, Elixir, Rust e Java | Node, Bun, Deno, Python, Go, Rust, Ruby e Java via mise | red-dev em runtimes modernos; Omakub inclui PHP/Elixir |
+| Bancos | MySQL, Redis e PostgreSQL selecionáveis via Docker | Sem jornada de bancos/serviços | Omakub |
+| Aplicativos | Catálogo amplo de workstation | Catálogo menor e centrado em desenvolvimento/RedDB | Omakub em abrangência; red-dev tem melhor identidade interna |
+| Web apps | Integrados ao menu e ao desktop | Implementação existe, mas está sem rota de CLI/menu e é Linux-only | Omakub |
+| Agentes | Não é o centro do produto | Dez opções, RedSkills em três hosts, extensões RedDB | red-dev, com lacunas Pi/Hermes |
+| Ferramentas RedDB | Não se aplica | `red`, `tq`, red-request, dit e red-ui conforme plataforma | red-dev |
+| Diagnóstico | Scripts/migrações, sem modelo de drift equivalente | `doctor`, capacidades, providers e preferências persistentes | red-dev |
+
+## Principais achados
+
+### 1. A vantagem estrutural do red-dev é real
+
+O Omakub é um produto vertical: escolhe Ubuntu GNOME e o transforma profundamente. Essa restrição é responsável por boa parte de sua coerência. O instalador oficial valida Ubuntu e arquitetura x86 e executa scripts Bash em sequência.
+
+O red-dev separa plataforma, ambiente e capacidades; usa providers diferentes para `apt`, `winget`, GitHub Releases e instaladores próprios; persiste preferências e migrações; e trata WSL e Windows como lados coordenados de uma mesma estação. O desenho permite crescer sem duplicar o produto inteiro por sistema operacional.
+
+Essa vantagem deve ser protegida. Portar scripts ad hoc do Omakub diretamente enfraqueceria o principal diferencial do red-dev. Cada nova entrega deveria entrar no mesmo modelo de manifesto, capacidade, ownership, convergência e diagnóstico.
+
+### 2. macOS ainda não é uma plataforma do produto
+
+`platform.ts` reconhece `darwin`, mas não existe ambiente Darwin nem coluna de provider macOS no manifesto. A seleção atual escolhe `u24` para qualquer sistema não Windows que não caia no ramo Ubuntu 26. Em outras palavras, macOS não apenas está ausente: sem uma guarda adicional, pode receber uma tentativa de instalação com providers Ubuntu.
+
+Os bootstraps e releases reforçam isso: há caminhos Linux/WSL e Windows x64, sem artefatos macOS x64/arm64. O primeiro conserto deve ser falhar fechado e explicar “macOS ainda não suportado”. Só depois devem entrar Homebrew/casks, caminhos de configuração, bootstrap, temas, fontes, hotkeys e artefatos universais.
+
+### 3. A atualização tem um buraco no componente mais importante
+
+O comando `red-dev update` faz upgrade do sistema por `apt` ou `winget`, atualiza RedSkills e converge os itens instalados. Ele não baixa uma nova release do próprio red-dev.
+
+O Omakub atualiza o próprio checkout com Git e executa migrações posteriores ao commit anterior. O red-dev já possui uma infraestrutura de migrações melhor tipada, mas ela só chega ao usuário se o binário novo for instalado por outra via.
+
+Uma trilha de upgrade confiável precisa incluir:
+
+- descoberta de canal e versão (`stable`, opcionalmente `preview`);
+- download do artefato correto para sistema e arquitetura;
+- validação por checksum e, idealmente, assinatura;
+- troca atômica do binário;
+- execução de migrações;
+- rollback para o binário anterior;
+- `doctor` detectando divergência entre binário, manifesto e versão instalada de RedSkills.
+
+### 4. “Todo agente pronto” ainda significa três hosts
+
+O catálogo do red-dev oferece Claude Code, Codex, OpenCode, Gemini, T3 Code, Herdr, OpenClaw, Hermes, Claude Desktop e Codex Desktop. Pi não está presente.
+
+A integração RedSkills está codificada para Claude Code, Codex e OpenCode. Hermes pode ser instalado, mas não recebe o shared skills directory nem configuração MCP do RedSkills. Isso cria uma diferença importante entre “agente instalado” e “agente corporativo pronto”.
+
+As fontes oficiais mostram um caminho prático:
+
+- Pi descobre skills em `~/.agents/skills/`, além dos diretórios próprios, e aceita packages para distribuir skills, extensions, prompts e temas. A primeira integração pode compartilhar as skills; uma integração completa pode usar um package/extensão para hooks, MCP e tema.
+- Hermes permite declarar diretórios externos de skills em `~/.hermes/config.yaml` e possui configuração MCP nativa. Portanto, pode apontar para `~/.agents/skills` e receber os servidores RedSkills sem duplicar o conteúdo.
+
+O modelo recomendado é substituir a lista rígida por um `SkillHostAdapter` com operações comuns: detectar, instalar, conectar o diretório compartilhado, configurar MCP/hooks/extensões, medir versão/frescor e executar uma prova de saúde.
+
+### 5. Omakub vence na experiência integrada de desktop Linux
+
+O Omakub configura seis workspaces fixos, navegação por teclado, atalhos para terminal/browser/launcher, favoritos do dock e extensões como Tactile, Just Perfection, Blur My Shell, Space Bar, Undecorate e TopHat. Isso não é um conjunto de detalhes isolados; é um modelo consistente de interação.
+
+No red-dev, a camada de hotkeys implementada hoje cobre dois atalhos Windows para abrir terminal. O README reconhece que hotkeys, extensões e dock do GNOME ainda não foram portados e que o desktop Ubuntu não foi validado em hardware real.
+
+A oportunidade é mais forte que uma cópia de teclas: criar um catálogo semântico de ações, por exemplo `terminal.new`, `terminal.workspace`, `launcher.open`, `window.tile.left`, `workspace.goto.1` e `screenshot.region`. Cada plataforma recebe bindings equivalentes, validação de conflitos e uma cheat sheet gerada. Assim, a memória muscular permanece coerente mesmo quando GNOME, PowerToys e o gerenciador escolhido no macOS usam formatos diferentes.
+
+### 6. Temas e fontes são um ponto forte, mas precisam virar contrato
+
+Os dois projetos oferecem hoje dez famílias de tema: Tokyo Night, Catppuccin, Gruvbox, Everforest, Kanagawa, Matte Black, Nord, Osaka Jade, Ristretto e Rose Pine.
+
+O red-dev aplica o tema a zellij, btop, Neovim quando já configurado, VS Code, bat, delta, lazygit, OpenCode, Herdr e superfícies do sistema operacional. A cobertura de ferramentas é excelente. O Omakub aplica de forma particularmente coesa ao GNOME, terminal, zellij, Neovim, btop, TopHat, VS Code e wallpaper.
+
+Para sustentar a expansão, o tema deve ser tratado como contrato de tokens e capacidades, não apenas como uma coleção de arquivos. Cada superfície deveria declarar suporte, ownership, estratégia de merge e verificação. Pi, Hermes, macOS, PowerToys/AeroSpace e wallpapers por plataforma entram como adapters desse contrato.
+
+### 7. A experiência de editor está abaixo da promessa de “setup sensacional”
+
+O Omakub instala uma configuração funcional de Neovim baseada em LazyVim e configura VS Code. O red-dev instala os executáveis e sabe tematizar, mas só toca o Neovim quando uma configuração já existe. Não há bootstrap de um baseline editorial nem um template completo e governado de VS Code.
+
+Para um colaborador novo, “editor instalado” não equivale a “editor pronto”. O comportamento seguro é:
+
+- quando não existe configuração, instalar um starter RedDB versionado;
+- quando existe, nunca sobrescrever: mostrar plano, oferecer adoção e fazer merge apenas de campos de propriedade explícita;
+- separar baseline corporativo, preferências pessoais e estado gerado;
+- testar reexecução e upgrade do template.
+
+### 8. Aplicativos, bancos e web apps não formam uma jornada única
+
+O Omakub oferece seleção inicial de apps, linguagens e bancos. Seu catálogo inclui browser, password manager, comunicação, mídia, escritório, screenshots, VPN, editores e ferramentas de desenvolvimento.
+
+O red-dev possui um conjunto moderno de CLI, ótimos runtimes e as ferramentas internas RedDB, mas não há seletor de bancos/serviços. Também existe um módulo com ChatGPT, Claude, Google Photos, Contacts, Tailscale e GitHub como web apps, porém ele não é chamado por comando ou menu e só gera atalhos Linux.
+
+Copiar todo o catálogo aumentaria custo de manutenção e opinião indesejada. Perfis resolvem melhor:
+
+- `minimal`: shell, terminal, Git, mise e CLI essenciais;
+- `desktop`: apps, fonts, themes, hotkeys, editor e web apps;
+- `reddb-employee`: desktop + stack RedDB + agentes aprovados + configurações corporativas;
+- `ai-heavy`: conjunto ampliado de agentes, runtimes e extensões.
+
+O primeiro run seleciona um perfil, permite diferenças e grava a intenção. Atualizações posteriores reconciliam essa intenção sem transformar preferências pessoais em drift.
+
+### 9. A stack RedDB é o diferencial mais valioso e deve ter SLO de prontidão
+
+O red-dev já distribui `red`, `tq`, red-request, dit e red-ui, além de RedSkills e extensões. Esse é o ponto que o transforma de “dotfiles sofisticados” em plataforma de onboarding da companhia.
+
+Hoje a disponibilidade varia por plataforma, com red-ui limitado a Linux e sem providers macOS. A instalação precisa terminar com um relatório de readiness, não apenas com processos bem-sucedidos:
+
+- cada CLI selecionada responde a `--version` ou `--help`;
+- cada app desktop selecionado possui artefato compatível e consegue iniciar;
+- Docker está ativo;
+- cada agente selecionado enxerga a mesma versão de RedSkills;
+- MCPs obrigatórios inicializam;
+- autenticações pendentes aparecem como ações humanas claras, sem armazenar segredos no red-dev;
+- skips têm motivo explícito e distinguem “não escolhido”, “não suportado” e “falhou”.
+
+### 10. A validação real precisa alcançar a ambição da matriz
+
+O próprio README registra limitações de validação: Ubuntu desktop e Ubuntu 26 ainda não foram exercitados como alvo completo, e o bootstrap Windows não foi validado em uma máquina totalmente limpa. As releases atuais cobrem apenas Linux x64 e Windows x64.
+
+O contrato mínimo de CI/E2E por alvo deve ser:
+
+1. máquina limpa;
+2. `plan` antes da instalação;
+3. instalação do perfil;
+4. segunda instalação com zero mudanças inesperadas;
+5. `doctor` verde;
+6. troca de tema/fonte e verificação das superfícies;
+7. atualização de N-1 para atual;
+8. rollback testado;
+9. smoke test dos agentes e ferramentas RedDB.
+
+## Detalhes de API, CLI e configuração
+
+### CLI proposta
+
+```text
+red-dev self-update [--channel stable|preview] [--version X]
+red-dev profile list
+red-dev profile show reddb-employee
+red-dev profile apply reddb-employee [--plan]
+red-dev agents doctor
+red-dev tools doctor
+red-dev hotkeys list
+red-dev hotkeys apply [--plan]
+red-dev webapps
+red-dev doctor --readiness
+red-dev rollback
+```
+
+`red-dev update` deveria orquestrar `self-update`, migrações e convergência, preservando um comando único para o caminho feliz.
+
+### Contratos internos propostos
+
+```ts
+interface PlatformProvider {
+  platform: "ubuntu" | "windows" | "macos";
+  architecture: "x64" | "arm64";
+  detect(): Promise<CapabilitySet>;
+  plan(item: DesiredItem): Promise<PlanStep[]>;
+  apply(step: PlanStep): Promise<Result>;
+  verify(item: DesiredItem): Promise<HealthResult>;
+}
+
+interface SkillHostAdapter {
+  id: "claude" | "codex" | "opencode" | "hermes" | "pi";
+  detect(): Promise<HostState>;
+  install(): Promise<Result>;
+  wireSharedSkills(path: string): Promise<Result>;
+  configureIntegrations(): Promise<Result>;
+  verify(): Promise<HealthResult>;
+}
+
+interface SemanticHotkey {
+  action: string;
+  description: string;
+  bindings: Partial<Record<"gnome" | "windows" | "macos", string>>;
+}
+```
+
+### Propriedade de configuração
+
+Todo adapter deve declarar uma destas estratégias:
+
+- `owned`: arquivo inteiramente gerado pelo red-dev;
+- `merged`: apenas chaves explícitas são gerenciadas;
+- `adopted`: arquivo existente é importado após confirmação;
+- `external`: red-dev apenas verifica e orienta.
+
+Essa distinção é essencial para upgrades seguros de VS Code, Neovim, configurações de agentes, GNOME, PowerToys e macOS.
+
+## Notas de versão
+
+- O checkout analisado do red-dev declara `0.19.0`, enquanto a última release estável encontrada é `v0.17.1`. O relatório avalia o código atual e sinaliza a diferença porque ela afeta a experiência de upgrade.
+- O Omakub analisado está em `1.5.0`, com release oficial correspondente.
+- A documentação manual do Omakub pode ficar atrás do repositório em inventários como quantidade de temas; quando houve divergência, o código fixado no commit analisado foi considerado a fonte de verdade.
+- Pi atualmente é publicado sob `earendil-works/pi`; links ou pacotes históricos podem apontar para nomes anteriores.
+
+## Gotchas
+
+- Multiplataforma não significa paridade artificial. Alguns recursos devem ter equivalentes semânticos, não implementações idênticas.
+- Não configurar `darwin` para “usar o que funcionar do Linux”. Providers devem falhar fechados para impedir chamadas `apt` em macOS.
+- Compartilhar o diretório de skills não garante integração total de RedSkills; MCP, hooks, plugins e ciclo de atualização precisam de verificação por host.
+- Alterar dotfiles existentes silenciosamente destruiria confiança. `plan`, ownership e adoção explícita são requisitos de produto.
+- Muitos aplicativos no core tornam a instalação lenta e frágil. Perfis devem manter o caminho mínimo pequeno.
+- Hotkeys globais conflitam com sistema, acessibilidade e apps. O schema precisa detectar colisões antes de aplicar.
+- Um download bem-sucedido não prova prontidão. O `doctor` deve testar o comportamento observável.
+- Atualização automática sem rollback transforma um instalador em ponto único de falha da estação de trabalho.
+
+## Questões em aberto
+
+1. Qual é o baseline obrigatório do perfil `reddb-employee` e quais itens permanecem opcionais?
+2. O macOS deve padronizar Bash para paridade, adotar Zsh nativo ou oferecer ambos sob o mesmo contrato?
+3. Qual combinação macOS será oficial para tiling e launcher? Essa decisão merece um spike com hardware real.
+4. A RedDB quer governar integralmente o template de Neovim/VS Code ou apenas distribuir starters atualizáveis?
+5. Quais MCPs e autenticações são obrigatórios por agente, e quais são pessoais?
+6. Releases preview serão consumidas por todos ou apenas por um canal interno?
+7. O perfil corporativo deve instalar apps de segurança/VPN/password manager ou somente preparar os hooks de integração?
+8. Quais métricas de onboarding podem ser coletadas de forma opt-in e sem expor informações da máquina?
+
+## Notas fonte a fonte
+
+### red-dev
+
+- O README define cinco alvos atuais/planejados, comandos, stack principal, agentes, temas, ferramentas RedDB e limitações conhecidas.
+- `platform.ts` comprova a presença de `darwin` no tipo de OS, mas ausência de um ambiente/provider macOS.
+- `manifest.ts` comprova as colunas Ubuntu 24, Ubuntu 26 e Windows e a seleção inadequada de Ubuntu para todo não Windows.
+- `providers.ts` e o comando de update mostram upgrades de sistema/ferramentas sem troca do binário red-dev.
+- `agents.ts` comprova o catálogo atual e a ausência de Pi.
+- A integração de RedSkills limita hosts a Claude, Codex e OpenCode; os caminhos adicionais cobrem extensão VS Code e plugin Herdr.
+- `hotkeys.ts` cobre apenas os dois atalhos Windows atuais.
+- `webapps.ts` contém a implementação, mas não há referência a ela em comando/menu.
+- `migrations.ts` demonstra que já existe uma base apropriada para upgrades de estado.
+
+### Omakub
+
+- README/site/manual definem a proposta deliberadamente opinionada para Ubuntu.
+- `install.sh` demonstra o pipeline Bash linear e a distinção terminal/desktop.
+- Os defaults do repositório mostram GNOME, extensões, dock, workspaces e hotkeys.
+- Os menus mostram seleção de apps, linguagens, bancos, temas, fontes, install/uninstall e update.
+- O catálogo de temas no commit analisado contém dez temas.
+- O fluxo de update usa o checkout Git e executa migrações por timestamp/commit.
+
+### Pi
+
+- O README oficial documenta instalação, diretórios de skills e modelo extensível.
+- A documentação de packages mostra distribuição e atualização de skills, extensions, prompts e temas.
+- A filosofia do projeto não inclui MCP no core; uma extensão é o caminho para integração adicional.
+
+### Hermes
+
+- A documentação oficial cobre Linux, macOS, WSL e Windows.
+- Skills externas podem ser declaradas em configuração, permitindo compartilhar `~/.agents/skills`.
+- MCPs são configuráveis nativamente, oferecendo um caminho direto para os serviços RedSkills.
+
+## Próximos passos recomendados
+
+### P0 — tornar a promessa honesta e atualizável
+
+1. Fazer macOS falhar fechado imediatamente; nunca selecionar provider Ubuntu para Darwin.
+2. Implementar `self-update` atômico com checksum, rollback e canal de release.
+3. Incorporar `self-update` ao caminho feliz de `red-dev update`.
+4. Gerar uma matriz pública de capacidade/plataforma a partir do manifesto.
+5. Adicionar `doctor --readiness` e distinguir installed/configured/healthy/auth-required.
+
+### P0 — completar o perfil RedDB Day One
+
+1. Definir e versionar o perfil `reddb-employee`.
+2. Adicionar Pi ao catálogo.
+3. Introduzir `SkillHostAdapter` para Claude, Codex, OpenCode, Hermes e Pi.
+4. Ligar Hermes ao diretório compartilhado e aos MCPs RedSkills.
+5. Ligar Pi às shared skills e construir package/extensão para a integração completa.
+6. Garantir providers e health checks para `red`, `tq`, red-request, dit, red-ui e RedSkills em cada alvo suportado.
+
+### P1 — alcançar o acabamento do Omakub no Linux
+
+1. Portar a intenção de GNOME do Omakub para adapters convergentes do red-dev.
+2. Criar o schema semântico de hotkeys e cheat sheet gerada.
+3. Entregar tiling, workspaces, launcher e dock como parte do perfil desktop.
+4. Bootstrap seguro de LazyVim e baseline VS Code quando não houver configuração.
+5. Conectar `webapps.ts` ao CLI/menu e adicionar adapters Windows/macOS.
+6. Oferecer bancos/serviços de desenvolvimento como módulo opcional.
+
+### P1 — entregar macOS de verdade
+
+1. Criar ambiente/capacidades Darwin e providers Homebrew/cask/builtin/GitHub Releases.
+2. Publicar x64 e arm64 com bootstrap e checksums.
+3. Adaptar caminhos, shell, terminal, fontes, temas e aplicativos.
+4. Fazer spike e ADR para tiling, launcher e hotkeys.
+5. Portar toda a stack RedDB antes de declarar paridade do perfil corporativo.
+
+### P2 — comprovar e sustentar
+
+1. CI/E2E em Ubuntu 24/26, WSL, Windows e macOS Intel/ARM.
+2. Testar instalação limpa, segunda convergência, N-1 update, rollback e doctor.
+3. Gerar docs, inventários de tema/app/agente e matriz de suporte a partir do código.
+4. Estabelecer SLOs de onboarding:
+   - perfil pronto em até 30 minutos, excluindo downloads e autenticações humanas;
+   - segunda convergência sem alterações inesperadas;
+   - `doctor` verde após setup;
+   - todo agente escolhido enxerga a versão esperada de RedSkills;
+   - toda ferramenta RedDB escolhida passa smoke test;
+   - atualização N-1 e rollback comprovados em cada plataforma.
+
+## Conclusão
+
+O red-dev não precisa competir com o Omakub pelo número de scripts ou aplicativos. Sua oportunidade é ser a versão governada, verificável e multiplataforma da mesma ideia: uma estação de desenvolvimento excelente como produto contínuo.
+
+Hoje ele já tem a melhor fundação para isso. Para transformar a tese em experiência, a prioridade deve ser fechar o ciclo completo — instalar, configurar, verificar, atualizar e recuperar — primeiro no perfil RedDB Day One, depois no desktop Linux e finalmente no macOS. Quando agentes, ferramentas internas, temas, fontes, hotkeys e editores forem expressos como contratos declarativos sobre essa fundação, o red-dev deixará de ser apenas uma evolução espiritual do Omakub e passará a ser uma plataforma de workstation que o Omakub, por escolha de escopo, não pretende ser.

--- a/.red/researches/2026-08-03-terminal-clipboard-and-windows-wsl-encoding-diagnosis.md
+++ b/.red/researches/2026-08-03-terminal-clipboard-and-windows-wsl-encoding-diagnosis.md
@@ -1,0 +1,524 @@
+# Diagnóstico de Clipboard e Encoding — Alacritty, Zellij, Herdr, Windows e WSL
+
+**Data:** 2026-08-03
+
+**Escopo:** investigar a cadeia real de copiar, colar e interromper em Alacritty → WSL 2 → Zellij → Herdr, e separar esse problema dos conflitos de encoding entre processos Windows e programas Linux/Bun dentro do WSL.
+
+**Método:** configuração efetivamente implantada, versões e ambiente em execução; documentação oficial; código-fonte pinado do Zellij; documentação e changelog do Herdr; inspeção de bytes; medições de latência; testes focados do repositório.
+
+## Conclusão executiva
+
+Não existe uma incompatibilidade estrutural que torne Alacritty, Zellij e Herdr incapazes de compartilhar o clipboard. A composição é suportável, mas tem **três donos possíveis da seleção** e um bridge Windows com requisitos de tempo e encoding que precisam ser explícitos.
+
+O defeito principal reproduzido foi este:
+
+1. Zellij entrega a seleção como UTF-8 no `stdin` de `copy_command`.
+2. A configuração anterior iniciava Windows PowerShell 5.1 para decodificar esse UTF-8 e chamar `Set-Clipboard`.
+3. O código do Zellij mata o processo de cópia que ainda estiver vivo depois de um segundo.
+4. Nesta máquina, o PowerShell levou entre **1.142 e 1.421 ms** mesmo sem a escrita final no clipboard.
+5. Portanto, Zellij mostrava que a seleção tinha sido copiada, mas matava o bridge antes de ele terminar; o clipboard permanecia com o conteúdo antigo.
+
+Esse mesmo defeito atingia seleções feitas dentro do Herdr. O Herdr emite OSC 52; o Zellij externo interpreta esse pedido e o encaminha para o seu próprio provider, que era exatamente o `copy_command` lento. Não são dois bugs independentes.
+
+O bridge ainda mais antigo, `copy_command "clip.exe"`, era rápido, mas recebia bytes UTF-8 onde `clip.exe` não os preservava corretamente. Acentos e emoji viravam mojibake. O caminho tecnicamente correto sob WSL é:
+
+```text
+seleção UTF-8 → iconv UTF-8/UTF-16LE sem BOM → clip.exe → clipboard Unicode do Windows
+```
+
+O bridge novo completou 20 de 20 execuções em **74–132 ms**, média de **95,9 ms**, bem abaixo do limite do Zellij.
+
+A segunda conclusão importante é que não existe um único “Windows usa UTF-16, WSL usa UTF-8”. Nesta mesma máquina foram observados:
+
+- UTF-8 no locale e na saída dos processos Linux do WSL;
+- UTF-16LE na saída redirecionada de comandos próprios do `wsl.exe`;
+- CP850 na saída padrão do `cmd.exe` e do Windows PowerShell 5.1;
+- UTF-16LE quando `cmd.exe` recebe `/u`;
+- UTF-16LE na entrada Base64 de `powershell.exe -EncodedCommand`;
+- UTF-8 no `stdin` que o Zellij fornece ao `copy_command`;
+- UTF-16LE sem BOM no bridge comprovadamente aceito por `clip.exe` nesta máquina.
+
+Logo, o conserto durável é declarar o encoding **por produtor e por canal**, não aplicar uma heurística genérica a toda saída Windows.
+
+## Contrato correto de teclas
+
+A correção de requisito feita durante a investigação está certa:
+
+- `Ctrl+C` é interrupção/cancelamento e deve chegar ao programa dentro do pane.
+- `Ctrl+Shift+C` é cópia da seleção que pertence ao Alacritty.
+- arrastar o mouse normalmente deve selecionar e copiar no multiplexer que possui o mouse naquele momento.
+- `Ctrl+V` e `Ctrl+Shift+V` colam o clipboard do Windows pelo Alacritty.
+
+O próprio guia do Herdr usa `Ctrl+C` como exemplo de tecla que deve continuar pertencendo ao programa no pane. O prefixo, por padrão `Ctrl+B`, existe para o multiplexer não roubar esses controles.
+
+## Topologia realmente observada
+
+```text
+Windows clipboard
+       ▲
+       │ Copy/Paste nativo; save_to_clipboard
+Windows Alacritty
+       │
+       │ ConPTY / wsl.exe
+       ▼
+Ubuntu 24.04 no WSL 2
+       │
+       ▼
+Zellij 0.44.3, mouse_mode=true, copy_on_select=true
+       │
+       ▼
+Herdr 0.7.5, mouse_capture=true e copy_on_select=true por padrão
+       │
+       ▼
+shell, editor ou agente — incluindo Codex
+```
+
+Ambiente observado:
+
+| Componente | Estado observado |
+|---|---|
+| Host | Windows, Alacritty nativo |
+| Guest | Ubuntu 24.04, WSL 2 |
+| Kernel | `6.18.33.2-microsoft-standard-WSL2` |
+| Zellij | `0.44.3` |
+| Herdr | `0.7.5` |
+| Locale Linux | `C.UTF-8` em todas as categorias |
+| WSL interop | registrado e funcional; executáveis `.exe` acessíveis |
+| Config Zellij | `/mnt/c/Users/filip/.reddev/config/zellij/config.kdl` |
+| Config Alacritty | `%APPDATA%\alacritty` no host |
+| Config Herdr | `~/.config/herdr/config.toml` |
+
+O locale Linux já é UTF-8. Trocar `LANG` ou `LC_ALL` não corrige os bytes que um executável Windows decidiu escrever no pipe.
+
+## Quem possui cada gesto
+
+| Gesto | Dono | Caminho | Resultado esperado |
+|---|---|---|---|
+| `Ctrl+C` em modo terminal normal | programa no pane | Alacritty → Zellij locked → Herdr terminal → processo | SIGINT/cancelamento |
+| `Ctrl+Shift+C` com seleção do Alacritty | Alacritty | seleção do terminal → clipboard Windows | copia |
+| `Ctrl+Shift+C` depois de uma seleção que pertence ao Herdr | Alacritty | não há seleção externa para copiar | pode parecer não fazer nada; a seleção interna já deveria ter autocopiado |
+| arrastar normalmente dentro do Herdr | Herdr | seleção → OSC 52 → Zellij → provider de clipboard | copia ao soltar |
+| `Ctrl+B`, depois `[`; selecionar; `y`/Enter | Herdr | copy mode → OSC 52 → Zellij → provider | copia scrollback |
+| arrastar num pane sem app interno capturando mouse | Zellij | seleção Zellij → `copy_command` | copia ao soltar |
+| `Shift` + arrastar | Alacritty | bypass temporário do mouse reporting → seleção externa | copia diretamente por `save_to_clipboard=true` |
+| `Ctrl+V` | Alacritty | lê clipboard Windows e injeta texto/paste bracketed | cola texto |
+| `Ctrl+Shift+V` | Alacritty | mesmo caminho de Paste | cola texto |
+
+O detalhe que explica grande parte da sensação de aleatoriedade é simples: `Ctrl+Shift+C` só consegue copiar uma seleção que o **Alacritty** conhece. Quando o Herdr desenha a seleção, o Alacritty não tem uma seleção própria. Nesse caso a cópia acontece — ou falha — pelo OSC 52 emitido pelo Herdr.
+
+O Zellij documenta que `mouse_mode` pode interferir com seleção de terminal e recomenda Shift para contornar temporariamente o mouse reporting. O Alacritty documenta `save_to_clipboard=true` como cópia automática do texto selecionado.
+
+## Auditoria das configurações de teclas
+
+### Alacritty
+
+A configuração efetiva importa `theme.toml`, `font.toml`, `shell.toml` e `keys.toml`.
+
+Bindings observados:
+
+```toml
+Ctrl+V       -> Paste
+Ctrl+Shift+V -> Paste
+Ctrl+Shift+C -> Copy
+F11          -> ToggleFullscreen
+```
+
+Também está ativo:
+
+```toml
+[selection]
+save_to_clipboard = true
+```
+
+Não há binding de `Ctrl+C` no Alacritty. Ele segue para a aplicação, como desejado.
+
+### Zellij
+
+O config efetivo:
+
+- inicia em `default_mode "locked"`;
+- usa `keybinds clear-defaults=true`;
+- em locked mode só captura `Ctrl+G` para desbloquear;
+- mantém `mouse_mode true` e `copy_on_select true`;
+- não captura `Ctrl+V` nem `Ctrl+Shift+V` em locked mode;
+- usa `Ctrl+C` apenas dentro dos modos próprios de scroll, busca e rename para sair desses modos.
+
+Logo, em uso terminal normal não há colisão Zellij × `Ctrl+C`/`Ctrl+V`.
+
+### Herdr
+
+A configuração local não sobrescreve os defaults relevantes. Na versão 0.7.5:
+
+- `keys.prefix` é `Ctrl+B` por padrão;
+- `ui.mouse_capture` é `true` por padrão;
+- `ui.copy_on_select` é `true` por padrão;
+- copy mode é `prefix+[`;
+- `Ctrl+C` continua sendo enviado ao programa do pane;
+- desde a correção documentada no changelog, um cliente **local** não usa `Ctrl+V` como paste de imagem e preserva o comportamento da aplicação.
+
+### Única colisão de tecla encontrada
+
+`keys.remote_image_paste` do Herdr é `Ctrl+V` por padrão e só se aplica ao cliente local de `herdr --remote`. O Alacritty captura `Ctrl+V` antes e o transforma em paste textual; nesse cenário específico o Herdr nunca recebe o chord cru para enviar uma imagem remota.
+
+Isso não quebra colar texto local. É uma incompatibilidade condicional para **colar imagem em sessão Herdr remota**. Se esse recurso entrar no contrato do red-dev, a tecla deve ser reconfigurada para um chord que o terminal externo não consuma.
+
+## Caminho de cópia interno Herdr → Zellij
+
+O changelog oficial do Herdr registra que:
+
+- pedidos OSC 52 emitidos por aplicações dentro dos panes são encaminhados ao clipboard do host;
+- sob WSL o Herdr passou a preferir OSC 52;
+- mouse selection/double-click e copy mode escrevem no clipboard;
+- copy mode vive em `prefix+[`;
+- clientes locais deixaram de tratar `Ctrl+V` como paste de imagem.
+
+Os logs desta sessão repetiram a mensagem `copied selection to clipboard`. O binário contém os caminhos de escrita OSC 52 e suas mensagens de erro. Isso confirma que o Herdr não tenta iniciar PowerShell para a seleção interna; ele pede ao terminal externo que copie.
+
+O código pinado do Zellij mostra dois providers:
+
+```text
+ClipboardProvider::Command(copy_command)
+ClipboardProvider::Osc52(clipboard)
+```
+
+Quando há `copy_command`, o conteúdo é escrito em bytes UTF-8 no `stdin` do processo. O processo é acompanhado em uma thread; se não terminar em um segundo, é morto e o Zellij registra `Copy operation times out after 1 second`.
+
+O Zellij também interpreta atualizações de clipboard vindas do pane. Portanto, em uma composição aninhada:
+
+```text
+Herdr seleciona
+  → Herdr emite OSC 52
+  → Zellij drena a atualização OSC 52 do pane
+  → Zellij chama seu ClipboardProvider
+  → provider chama copy_command
+```
+
+Essa é a razão de uma mensagem “copiado” do Herdr não provar que o clipboard Windows foi atualizado: a confirmação visual ocorre antes do subprocesso ser eventualmente morto pelo Zellij.
+
+## Reprodução e medições do defeito
+
+### Hipóteses ordenadas
+
+| Ordem | Hipótese | Resultado |
+|---|---|---|
+| 1 | PowerShell excede o deadline do Zellij | confirmada e causal |
+| 2 | bytes UTF-8 entregues diretamente a `clip.exe` sofrem decode errado | confirmada para o bridge antigo |
+| 3 | Zellij bloqueia o OSC 52 produzido pelo Herdr | rejeitada; ele o interpreta e encaminha |
+| 4 | Herdr captura `Ctrl+C` ou `Ctrl+V` localmente | rejeitada em modo terminal local na 0.7.5 |
+| 5 | Zellij locked mode captura os chords | rejeitada pela configuração efetiva |
+| 6 | locale do WSL não é UTF-8 | rejeitada; todo o locale é `C.UTF-8` |
+
+### PowerShell antigo
+
+O script de bridge anterior foi exercitado sem a chamada mutante `Set-Clipboard`, para medir apenas startup, leitura e decode:
+
+| Execução | Resultado com limite de 1 s |
+|---|---|
+| 1–5 | timeout em todas, aproximadamente 1.012 ms |
+
+Sem o limite:
+
+| Execução | Tempo |
+|---|---:|
+| 1 | 1.142 ms |
+| 2 | 1.178 ms |
+| 3 | 1.421 ms |
+
+Como o limite no código-fonte do Zellij é exatamente um segundo, a causa não depende de conjectura.
+
+### Bridge novo
+
+O bridge `iconv | clip.exe` foi exercitado 20 vezes:
+
+| Métrica | Valor |
+|---|---:|
+| Sucessos | 20/20 |
+| Mínimo | 74 ms |
+| Máximo | 132 ms |
+| Média | 95,9 ms |
+
+O teste automatizado usa um `clip.exe` falso e verifica que `copiar e colar: ação — 🧪` chega como UTF-16LE sem BOM em menos de um segundo. Esse teste não depende do clipboard real.
+
+### Estado presente no worktree durante a auditoria
+
+Outro fluxo de trabalho alterou estes arquivos enquanto o diagnóstico estava em andamento; estas mudanças não foram produzidas por este relatório:
+
+- `config/bash/windows-clipboard.sh`;
+- `src/dotfiles.ts`;
+- `src/clipboard.test.ts`;
+- `src/windows-output.ts` e teste;
+- `src/alacritty.ts`;
+- `src/wsl-provision.ts`, `src/wsl-sync.ts` e testes relacionados.
+
+O config implantado passou a conter:
+
+```kdl
+copy_command "bash /home/cyber/.local/share/red-dev/config/bash/windows-clipboard.sh"
+```
+
+O helper implantado é idêntico ao helper do repositório e é invocado explicitamente por `bash`, portanto o modo de arquivo `0644` não é um problema.
+
+Isso valida a direção da correção, mas não prova rollout completo:
+
+- o worktree ainda está sujo e sem evidência de commit/merge neste diagnóstico;
+- a sessão Zellij atual é mais antiga que a alteração do arquivo;
+- um arquivo alterado em disco não prova que o processo já recarregou a opção;
+- a validação final deve ocorrer em uma sessão nova ou depois de um reload explicitamente comprovado.
+
+## Charset: o que realmente está acontecendo
+
+### Evidência em bytes
+
+Texto de prova: `ação`.
+
+| Produtor | Configuração | Bytes observados | Decode correto |
+|---|---|---|---|
+| processo Linux no WSL | locale `C.UTF-8` | `61 c3 a7 c3 a3 6f` | UTF-8 |
+| `wsl.exe -l -v` redirecionado | padrão do launcher | pares como `20 00 4e 00 ...` | UTF-16LE |
+| `cmd.exe /c echo ação` | code page 850 | `61 87 c6 6f 0d 0a` | CP850/OEM atual |
+| `cmd.exe /u /c echo ação` | `/u` | `61 00 e7 00 e3 00 6f 00` | UTF-16LE |
+| Windows PowerShell 5.1 | output padrão observado | `61 87 c6 6f 0d 0a` | CP850/OEM atual |
+| PowerShell 5.1 com `Console.OutputEncoding=UTF8` | output normalizado | `61 c3 a7 c3 a3 6f` | UTF-8 |
+
+Na sessão observada, Windows PowerShell 5.1 reportou:
+
+| Propriedade | Valor |
+|---|---|
+| `Console.InputEncoding` | `ibm850` |
+| `Console.OutputEncoding` | `ibm850` |
+| `$OutputEncoding` | `us-ascii` |
+| `[Text.Encoding]::Default` | Windows-1252 |
+| `chcp` | 850 |
+
+Decodificar o output CP850 com `new Response(proc.stdout).text()` — que assume UTF-8 — produziu `a��o`.
+
+### Por que não é “UTF-16 versus UTF-8” apenas
+
+Há pelo menos quatro decisões distintas:
+
+1. encoding do texto do comando passado ao PowerShell;
+2. encoding do `stdin` recebido pelo processo filho;
+3. encoding do `stdout`/`stderr` produzido pelo executável;
+4. formato armazenado no clipboard ou no arquivo.
+
+`powershell.exe -EncodedCommand` exige Base64 de uma string UTF-16LE. Isso descreve a **entrada do comando**, não garante que o stdout será UTF-16LE.
+
+`$OutputEncoding` controla como PowerShell envia texto para programas nativos. `[Console]::OutputEncoding` controla como a aplicação escreve para a saída do console. Nenhuma dessas propriedades conserta automaticamente os bytes que `wsl.exe` ou `cmd.exe` escolheram emitir.
+
+`chcp 65001` também não é uma política suficiente: depende de console, processo, versão e modo de redirecionamento; não muda o contrato particular de `wsl.exe`, nem o requisito UTF-16LE de `-EncodedCommand`.
+
+### O clipboard é outro canal
+
+O Windows possui formatos de clipboard como `CF_TEXT`, `CF_OEMTEXT` e `CF_UNICODETEXT`, e pode sintetizar conversões entre eles. O comando `clip` recebe bytes redirecionados e os coloca no clipboard, mas sua documentação não promete que bytes UTF-8 arbitrários serão interpretados como UTF-8.
+
+Por isso, o bridge não deve depender da code page ativa. A conversão explícita de UTF-8 para UTF-16LE, validada com acentos, travessão e emoji, torna o contrato determinístico nesta fronteira.
+
+## Auditoria de fronteiras Windows no código
+
+### Já tratadas pelas mudanças presentes
+
+| Local | Produtor | Situação |
+|---|---|---|
+| `src/wsl-provision.ts` | `wsl.exe -l -v/-q` | usa `readWindowsOutput`; cobre UTF-16LE redirecionado |
+| `src/wsl-sync.ts` | `wsl.exe -d ...` | usa `readWindowsOutput`; cobre stdout UTF-8 do distro e erro UTF-16LE do launcher |
+| `src/alacritty.ts`, `defaultWslDistro` | `wsl.exe -l -q` | usa `readWindowsOutput` |
+| `src/alacritty.ts`, leitura/escrita de arquivos | PowerShell → Base64 ASCII | seguro para conteúdo arbitrário; bytes do arquivo continuam UTF-8 |
+| `src/dotfiles.ts` + helper | Zellij UTF-8 → `clip.exe` | conversão explícita UTF-16LE e deadline atendido |
+
+### Ainda frágeis para texto não ASCII
+
+| Prioridade | Local | Problema | Impacto provável |
+|---|---|---|---|
+| alta | `src/alacritty.ts:25-29`, `105-133` | `cmd.exe /c echo %APPDATA%` decodificado como UTF-8 | perfil Windows com acento pode impedir localizar/configurar Alacritty |
+| alta | `src/wsl.ts:44-49`, `75`, `100` | `%LOCALAPPDATA%` e `%USERPROFILE%` por `cmd.exe /c` + UTF-8 ingênuo | nomes de usuário e perfis redirecionados com acento corrompem paths |
+| alta | `src/theme-editors.ts:96-105` | `%APPDATA%` por `cmd.exe /c` + UTF-8 ingênuo | tema do VS Code não encontra `settings.json` |
+| alta | `src/wallpaper.ts:186-220` | caminho de wallpaper sai do PowerShell sem encoding declarado | wallpaper com diretório/nome acentuado vira path inválido |
+| média | `src/hotkeys.ts:117-131` | stdout e stderr do PowerShell decodificados como UTF-8 | labels, targets ou erros localizados aparecem corrompidos |
+| média | `src/providers.ts:200-230` | saída do Winget via `cmd.exe` decodificada como UTF-8 | detecção por mensagem e diagnóstico quebram em Windows localizado |
+| baixa | `src/drift.ts:284-300` | nome de família retornado pelo PowerShell sem encoding declarado | fontes futuras com nome não ASCII podem aparecer corrompidas |
+| baixa | `src/migrations.ts:56-73`, `101-115` | retorno atual é numérico ASCII | caminho feliz é seguro, mas o padrão não documenta o contrato |
+
+### ASCII seguro, mas stderr ainda merece contrato
+
+Estes caminhos retornam tokens controlados como `yes/no`, `added/present`, `ok` ou Base64 e não corrompem o dado principal:
+
+- `hostFileExists` e `readThroughHost` em `src/alacritty.ts`;
+- `addWindowsBinToPath` em `src/shared-root.ts`;
+- `applyWindowsTheme` em `src/windows-theme.ts`.
+
+Porém, quando o stderr de PowerShell contém uma mensagem localizada, o decode UTF-8 ingênuo ainda pode destruir justamente o diagnóstico apresentado ao usuário.
+
+## Limite do decoder heurístico atual
+
+`src/windows-output.ts` detecta:
+
+- BOM UTF-16LE;
+- texto ASCII-heavy em UTF-16LE pela distribuição dos NULs;
+- caso contrário, UTF-8.
+
+Isso é apropriado para o comportamento misto de `wsl.exe`: sucesso de um processo Linux pode ser UTF-8, enquanto erro do launcher pode vir em UTF-16LE.
+
+Não é um decoder universal de “saída Windows”:
+
+- CP850 não possui NULs e será confundido com UTF-8;
+- a página OEM varia por máquina e idioma;
+- texto UTF-16LE majoritariamente não ASCII pode ter poucos NULs e escapar da heurística;
+- UTF-16BE não é tratado;
+- heurística não substitui um contrato conhecido do produtor.
+
+O nome `readWindowsOutput` sugere uma generalidade que a implementação não deve ganhar. Ele deve permanecer restrito ao boundary misto do `wsl.exe`, ou ser renomeado para tornar essa limitação impossível de esquecer.
+
+## Arquitetura recomendada
+
+Em vez de um `capture()` que sempre chama `Response.text()`, cada spawn Windows deveria declarar o contrato:
+
+```ts
+type ProducerEncoding =
+  | "utf8"
+  | "utf16le"
+  | "wsl-mixed"
+  | "ascii"
+  | "base64-ascii";
+```
+
+Helpers recomendados:
+
+| Helper conceitual | Uso |
+|---|---|
+| `captureUtf8(argv)` | produtor explicitamente normalizado para UTF-8 |
+| `captureUtf16Le(argv)` | `cmd.exe /u` e outros produtores com contrato UTF-16LE |
+| `captureWslMixed(argv)` | apenas `wsl.exe`, onde child stdout e launcher error diferem |
+| `capturePowerShellUtf8(script)` | prefixa `[Console]::OutputEncoding = New-Object Text.UTF8Encoding($false)` |
+| `captureBase64(argv)` | paths e conteúdo arbitrário devolvidos como Base64 ASCII |
+
+Regras por produtor:
+
+1. **`cmd.exe`:** para valores de ambiente e paths, usar `/d /u /c` e decodificar explicitamente UTF-16LE; `/d` evita AutoRun do usuário contaminando a saída.
+2. **Windows PowerShell 5.1:** normalizar `[Console]::OutputEncoding` para UTF-8 sem BOM no próprio script, ou retornar Base64/JSON ASCII quando o conteúdo for arbitrário.
+3. **`wsl.exe`:** manter leitura de bytes e decode misto, coberto por fixtures de sucesso UTF-8 e erro/listagem UTF-16LE.
+4. **Arquivos:** transferir bytes em Base64 quando cruzar PowerShell/WSL; não transportar TOML/JSON multiline diretamente por quoting de shell.
+5. **Clipboard:** Zellij UTF-8 → UTF-16LE sem BOM → `clip.exe`, sempre com teste de latência abaixo de 1 s.
+6. **stderr:** aplicar o mesmo contrato do produtor; não corrigir apenas stdout.
+
+## Testes de aceitação necessários
+
+### Clipboard
+
+- texto ASCII;
+- `ação, configuração, São Paulo`;
+- travessão e aspas tipográficas;
+- CJK;
+- emoji fora do BMP, por exemplo `🧪`;
+- múltiplas linhas;
+- payload vazio;
+- payload grande o bastante para expor bloqueio de pipe;
+- 20–50 repetições, todas abaixo de 1 s com margem;
+- WSL interop ausente deve falhar de forma explícita;
+- `iconv` ausente deve falhar de forma explícita.
+
+### Gestos
+
+- `Ctrl+C` interrompe processo no shell dentro de Herdr dentro de Zellij;
+- seleção normal do mouse no Herdr atualiza clipboard Windows;
+- copy mode do Herdr atualiza clipboard Windows;
+- seleção própria do Zellij atualiza clipboard Windows;
+- `Shift` + drag cria seleção externa do Alacritty e copia;
+- `Ctrl+Shift+C` copia seleção externa;
+- `Ctrl+V` e `Ctrl+Shift+V` colam uma vez, com multiline como bracketed paste;
+- o caso `herdr --remote` documenta ou reconfigura paste de imagem.
+
+### Paths e stdout Windows
+
+Usar fixtures e, em CI Windows/WSL, perfis contendo:
+
+- `C:\Users\João`;
+- `C:\Dados\Configuração`;
+- wallpaper `São Paulo — noite.png`;
+- output em CP850;
+- output UTF-8;
+- output UTF-16LE com e sem BOM;
+- erro localizado em stderr;
+- listagem do WSL com nome de distribuição não ASCII.
+
+## Critérios de conclusão para o conserto
+
+O problema só deve ser considerado resolvido quando:
+
+1. o config implantado usa o bridge rápido;
+2. a sessão Zellij efetivamente em execução foi reiniciada/recarregada e isso foi reobservado;
+3. mouse selection no Herdr e copy mode atualizam o clipboard Windows com texto Unicode;
+4. `Ctrl+C` continua interrompendo;
+5. `Ctrl+Shift+C`, `Ctrl+V` e `Ctrl+Shift+V` obedecem ao contrato acima;
+6. todos os testes focados passam;
+7. os paths `%APPDATA%`, `%LOCALAPPDATA%` e `%USERPROFILE%` não dependem de decode CP850 como UTF-8;
+8. os boundaries restantes de PowerShell/cmd têm encoding declarado;
+9. a mudança está commitada, integrada e validada numa sessão nova — não apenas presente num worktree sujo.
+
+## Validação automatizada observada
+
+Com as mudanças concorrentes presentes, o comando focado passou:
+
+```text
+bun test src/clipboard.test.ts src/windows-output.test.ts src/wsl-provision.test.ts
+
+22 pass
+0 fail
+33 expect()
+```
+
+O teste de clipboard usa um executável falso e não toca o clipboard real.
+
+Não foi possível abrir uma segunda instância Herdr totalmente isolada dentro da sessão Herdr já ativa: o produto bloqueia nested launch por padrão e o processo continuou encontrando o namespace existente mesmo com variáveis removidas. Forçar ou parar a sessão real destruiria trabalho em andamento, então o seam completo de paste não foi exercitado. A sessão Zellij diagnóstica criada para essa tentativa foi encerrada ao final.
+
+Durante um probe anterior do bridge, o clipboard real foi sobrescrito por texto ASCII e o conteúdo anterior não pôde ser recuperado. Depois desse incidente todos os testes foram movidos para doubles/fakes e nenhum outro probe alterou o clipboard real.
+
+## Fontes oficiais
+
+### Alacritty
+
+- [Configuração oficial do Alacritty](https://alacritty.org/config-alacritty.html) — `save_to_clipboard`, ações `Copy` e `Paste`.
+
+### Zellij
+
+- [Zellij options](https://zellij.dev/documentation/options.html) — `mouse_mode`, `copy_command`, `copy_on_select` e fallback OSC 52.
+- [Clipboard provider no código pinado](https://github.com/zellij-org/zellij/blob/a7259350a835dd89e89ce26dc88f2e31f2f38f6f/zellij-server/src/tab/clipboard.rs) — provider Command versus OSC 52.
+- [Implementação pinada de copy_command](https://github.com/zellij-org/zellij/blob/a7259350a835dd89e89ce26dc88f2e31f2f38f6f/zellij-server/src/tab/copy_command.rs) — bytes escritos no stdin e timeout de um segundo.
+- [Tratamento de output/OSC no tab do Zellij](https://github.com/zellij-org/zellij/blob/a7259350a835dd89e89ce26dc88f2e31f2f38f6f/zellij-server/src/tab/mod.rs) — atualização de clipboard emitida por pane aninhado.
+
+### Herdr
+
+- [Herdr keyboard](https://herdr.dev/docs/keyboard/) — `Ctrl+C` pertence ao programa, prefixo, copy mode e mouse drag-select.
+- [Herdr config reference](https://herdr.dev/docs/config-reference/) — defaults de `prefix`, `remote_image_paste`, `mouse_capture` e `copy_on_select`.
+- [Herdr changelog](https://github.com/herdrdev/herdr/blob/master/CHANGELOG.md) — OSC 52 aninhado, WSL clipboard, copy mode, bracketed paste e correção do `Ctrl+V` local.
+
+### Windows e PowerShell
+
+- [PowerShell about_Character_Encoding](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_character_encoding?view=powershell-7.6) — inconsistências históricas do Windows PowerShell e papel de `$OutputEncoding`.
+- [PowerShell 5.1 executable](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_powershell_exe?view=powershell-5.1) — `-EncodedCommand` exige UTF-16LE antes de Base64.
+- [.NET Console.OutputEncoding](https://learn.microsoft.com/en-us/dotnet/api/system.console.outputencoding) — encoding usado para escrever output do console.
+- [`cmd.exe`](https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/cmd) — `/u` produz output Unicode e `/d` desativa AutoRun.
+- [`clip`](https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/clip) — entrada redirecionada para o clipboard.
+- [Formatos do clipboard Win32](https://learn.microsoft.com/en-us/windows/win32/dataxchg/clipboard-formats) — `CF_TEXT`, `CF_OEMTEXT`, `CF_UNICODETEXT` e conversões do sistema.
+
+## Decisão recomendada
+
+Manter a composição Alacritty + Zellij + Herdr. Ela não precisa ser removida para obter clipboard confiável.
+
+Padronizar a experiência assim:
+
+```text
+Ctrl+C                interrupção
+Ctrl+Shift+C          cópia de seleção do Alacritty
+mouse drag            seleção/cópia do Herdr ou Zellij
+Shift+mouse drag      seleção/cópia externa do Alacritty
+Ctrl+V                paste do clipboard Windows
+Ctrl+Shift+V          paste alternativo do clipboard Windows
+Ctrl+B [ ... y        copy mode do Herdr
+```
+
+Completar o trabalho em duas trilhas separadas:
+
+1. **Clipboard:** integrar e validar o helper rápido numa sessão Zellij nova, incluindo Unicode e os gestos acima.
+2. **Encoding:** substituir captures genéricos nos boundaries Windows por contratos explícitos, começando pelos paths de `%APPDATA%`, `%LOCALAPPDATA%` e `%USERPROFILE%`.
+
+Essa separação evita a correção cosmética de trocar locale ou code page global, que pode mascarar um produtor e quebrar outro.


### PR DESCRIPTION
Lands the four research documents cited by the Spec #5 tickets (workers could not read uncommitted evidence), plus the project statusline settings, and ignores `.claude/settings.local.json`. Clearing the untracked paths lets the worker boot guard auto-fast-forward the local trunk, ending the boot-loop that killed fleet waves whenever the release bot moved main.

Two studies are in Portuguese — translation debt tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0172iFcxJFvKcyTSHmgejY89

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788376908&installation_model_id=20659&pr_number=26&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F26&signature=2630436e68484465547ba05f22097766006d0579640c48cfe36531b6da15e8ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->