### PR TITLE
merge: #12 VS Code theming parses JSONC settings; Osaka Jade states its real coverage

### DIFF
--- a/scripts/check-vscode-themes.ts
+++ b/scripts/check-vscode-themes.ts
@@ -45,6 +45,7 @@ async function exists(id: string): Promise<boolean> {
 
 const missing: string[] = [];
 for (const [slug, spec] of Object.entries(VSCODE_THEMES)) {
+  if (spec.status !== "exact") continue;
   const ok = await exists(spec.extension);
   console.log(`  ${ok ? "ok     " : "MISSING"} ${slug.padEnd(12)} ${spec.extension}`);
   if (!ok) missing.push(`${slug} -> ${spec.extension}`);

--- a/src/theme-editors.test.ts
+++ b/src/theme-editors.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { codeArgv, gnomeColorScheme } from "./theme-editors.ts";
+import { codeArgv, gnomeColorScheme, VSCODE_THEMES, vscodeSettingsJson } from "./theme-editors.ts";
 import { THEMES } from "./themes.ts";
 
 describe("codeArgv", () => {
@@ -31,6 +31,33 @@ describe("codeArgv", () => {
 
   test("does not wrap a path that merely contains .cmd", () => {
     expect(codeArgv(["C:\\cmd.tools\\code.exe"], "win32")).toEqual(["C:\\cmd.tools\\code.exe"]);
+  });
+});
+
+describe("VS Code themes", () => {
+  test("themes settings.json that contains comments and a trailing comma", () => {
+    const next = vscodeSettingsJson(
+      `{
+  // kept by VS Code
+  "editor.fontFamily": "FiraCode Nerd Font",
+  "workbench.colorTheme": "Default Dark Modern",
+}
+`,
+      "Tokyo Night",
+    );
+
+    expect(JSON.parse(next)).toEqual({
+      "editor.fontFamily": "FiraCode Nerd Font",
+      "workbench.colorTheme": "Tokyo Night",
+    });
+  });
+
+  test("reports Osaka Jade as unsupported instead of exact", () => {
+    expect(VSCODE_THEMES["osaka-jade"]).toEqual({
+      status: "unsupported",
+      reason:
+        "no exact Osaka Jade VS Code theme is published; Solarized Osaka is a different palette",
+    });
   });
 });
 

--- a/src/theme-editors.ts
+++ b/src/theme-editors.ts
@@ -42,32 +42,127 @@ export function codeArgv(argv: string[], platform: string = process.platform): s
  * `workbench.colorTheme` to a theme that is not installed leaves VS
  * Code on its default with a notification nobody reads.
  */
-export const VSCODE_THEMES: Record<string, { extension: string; label: string }> = {
-  "tokyo-night": { extension: "enkia.tokyo-night", label: "Tokyo Night" },
-  catppuccin: { extension: "Catppuccin.catppuccin-vsc", label: "Catppuccin Macchiato" },
-  gruvbox: { extension: "jdinhlife.gruvbox", label: "Gruvbox Dark Medium" },
-  everforest: { extension: "sainnhe.everforest", label: "Everforest Dark" },
-  kanagawa: { extension: "qufiwefefwoyn.kanagawa", label: "Kanagawa" },
+export type VsCodeThemeSpec =
+  | { status: "exact"; extension: string; label: string }
+  | { status: "unsupported"; reason: string };
+
+export const VSCODE_THEMES: Record<string, VsCodeThemeSpec> = {
+  "tokyo-night": { status: "exact", extension: "enkia.tokyo-night", label: "Tokyo Night" },
+  catppuccin: { status: "exact", extension: "Catppuccin.catppuccin-vsc", label: "Catppuccin Macchiato" },
+  gruvbox: { status: "exact", extension: "jdinhlife.gruvbox", label: "Gruvbox Dark Medium" },
+  everforest: { status: "exact", extension: "sainnhe.everforest", label: "Everforest Dark" },
+  kanagawa: { status: "exact", extension: "qufiwefefwoyn.kanagawa", label: "Kanagawa" },
   // Was AndreiVoronkov.matte-black, which the marketplace has never
   // published. Label taken from the extension's own contributes.themes
   // rather than from its display name — "Matte Black Theme", not
   // "Matte Black", and workbench.colorTheme wants the former.
-  "matte-black": { extension: "CleanThemes.matte-black-theme", label: "Matte Black Theme" },
-  nord: { extension: "arcticicestudio.nord-visual-studio-code", label: "Nord" },
+  "matte-black": { status: "exact", extension: "CleanThemes.matte-black-theme", label: "Matte Black Theme" },
+  nord: { status: "exact", extension: "arcticicestudio.nord-visual-studio-code", label: "Nord" },
   // Was kaiwood.monokai-pro, which does not exist; this is the
   // publisher's own.
   ristretto: {
+    status: "exact",
     extension: "monokai.theme-monokai-pro-vscode",
     label: "Monokai Pro (Filter Ristretto)",
   },
-  "rose-pine": { extension: "mvllow.rose-pine", label: "Rosé Pine" },
-  // osaka-jade is deliberately absent. solomonhyt.osaka-jade does not
-  // exist either, and no VS Code theme of that name does — the nearest
-  // matches are Solarized Osaka, which is a different palette. Falling
-  // through to "no VS Code theme mapped" leaves the editor alone, which
-  // is honest; pointing at a plausible-looking neighbour would theme it
-  // wrong and say it succeeded.
+  "rose-pine": { status: "exact", extension: "mvllow.rose-pine", label: "Rosé Pine" },
+  "osaka-jade": {
+    status: "unsupported",
+    reason:
+      "no exact Osaka Jade VS Code theme is published; Solarized Osaka is a different palette",
+  },
 };
+
+function stripJsonComments(text: string): string {
+  let out = "";
+  let inString = false;
+  let inLine = false;
+  let inBlock = false;
+  for (let i = 0; i < text.length; i++) {
+    const c = text[i]!;
+    const next = text[i + 1];
+    if (inLine) {
+      if (c === "\n") {
+        inLine = false;
+        out += c;
+      }
+      continue;
+    }
+    if (inBlock) {
+      if (c === "*" && next === "/") {
+        inBlock = false;
+        i++;
+      }
+      continue;
+    }
+    if (inString) {
+      out += c;
+      if (c === "\\") {
+        out += text[i + 1] ?? "";
+        i++;
+        continue;
+      }
+      if (c === '"') inString = false;
+      continue;
+    }
+    if (c === '"') {
+      inString = true;
+      out += c;
+      continue;
+    }
+    if (c === "/" && next === "/") {
+      inLine = true;
+      i++;
+      continue;
+    }
+    if (c === "/" && next === "*") {
+      inBlock = true;
+      i++;
+      continue;
+    }
+    out += c;
+  }
+  return out;
+}
+
+function stripTrailingCommas(text: string): string {
+  let out = "";
+  let inString = false;
+  for (let i = 0; i < text.length; i++) {
+    const c = text[i]!;
+    if (inString) {
+      out += c;
+      if (c === "\\") {
+        out += text[i + 1] ?? "";
+        i++;
+        continue;
+      }
+      if (c === '"') inString = false;
+      continue;
+    }
+    if (c === '"') {
+      inString = true;
+      out += c;
+      continue;
+    }
+    if (c === ",") {
+      const rest = text.slice(i + 1);
+      if (/^\s*[\]}]/.test(rest)) continue;
+    }
+    out += c;
+  }
+  return out;
+}
+
+export function parseJsoncObject(text: string): Record<string, unknown> {
+  return JSON.parse(stripTrailingCommas(stripJsonComments(text))) as Record<string, unknown>;
+}
+
+export function vscodeSettingsJson(original: string, label: string): string {
+  const settings = original.trim() ? parseJsoncObject(original) : {};
+  settings["workbench.colorTheme"] = label;
+  return JSON.stringify(settings, null, 2) + "\n";
+}
 
 /**
  * Where the VS Code that will actually run reads its settings.
@@ -129,6 +224,10 @@ export async function applyVsCodeTheme(theme: Theme, p: Platform, slug: string):
     log.skip(`no VS Code theme mapped for ${slug}`);
     return false;
   }
+  if (spec.status === "unsupported") {
+    log.skip(`no VS Code theme mapped for ${slug}: ${spec.reason}`);
+    return false;
+  }
 
   // Installing the extension first: setting a theme that is not there
   // leaves the editor on its default.
@@ -152,10 +251,11 @@ export async function applyVsCodeTheme(theme: Theme, p: Platform, slug: string):
     return false;
   }
 
-  let settings: Record<string, unknown> = {};
+  let original = "";
   if (existsSync(path)) {
     try {
-      settings = JSON.parse(await Bun.file(path).text()) as Record<string, unknown>;
+      original = await Bun.file(path).text();
+      parseJsoncObject(original);
     } catch {
       // A settings.json with comments or a trailing comma is common and
       // valid to VS Code but not to JSON.parse. Overwriting it would
@@ -167,8 +267,7 @@ export async function applyVsCodeTheme(theme: Theme, p: Platform, slug: string):
     mkdirSync(path.replace(/[\\/][^\\/]+$/, ""), { recursive: true });
   }
 
-  settings["workbench.colorTheme"] = spec.label;
-  await Bun.write(path, JSON.stringify(settings, null, 2) + "\n");
+  await Bun.write(path, vscodeSettingsJson(original, spec.label));
   void theme;
   return true;
 }


### PR DESCRIPTION
<!-- afk:reseed-trail v1 issue=12 -->
🤖 **Re-seed trail** — #12 on `afk/12-vs-code-theming-parses-jsonc-settings-os`, lane `/afk`.

Rounds spent: 1/4. A Re-seed re-instructs the implementer in place —
same Worker, same Worktree, same branch — after a gate stage blocked the work.

| round | trigger | what it was asked to fix |
| --- | --- | --- |
| 1/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE; correction retry 1/3. |

The Worker's branch and iteration log are the source of truth; this is a derived projection.

Closes #12

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788377776&installation_model_id=20659&pr_number=29&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F29&signature=d36ae0f0b81a9a712ab3e07594ba886d64e0e04310fbd193123ae9a7dadcb5a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->