### PR TITLE
docs: amend ADR 0001 — drop the incremental E2E fleet

### DIFF
--- a/.red/adr/0001-cross-platform-phased-not-a-distro.md
+++ b/.red/adr/0001-cross-platform-phased-not-a-distro.md
@@ -24,7 +24,9 @@ red-dev **stays cross-platform** (Linux, Windows/WSL, and eventually macOS) and 
 4. **Phase 4 — Contracts:** the remaining contracts (atomic per-surface theme contract, lifecycle/transactions, asset provenance, full command registry).
 5. **Phase 5 — macOS:** Darwin is born as an adapter of the Phase 4 contracts, never as a third ad-hoc implementation.
 
-Cross-cutting: an **incremental** clean-machine E2E fleet — each phase only closes with lanes covering what it shipped. MCP is **optional-with-fallback**: every required capability has a stable CLI path.
+Cross-cutting: MCP is **optional-with-fallback**: every required capability has a stable CLI path.
+
+**Amendment (2026-08-03):** the incremental clean-machine E2E fleet originally decided here was dropped by maintainer decision before any lane was built (#17, #18 closed as not planned). red-dev is a development environment for developers; validation happens by provisioning real environments — converge followed by a second converge with zero planned changes, plus the readiness report — not by CI-hosted clean-VM lanes. A phase closes when its promised behaviors are true on real environments and covered by the unit/integration suite.
 
 ## Consequences
 


### PR DESCRIPTION
Records the maintainer's reversal of the incremental clean-machine E2E decision: #17/#18 closed as not planned. Validation happens on real environments via converge + readiness report, not CI-hosted clean-VM lanes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0172iFcxJFvKcyTSHmgejY89

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788383909&installation_model_id=20659&pr_number=36&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F36&signature=6ca5a841ad76ca08e3dff645cc6b3d7800379ea777995bff090dc67e8643715b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->