### PR TITLE
chore: #15 Remove dead code: fzfColors

### DIFF
--- a/src/theme-cli.ts
+++ b/src/theme-cli.ts
@@ -222,25 +222,3 @@ export async function applyHerdr(p: Platform, slug: string): Promise<boolean> {
   await Bun.write(path, `${existing.trimEnd()}\n\n${block}`);
   return true;
 }
-
-/**
- * fzf, which takes its colours from an environment variable.
- *
- * Not a file, so this returns the line for the shell config rather than
- * writing anything — the dotfiles own the environment.
- */
-export function fzfColors(theme: Theme): string {
-  const c = theme.terminal;
-  return [
-    `--color=bg+:${c.selectionBackground}`,
-    `fg:${c.foreground}`,
-    `fg+:${c.brightWhite}`,
-    `hl:${c.blue}`,
-    `hl+:${c.brightBlue}`,
-    `info:${c.brightBlack}`,
-    `prompt:${c.red}`,
-    `pointer:${c.purple}`,
-    `marker:${c.green}`,
-    `border:${c.brightBlack}`,
-  ].join(",");
-}


### PR DESCRIPTION
Automated AFK landing for #15. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #15

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788377595&installation_model_id=20659&pr_number=28&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F28&signature=02190e7b1185e79e1ec1ba346d66a2c6ccfcbb10959cfbb51746abf1840db578"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->