### PR TITLE
chore: #14 Persisted preferences hydrate the apply context on every entry path

### DIFF
--- a/src/apply-context.test.ts
+++ b/src/apply-context.test.ts
@@ -1,0 +1,71 @@
+import { mkdirSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { describe, expect, test } from "bun:test";
+import {
+  applyContextForEntry,
+  type ApplyContextEntryPath,
+  type InvocationDefaults,
+} from "./preferences.ts";
+import type { Platform } from "./platform.ts";
+
+const linux: Platform = {
+  os: "linux",
+  distro: "ubuntu",
+  version: "24.04",
+  codename: "noble",
+  env: "desktop",
+  arch: "x64",
+  caps: { apt: true, gui: false, systemd: true, winget: false, flatpak: true },
+};
+
+async function withHome<T>(run: () => Promise<T>): Promise<T> {
+  const previous = process.env["HOME"];
+  process.env["HOME"] = mkdtempSync(`${tmpdir()}/red-dev-prefs-`);
+  try {
+    mkdirSync(`${process.env["HOME"]}/.config/alacritty`, { recursive: true });
+    await Bun.write(
+      `${process.env["HOME"]}/.config/alacritty/red-dev.json`,
+      JSON.stringify({ theme: "gruvbox", font: "jetbrainsmono", fontSize: 14 }) + "\n",
+    );
+    return await run();
+  } finally {
+    if (previous === undefined) delete process.env["HOME"];
+    else process.env["HOME"] = previous;
+  }
+}
+
+const defaults: InvocationDefaults = {
+  themeName: "tokyo-night",
+  font: "firacode",
+  opacity: 90,
+};
+
+describe("apply context preferences", () => {
+  test("a theme switch context preserves a persisted non-default font and size", async () => {
+    await withHome(async () => {
+      const ctx = await applyContextForEntry(linux, defaults, "theme");
+
+      expect(ctx).toMatchObject({
+        theme: "gruvbox",
+        font: "jetbrainsmono",
+        fontSize: 14,
+      });
+    });
+  });
+
+  test("all apply entry paths hydrate through the same preference seam", async () => {
+    await withHome(async () => {
+      const entries: ApplyContextEntryPath[] = ["plan", "install", "update", "theme"];
+      const contexts = await Promise.all(
+        entries.map((entry) => applyContextForEntry(linux, defaults, entry)),
+      );
+
+      expect(contexts.map((ctx) => [ctx.theme, ctx.font, ctx.fontSize])).toEqual([
+        ["gruvbox", "jetbrainsmono", 14],
+        ["gruvbox", "jetbrainsmono", 14],
+        ["gruvbox", "jetbrainsmono", 14],
+        ["gruvbox", "jetbrainsmono", 14],
+      ]);
+    });
+  });
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,6 +17,7 @@ import {
 } from "./manifest.ts";
 import { detect, summary, type Platform } from "./platform.ts";
 import { applyProvider, systemUpdate, type ApplyContext } from "./providers.ts";
+import { applyContextForEntry, type ApplyContextEntryPath } from "./preferences.ts";
 import { THEMES, themeNames } from "./themes.ts";
 import { interactive, select } from "./ui.ts";
 
@@ -24,13 +25,12 @@ function resolveScopes(p: Platform, arg?: string): Scope[] {
   return arg ? [arg as Scope] : applicableScopes(p);
 }
 
-function contextFor(p: Platform, inv: Invocation): ApplyContext {
-  return {
-    platform: p,
-    theme: inv.themeName,
-    font: inv.font,
-    opacity: inv.opacity,
-  };
+async function contextFor(
+  p: Platform,
+  inv: Invocation,
+  entry: ApplyContextEntryPath,
+): Promise<ApplyContext> {
+  return await applyContextForEntry(p, inv, entry);
 }
 
 function cmdPlatform(p: Platform): number {
@@ -38,7 +38,8 @@ function cmdPlatform(p: Platform): number {
   return 0;
 }
 
-function cmdPlan(p: Platform, inv: Invocation): number {
+async function cmdPlan(p: Platform, inv: Invocation): Promise<number> {
+  await contextFor(p, inv, "plan");
   for (const scope of resolveScopes(p, inv.scope)) {
     log.plain(`\n[${scope}]`);
     for (const tool of toolsInScope(scope)) {
@@ -110,8 +111,12 @@ async function cmdDoctor(p: Platform, inv: Invocation): Promise<number> {
   return 0;
 }
 
-async function cmdInstall(p: Platform, inv: Invocation): Promise<number> {
-  let ctx = contextFor(p, inv);
+async function cmdInstall(
+  p: Platform,
+  inv: Invocation,
+  entry: "install" | "update" = "install",
+): Promise<number> {
+  let ctx = await contextFor(p, inv, entry);
   let extraScopes: Scope[] = [];
 
   // Ask once, on a real terminal, when this machine is new. Every ui.ts
@@ -220,12 +225,13 @@ async function cmdUpdate(p: Platform, inv: Invocation): Promise<number> {
 
   // Upgrading can leave the manifest unsatisfied (a package removed, a
   // binary replaced), so always re-converge afterwards.
-  return await cmdInstall(p, inv);
+  return await cmdInstall(p, inv, "update");
 }
 
 async function cmdTheme(p: Platform, inv: Invocation, name?: string): Promise<number> {
+  const ctx = await contextFor(p, inv, "theme");
   const chosen =
-    name ?? (await select("Theme?", themeNames() as [string, ...string[]], inv.themeName));
+    name ?? (await select("Theme?", themeNames() as [string, ...string[]], ctx.theme));
   const theme = THEMES[chosen];
   if (!theme) {
     log.err(`unknown theme '${chosen}' (known: ${themeNames().join(", ")})`);
@@ -233,9 +239,9 @@ async function cmdTheme(p: Platform, inv: Invocation, name?: string): Promise<nu
   }
 
   const wsl = await import("./wsl.ts");
-  const spec = wsl.NERD_FONTS[inv.font];
+  const spec = wsl.NERD_FONTS[ctx.font];
   if (!spec) {
-    log.err(`unknown font '${inv.font}'`);
+    log.err(`unknown font '${ctx.font}'`);
     return 1;
   }
 
@@ -250,7 +256,8 @@ async function cmdTheme(p: Platform, inv: Invocation, name?: string): Promise<nu
       platform: p,
       theme,
       fontFamily: spec.family,
-      opacity: inv.opacity,
+      fontSize: ctx.fontSize,
+      opacity: ctx.opacity,
     });
   } catch (err) {
     log.err(`alacritty: ${(err as Error).message}`);
@@ -277,7 +284,7 @@ async function cmdTheme(p: Platform, inv: Invocation, name?: string): Promise<nu
       await wsl.configureWindowsTerminal({
         fontFace: spec.family,
         theme,
-        opacity: inv.opacity,
+        opacity: ctx.opacity,
         distro: process.env["WSL_DISTRO_NAME"] ?? undefined,
         home: process.env["HOME"] ?? undefined,
       });
@@ -323,7 +330,7 @@ async function cmdApps(p: Platform, inv: Invocation): Promise<number> {
 
   // Map the decorated labels back to tool names.
   const names = picked.map((l) => l.split(" ")[0]!.trim());
-  const ctx = contextFor(p, inv);
+  const ctx = await contextFor(p, inv, "install");
   let failures = 0;
 
   for (const name of names) {
@@ -390,14 +397,16 @@ async function cmdShell(p: Platform, inv: Invocation): Promise<number> {
   try {
     const { configureAlacritty } = await import("./alacritty.ts");
     const wsl = await import("./wsl.ts");
-    const theme = THEMES[inv.themeName];
-    const spec = wsl.NERD_FONTS[inv.font];
+    const ctx = await contextFor(p, inv, "theme");
+    const theme = THEMES[ctx.theme];
+    const spec = wsl.NERD_FONTS[ctx.font];
     if (theme && spec) {
       await configureAlacritty({
         platform: p,
         theme,
         fontFamily: spec.family,
-        opacity: inv.opacity,
+        fontSize: ctx.fontSize,
+        opacity: ctx.opacity,
       });
     }
     log.plain("     open a new terminal window to see it");
@@ -513,7 +522,7 @@ async function cmdUi(p: Platform, inv: Invocation): Promise<number> {
     p,
     {
       platform: p,
-      ctx: contextFor(p, inv),
+      ctx: await contextFor(p, inv, "install"),
       scopes: resolveScopes(p, inv.scope),
     },
     // Every one of these runs inside the interface now. Choosing a theme
@@ -725,7 +734,8 @@ async function cmdMenu(p: Platform, inv: Invocation, cliHelp: string): Promise<n
     applyFont: async (font, size) => {
       const wsl = await import("./wsl.ts");
       const spec = wsl.NERD_FONTS[font];
-      const theme = THEMES[inv.themeName];
+      const ctx = await contextFor(p, inv, "theme");
+      const theme = THEMES[ctx.theme];
       if (!spec || !theme) return;
       const { configureAlacritty } = await import("./alacritty.ts");
       await configureAlacritty({
@@ -733,7 +743,7 @@ async function cmdMenu(p: Platform, inv: Invocation, cliHelp: string): Promise<n
         theme,
         fontFamily: spec.family,
         fontSize: size,
-        opacity: inv.opacity,
+        opacity: ctx.opacity,
       });
     },
   });
@@ -847,7 +857,7 @@ async function main(): Promise<number> {
     case "platform":
       return cmdPlatform(p);
     case "plan":
-      return cmdPlan(p, inv);
+      return await cmdPlan(p, inv);
     case "doctor":
       return await cmdDoctor(p, inv);
     case "install":

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -46,7 +46,7 @@ type Handlers = {
   install: () => Promise<number>;
   update: () => Promise<number>;
   doctor: () => Promise<number>;
-  plan: () => number;
+  plan: () => Promise<number>;
   platform: () => number;
   apps: () => Promise<number>;
   lang: () => Promise<number>;
@@ -168,7 +168,7 @@ export async function runMenu(
         last = await h.update();
         break;
       case "Plan":
-        last = h.plan();
+        last = await h.plan();
         break;
       case "Doctor":
         last = await h.doctor();

--- a/src/preferences.ts
+++ b/src/preferences.ts
@@ -16,6 +16,7 @@
  */
 
 import { existsSync, mkdirSync } from "node:fs";
+import type { ApplyContext } from "./providers.ts";
 import type { Platform } from "./platform.ts";
 
 export type TerminalShell = "wsl" | "gitbash";
@@ -83,4 +84,36 @@ export async function resolveTerminalShell(p: Platform): Promise<TerminalShell> 
   const prefs = await readPreferences(p);
   if (prefs.terminalShell) return prefs.terminalShell;
   return p.env === "wsl" ? "wsl" : "gitbash";
+}
+
+export type ApplyContextEntryPath = "plan" | "install" | "update" | "theme";
+
+export interface InvocationDefaults {
+  themeName: string;
+  font: string;
+  opacity: number;
+}
+
+/**
+ * Build the apply context after durable preferences have had their say.
+ *
+ * Command flags remain a run's defaults, but recorded user choices are
+ * the better answer when a non-interactive entry point regenerates
+ * terminal configuration. Without this, theme switches and converges
+ * rewrote font.toml with FiraCode 11 even on machines configured for a
+ * different font.
+ */
+export async function applyContextForEntry(
+  p: Platform,
+  inv: InvocationDefaults,
+  _entry: ApplyContextEntryPath,
+): Promise<ApplyContext> {
+  const prefs = await readPreferences(p);
+  return {
+    platform: p,
+    theme: prefs.theme ?? inv.themeName,
+    font: prefs.font ?? inv.font,
+    fontSize: prefs.fontSize,
+    opacity: inv.opacity,
+  };
 }

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -695,6 +695,8 @@ export interface ApplyContext {
   theme: string;
   /** Font key from src/wsl.ts NERD_FONTS. */
   font: string;
+  /** Terminal font size in points. */
+  fontSize?: number;
   /** Terminal background opacity, 0-100. */
   opacity: number;
 }
@@ -763,6 +765,7 @@ export async function applyProvider(pr: Provider, ctx: ApplyContext): Promise<vo
             platform: ctx.platform,
             theme,
             fontFamily: spec.family,
+            fontSize: ctx.fontSize,
             opacity: ctx.opacity,
           });
         } catch (err) {


### PR DESCRIPTION
Automated AFK landing for #14. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #14

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788377879&installation_model_id=20659&pr_number=30&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F30&signature=057b34b360632ebf8f8708eda627c455104112439a340bb14e58ff73e2d78617"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->