### PR TITLE
chore: #39 /go: Update red-dev so Claude Code uses Shift+Enter to insert a newline on ev

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,9 @@ a third-party wrapper and winget's `T3Tools.T3Code` is the publisher's own.
 Picking any CLI agent then offers
 [red-skills](https://github.com/reddb-io/red-skills), which registers its
 marketplace in Claude Code and Codex and generates plugin modules for OpenCode.
+Convergence also writes `~/.claude/keybindings.json` to map Shift+Enter to a
+newline in Chat — non-destructively: malformed JSON and explicit conflicting
+bindings are never overwritten silently, and re-running is a no-op.
 
 **Web apps** — a page in its own window, its own icon and its own alt-tab entry, the way omakub's `web2app` does it. Desktop sessions only: a `.desktop` file needs a menu to appear in.
 

--- a/src/claude-keybindings.test.ts
+++ b/src/claude-keybindings.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Shift+Enter → chat:newline, without stepping on what the user already chose.
+ *
+ * The five cases worth testing independently:
+ *   - no file yet: create it
+ *   - already correct: skip without touching the file
+ *   - unrelated bindings present: add ours, keep theirs
+ *   - explicit conflicting binding: preserve it, report conflict
+ *   - malformed JSON: leave the file untouched
+ */
+
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { convergeClaudeKeybinding } from "./claude-keybindings.ts";
+
+function tempPath(): string {
+  const dir = mkdtempSync(`${tmpdir()}/claude-kb-`);
+  return `${dir}/keybindings.json`;
+}
+
+describe("absent file", () => {
+  test("creates it with the shift+enter binding", async () => {
+    const path = tempPath();
+    const outcome = await convergeClaudeKeybinding(path);
+    expect(outcome).toBe("wrote");
+    const content = JSON.parse(await Bun.file(path).text());
+    const chat = content.bindings.find((b: { context?: string }) => b.context === "Chat");
+    expect(chat?.bindings?.["shift+enter"]).toBe("chat:newline");
+  });
+});
+
+describe("already-correct binding", () => {
+  test("returns already-set and does not rewrite the file", async () => {
+    const path = tempPath();
+    const original = JSON.stringify({
+      bindings: [{ context: "Chat", bindings: { "shift+enter": "chat:newline" } }],
+    });
+    await Bun.write(path, original);
+    expect(await convergeClaudeKeybinding(path)).toBe("already-set");
+    expect(await convergeClaudeKeybinding(path)).toBe("already-set");
+    expect(JSON.parse(await Bun.file(path).text()).bindings).toHaveLength(1);
+  });
+});
+
+describe("unrelated existing bindings", () => {
+  test("adds the Chat binding and preserves the other context", async () => {
+    const path = tempPath();
+    await Bun.write(
+      path,
+      JSON.stringify({
+        bindings: [{ context: "Other", bindings: { "ctrl+k": "other:action" } }],
+      }),
+    );
+    expect(await convergeClaudeKeybinding(path)).toBe("wrote");
+    const content = JSON.parse(await Bun.file(path).text());
+    const other = content.bindings.find((b: { context?: string }) => b.context === "Other");
+    expect(other?.bindings?.["ctrl+k"]).toBe("other:action");
+    const chat = content.bindings.find((b: { context?: string }) => b.context === "Chat");
+    expect(chat?.bindings?.["shift+enter"]).toBe("chat:newline");
+  });
+
+  test("preserves top-level fields like $schema", async () => {
+    const path = tempPath();
+    await Bun.write(
+      path,
+      JSON.stringify({
+        $schema: "https://www.schemastore.org/claude-code-keybindings.json",
+        bindings: [],
+      }),
+    );
+    await convergeClaudeKeybinding(path);
+    const content = JSON.parse(await Bun.file(path).text());
+    expect(content.$schema).toBe("https://www.schemastore.org/claude-code-keybindings.json");
+  });
+
+  test("adds shift+enter alongside existing Chat bindings", async () => {
+    const path = tempPath();
+    await Bun.write(
+      path,
+      JSON.stringify({
+        bindings: [{ context: "Chat", bindings: { "ctrl+enter": "submit" } }],
+      }),
+    );
+    expect(await convergeClaudeKeybinding(path)).toBe("wrote");
+    const content = JSON.parse(await Bun.file(path).text());
+    const chat = content.bindings.find((b: { context?: string }) => b.context === "Chat");
+    expect(chat?.bindings?.["ctrl+enter"]).toBe("submit");
+    expect(chat?.bindings?.["shift+enter"]).toBe("chat:newline");
+  });
+});
+
+describe("conflicting explicit binding", () => {
+  test("returns conflict and leaves shift+enter untouched", async () => {
+    const path = tempPath();
+    await Bun.write(
+      path,
+      JSON.stringify({
+        bindings: [{ context: "Chat", bindings: { "shift+enter": "submit" } }],
+      }),
+    );
+    expect(await convergeClaudeKeybinding(path)).toBe("conflict");
+    const content = JSON.parse(await Bun.file(path).text());
+    const chat = content.bindings.find((b: { context?: string }) => b.context === "Chat");
+    expect(chat?.bindings?.["shift+enter"]).toBe("submit");
+  });
+});
+
+describe("malformed JSON", () => {
+  test("returns malformed and does not overwrite the file", async () => {
+    const path = tempPath();
+    const bad = "not valid json {{{";
+    await Bun.write(path, bad);
+    expect(await convergeClaudeKeybinding(path)).toBe("malformed");
+    expect(await Bun.file(path).text()).toBe(bad);
+  });
+});

--- a/src/claude-keybindings.ts
+++ b/src/claude-keybindings.ts
@@ -1,0 +1,164 @@
+/**
+ * Claude Code keybindings convergence.
+ *
+ * Claude Code reads ~/.claude/keybindings.json for per-context bindings.
+ * The file format is an object with a "bindings" array; each entry carries
+ * a "context" string and a "bindings" map of key to action.
+ *
+ * The one binding every machine wants: Shift+Enter inserts a newline in
+ * Chat rather than submitting the message. Without it, every multi-line
+ * prompt has to be built somewhere else and pasted in.
+ *
+ * Three constraints shape this:
+ *   - idempotent: re-running on a machine that already has it does nothing
+ *   - non-destructive: unrelated top-level fields, contexts and bindings survive
+ *   - conservative: malformed JSON and explicit conflicting bindings are
+ *     never overwritten silently — a warning is emitted and the file is left alone
+ */
+
+import { existsSync } from "node:fs";
+import { log } from "./log.ts";
+
+const CONTEXT = "Chat";
+const KEY = "shift+enter";
+const ACTION = "chat:newline";
+
+function defaultPath(): string {
+  const home = process.env["HOME"] ?? process.env["USERPROFILE"] ?? "";
+  return `${home.replace(/\\/g, "/")}/.claude/keybindings.json`;
+}
+
+export type BindingOutcome = "wrote" | "already-set" | "conflict" | "malformed";
+
+type BindingEntry = { context?: string; bindings?: Record<string, string> } & Record<
+  string,
+  unknown
+>;
+type KeybindingFile = { bindings?: BindingEntry[] } & Record<string, unknown>;
+
+/**
+ * Ensure ~/.claude/keybindings.json maps Shift+Enter to chat:newline in Chat.
+ *
+ * Accepts an explicit path for tests; omit to use the real Claude config dir.
+ */
+export async function convergeClaudeKeybinding(path?: string): Promise<BindingOutcome> {
+  const target = path ?? defaultPath();
+
+  if (!existsSync(target)) {
+    await Bun.write(
+      target,
+      JSON.stringify(
+        { bindings: [{ context: CONTEXT, bindings: { [KEY]: ACTION } }] },
+        null,
+        2,
+      ) + "\n",
+    );
+    return "wrote";
+  }
+
+  let raw: string;
+  try {
+    raw = await Bun.file(target).text();
+  } catch {
+    log.warn(`claude keybindings: cannot read ${target} — leaving it alone`);
+    return "malformed";
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    log.warn(`claude keybindings: ${target} is not valid JSON — leaving it alone`);
+    return "malformed";
+  }
+
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    log.warn(`claude keybindings: ${target} has an unexpected root type — leaving it alone`);
+    return "malformed";
+  }
+
+  const obj = parsed as KeybindingFile;
+  const bindings = obj.bindings;
+
+  if (!Array.isArray(bindings)) {
+    await Bun.write(
+      target,
+      JSON.stringify(
+        { ...obj, bindings: [{ context: CONTEXT, bindings: { [KEY]: ACTION } }] },
+        null,
+        2,
+      ) + "\n",
+    );
+    return "wrote";
+  }
+
+  const chatEntry = bindings.find(
+    (b): b is BindingEntry => typeof b === "object" && b !== null && b.context === CONTEXT,
+  );
+
+  if (!chatEntry) {
+    await Bun.write(
+      target,
+      JSON.stringify(
+        { ...obj, bindings: [...bindings, { context: CONTEXT, bindings: { [KEY]: ACTION } }] },
+        null,
+        2,
+      ) + "\n",
+    );
+    return "wrote";
+  }
+
+  const existing = chatEntry.bindings?.[KEY];
+  if (existing === ACTION) return "already-set";
+
+  if (existing !== undefined) {
+    log.warn(
+      `claude keybindings: ${KEY} is already bound to "${existing}" — leaving it alone`,
+    );
+    return "conflict";
+  }
+
+  await Bun.write(
+    target,
+    JSON.stringify(
+      {
+        ...obj,
+        bindings: bindings.map((b) =>
+          b === chatEntry
+            ? { ...b, bindings: { ...(b.bindings ?? {}), [KEY]: ACTION } }
+            : b,
+        ),
+      },
+      null,
+      2,
+    ) + "\n",
+  );
+  return "wrote";
+}
+
+/**
+ * Convergence entry-point called from the builtin dispatcher.
+ *
+ * Skipped silently when Claude Code is not installed: the keybinding has
+ * nowhere to go without the CLI.
+ */
+export async function convergeClaudeKeybindings(): Promise<void> {
+  if (!Bun.which("claude")) {
+    log.skip("claude keybindings: claude not installed");
+    return;
+  }
+
+  const outcome = await convergeClaudeKeybinding();
+  switch (outcome) {
+    case "wrote":
+      log.ok(`claude keybindings: ${KEY} → ${ACTION}`);
+      break;
+    case "already-set":
+      log.skip(`claude keybindings: ${KEY} already maps to ${ACTION}`);
+      break;
+    case "conflict":
+    case "malformed":
+      // Warning already emitted inside convergeClaudeKeybinding.
+      break;
+  }
+}

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -109,7 +109,8 @@ export type Provider =
         | "red-skills-vscode"
         | "red-skills-herdr"
         | "blender"
-        | "wsl-sync";
+        | "wsl-sync"
+        | "claude-keybindings";
     }
   /** Not installed here, deliberately. The reason is required. */
   | { kind: "skip"; reason: string };
@@ -214,7 +215,8 @@ const builtin = (
     | "red-skills"
     | "red-skills-vscode"
     | "red-skills-herdr"
-    | "blender",
+    | "blender"
+    | "claude-keybindings",
 ): Provider => ({ kind: "builtin", name });
 const skip = (reason: string): Provider => ({ kind: "skip", reason });
 
@@ -738,6 +740,17 @@ export const TOOLS: Tool[] = [
     managed: true,
     u24: builtin("red-skills"),
     win: builtin("red-skills"),
+  },
+  {
+    // Skipped silently when claude is not installed. Idempotent and
+    // non-destructive: malformed JSON and explicit conflicting bindings
+    // are never overwritten silently.
+    name: "claude-keybindings",
+    about: "Shift+Enter → newline in Claude Code Chat",
+    scope: "core",
+    managed: true,
+    u24: builtin("claude-keybindings"),
+    win: builtin("claude-keybindings"),
   },
   {
     name: "wsl-interop",

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -800,6 +800,11 @@ export async function applyProvider(pr: Provider, ctx: ApplyContext): Promise<vo
         await convergeRedSkills(ctx.platform);
         return;
       }
+      if (pr.name === "claude-keybindings") {
+        const { convergeClaudeKeybindings } = await import("./claude-keybindings.ts");
+        await convergeClaudeKeybindings();
+        return;
+      }
       if (pr.name === "hotkeys") {
         const { installWindowsHotkeys } = await import("./hotkeys.ts");
         await installWindowsHotkeys(ctx.platform);


### PR DESCRIPTION
Automated AFK landing for #39. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #39

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788437765&installation_model_id=20659&pr_number=40&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F40&signature=780de748d2528cb2ed8b9ef303b82033f6e73f427c270eed20ec83692f5d8fa8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->