### PR TITLE
chore: #16 Native Windows theme switches cover the full CLI surface set

### DIFF
--- a/src/theme-apply.test.ts
+++ b/src/theme-apply.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import type { Platform } from "./platform.ts";
+import { themeSurfaceNames } from "./theme-apply.ts";
+
+const basePlatform = {
+  distro: null,
+  version: null,
+  codename: null,
+  arch: "x64",
+  caps: {
+    apt: false,
+    gui: true,
+    systemd: false,
+    winget: true,
+    flatpak: false,
+  },
+} satisfies Omit<Platform, "os" | "env">;
+
+const wsl = {
+  ...basePlatform,
+  os: "linux",
+  env: "wsl",
+} satisfies Platform;
+
+const windows = {
+  ...basePlatform,
+  os: "windows",
+  env: "windows",
+} satisfies Platform;
+
+describe("theme surfaces", () => {
+  test("native Windows receives the full portable CLI surface set", () => {
+    expect(themeSurfaceNames(windows)).toEqual([
+      "zellij",
+      "btop",
+      "neovim",
+      "vscode",
+      "bat",
+      "delta",
+      "lazygit",
+      "opencode",
+      "herdr",
+      "windows",
+    ]);
+  });
+
+  test("native Windows stays in parity with WSL for portable CLI surfaces", () => {
+    const portable = (name: string) => name !== "gnome";
+
+    expect(themeSurfaceNames(windows).filter(portable)).toEqual(
+      themeSurfaceNames(wsl).filter(portable),
+    );
+  });
+});

--- a/src/theme-apply.ts
+++ b/src/theme-apply.ts
@@ -189,26 +189,23 @@ return {
 
 // --------------------------------------------------------- entrypoint
 
-/**
- * The command-line surfaces, which omakub leaves alone.
- *
- * A Kanagawa terminal showing a Monokai diff is the seam this closes.
- * Every one of these is a config file, so unlike the GNOME layer they
- * work on all five targets — including native Windows, where they are
- * the *only* surfaces there are.
- */
-function cliSurfaces(
-  theme: Theme,
-  p: Platform,
-  key: string,
-): [string, () => Promise<boolean>][] {
+const PORTABLE_SURFACE_NAMES = [
+  "zellij",
+  "btop",
+  "neovim",
+  "vscode",
+  "bat",
+  "delta",
+  "lazygit",
+  "opencode",
+  "herdr",
+];
+
+export function themeSurfaceNames(p: Platform): string[] {
   return [
-    ["bat", () => applyBat(theme, p, key)],
-    ["delta", () => applyDelta(theme, key)],
-    ["lazygit", () => applyLazygit(theme, p)],
-    ["opencode", () => applyOpencode(p)],
-    ["herdr", () => applyHerdr(p, key)],
-    ...(p.env === "wsl" ? [["windows", () => applyWindowsDesktopTheme(theme, p, key)] as [string, () => Promise<boolean>]] : []),
+    ...PORTABLE_SURFACE_NAMES,
+    ...(p.env === "wsl" || p.env === "windows" ? ["windows"] : []),
+    ...(p.os !== "windows" ? ["gnome"] : []),
   ];
 }
 
@@ -230,23 +227,20 @@ export async function applyThemeEverywhere(
   // one, so `theme gruvbox` and the menu both reach the same mapping.
   const key = slug ?? theme.name.toLowerCase().replace(/\s+/g, "-");
 
-  // These live in the Linux filesystem and mean nothing on native
-  // Windows, where btop4win and zellij either differ or do not exist.
-  const surfaces: [string, () => Promise<boolean>][] =
-    p.os === "windows"
-      ? [
-          ["neovim", () => applyNeovim(theme)],
-          ["vscode", () => applyVsCodeTheme(theme, p, key)],
-          ["windows", () => applyWindowsDesktopTheme(theme, p, key)],
-        ]
-      : [
-          ["zellij", () => applyZellij(theme, p)],
-          ["btop", () => applyBtop(theme)],
-          ["neovim", () => applyNeovim(theme)],
-          ["vscode", () => applyVsCodeTheme(theme, p, key)],
-          ...cliSurfaces(theme, p, key),
-          ["gnome", () => applyGnomeTheme(p, theme, key)],
-        ];
+  const surfaceFns: Record<string, () => Promise<boolean>> = {
+    zellij: () => applyZellij(theme, p),
+    btop: () => applyBtop(theme),
+    neovim: () => applyNeovim(theme),
+    vscode: () => applyVsCodeTheme(theme, p, key),
+    bat: () => applyBat(theme, p, key),
+    delta: () => applyDelta(theme, key),
+    lazygit: () => applyLazygit(theme, p),
+    opencode: () => applyOpencode(p),
+    herdr: () => applyHerdr(p, key),
+    windows: () => applyWindowsDesktopTheme(theme, p, key),
+    gnome: () => applyGnomeTheme(p, theme, key),
+  };
+  const surfaces = themeSurfaceNames(p).map((name) => [name, surfaceFns[name]!] as const);
 
   for (const [name, fn] of surfaces) {
     try {


### PR DESCRIPTION
Automated AFK landing for #16. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #16

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788380601&installation_model_id=20659&pr_number=32&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F32&signature=2061f308136c9a2ae9f82a5eb496fe5a6ba78bb47b8ccf19283b0af2e4adcb67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->