### PR TITLE
chore: #13 Nerd Fonts installed and verified on Ubuntu desktop and native Windows

### DIFF
--- a/src/manifest.test.ts
+++ b/src/manifest.test.ts
@@ -148,6 +148,30 @@ describe("the manifest itself", () => {
     expect(plan).toContain("red-ui");
   });
 
+  test("Ubuntu desktop installs the configured Nerd Font", () => {
+    const plan = applicableScopes(DESKTOP)
+      .flatMap((scope) => toolsInScope(scope))
+      .filter((tool) => providerFor(tool, DESKTOP).kind !== "skip")
+      .map((tool) => tool.name);
+    expect(plan).toContain("nerd-font");
+  });
+
+  test("native Windows installs the configured Nerd Font", () => {
+    const plan = applicableScopes(WINDOWS)
+      .flatMap((scope) => toolsInScope(scope))
+      .filter((tool) => providerFor(tool, WINDOWS).kind !== "skip")
+      .map((tool) => tool.name);
+    expect(plan).toContain("nerd-font");
+  });
+
+  test("WSL keeps installing the font on the Windows host", () => {
+    const plan = applicableScopes(WSL24)
+      .flatMap((scope) => toolsInScope(scope))
+      .filter((tool) => providerFor(tool, WSL24).kind !== "skip")
+      .map((tool) => tool.name);
+    expect(plan).toContain("nerd-font");
+  });
+
   test("every skip carries a reason", () => {
     // A skip is a decision. One without a reason is an undocumented gap
     // wearing a decision's clothes.

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -748,6 +748,13 @@ export const TOOLS: Tool[] = [
   },
   {
     name: "nerd-font",
+    scope: "desktop",
+    managed: true,
+    u24: builtin("nerd-font"),
+    win: builtin("nerd-font"),
+  },
+  {
+    name: "nerd-font",
     scope: "wsl",
     managed: true,
     u24: builtin("nerd-font"),

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -821,7 +821,7 @@ export async function applyProvider(pr: Provider, ctx: ApplyContext): Promise<vo
         return;
       }
       if (pr.name === "nerd-font") {
-        await wsl.installNerdFont(ctx.font);
+        await wsl.installNerdFont(ctx.font, ctx.platform);
       } else {
         const { THEMES } = await import("./themes.ts");
         const theme = THEMES[ctx.theme];

--- a/src/regressions.test.ts
+++ b/src/regressions.test.ts
@@ -10,7 +10,7 @@
 
 import { describe, expect, test } from "bun:test";
 import { wingetArgv } from "./providers.ts";
-import { machineWideFontScript } from "./wsl.ts";
+import { linuxFontProbeArgv, machineWideFontScript, windowsFontProbeArgv } from "./wsl.ts";
 
 describe("winget invocation", () => {
   /**
@@ -218,5 +218,24 @@ if ($errors.Count) { $errors | ForEach-Object { $_.Message }; exit 1 }
       win(path),
     ]);
     expect(new TextDecoder().decode(proc.stdout).trim()).toBe("parsed");
+  });
+});
+
+describe("font installation verification", () => {
+  test("Linux verifies through fontconfig, not terminal config", () => {
+    expect(linuxFontProbeArgv("FiraCode Nerd Font Mono")).toEqual([
+      "fc-match",
+      "--format",
+      "%{family}\n",
+      "FiraCode Nerd Font Mono",
+    ]);
+  });
+
+  test("Windows verifies through the installed font collection", () => {
+    const argv = windowsFontProbeArgv("FiraCode Nerd Font Mono");
+    expect(argv).toContain("-Command");
+    expect(argv.join(" ")).toContain("InstalledFontCollection");
+    expect(argv.join(" ")).toContain("FiraCode Nerd Font Mono");
+    expect(argv.join(" ")).not.toContain("settings.json");
   });
 });

--- a/src/wsl.ts
+++ b/src/wsl.ts
@@ -13,8 +13,9 @@
  * which is why config/bash/path.sh prepends instead.
  */
 
-import { existsSync } from "node:fs";
+import { copyFileSync, existsSync, mkdirSync, rmSync } from "node:fs";
 import { log, RedError } from "./log.ts";
+import type { Platform } from "./platform.ts";
 import { THEMES, type Theme } from "./themes.ts";
 
 /**
@@ -204,7 +205,16 @@ async function ghAsset(repo: string, name: string): Promise<string> {
  * HKCU. Both halves are required — a file the registry does not know
  * about is invisible to applications.
  */
-export async function installNerdFont(key: string): Promise<void> {
+export async function installNerdFont(key: string, platform?: Platform): Promise<void> {
+  if (platform?.os === "linux" && platform.env === "desktop") {
+    await installLinuxNerdFont(key);
+    return;
+  }
+
+  await installWindowsNerdFont(key);
+}
+
+async function installWindowsNerdFont(key: string): Promise<void> {
   const spec = NERD_FONTS[key];
   if (!spec) {
     throw new RedError(
@@ -262,6 +272,72 @@ export async function installNerdFont(key: string): Promise<void> {
   await ensureFontVisible(spec);
 }
 
+export function linuxFontProbeArgv(family: string): string[] {
+  return ["fc-match", "--format", "%{family}\n", family];
+}
+
+async function fontVisibleToLinux(family: string): Promise<boolean> {
+  try {
+    const out = await capture(linuxFontProbeArgv(family));
+    return out
+      .split(",")
+      .map((part) => part.trim())
+      .includes(family);
+  } catch {
+    return false;
+  }
+}
+
+async function installLinuxNerdFont(key: string): Promise<void> {
+  const spec = NERD_FONTS[key];
+  if (!spec) {
+    throw new RedError(
+      `unknown font '${key}' (known: ${Object.keys(NERD_FONTS).join(", ")})`,
+    );
+  }
+
+  if (await fontVisibleToLinux(spec.family)) {
+    log.skip(`${spec.family} visible to fontconfig`);
+    return;
+  }
+
+  const url = await ghAsset("ryanoasis/nerd-fonts", `${spec.asset}.zip`);
+  log.step(`nerd font: ${spec.asset} -> ${spec.family}`);
+
+  const tmp = `/tmp/red-dev-font-${spec.asset}`;
+  await run(["rm", "-rf", tmp]);
+  await run(["mkdir", "-p", tmp]);
+
+  const res = await fetch(url);
+  if (!res.ok) throw new RedError(`font download failed ${res.status}`);
+  await Bun.write(`${tmp}/font.zip`, res);
+  await run(["unzip", "-qo", `${tmp}/font.zip`, "-d", tmp]);
+
+  const fontDir = `${process.env["HOME"] ?? ""}/.local/share/fonts/red-dev/${spec.asset}`;
+  rmSync(fontDir, { recursive: true, force: true });
+  mkdirSync(fontDir, { recursive: true });
+
+  const listing = await capture(["find", tmp, "-name", "*.ttf", "-type", "f"]);
+  const wanted = /NerdFontMono-(Regular|Bold|Italic|BoldItalic)\.ttf$/;
+  const faces = listing.split("\n").filter((f) => wanted.test(f));
+  if (faces.length === 0) {
+    throw new RedError(`no Mono faces found in ${spec.asset}.zip`);
+  }
+
+  for (const face of faces) {
+    const base = face.split("/").pop() ?? "";
+    copyFileSync(face, `${fontDir}/${base}`);
+  }
+
+  await run(["fc-cache", "-f", fontDir]);
+  await run(["rm", "-rf", tmp]);
+
+  if (!(await fontVisibleToLinux(spec.family))) {
+    throw new RedError(`${spec.family} installed but fontconfig cannot resolve it`);
+  }
+  log.ok(`${spec.family} installed (${faces.length} faces)`);
+}
+
 /**
  * Whether Windows applications can resolve a family by name.
  *
@@ -271,20 +347,24 @@ export async function installNerdFont(key: string): Promise<void> {
  */
 async function fontVisibleToWindows(family: string): Promise<boolean> {
   try {
-    const out = await capture([
-      powershellBin(),
-      "-NoProfile",
-      "-Command",
-      "Add-Type -AssemblyName System.Drawing; " +
-        "(New-Object System.Drawing.Text.InstalledFontCollection).Families | " +
-        `Where-Object { $_.Name -eq '${family.replace(/'/g, "''")}' } | ` +
-        "Measure-Object | Select-Object -ExpandProperty Count",
-    ]);
+    const out = await capture(windowsFontProbeArgv(family));
     return /^[1-9]/.test(out.split("\n").pop()?.trim() ?? "");
   } catch {
     // A check that cannot run is not evidence the font is missing.
     return true;
   }
+}
+
+export function windowsFontProbeArgv(family: string): string[] {
+  return [
+    powershellBin(),
+    "-NoProfile",
+    "-Command",
+    "Add-Type -AssemblyName System.Drawing; " +
+      "(New-Object System.Drawing.Text.InstalledFontCollection).Families | " +
+      `Where-Object { $_.Name -eq '${family.replace(/'/g, "''")}' } | ` +
+      "Measure-Object | Select-Object -ExpandProperty Count",
+  ];
 }
 
 /**


### PR DESCRIPTION
Automated AFK landing for #13. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #13

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788382505&installation_model_id=20659&pr_number=35&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F35&signature=73da37ecc11920ee168341d7e029a3bb856ca633ce1dde0e9e7d94a454ace940"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->