### PR TITLE
chore: #37 /go: Redesign the red-dev README to match the visual and editorial standard o

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ surface.
 
 ---
 
+<img src="docs/targets.svg" alt="The support matrix — two axes, not five cases: Ubuntu desktop and WSL each span 24.04 and 26.04, native Windows is one target with no distro axis" width="100%">
+
 ## The support matrix
 
 |                         | Ubuntu 24.04 | Ubuntu 26.04 |
@@ -188,10 +190,13 @@ Because zellij is now always on, its own keybindings would be taking `Ctrl-p`,
 unlocks, every binding returns to locked, and `Alt` plus arrows or `hjkl` moves
 between panes without leaving it.
 
-Clipboard text stays Unicode across WSL: zellij sends UTF-8, and red-dev's
-low-latency bridge converts it to BOM-less UTF-16LE before `clip.exe` reads it.
-That avoids both `clip.exe`'s OEM-code-page mojibake and zellij's one-second
-timeout for clipboard commands. Mouse selection copies automatically. In
+The clipboard is one behaviour reached three ways. On a real Linux desktop
+zellij's copy command targets `wl-copy`, so `wl-clipboard` is a declared
+`desktop` dependency rather than a tool you are assumed to already have. WSL and
+native Windows cross to the Windows clipboard instead, and there text stays
+Unicode: zellij sends UTF-8, and red-dev's low-latency bridge converts it to
+BOM-less UTF-16LE before `clip.exe` reads it. That avoids both `clip.exe`'s
+OEM-code-page mojibake and zellij's one-second timeout for clipboard commands. Mouse selection copies automatically. In
 Alacritty, paste is `Ctrl+V` or `Ctrl+Shift+V`; `Ctrl+Shift+C` copies an
 Alacritty selection, while plain `Ctrl+C` remains the application's interrupt
 key. Inside a mouse-capturing TUI such as herdr, normal drag selection belongs
@@ -213,7 +218,7 @@ developer works in:
 | [`red`](https://github.com/reddb-io/reddb) | the RedDB CLI | every target |
 | [`tq`](https://github.com/reddb-io/toon) | query and convert TOON | every target |
 | [`red-request`](https://github.com/reddb-io/red-request) | API client, powered by recker | desktop sessions |
-| [`red-ui`](https://github.com/reddb-io/red-ui) | universal client for reddb | **Linux desktop only** — see below |
+| [`red-ui`](https://github.com/reddb-io/red-ui) | universal client for reddb | desktop sessions — see below |
 | [`dit`](https://github.com/reddb-io/dit) | push-to-toggle voice dictation | desktop sessions |
 | [`herdr`](https://herdr.dev) | several agents in one terminal, alive over SSH | Linux and WSL |
 
@@ -265,8 +270,11 @@ another on the same machine.
 
 Aliases that normalise Debian's renames (`bat` → `batcat`, `fd` → `fdfind`), the
 readline bindings that put history search on the arrow keys, `autocd`,
-`cdspell`, `globstar`, a curated git alias set — and the integrations that make
-the tools above actually do something rather than merely exist:
+`cdspell`, `globstar`, a curated git alias set, and shell functions like
+`webm2mp4` — and the integrations that make the tools above actually do
+something rather than merely exist. A shipped function is only honest if what it
+shells out to is present, so `webm2mp4`'s `ffmpeg` dependency is declared as a
+`core` tool rather than assumed:
 
 **Docker** is one daemon, never two. Under WSL, if Docker Desktop already serves
 the distro, red-dev does not install `docker-ce` — a second daemon means
@@ -521,7 +529,11 @@ curl -fsSL https://raw.githubusercontent.com/reddb-io/red-dev/main/boot.sh | sh
 ```
 
 Scopes: `core` + `desktop`. Everything installs locally; Alacritty and zellij
-run natively, and the wallpaper goes through `gsettings`.
+run natively, the Nerd Font is registered in the local font store, and the
+wallpaper goes through `gsettings`. The `desktop` scope owns the font on the two
+targets that have no Windows host to reach — bare-metal Ubuntu and native
+Windows — and it verifies the family resolves before configuring the terminals
+that depend on it, rather than trusting the copy to have taken.
 
 > [!WARNING]
 > This target is **implemented and unproven** — no bare-metal Ubuntu has run it.
@@ -707,7 +719,8 @@ surfaces too, and unlike the desktop ones they work on all five targets:
 
 | surface | how |
 | --- | --- |
-| alacritty, zellij, btop, neovim, VS Code | a generated theme file each |
+| alacritty, zellij, btop, neovim | a generated theme file each |
+| VS Code | `workbench.colorTheme` in a settings file parsed as JSONC — comments and trailing commas survive the edit, and where no exact theme is published (Osaka Jade) it says so rather than picking a lookalike |
 | `bat` | written twice, since Debian renames the binary and the config follows it |
 | `delta` | through git config, where red-dev already made it the pager |
 | `lazygit` | our block only; anything else in the file survives |
@@ -745,7 +758,7 @@ places to look — in this order.
 | **Ubuntu 26.04** | The `u26` manifest column exists and **no 26.04 machine has exercised it**. Package-name drift is undiscovered. |
 | **WSL** | Windows interop cannot work under `sudo -u <other-user>`: `WSL_INTEROP` points at a per-session socket that sudo drops. Real invocations run as you, so this affects test harnesses only. |
 | **Native Windows** | No switching to a *numbered* virtual desktop — Windows offers only sequential navigation, and reaching a specific one means an interface that changes between builds. No zellij session persistence across reboots. No `ble.sh`-style line editor. |
-| **All** | `red-ui` installs on Linux desktop only, because that release has no Windows or macOS asset to install. |
+| **All** | `red-ui` is a `desktop` app: it installs on Ubuntu desktop and native Windows, never inside WSL, where a Linux GUI has no display to draw on. |
 
 Stated plainly because "implemented" and "known to work" are different claims,
 and a README that blurs them costs someone an afternoon.
@@ -776,18 +789,22 @@ Not an environment variable. `bun build --compile` substitutes
 `process.env.NODE_ENV` at build time, so nothing at runtime — not this program,
 not your shell — can reach that check.
 
-### `red-ui` on Windows
+### `red-ui`, on both desktops now
 
-Not an oversight on either side. That release publishes a `.deb`, an
-`.AppImage`, an `.rpm` and a web bundle, and nothing else — so red-dev skips it
-there with that as the stated reason, rather than pointing a provider at a
-filename nobody published.
+For a while this end pointed a provider at a filename nobody published — red-ui's
+release carried a `.deb`, an `.AppImage`, an `.rpm` and a web bundle, and no
+Windows asset, so red-dev skipped it there with that as the stated reason.
 
-It is two commented lines away in `red-ui`'s own `release.yml`: the staging step
-for `red-ui-windows-x86_64-setup.exe` and the `WINDOWS_CERTIFICATE` secrets are
-already wired, and the matrix entry is commented out with "intentionally
-commented out until the Linux pipeline is green end-to-end". When it comes back,
-this end is one line.
+The Windows staging step has since landed upstream: red-ui now publishes
+`red-ui-windows-x86_64-setup.exe`, and the manifest consumes it the same way
+red-request does — Linux takes the `red-ui_*_amd64.deb`, native Windows runs the
+setup installer silently with `/S`, so a clean native-Windows converge gets the
+app. The glob keeps the wildcard where the version goes; anchoring it to today's
+release is the 404-on-next-release bug this project already learned once.
+
+WSL is still the one place it is not installed, and on purpose: red-ui is a GUI
+app, and a Linux GUI inside a distro with no display is the exact mistake the
+`desktop` scope exists to avoid — the Windows target already covers that machine.
 
 ## Under the hood
 
@@ -906,6 +923,9 @@ Early, but the loop runs end to end.
   registry as the colour the theme asked for
 - Configuration shared across the boundary both ways, with the same bytes read
   from `/mnt/c/...` and `C:\...`
+- Nerd Fonts installed and verified — the family is confirmed to resolve before
+  the terminals that need it are configured — on Ubuntu desktop and native
+  Windows, alongside the existing WSL-reaches-Windows font path
 
 See [Known limitations](#known-limitations-per-target) for what is implemented
 but unproven.

--- a/docs/hero.svg
+++ b/docs/hero.svg
@@ -1,62 +1,87 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 340" width="1200" height="340" role="img" aria-label="red-dev — one development environment across Ubuntu 24.04, Ubuntu 26.04, WSL and Windows">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 420" width="1200" height="420" role="img" aria-labelledby="rd-hero-title rd-hero-desc">
+  <title id="rd-hero-title">red-dev — one development environment across five targets</title>
+  <desc id="rd-hero-desc">red-dev installs the same tools, shell, terminal, tiling and theme on bare-metal Ubuntu 24.04 and 26.04, inside WSL, and on native Windows — from one standalone binary that branches on what a machine is and what it can do.</desc>
+
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#07080a"/>
-      <stop offset="100%" stop-color="#0c0e11"/>
+    <linearGradient id="rd-bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0d1117"/>
+      <stop offset="1" stop-color="#07090d"/>
     </linearGradient>
-    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#ff2056"/>
-      <stop offset="100%" stop-color="#ff5470"/>
+    <radialGradient id="rd-glow" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0" stop-color="#ff2056" stop-opacity="0.30"/>
+      <stop offset="1" stop-color="#ff2056" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="rd-rule" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#ff2056"/>
+      <stop offset="1" stop-color="#ff2056" stop-opacity="0"/>
     </linearGradient>
-    <linearGradient id="rule" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#ff2056" stop-opacity="0.9"/>
-      <stop offset="100%" stop-color="#ff2056" stop-opacity="0"/>
-    </linearGradient>
+    <pattern id="rd-grid" width="24" height="24" patternUnits="userSpaceOnUse">
+      <path d="M24 0H0V24" fill="none" stroke="#ffffff" stroke-opacity="0.028" stroke-width="1"/>
+    </pattern>
+    <clipPath id="rd-frame">
+      <rect x="0" y="0" width="1200" height="420" rx="18"/>
+    </clipPath>
   </defs>
 
-  <rect width="1200" height="340" fill="url(#bg)"/>
+  <g clip-path="url(#rd-frame)">
+    <rect width="1200" height="420" fill="url(#rd-bg)"/>
+    <rect width="1200" height="420" fill="url(#rd-grid)"/>
+    <ellipse cx="120" cy="60" rx="420" ry="300" fill="url(#rd-glow)"/>
+    <ellipse cx="1120" cy="410" rx="360" ry="240" fill="url(#rd-glow)" opacity="0.5"/>
 
-  <!-- subtle grid, echoing the two-axis support matrix -->
-  <g stroke="#7a8088" stroke-opacity="0.07">
-    <path d="M0 85H1200M0 170H1200M0 255H1200"/>
-    <path d="M300 0V340M600 0V340M900 0V340"/>
-  </g>
+    <!-- left: the wordmark, what it does, what it bundles -->
+    <g font-family="ui-monospace, SFMono-Regular, 'JetBrains Mono', Menlo, Consolas, monospace">
+      <text x="72" y="150" font-size="84" font-weight="700" fill="#f0f6fc" letter-spacing="-3">red-dev</text>
+      <rect x="430" y="102" width="18" height="50" fill="#ff2056"/>
 
-  <g font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace">
-    <!-- prompt glyph, the one the shell actually ships -->
-    <text x="72" y="128" font-size="46" fill="url(#accent)" font-weight="700">&#8250;_</text>
-    <text x="130" y="128" font-size="62" fill="#f4f5f7" font-weight="700">red-dev</text>
+      <text x="72" y="204" font-size="32" font-weight="600" fill="#ff2056" letter-spacing="-1">one environment &#183; five targets</text>
 
-    <rect x="74" y="152" width="420" height="3" fill="url(#rule)"/>
+      <rect x="74" y="230" width="150" height="3" fill="url(#rd-rule)"/>
 
-    <text x="74" y="196" font-size="21" fill="#7a8088">One development environment. Five targets. Same experience.</text>
+      <text x="72" y="272" font-size="19" fill="#8b949e">Same tools, shell, terminal, tiling and theme &#8212;</text>
+      <text x="72" y="298" font-size="19" fill="#8b949e">bare-metal Ubuntu, WSL, and native Windows.</text>
 
-    <!-- the matrix, as the README states it -->
-    <g font-size="15">
-      <text x="74" y="252" fill="#7a8088">desktop</text>
-      <text x="74" y="284" fill="#7a8088">wsl</text>
-      <text x="74" y="316" fill="#7a8088">windows</text>
-
-      <text x="210" y="224" fill="#7a8088">ubuntu 24.04</text>
-      <text x="380" y="224" fill="#7a8088">ubuntu 26.04</text>
-
-      <g fill="#ff2056">
-        <text x="210" y="252">&#9679;</text>
-        <text x="380" y="252">&#9679;</text>
-        <text x="210" y="284">&#9679;</text>
-        <text x="380" y="284">&#9679;</text>
-        <text x="210" y="316">&#9679;</text>
+      <text x="72" y="322" font-size="11" fill="#6e7681" letter-spacing="2.5">BUNDLES THE REDDB BELT</text>
+      <g font-size="14">
+        <rect x="72" y="332" width="60" height="28" rx="14" fill="#ffffff" fill-opacity="0.04" stroke="#ff2056" stroke-opacity="0.35"/>
+        <text x="88" y="351" fill="#c9d1d9">red</text>
+        <rect x="142" y="332" width="54" height="28" rx="14" fill="#ffffff" fill-opacity="0.04" stroke="#ffffff" stroke-opacity="0.08"/>
+        <text x="158" y="351" fill="#c9d1d9">tq</text>
+        <rect x="206" y="332" width="88" height="28" rx="14" fill="#ffffff" fill-opacity="0.04" stroke="#ffffff" stroke-opacity="0.08"/>
+        <text x="222" y="351" fill="#c9d1d9">red-ui</text>
+        <rect x="304" y="332" width="80" height="28" rx="14" fill="#ffffff" fill-opacity="0.04" stroke="#ffffff" stroke-opacity="0.08"/>
+        <text x="320" y="351" fill="#c9d1d9">herdr</text>
       </g>
-      <text x="238" y="316" fill="#7a8088">native</text>
+
+      <text x="72" y="392" font-size="11" fill="#6e7681" letter-spacing="2">RUNS ON</text>
+      <text x="150" y="392" font-size="14" fill="#8b949e">Ubuntu 24.04 &#183; 26.04 &#183; WSL &#183; native Windows</text>
     </g>
 
-    <!-- the stack, right aligned -->
-    <g font-size="16" text-anchor="end">
-      <text x="1128" y="232" fill="#7a8088">alacritty</text>
-      <text x="1128" y="262" fill="#7a8088">zellij</text>
-      <text x="1128" y="292" fill="#7a8088">bash</text>
-      <text x="1128" y="196" fill="#4a4f57" font-size="13">ONE CONFIG EACH</text>
+    <!-- right: ask a machine what it is -->
+    <g font-family="ui-monospace, SFMono-Regular, 'JetBrains Mono', Menlo, Consolas, monospace">
+      <rect x="680" y="56" width="464" height="308" rx="12" fill="#0b0f15" stroke="#ffffff" stroke-opacity="0.09"/>
+      <circle cx="704" cy="84" r="5" fill="#ff5f56"/>
+      <circle cx="722" cy="84" r="5" fill="#ffbd2e"/>
+      <circle cx="740" cy="84" r="5" fill="#27c93f"/>
+      <text x="760" y="89" font-size="12" fill="#6e7681" letter-spacing="1">red-dev platform</text>
+
+      <g font-size="15">
+        <text x="704" y="128"><tspan fill="#ff2056">$</tspan> <tspan fill="#c9d1d9">red-dev platform</tspan></text>
+        <text x="704" y="154" fill="#8b949e">os=linux distro=ubuntu env=wsl</text>
+        <text x="704" y="176" fill="#8b949e">version=24.04 arch=x64</text>
+        <text x="704" y="200"><tspan fill="#6e7681">caps: apt=1 </tspan><tspan fill="#ff2056">gui=0</tspan><tspan fill="#6e7681"> systemd=1 </tspan><tspan fill="#ff2056">winget=1</tspan></text>
+
+        <line x1="704" y1="222" x2="1120" y2="222" stroke="#ffffff" stroke-opacity="0.08"/>
+
+        <text x="704" y="252" fill="#6e7681"># the same probe, on the host</text>
+        <text x="704" y="278"><tspan fill="#ff2056">$</tspan> <tspan fill="#c9d1d9">red-dev platform</tspan></text>
+        <text x="704" y="304" fill="#8b949e">os=windows env=windows arch=x64</text>
+        <text x="704" y="326"><tspan fill="#6e7681">caps: apt=0 </tspan><tspan fill="#3fb950">gui=1</tspan><tspan fill="#6e7681"> systemd=0 winget=1</tspan></text>
+      </g>
+
+      <text x="704" y="352" font-size="12" fill="#6e7681">two axes, not five cases &#8212; never a raw version string</text>
     </g>
-    <rect x="1140" y="180" width="3" height="120" fill="#ff2056" fill-opacity="0.5"/>
+
+    <rect x="0" y="416" width="1200" height="4" fill="#ff2056"/>
   </g>
 </svg>

--- a/docs/stack.svg
+++ b/docs/stack.svg
@@ -1,22 +1,44 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 150" width="1200" height="150" role="img" aria-label="The identical layer — Alacritty, zellij and bash, one config each, on all five targets">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 220" width="1200" height="220" role="img" aria-labelledby="stack-title stack-desc">
+  <title id="stack-title">The identical layer</title>
+  <desc id="stack-desc">Alacritty, zellij and bash — one config file each, the same on all five targets, with the panes living inside the terminal so tiling survives SSH.</desc>
   <defs>
-    <linearGradient id="sbg" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#07080a"/>
-      <stop offset="100%" stop-color="#14171c"/>
+    <linearGradient id="stack-bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0d1117"/>
+      <stop offset="1" stop-color="#07090d"/>
     </linearGradient>
+    <radialGradient id="stack-glow" cx="0.2" cy="0.1" r="0.8">
+      <stop offset="0" stop-color="#ff2056" stop-opacity="0.30"/>
+      <stop offset="1" stop-color="#ff2056" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="stack-rule" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#ff2056"/>
+      <stop offset="1" stop-color="#ff2056" stop-opacity="0"/>
+    </linearGradient>
+    <pattern id="stack-grid" width="24" height="24" patternUnits="userSpaceOnUse">
+      <path d="M24 0H0V24" fill="none" stroke="#ffffff" stroke-opacity="0.028" stroke-width="1"/>
+    </pattern>
+    <clipPath id="stack-frame">
+      <rect x="0" y="0" width="1200" height="220" rx="18"/>
+    </clipPath>
   </defs>
-  <rect width="1200" height="150" fill="url(#sbg)"/>
-  <rect width="4" height="150" fill="#ff2056"/>
+  <g clip-path="url(#stack-frame)">
+    <rect width="1200" height="220" fill="url(#stack-bg)"/>
+    <rect width="1200" height="220" fill="url(#stack-grid)"/>
+    <ellipse cx="160" cy="20" rx="400" ry="210" fill="url(#stack-glow)"/>
+    <g font-family="ui-monospace, SFMono-Regular, 'JetBrains Mono', Menlo, Consolas, monospace">
+      <text x="72" y="92" font-size="26" fill="#ff2056" letter-spacing="2">THE IDENTICAL LAYER</text>
+      <text x="72" y="142" font-size="44" font-weight="700" fill="#f0f6fc">alacritty &#183; zellij &#183; bash</text>
+      <rect x="72" y="164" width="200" height="3" fill="url(#stack-rule)"/>
+      <text x="72" y="194" font-size="18" fill="#8b949e">one config each &#183; panes inside the terminal &#183; still tiling over SSH</text>
 
-  <g font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace">
-    <text x="44" y="52" font-size="13" fill="#ff2056" letter-spacing="2">THE IDENTICAL LAYER</text>
-    <text x="44" y="90" font-size="30" fill="#f4f5f7" font-weight="700">alacritty &#183; zellij &#183; bash</text>
-    <text x="44" y="120" font-size="15" fill="#7a8088">One config each. Five targets. No second copy to keep in sync.</text>
-
-    <g font-size="13" fill="#4a4f57" text-anchor="end">
-      <text x="1156" y="62">renderer</text>
-      <text x="1156" y="88">panes, tabs, sessions &#8212; and over SSH</text>
-      <text x="1156" y="114">shell, Git Bash on Windows</text>
+      <rect x="780" y="54" width="360" height="112" rx="12" fill="#0b0f15" stroke="#ffffff" stroke-opacity="0.09"/>
+      <text x="804" y="86" font-size="14" fill="#6e7681">alacritty.toml</text>
+      <text x="1116" y="86" font-size="14" fill="#8b949e" text-anchor="end">renderer</text>
+      <text x="804" y="116" font-size="14" fill="#6e7681">config.kdl</text>
+      <text x="1116" y="116" font-size="14" fill="#8b949e" text-anchor="end">panes, tabs, sessions</text>
+      <text x="804" y="146" font-size="14" fill="#6e7681">bash dotfiles</text>
+      <text x="1116" y="146" font-size="14" fill="#3fb950" text-anchor="end">Git Bash on Windows</text>
     </g>
+    <rect x="0" y="216" width="1200" height="4" fill="#ff2056"/>
   </g>
 </svg>

--- a/docs/targets.svg
+++ b/docs/targets.svg
@@ -1,0 +1,54 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 220" width="1200" height="220" role="img" aria-labelledby="targets-title targets-desc">
+  <title id="targets-title">The support matrix</title>
+  <desc id="targets-desc">Two axes, not five cases: Ubuntu desktop and WSL each span 24.04 and 26.04, while native Windows is one target with no distro axis. Code branches on where it runs and what that place can do, never on a raw version string.</desc>
+  <defs>
+    <linearGradient id="tg-bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0d1117"/>
+      <stop offset="1" stop-color="#07090d"/>
+    </linearGradient>
+    <radialGradient id="tg-glow" cx="0.2" cy="0.1" r="0.8">
+      <stop offset="0" stop-color="#ff2056" stop-opacity="0.30"/>
+      <stop offset="1" stop-color="#ff2056" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="tg-rule" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#ff2056"/>
+      <stop offset="1" stop-color="#ff2056" stop-opacity="0"/>
+    </linearGradient>
+    <pattern id="tg-grid" width="24" height="24" patternUnits="userSpaceOnUse">
+      <path d="M24 0H0V24" fill="none" stroke="#ffffff" stroke-opacity="0.028" stroke-width="1"/>
+    </pattern>
+    <clipPath id="tg-frame">
+      <rect x="0" y="0" width="1200" height="220" rx="18"/>
+    </clipPath>
+  </defs>
+  <g clip-path="url(#tg-frame)">
+    <rect width="1200" height="220" fill="url(#tg-bg)"/>
+    <rect width="1200" height="220" fill="url(#tg-grid)"/>
+    <ellipse cx="160" cy="20" rx="400" ry="210" fill="url(#tg-glow)"/>
+    <g font-family="ui-monospace, SFMono-Regular, 'JetBrains Mono', Menlo, Consolas, monospace">
+      <text x="72" y="92" font-size="26" fill="#ff2056" letter-spacing="2">THE SUPPORT MATRIX</text>
+      <text x="72" y="142" font-size="44" font-weight="700" fill="#f0f6fc">two axes, not five cases</text>
+      <rect x="72" y="164" width="200" height="3" fill="url(#tg-rule)"/>
+      <text x="72" y="194" font-size="18" fill="#8b949e">where it runs &#215; what that place can do &#8212; never a version string</text>
+
+      <!-- the matrix: rows desktop / wsl / windows, columns 24.04 / 26.04 -->
+      <g font-size="14">
+        <text x="960" y="66" fill="#6e7681" text-anchor="middle">24.04</text>
+        <text x="1080" y="66" fill="#6e7681" text-anchor="middle">26.04</text>
+
+        <text x="792" y="102" fill="#8b949e">desktop</text>
+        <text x="960" y="102" fill="#ff2056" text-anchor="middle">&#9679;</text>
+        <text x="1080" y="102" fill="#ff2056" text-anchor="middle">&#9679;</text>
+
+        <text x="792" y="138" fill="#8b949e">wsl</text>
+        <text x="960" y="138" fill="#ff2056" text-anchor="middle">&#9679;</text>
+        <text x="1080" y="138" fill="#ff2056" text-anchor="middle">&#9679;</text>
+
+        <text x="792" y="174" fill="#8b949e">windows</text>
+        <text x="1020" y="174" fill="#3fb950" text-anchor="middle">native &#8212; no distro axis</text>
+      </g>
+      <line x1="880" y1="112" x2="880" y2="184" stroke="#ffffff" stroke-opacity="0.08"/>
+    </g>
+    <rect x="0" y="216" width="1200" height="4" fill="#ff2056"/>
+  </g>
+</svg>

--- a/docs/themes.svg
+++ b/docs/themes.svg
@@ -1,41 +1,61 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 150" width="1200" height="150" role="img" aria-label="Themes — tokyo-night, catppuccin and gruvbox applied to terminal, multiplexer, monitor, editor and wallpaper">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 220" width="1200" height="220" role="img" aria-labelledby="themes-title themes-desc">
+  <title id="themes-title">Themes</title>
+  <desc id="themes-desc">Ten palettes, each applied to every surface with a window and every command-line tool — terminal, multiplexer, monitor, editor, CLI tools and a wallpaper generated from the palette, not shipped as a photograph.</desc>
   <defs>
-    <linearGradient id="tbg" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#07080a"/>
-      <stop offset="100%" stop-color="#14171c"/>
+    <linearGradient id="th-bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0d1117"/>
+      <stop offset="1" stop-color="#07090d"/>
     </linearGradient>
+    <radialGradient id="th-glow" cx="0.2" cy="0.1" r="0.8">
+      <stop offset="0" stop-color="#ff2056" stop-opacity="0.30"/>
+      <stop offset="1" stop-color="#ff2056" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="th-rule" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#ff2056"/>
+      <stop offset="1" stop-color="#ff2056" stop-opacity="0"/>
+    </linearGradient>
+    <pattern id="th-grid" width="24" height="24" patternUnits="userSpaceOnUse">
+      <path d="M24 0H0V24" fill="none" stroke="#ffffff" stroke-opacity="0.028" stroke-width="1"/>
+    </pattern>
+    <clipPath id="th-frame">
+      <rect x="0" y="0" width="1200" height="220" rx="18"/>
+    </clipPath>
   </defs>
-  <rect width="1200" height="150" fill="url(#tbg)"/>
-  <rect width="4" height="150" fill="#ff2056"/>
+  <g clip-path="url(#th-frame)">
+    <rect width="1200" height="220" fill="url(#th-bg)"/>
+    <rect width="1200" height="220" fill="url(#th-grid)"/>
+    <ellipse cx="160" cy="20" rx="400" ry="210" fill="url(#th-glow)"/>
+    <g font-family="ui-monospace, SFMono-Regular, 'JetBrains Mono', Menlo, Consolas, monospace">
+      <text x="72" y="92" font-size="26" fill="#ff2056" letter-spacing="2">THEMES</text>
+      <text x="72" y="142" font-size="44" font-weight="700" fill="#f0f6fc">one palette, every surface</text>
+      <rect x="72" y="164" width="200" height="3" fill="url(#th-rule)"/>
+      <text x="72" y="194" font-size="18" fill="#8b949e">terminal &#183; multiplexer &#183; monitor &#183; editor &#183; CLI tools &#183; wallpaper</text>
 
-  <g font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace">
-    <text x="44" y="52" font-size="13" fill="#ff2056" letter-spacing="2">THEMES</text>
-    <text x="44" y="90" font-size="30" fill="#f4f5f7" font-weight="700">one palette, every surface</text>
-    <text x="44" y="120" font-size="15" fill="#7a8088">terminal &#183; multiplexer &#183; monitor &#183; editor &#183; wallpaper</text>
+      <!-- three of the ten shipped palettes, values from src/themes.ts -->
+      <g font-size="12" fill="#6e7681">
+        <text x="686" y="60">tokyo-night</text>
+        <text x="852" y="60">catppuccin</text>
+        <text x="1018" y="60">gruvbox</text>
+      </g>
+      <g>
+        <rect x="686" y="72" width="34" height="34" rx="5" fill="#1A1B26"/>
+        <rect x="724" y="72" width="34" height="34" rx="5" fill="#7AA2F7"/>
+        <rect x="762" y="72" width="34" height="34" rx="5" fill="#9ECE6A"/>
+        <rect x="800" y="72" width="34" height="34" rx="5" fill="#F7768E"/>
 
-    <!-- The three shipped palettes, values taken from src/themes.ts.
-         Each label sits directly above its own four swatches. -->
-    <g font-size="12" fill="#4a4f57">
-      <text x="700" y="48">tokyo-night</text>
-      <text x="866" y="48">catppuccin</text>
-      <text x="1032" y="48">gruvbox</text>
+        <rect x="852" y="72" width="34" height="34" rx="5" fill="#24273A"/>
+        <rect x="890" y="72" width="34" height="34" rx="5" fill="#8AADF4"/>
+        <rect x="928" y="72" width="34" height="34" rx="5" fill="#A6DA95"/>
+        <rect x="966" y="72" width="34" height="34" rx="5" fill="#ED8796"/>
+
+        <rect x="1018" y="72" width="34" height="34" rx="5" fill="#282828"/>
+        <rect x="1056" y="72" width="34" height="34" rx="5" fill="#458588"/>
+        <rect x="1094" y="72" width="34" height="34" rx="5" fill="#98971A"/>
+        <rect x="1132" y="72" width="34" height="34" rx="5" fill="#CC241D"/>
+      </g>
+      <text x="686" y="150" font-size="13" fill="#8b949e">gruvbox is orange on the terminal, the editor, and Windows accent alike</text>
+      <text x="686" y="176" font-size="12" fill="#6e7681">wallpapers generated from the palette, not shipped as photographs</text>
     </g>
-    <g>
-      <rect x="700" y="60" width="34" height="34" rx="4" fill="#1A1B26"/>
-      <rect x="738" y="60" width="34" height="34" rx="4" fill="#7AA2F7"/>
-      <rect x="776" y="60" width="34" height="34" rx="4" fill="#9ECE6A"/>
-      <rect x="814" y="60" width="34" height="34" rx="4" fill="#F7768E"/>
-
-      <rect x="866" y="60" width="34" height="34" rx="4" fill="#24273A"/>
-      <rect x="904" y="60" width="34" height="34" rx="4" fill="#8AADF4"/>
-      <rect x="942" y="60" width="34" height="34" rx="4" fill="#A6DA95"/>
-      <rect x="980" y="60" width="34" height="34" rx="4" fill="#ED8796"/>
-
-      <rect x="1032" y="60" width="34" height="34" rx="4" fill="#282828"/>
-      <rect x="1070" y="60" width="34" height="34" rx="4" fill="#458588"/>
-      <rect x="1108" y="60" width="34" height="34" rx="4" fill="#98971A"/>
-      <rect x="1146" y="60" width="34" height="34" rx="4" fill="#CC241D"/>
-    </g>
-    <text x="700" y="120" font-size="12" fill="#4a4f57">wallpapers generated from the palette, not shipped as photographs</text>
+    <rect x="0" y="216" width="1200" height="4" fill="#ff2056"/>
   </g>
 </svg>


### PR DESCRIPTION
Automated AFK landing for #37. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #37

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788385062&installation_model_id=20659&pr_number=38&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F38&signature=ad0434c72b882d7ad722972fff1fb3b035ac65a620f953edf99fedd876fa8e92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->