### PR TITLE
chore: #8 Manifest corrections: wl-clipboard, ffmpeg dependency, current red-ui Windows asset

### DIFF
--- a/src/manifest.test.ts
+++ b/src/manifest.test.ts
@@ -117,6 +117,37 @@ describe("isInstalled", () => {
 });
 
 describe("the manifest itself", () => {
+  test("Linux desktop declares wl-clipboard for Zellij copy", () => {
+    const tool = TOOLS.find((t) => t.name === "wl-clipboard");
+    expect(tool?.scope).toBe("desktop");
+    expect(providerFor(tool!, DESKTOP)).toEqual({ kind: "apt", pkg: "wl-clipboard" });
+  });
+
+  test("webm2mp4's ffmpeg dependency is declared", () => {
+    const tool = TOOLS.find((t) => t.name === "ffmpeg");
+    expect(tool?.scope).toBe("core");
+    expect(providerFor(tool!, WSL24)).toEqual({ kind: "apt", pkg: "ffmpeg" });
+    expect(providerFor(tool!, WINDOWS)).toEqual({ kind: "winget", id: "Gyan.FFmpeg" });
+  });
+
+  test("red-ui consumes the current Windows release asset", () => {
+    const tool = TOOLS.find((t) => t.name === "red-ui");
+    expect(providerFor(tool!, WINDOWS)).toEqual({
+      kind: "gh",
+      repo: "reddb-io/red-ui",
+      asset: "red-ui-windows-x86_64-setup.exe",
+      silentArgs: ["/S"],
+    });
+  });
+
+  test("a clean Windows plan includes red-ui", () => {
+    const plan = applicableScopes(WINDOWS)
+      .flatMap((scope) => toolsInScope(scope))
+      .filter((tool) => providerFor(tool, WINDOWS).kind !== "skip")
+      .map((tool) => tool.name);
+    expect(plan).toContain("red-ui");
+  });
+
   test("every skip carries a reason", () => {
     // A skip is a decision. One without a reason is an undocumented gap
     // wearing a decision's clothes.

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -258,6 +258,14 @@ export const TOOLS: Tool[] = [
   { name: "btop", scope: "core", u24: apt("btop"), win: winget("aristocratos.btop4win") },
   { name: "jq", scope: "core", u24: apt("jq"), win: winget("jqlang.jq") },
   {
+    // config/bash/functions.sh ships webm2mp4, and that helper is only
+    // honest if the binary it shells out to is part of the base toolset.
+    name: "ffmpeg",
+    scope: "core",
+    u24: apt("ffmpeg"),
+    win: winget("Gyan.FFmpeg"),
+  },
+  {
     // Beside jq rather than instead of it: the same shape of tool for a
     // different format, and the reason it is core is that a data tool
     // you cannot rely on being present is one you stop reaching for.
@@ -501,6 +509,14 @@ export const TOOLS: Tool[] = [
   },
   { name: "flatpak", scope: "desktop", u24: apt("flatpak"), win: skip(NO_GUI) },
   {
+    // Zellij's configured copy command targets wl-copy on real Linux
+    // desktops. WSL and native Windows use their own clipboard bridges.
+    name: "wl-clipboard",
+    scope: "desktop",
+    u24: apt("wl-clipboard"),
+    win: skip(NO_GUI),
+  },
+  {
     // A GUI app, so `desktop` — which also means WSL never attempts it,
     // because applicableScopes gates that scope on caps.gui. That is the
     // right answer rather than an omission: a Linux GUI app installed
@@ -531,12 +547,9 @@ export const TOOLS: Tool[] = [
     win: ghInstaller("reddb-io/red-request", "red-request-windows-x86_64-setup.exe", "/S"),
   },
   {
-    // The other RedDB desktop app. Same shape as red-request and a
-    // different answer on Windows, because the release genuinely has no
-    // Windows asset — .deb, .AppImage, .rpm and a web bundle, nothing
-    // else. skip() with the real reason rather than pointing the
-    // provider at a name that does not exist, which is the failure the
-    // gh provider was written to make impossible.
+    // The other RedDB desktop app. Same shape as red-request: Linux
+    // takes the deb, while Windows consumes the published installer
+    // asset directly so a clean native Windows converge gets the app.
     //
     // The glob carries a wildcard where the version goes:
     // red-ui_0.1.0_amd64.deb. Anchoring it to today's version is exactly
@@ -545,7 +558,7 @@ export const TOOLS: Tool[] = [
     about: "universal client for reddb — embedded, server, docker, cluster",
     scope: "desktop",
     u24: gh("reddb-io/red-ui", "red-ui_*_amd64.deb"),
-    win: skip("red-ui publishes no Windows build yet — deb, AppImage, rpm and web only"),
+    win: ghInstaller("reddb-io/red-ui", "red-ui-windows-x86_64-setup.exe", "/S"),
   },
   {
     // A CLI, and still `desktop` rather than `core`, because what it


### PR DESCRIPTION
Automated AFK landing for #8. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #8

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788380265&installation_model_id=20659&pr_number=31&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F31&signature=5b2c0487f5d4c43954b2ca51b2a3fe2e6c46b5f90062df411f2e044126b29982"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->