### PR TITLE
Version floors, the .red/dev share, and one converge for both modes

### DIFF
--- a/config/bash/rc.sh
+++ b/config/bash/rc.sh
@@ -121,6 +121,27 @@ for _red_part in path shared zellij init aliases functions prompt; do
 done
 unset _red_part _red_file
 
+# Yours, and sourced last so it wins.
+#
+# Everything above is generated and rewritten on every converge, so an
+# alias added to any of it survives until the next install and then
+# quietly does not. These two files are never written by red-dev after
+# they are created, which makes them the only place a personal setting
+# can actually live.
+#
+# Two, because "personal" splits in a way one file cannot serve: the
+# shared one travels with the configuration to every machine, and the
+# local one is for what is true here and nowhere else — a work proxy, a
+# path to a checkout, a key that exists on this laptop. Local is sourced
+# after shared, so this machine gets the last word about itself.
+for _red_mine in "${RED_SHARE:+$RED_SHARE/config/bash/local.sh}" "$HOME/.config/red-dev/local.sh"; do
+  if [ -n "$_red_mine" ] && [ -r "$_red_mine" ]; then
+    # shellcheck disable=SC1090
+    . "$_red_mine"
+  fi
+done
+unset _red_mine
+
 # Attach last, after every keybinding above is registered. Guarded on
 # BLE_VERSION so this is inert when ble.sh was never loaded.
 if [ -n "${BLE_VERSION-}" ]; then

--- a/config/bash/rc.sh
+++ b/config/bash/rc.sh
@@ -71,14 +71,14 @@ fi
 
 # The shared root: one directory, reachable from both sides.
 #
-# RED_SHARE_WIN holds it the way Windows spells it — `C:\Users\me\.reddev`
+# RED_SHARE_WIN holds it the way Windows spells it — `C:\Users\me\.red\dev`
 # — because that is the only spelling both environments can agree to
 # store. Each side then translates, and there are three spellings rather
 # than the two you would expect:
 #
-#   C:\Users\me\.reddev       PowerShell, and any GUI application
-#   /c/Users/me/.reddev       Git Bash on native Windows
-#   /mnt/c/Users/me/.reddev   WSL
+#   C:\Users\me\.red\dev       PowerShell, and any GUI application
+#   /c/Users/me/.red/dev       Git Bash on native Windows
+#   /mnt/c/Users/me/.red/dev   WSL
 #
 # Translated here in shell rather than by calling wslpath, because this
 # runs before PATH is built and cannot assume any binary exists yet.

--- a/src/alacritty-migrate.test.ts
+++ b/src/alacritty-migrate.test.ts
@@ -12,7 +12,7 @@
 import { describe, expect, test } from "bun:test";
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { migrateImportKey } from "./alacritty.ts";
+import { migrateImportKey, requiredImports } from "./alacritty.ts";
 
 const OLD = `# red-dev — Alacritty.
 
@@ -30,7 +30,7 @@ async function migrate(content: string): Promise<string> {
   const dir = mkdtempSync(`${tmpdir()}/alacritty-`);
   const path = `${dir}/alacritty.toml`;
   await Bun.write(path, content);
-  await migrateImportKey(path);
+  await migrateImportKey(path, requiredImports(null));
   return await Bun.file(path).text();
 }
 

--- a/src/alacritty.ts
+++ b/src/alacritty.ts
@@ -342,10 +342,57 @@ action = 'ToggleFullscreen'
 `;
 }
 
-/** The files alacritty.toml has to import for red-dev to reach it. */
-const REQUIRED_IMPORTS = ['theme.toml', 'font.toml', 'shell.toml', 'keys.toml'] as const;
+/**
+ * The parts that are the same on every machine, so they go in the share.
+ *
+ * Colours, a font family and a set of key bindings describe a preference
+ * and name nothing local. One copy, read by the Alacritty on this
+ * machine and by the one on the next.
+ */
+const SHARED_PARTS = ["theme.toml", "font.toml", "keys.toml"] as const;
 
-function mainToml(opacity: number): string {
+/**
+ * The part that cannot be shared, and the reason the split exists.
+ *
+ * shell.toml names `wsl.exe -d Ubuntu-24.04` or a path to bash.exe —
+ * it *is* the WSL-or-native choice, written down. Sharing it would make
+ * two machines fight over which one they both are.
+ */
+const LOCAL_PARTS = ["shell.toml"] as const;
+
+/**
+ * What alacritty.toml has to import, given where the share is.
+ *
+ * Absolute Windows paths for the shared parts, because alacritty.exe
+ * resolves relative imports against the file's own directory and the
+ * share is not there. Spelled in TOML literal strings — single quotes —
+ * so the backslashes stay backslashes.
+ *
+ * A null share is a machine with no second environment to share with,
+ * and everything stays beside alacritty.toml exactly as before.
+ */
+export function requiredImports(shareWinRoot: string | null): string[] {
+  const local = [...LOCAL_PARTS];
+  if (!shareWinRoot) return [...SHARED_PARTS, ...local];
+  const dir = `${shareWinRoot.replace(/[\\/]+$/, "")}\\config\\alacritty`;
+  return [...SHARED_PARTS.map((p) => `${dir}\\${p}`), ...local];
+}
+
+/** Whether an import entry is one red-dev owns, wherever it points. */
+function isOurs(entry: string): boolean {
+  const base = entry.split(/[\\/]/).pop() ?? entry;
+  return ([...SHARED_PARTS, ...LOCAL_PARTS] as string[]).includes(base);
+}
+
+/** Same entries in any order. */
+function sameEntries(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  const x = [...a].sort();
+  const y = [...b].sort();
+  return x.every((v, i) => v === y[i]);
+}
+
+function mainToml(opacity: number, required: string[]): string {
   return `# red-dev — Alacritty.
 #
 # This file is created once and never rewritten, so it is yours to edit.
@@ -362,10 +409,7 @@ function mainToml(opacity: number): string {
 # once and never rewritten, so an install from before the rename keeps
 # warning until this file is replaced by hand.
 import = [
-  'theme.toml',
-  'font.toml',
-  'shell.toml',
-  'keys.toml',
+${required.map((i) => `  '${i}',`).join("\n")}
 ]
 
 [window]
@@ -448,13 +492,38 @@ export async function configureAlacritty(opts: AlacrittyOptions): Promise<void> 
     else await Bun.write(`${dir}${sep}${name}`, content);
   };
 
-  // theme and font are regenerated; the main file is written once so a
-  // user who tunes padding or bindings does not lose it on every run.
-  await put("theme.toml", colorsToml(opts.theme.terminal));
-  await put("font.toml", fontToml(opts.fontFamily, opts.fontSize ?? 11));
-  await put("keys.toml", keysToml());
-  // Regenerated, not written-once: which shell to launch is red-dev's
-  // decision, not a user preference we would be clobbering.
+  // The share, when this machine has one.
+  //
+  // Written straight through the filesystem rather than through the
+  // host, unlike %APPDATA%\alacritty above: the dual-NTFS-record problem
+  // documented there is a property of that directory, not of /mnt/c, and
+  // the shared zellij config has been read and written this way from
+  // both sides since the share existed.
+  const { recordedShareRoot, localPath } = await import("./shared-root.ts");
+  const shareWin = recordedShareRoot();
+  const shareLocal = shareWin ? localPath(shareWin, opts.platform.env) : null;
+  const shared =
+    shareWin && shareLocal && existsSync(shareLocal)
+      ? { win: shareWin, dir: `${shareLocal}/config/alacritty` }
+      : null;
+
+  const putShared = async (name: string, content: string): Promise<void> => {
+    if (!shared) return put(name, content);
+    mkdirSync(shared.dir, { recursive: true });
+    await Bun.write(`${shared.dir}/${name}`, content);
+  };
+
+  const required = requiredImports(shared?.win ?? null);
+
+  // theme, font and keys are the same on every machine, so they go to
+  // the share when there is one; the main file is written once so a user
+  // who tunes padding or bindings does not lose it on every run.
+  await putShared("theme.toml", colorsToml(opts.theme.terminal));
+  await putShared("font.toml", fontToml(opts.fontFamily, opts.fontSize ?? 11));
+  await putShared("keys.toml", keysToml());
+  // Local and regenerated. Local because it encodes WSL-or-native, which
+  // is this machine's answer; regenerated because which shell to launch
+  // is red-dev's decision, not a user preference we would be clobbering.
   await put("shell.toml", await shellToml(opts.platform));
 
   // Existence is asked of the host too, for the same reason: from the
@@ -463,8 +532,9 @@ export async function configureAlacritty(opts: AlacrittyOptions): Promise<void> 
   const mainExists = winDir ? await hostFileExists(`${winDir}\\alacritty.toml`) : existsSync(main);
 
   if (!mainExists) {
-    await put("alacritty.toml", mainToml(opts.opacity));
+    await put("alacritty.toml", mainToml(opts.opacity, required));
     log.ok(`alacritty: config written to ${winDir ?? dir}`);
+    if (shared) log.plain(`       theme, font and keys shared from ${shared.win}`);
     return;
   }
 
@@ -474,11 +544,12 @@ export async function configureAlacritty(opts: AlacrittyOptions): Promise<void> 
   const current = winDir
     ? await readThroughHost(`${winDir}\\alacritty.toml`)
     : await Bun.file(main).text();
-  const repaired = current === null ? null : repairedImports(current);
+  const repaired = current === null ? null : repairedImports(current, required);
 
   if (repaired !== null) {
     await put("alacritty.toml", repaired);
-    log.ok(`alacritty.toml: import block repaired — ${REQUIRED_IMPORTS.join(", ")}`);
+    log.ok(`alacritty.toml: import block repaired — ${required.length} entries`);
+    if (shared) log.plain(`       theme, font and keys now read from ${shared.win}`);
   } else {
     log.skip(`alacritty.toml exists — theme, font and keys updated, yours left alone`);
   }
@@ -497,8 +568,8 @@ export async function configureAlacritty(opts: AlacrittyOptions): Promise<void> 
  * no [general] section already, and only when the block is the shape
  * this file writes. Anything else is the user's and is left alone.
  */
-export async function migrateImportKey(path: string): Promise<boolean> {
-  const repaired = repairedImports(await Bun.file(path).text());
+export async function migrateImportKey(path: string, required: string[]): Promise<boolean> {
+  const repaired = repairedImports(await Bun.file(path).text(), required);
   if (repaired === null) return false;
   await Bun.write(path, repaired);
   return true;
@@ -514,7 +585,7 @@ export async function migrateImportKey(path: string): Promise<boolean> {
  * repair never ran on the one target whose config lives on the other
  * side of a boundary, which is the target that needs it most.
  */
-export function repairedImports(text: string): string | null {
+export function repairedImports(text: string, required: string[]): string | null {
   const block = /(^\s*\[general\]\r?\n(?:[^[]*?))?^(\s*)import = \[\r?\n([^\]]*?)\r?\n\s*\]/m;
   const m = block.exec(text);
   if (!m) return null;
@@ -525,17 +596,26 @@ export function repairedImports(text: string): string | null {
     .map((l) => l.trim().replace(/^['"]|['"],?$/g, ""))
     .filter(Boolean);
 
-  // Missing entries matter more than the deprecation did.
+  // Ours are replaced; theirs are kept.
   //
-  // The file is written once, so one that predates a new import never
-  // gains it: this machine's had theme and font and no shell, which is
-  // why `red-dev shell` had no effect on that side — the choice was
-  // being written to a file nothing read. Adding is safe in a way
-  // rewriting is not; anything the user put there is kept.
-  const missing = REQUIRED_IMPORTS.filter((r) => !listed.includes(r));
-  if (hasGeneral && missing.length === 0) return null;
+  // Replaced rather than appended, which the previous version did. Once
+  // theme.toml moved into the share, appending the absolute path left
+  // the bare `theme.toml` beside it — two imports of the same file, the
+  // stale local copy still on disk, and the answer depending on which
+  // Alacritty merges last. Ownership is decided by the file name, so a
+  // path that moved is still recognised as the entry it replaces.
+  //
+  // Anything the user added is not ours and survives untouched, which is
+  // the property that makes rewriting safe at all here.
+  const theirs = listed.filter((e) => !isOurs(e));
+  const merged = [...required, ...theirs];
 
-  const merged = [...listed, ...missing];
+  // Compared as a set, not as a sequence. Our four files touch disjoint
+  // keys — colours, font, bindings, shell — so their order decides
+  // nothing, and comparing positionally would rewrite the block on every
+  // converge just to reorder it.
+  if (hasGeneral && sameEntries(merged, listed)) return null;
+
   const rebuilt = `[general]\nimport = [\n${merged.map((i) => `  '${i}',`).join("\n")}\n]`;
   return text.replace(block, rebuilt);
 }

--- a/src/apt-batch.test.ts
+++ b/src/apt-batch.test.ts
@@ -1,0 +1,69 @@
+/**
+ * The apt batch has to be bracketed like a step.
+ *
+ * It is the one piece of work that runs between scopeStart and the first
+ * stepStart, and the fullscreen view only redirects child output while a
+ * bracket is open. Unbracketed, the loudest command of the whole run —
+ * a hundred packages, minutes of progress bars — wrote straight to the
+ * terminal and painted over the frame.
+ *
+ * The property that matters most is the second test: a batchStart whose
+ * batchEnd never fires leaves the redirect open forever, and every line
+ * after it disappears into a sink nobody is reading.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { runAptBatch, type ConvergeObserver } from "./converge.ts";
+
+function recorder(): { events: string[]; observer: ConvergeObserver } {
+  const events: string[] = [];
+  return {
+    events,
+    observer: {
+      batchStart: (pkgs) => events.push(`start:${pkgs.join(",")}`),
+      batchEnd: (error) => events.push(`end:${error ?? "ok"}`),
+    },
+  };
+}
+
+describe("runAptBatch", () => {
+  test("brackets a successful transaction", async () => {
+    const { events, observer } = recorder();
+    const seen: string[][] = [];
+    const error = await runAptBatch(["git", "curl"], observer, async (pkgs) => {
+      seen.push(pkgs);
+      events.push("install");
+    });
+    expect(error).toBeNull();
+    expect(events).toEqual(["start:git,curl", "install", "end:ok"]);
+    expect(seen).toEqual([["git", "curl"]]);
+  });
+
+  test("closes the bracket when the transaction throws", async () => {
+    const { events, observer } = recorder();
+    const error = await runAptBatch(["git"], observer, async () => {
+      throw new Error("apt-get install failed (100)");
+    });
+    expect(error).toBe("apt-get install failed (100)");
+    expect(events).toEqual(["start:git", "end:apt-get install failed (100)"]);
+  });
+
+  test("reports the failure rather than throwing it", async () => {
+    // The caller has to report the failure once per tool in the batch,
+    // which it cannot do from inside a rejected promise.
+    const { observer } = recorder();
+    const promise = runAptBatch(["git"], observer, async () => {
+      throw new Error("boom");
+    });
+    await expect(promise).resolves.toBe("boom");
+  });
+
+  test("survives an observer that implements neither hook", async () => {
+    let ran = false;
+    const error = await runAptBatch(["git"], {}, async () => {
+      ran = true;
+    });
+    expect(ran).toBe(true);
+    expect(error).toBeNull();
+  });
+});

--- a/src/claude-keybindings.test.ts
+++ b/src/claude-keybindings.test.ts
@@ -1,50 +1,80 @@
 /**
- * Shift+Enter → chat:newline, without stepping on what the user already chose.
+ * Shift+Enter → chat:newline and Ctrl+G unbound, without stepping on what
+ * the user already chose.
  *
- * The five cases worth testing independently:
- *   - no file yet: create it
+ * The cases worth testing independently:
+ *   - no file yet: create it with both managed keys
  *   - already correct: skip without touching the file
  *   - unrelated bindings present: add ours, keep theirs
- *   - explicit conflicting binding: preserve it, report conflict
+ *   - explicit conflicting binding: preserve it, report conflict for that key
+ *     alone while the other key still converges
+ *   - null is a value, not an absence: an explicit "ctrl+g": null already
+ *     satisfies the unbind rather than being rewritten
  *   - malformed JSON: leave the file untouched
  */
 
 import { describe, expect, test } from "bun:test";
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { convergeClaudeKeybinding } from "./claude-keybindings.ts";
+import { convergeClaudeKeybinding, type ConvergeResult } from "./claude-keybindings.ts";
 
 function tempPath(): string {
   const dir = mkdtempSync(`${tmpdir()}/claude-kb-`);
   return `${dir}/keybindings.json`;
 }
 
+async function chatOf(path: string): Promise<Record<string, string | null>> {
+  const content = JSON.parse(await Bun.file(path).text());
+  const chat = content.bindings.find((b: { context?: string }) => b.context === "Chat");
+  return chat?.bindings ?? {};
+}
+
 describe("absent file", () => {
-  test("creates it with the shift+enter binding", async () => {
+  test("creates it with both managed bindings", async () => {
     const path = tempPath();
     const outcome = await convergeClaudeKeybinding(path);
-    expect(outcome).toBe("wrote");
-    const content = JSON.parse(await Bun.file(path).text());
-    const chat = content.bindings.find((b: { context?: string }) => b.context === "Chat");
-    expect(chat?.bindings?.["shift+enter"]).toBe("chat:newline");
+    expect(outcome).toEqual({ "shift+enter": "wrote", "ctrl+g": "wrote" });
+    const chat = await chatOf(path);
+    expect(chat["shift+enter"]).toBe("chat:newline");
+    expect(chat["ctrl+g"]).toBeNull();
+  });
+
+  test("writes ctrl+g as a present key, not an omitted one", async () => {
+    const path = tempPath();
+    await convergeClaudeKeybinding(path);
+    expect(Object.keys(await chatOf(path))).toContain("ctrl+g");
   });
 });
 
-describe("already-correct binding", () => {
+describe("already-correct bindings", () => {
   test("returns already-set and does not rewrite the file", async () => {
     const path = tempPath();
-    const original = JSON.stringify({
-      bindings: [{ context: "Chat", bindings: { "shift+enter": "chat:newline" } }],
-    });
-    await Bun.write(path, original);
-    expect(await convergeClaudeKeybinding(path)).toBe("already-set");
-    expect(await convergeClaudeKeybinding(path)).toBe("already-set");
+    await Bun.write(
+      path,
+      JSON.stringify({
+        bindings: [{ context: "Chat", bindings: { "shift+enter": "chat:newline", "ctrl+g": null } }],
+      }),
+    );
+    const expected: ConvergeResult = { "shift+enter": "already-set", "ctrl+g": "already-set" };
+    expect(await convergeClaudeKeybinding(path)).toEqual(expected);
+    expect(await convergeClaudeKeybinding(path)).toEqual(expected);
     expect(JSON.parse(await Bun.file(path).text()).bindings).toHaveLength(1);
+  });
+
+  test("an explicit null already satisfies the ctrl+g unbind", async () => {
+    const path = tempPath();
+    await Bun.write(
+      path,
+      JSON.stringify({ bindings: [{ context: "Chat", bindings: { "ctrl+g": null } }] }),
+    );
+    const outcome = await convergeClaudeKeybinding(path);
+    expect(outcome["ctrl+g"]).toBe("already-set");
+    expect(outcome["shift+enter"]).toBe("wrote");
   });
 });
 
 describe("unrelated existing bindings", () => {
-  test("adds the Chat binding and preserves the other context", async () => {
+  test("adds the Chat bindings and preserves the other context", async () => {
     const path = tempPath();
     await Bun.write(
       path,
@@ -52,12 +82,16 @@ describe("unrelated existing bindings", () => {
         bindings: [{ context: "Other", bindings: { "ctrl+k": "other:action" } }],
       }),
     );
-    expect(await convergeClaudeKeybinding(path)).toBe("wrote");
+    expect(await convergeClaudeKeybinding(path)).toEqual({
+      "shift+enter": "wrote",
+      "ctrl+g": "wrote",
+    });
     const content = JSON.parse(await Bun.file(path).text());
     const other = content.bindings.find((b: { context?: string }) => b.context === "Other");
     expect(other?.bindings?.["ctrl+k"]).toBe("other:action");
-    const chat = content.bindings.find((b: { context?: string }) => b.context === "Chat");
-    expect(chat?.bindings?.["shift+enter"]).toBe("chat:newline");
+    const chat = await chatOf(path);
+    expect(chat["shift+enter"]).toBe("chat:newline");
+    expect(chat["ctrl+g"]).toBeNull();
   });
 
   test("preserves top-level fields like $schema", async () => {
@@ -74,7 +108,7 @@ describe("unrelated existing bindings", () => {
     expect(content.$schema).toBe("https://www.schemastore.org/claude-code-keybindings.json");
   });
 
-  test("adds shift+enter alongside existing Chat bindings", async () => {
+  test("adds ours alongside existing Chat bindings", async () => {
     const path = tempPath();
     await Bun.write(
       path,
@@ -82,16 +116,19 @@ describe("unrelated existing bindings", () => {
         bindings: [{ context: "Chat", bindings: { "ctrl+enter": "submit" } }],
       }),
     );
-    expect(await convergeClaudeKeybinding(path)).toBe("wrote");
-    const content = JSON.parse(await Bun.file(path).text());
-    const chat = content.bindings.find((b: { context?: string }) => b.context === "Chat");
-    expect(chat?.bindings?.["ctrl+enter"]).toBe("submit");
-    expect(chat?.bindings?.["shift+enter"]).toBe("chat:newline");
+    expect(await convergeClaudeKeybinding(path)).toEqual({
+      "shift+enter": "wrote",
+      "ctrl+g": "wrote",
+    });
+    const chat = await chatOf(path);
+    expect(chat["ctrl+enter"]).toBe("submit");
+    expect(chat["shift+enter"]).toBe("chat:newline");
+    expect(chat["ctrl+g"]).toBeNull();
   });
 });
 
 describe("conflicting explicit binding", () => {
-  test("returns conflict and leaves shift+enter untouched", async () => {
+  test("reports conflict for shift+enter and leaves it untouched", async () => {
     const path = tempPath();
     await Bun.write(
       path,
@@ -99,19 +136,47 @@ describe("conflicting explicit binding", () => {
         bindings: [{ context: "Chat", bindings: { "shift+enter": "submit" } }],
       }),
     );
-    expect(await convergeClaudeKeybinding(path)).toBe("conflict");
-    const content = JSON.parse(await Bun.file(path).text());
-    const chat = content.bindings.find((b: { context?: string }) => b.context === "Chat");
-    expect(chat?.bindings?.["shift+enter"]).toBe("submit");
+    const outcome = await convergeClaudeKeybinding(path);
+    expect(outcome["shift+enter"]).toBe("conflict");
+    expect((await chatOf(path))["shift+enter"]).toBe("submit");
+  });
+
+  test("a conflict on one key does not block the other", async () => {
+    const path = tempPath();
+    await Bun.write(
+      path,
+      JSON.stringify({
+        bindings: [{ context: "Chat", bindings: { "shift+enter": "submit" } }],
+      }),
+    );
+    const outcome = await convergeClaudeKeybinding(path);
+    expect(outcome["ctrl+g"]).toBe("wrote");
+    expect((await chatOf(path))["ctrl+g"]).toBeNull();
+  });
+
+  test("a ctrl+g the user bound on purpose is kept", async () => {
+    const path = tempPath();
+    await Bun.write(
+      path,
+      JSON.stringify({
+        bindings: [{ context: "Chat", bindings: { "ctrl+g": "chat:externalEditor" } }],
+      }),
+    );
+    const outcome = await convergeClaudeKeybinding(path);
+    expect(outcome["ctrl+g"]).toBe("conflict");
+    expect((await chatOf(path))["ctrl+g"]).toBe("chat:externalEditor");
   });
 });
 
 describe("malformed JSON", () => {
-  test("returns malformed and does not overwrite the file", async () => {
+  test("returns malformed for every key and does not overwrite the file", async () => {
     const path = tempPath();
     const bad = "not valid json {{{";
     await Bun.write(path, bad);
-    expect(await convergeClaudeKeybinding(path)).toBe("malformed");
+    expect(await convergeClaudeKeybinding(path)).toEqual({
+      "shift+enter": "malformed",
+      "ctrl+g": "malformed",
+    });
     expect(await Bun.file(path).text()).toBe(bad);
   });
 });

--- a/src/claude-keybindings.ts
+++ b/src/claude-keybindings.ts
@@ -3,11 +3,22 @@
  *
  * Claude Code reads ~/.claude/keybindings.json for per-context bindings.
  * The file format is an object with a "bindings" array; each entry carries
- * a "context" string and a "bindings" map of key to action.
+ * a "context" string and a "bindings" map of key to action. A null action
+ * unbinds a Claude Code default.
  *
- * The one binding every machine wants: Shift+Enter inserts a newline in
- * Chat rather than submitting the message. Without it, every multi-line
- * prompt has to be built somewhere else and pasted in.
+ * Two bindings, both in the Chat context:
+ *
+ *   Shift+Enter -> chat:newline. Without it, every multi-line prompt has
+ *   to be built somewhere else and pasted in.
+ *
+ *   Ctrl+G -> nothing. Claude Code binds it to chat:externalEditor by
+ *   default, and config/zellij/config.kdl already spends Ctrl+G on the
+ *   unlock. Two owners for one key means the key does different things
+ *   depending on whether the shell happens to be inside zellij, which is
+ *   exactly what the zellij table was arranged to avoid. zellij is the
+ *   layer that cannot move — it has to catch the key before the pane
+ *   sees it — so Claude Code yields, and chat:externalEditor stays
+ *   reachable on its second default, Ctrl+X Ctrl+E.
  *
  * Three constraints shape this:
  *   - idempotent: re-running on a machine that already has it does nothing
@@ -20,8 +31,19 @@ import { existsSync } from "node:fs";
 import { log } from "./log.ts";
 
 const CONTEXT = "Chat";
-const KEY = "shift+enter";
-const ACTION = "chat:newline";
+
+/** A key red-dev owns in the Chat context. A null action unbinds it. */
+type Managed = { key: string; action: string | null };
+
+const MANAGED: readonly Managed[] = [
+  { key: "shift+enter", action: "chat:newline" },
+  { key: "ctrl+g", action: null },
+];
+
+/** How a managed binding reads in the file, for logs. */
+function describe(b: Managed): string {
+  return b.action === null ? `${b.key} unbound` : `${b.key} → ${b.action}`;
+}
 
 function defaultPath(): string {
   const home = process.env["HOME"] ?? process.env["USERPROFILE"] ?? "";
@@ -30,30 +52,46 @@ function defaultPath(): string {
 
 export type BindingOutcome = "wrote" | "already-set" | "conflict" | "malformed";
 
-type BindingEntry = { context?: string; bindings?: Record<string, string> } & Record<
-  string,
-  unknown
->;
+/** One outcome per managed key. Keys that share a file still differ here. */
+export type ConvergeResult = Record<string, BindingOutcome>;
+
+type BindingMap = Record<string, string | null>;
+type BindingEntry = { context?: string; bindings?: BindingMap } & Record<string, unknown>;
 type KeybindingFile = { bindings?: BindingEntry[] } & Record<string, unknown>;
 
+/** The same verdict for every managed key — the file-level failures. */
+function uniform(outcome: BindingOutcome): ConvergeResult {
+  return Object.fromEntries(MANAGED.map((b) => [b.key, outcome]));
+}
+
+/** Every managed binding as Claude Code stores it. */
+function managedMap(): BindingMap {
+  return Object.fromEntries(MANAGED.map((b) => [b.key, b.action]));
+}
+
+function save(target: string, file: KeybindingFile): Promise<number> {
+  return Bun.write(target, JSON.stringify(file, null, 2) + "\n");
+}
+
+/** What the file currently says, phrased for a warning. */
+function render(action: string | null | undefined): string {
+  return action === null ? "null" : `"${action}"`;
+}
+
 /**
- * Ensure ~/.claude/keybindings.json maps Shift+Enter to chat:newline in Chat.
+ * Converge every binding in MANAGED into ~/.claude/keybindings.json.
+ *
+ * One read and at most one write, so a malformed file warns once rather
+ * than once per key.
  *
  * Accepts an explicit path for tests; omit to use the real Claude config dir.
  */
-export async function convergeClaudeKeybinding(path?: string): Promise<BindingOutcome> {
+export async function convergeClaudeKeybinding(path?: string): Promise<ConvergeResult> {
   const target = path ?? defaultPath();
 
   if (!existsSync(target)) {
-    await Bun.write(
-      target,
-      JSON.stringify(
-        { bindings: [{ context: CONTEXT, bindings: { [KEY]: ACTION } }] },
-        null,
-        2,
-      ) + "\n",
-    );
-    return "wrote";
+    await save(target, { bindings: [{ context: CONTEXT, bindings: managedMap() }] });
+    return uniform("wrote");
   }
 
   let raw: string;
@@ -61,7 +99,7 @@ export async function convergeClaudeKeybinding(path?: string): Promise<BindingOu
     raw = await Bun.file(target).text();
   } catch {
     log.warn(`claude keybindings: cannot read ${target} — leaving it alone`);
-    return "malformed";
+    return uniform("malformed");
   }
 
   let parsed: unknown;
@@ -69,27 +107,23 @@ export async function convergeClaudeKeybinding(path?: string): Promise<BindingOu
     parsed = JSON.parse(raw);
   } catch {
     log.warn(`claude keybindings: ${target} is not valid JSON — leaving it alone`);
-    return "malformed";
+    return uniform("malformed");
   }
 
   if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
     log.warn(`claude keybindings: ${target} has an unexpected root type — leaving it alone`);
-    return "malformed";
+    return uniform("malformed");
   }
 
   const obj = parsed as KeybindingFile;
   const bindings = obj.bindings;
 
   if (!Array.isArray(bindings)) {
-    await Bun.write(
-      target,
-      JSON.stringify(
-        { ...obj, bindings: [{ context: CONTEXT, bindings: { [KEY]: ACTION } }] },
-        null,
-        2,
-      ) + "\n",
-    );
-    return "wrote";
+    await save(target, {
+      ...obj,
+      bindings: [{ context: CONTEXT, bindings: managedMap() }],
+    });
+    return uniform("wrote");
   }
 
   const chatEntry = bindings.find(
@@ -97,49 +131,51 @@ export async function convergeClaudeKeybinding(path?: string): Promise<BindingOu
   );
 
   if (!chatEntry) {
-    await Bun.write(
-      target,
-      JSON.stringify(
-        { ...obj, bindings: [...bindings, { context: CONTEXT, bindings: { [KEY]: ACTION } }] },
-        null,
-        2,
-      ) + "\n",
-    );
-    return "wrote";
+    await save(target, {
+      ...obj,
+      bindings: [...bindings, { context: CONTEXT, bindings: managedMap() }],
+    });
+    return uniform("wrote");
   }
 
-  const existing = chatEntry.bindings?.[KEY];
-  if (existing === ACTION) return "already-set";
+  // hasOwnProperty rather than a truthiness or undefined check: null is a
+  // value Claude Code gives meaning to, and one this module writes.
+  const current = chatEntry.bindings ?? {};
+  const result: ConvergeResult = {};
+  const additions: BindingMap = {};
 
-  if (existing !== undefined) {
+  for (const b of MANAGED) {
+    if (!Object.prototype.hasOwnProperty.call(current, b.key)) {
+      additions[b.key] = b.action;
+      result[b.key] = "wrote";
+      continue;
+    }
+    if (current[b.key] === b.action) {
+      result[b.key] = "already-set";
+      continue;
+    }
     log.warn(
-      `claude keybindings: ${KEY} is already bound to "${existing}" — leaving it alone`,
+      `claude keybindings: ${b.key} is already bound to ${render(current[b.key])} — leaving it alone`,
     );
-    return "conflict";
+    result[b.key] = "conflict";
   }
 
-  await Bun.write(
-    target,
-    JSON.stringify(
-      {
-        ...obj,
-        bindings: bindings.map((b) =>
-          b === chatEntry
-            ? { ...b, bindings: { ...(b.bindings ?? {}), [KEY]: ACTION } }
-            : b,
-        ),
-      },
-      null,
-      2,
-    ) + "\n",
-  );
-  return "wrote";
+  if (Object.keys(additions).length > 0) {
+    await save(target, {
+      ...obj,
+      bindings: bindings.map((b) =>
+        b === chatEntry ? { ...b, bindings: { ...current, ...additions } } : b,
+      ),
+    });
+  }
+
+  return result;
 }
 
 /**
  * Convergence entry-point called from the builtin dispatcher.
  *
- * Skipped silently when Claude Code is not installed: the keybinding has
+ * Skipped silently when Claude Code is not installed: the keybindings have
  * nowhere to go without the CLI.
  */
 export async function convergeClaudeKeybindings(): Promise<void> {
@@ -148,17 +184,19 @@ export async function convergeClaudeKeybindings(): Promise<void> {
     return;
   }
 
-  const outcome = await convergeClaudeKeybinding();
-  switch (outcome) {
-    case "wrote":
-      log.ok(`claude keybindings: ${KEY} → ${ACTION}`);
-      break;
-    case "already-set":
-      log.skip(`claude keybindings: ${KEY} already maps to ${ACTION}`);
-      break;
-    case "conflict":
-    case "malformed":
-      // Warning already emitted inside convergeClaudeKeybinding.
-      break;
+  const result = await convergeClaudeKeybinding();
+  for (const b of MANAGED) {
+    switch (result[b.key]) {
+      case "wrote":
+        log.ok(`claude keybindings: ${describe(b)}`);
+        break;
+      case "already-set":
+        log.skip(`claude keybindings: ${describe(b)} already`);
+        break;
+      case "conflict":
+      case "malformed":
+        // Warning already emitted inside convergeClaudeKeybinding.
+        break;
+    }
   }
 }

--- a/src/clipboard.test.ts
+++ b/src/clipboard.test.ts
@@ -15,7 +15,7 @@ import { describe, expect, test } from "bun:test";
 import { chmodSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { zellijConfigAction, zellijConfigFor } from "./dotfiles.ts";
-import { repairedImports } from "./alacritty.ts";
+import { repairedImports, requiredImports } from "./alacritty.ts";
 import type { Platform } from "./platform.ts";
 
 function platform(over: Partial<Platform>): Platform {
@@ -110,15 +110,13 @@ describe("paste", () => {
     // In alacritty.toml it would never reach a machine that already had
     // one — the mistake that kept a deprecation warning alive for two
     // releases.
-    expect(src).toContain("await put(\"keys.toml\", keysToml());");
+    expect(src).toContain("await putShared(\"keys.toml\", keysToml());");
   });
 
   test("and that file is repaired into an existing config", () => {
-    // REQUIRED_IMPORTS is what the repair pass adds to an alacritty.toml
-    // that predates it.
-    expect(src).toContain("'keys.toml'");
-    const block = src.slice(src.indexOf("const REQUIRED_IMPORTS"));
-    expect(block.slice(0, 120)).toContain("keys.toml");
+    // requiredImports is what the repair pass writes into an
+    // alacritty.toml that predates it.
+    expect(requiredImports(null)).toContain("keys.toml");
   });
 });
 
@@ -184,7 +182,7 @@ copy_command "powershell.exe -NoProfile -EncodedCommand ${encoded}"
       "[window]",
       "opacity = 0.98",
     ].join("\n");
-    const after = repairedImports(before);
+    const after = repairedImports(before, requiredImports(null));
     expect(after).not.toBeNull();
     expect(after).toContain("keys.toml");
     // And keeps what was already there.
@@ -202,7 +200,7 @@ copy_command "powershell.exe -NoProfile -EncodedCommand ${encoded}"
       "  'keys.toml',",
       "]",
     ].join("\n");
-    expect(repairedImports(complete)).toBeNull();
+    expect(repairedImports(complete, requiredImports(null))).toBeNull();
   });
 
   test("is a pure function, so it can repair across the WSL boundary", () => {
@@ -211,6 +209,81 @@ copy_command "powershell.exe -NoProfile -EncodedCommand ${encoded}"
     // target whose config lives on the far side of a boundary was the
     // one target that could never be repaired.
     const before = "[general]\nimport = [\n  'theme.toml',\n]";
-    expect(repairedImports(before)).toContain("keys.toml");
+    expect(repairedImports(before, requiredImports(null))).toContain("keys.toml");
+  });
+});
+
+/**
+ * Moving theme, font and keys into the share changes what an existing
+ * alacritty.toml has to say, on a file this project promises to write
+ * once and leave alone. The repair pass is the only way those machines
+ * ever point at the share.
+ */
+describe("imports when there is a shared root", () => {
+  const SHARE = "C:\\Users\\filip\\.red\\dev";
+  const shareDir = `${SHARE}\\config\\alacritty`;
+
+  test("the shared parts are absolute and the local one is not", () => {
+    const req = requiredImports(SHARE);
+    expect(req).toContain(`${shareDir}\\theme.toml`);
+    expect(req).toContain(`${shareDir}\\font.toml`);
+    expect(req).toContain(`${shareDir}\\keys.toml`);
+    // shell.toml names wsl.exe or bash.exe: it is the machine's answer
+    // to WSL-or-native and must not follow the theme to another machine.
+    expect(req).toContain("shell.toml");
+    expect(req).not.toContain(`${shareDir}\\shell.toml`);
+  });
+
+  test("a relative entry is replaced by the shared one, not joined by it", () => {
+    // The bug this guards: appending left both 'theme.toml' and the
+    // absolute path in the list, with the stale local copy still on
+    // disk. Which one won depended on merge order.
+    const before = [
+      "[general]",
+      "import = [",
+      "  'theme.toml',",
+      "  'font.toml',",
+      "  'shell.toml',",
+      "  'keys.toml',",
+      "]",
+    ].join("\n");
+    const after = repairedImports(before, requiredImports(SHARE));
+    expect(after).not.toBeNull();
+    expect(after).toContain(`${shareDir}\\theme.toml`);
+    expect(after).not.toMatch(/^\s*'theme\.toml',$/m);
+    expect(after).toMatch(/^\s*'shell\.toml',$/m);
+  });
+
+  test("an import the user added is kept", () => {
+    const before = [
+      "[general]",
+      "import = [",
+      "  'theme.toml',",
+      "  'my-overrides.toml',",
+      "]",
+    ].join("\n");
+    const after = repairedImports(before, requiredImports(SHARE));
+    expect(after).toContain("my-overrides.toml");
+  });
+
+  test("a root that moved is repointed rather than duplicated", () => {
+    // Exactly what the .reddev to .red\dev migration leaves behind: a
+    // valid absolute import at an address nothing writes to any more.
+    const before = [
+      "[general]",
+      "import = [",
+      "  'C:\\Users\\filip\\.reddev\\config\\alacritty\\theme.toml',",
+      "  'shell.toml',",
+      "]",
+    ].join("\n");
+    const after = repairedImports(before, requiredImports(SHARE));
+    expect(after).toContain(`${shareDir}\\theme.toml`);
+    expect(after).not.toContain(".reddev");
+  });
+
+  test("nothing to repair once it already points at the share", () => {
+    const req = requiredImports(SHARE);
+    const settled = `[general]\nimport = [\n${req.map((i) => `  '${i}',`).join("\n")}\n]`;
+    expect(repairedImports(settled, req)).toBeNull();
   });
 });

--- a/src/converge.ts
+++ b/src/converge.ts
@@ -15,6 +15,7 @@
 import { aptInstall, applyProvider, type ApplyContext } from "./providers.ts";
 import {
   describeProvider,
+  installState,
   isInstalled,
   providerFor,
   toolsInScope,
@@ -43,6 +44,22 @@ export interface ConvergeObserver {
   scopeStart?: (scope: Scope, total: number) => void;
   /** A note that is not a step — the apt batch, mostly. */
   note?: (message: string) => void;
+  /**
+   * The batched apt transaction, bracketed like a step.
+   *
+   * It needs its own pair because it is the one piece of work that runs
+   * between scopeStart and the first stepStart, and the fullscreen view
+   * only redirects child output while a step is open. Without this the
+   * largest, longest and loudest command of the whole run — a hundred
+   * packages, hundreds of lines, minutes of progress bars — was the one
+   * command writing straight to the terminal, painting over the frame
+   * the renderer believes it owns.
+   *
+   * batchEnd fires even when the transaction throws. A view that opens a
+   * redirect here and never closes it loses every line that follows.
+   */
+  batchStart?: (packages: string[]) => void;
+  batchEnd?: (error: string | null) => void;
   stepStart?: (event: StepEvent) => void;
   stepEnd?: (result: StepResult) => void;
 }
@@ -62,6 +79,31 @@ export interface ConvergeSummary {
 /** Total steps across every scope, so a progress bar has a denominator. */
 export function countSteps(scopes: Scope[]): number {
   return scopes.reduce((n, s) => n + toolsInScope(s).length, 0);
+}
+
+/**
+ * Run the batched apt transaction inside its observer bracket.
+ *
+ * Its own function so the bracket can be tested without a package
+ * manager: `install` is the real aptInstall everywhere but the test.
+ *
+ * Returns the failure message, or null. Throwing instead would skip
+ * batchEnd, and the caller has to report a failed batch per tool anyway.
+ */
+export async function runAptBatch(
+  pkgs: string[],
+  observer: ConvergeObserver,
+  install: (pkgs: string[]) => Promise<void> = aptInstall,
+): Promise<string | null> {
+  observer.batchStart?.(pkgs);
+  let error: string | null = null;
+  try {
+    await install(pkgs);
+  } catch (err) {
+    error = (err as Error).message;
+  }
+  observer.batchEnd?.(error);
+  return error;
 }
 
 export async function converge(
@@ -93,11 +135,7 @@ export async function converge(
     let aptError: string | null = null;
     if (!dryRun && aptPkgs.length > 0) {
       observer.note?.(`apt: ${aptPkgs.length} packages in one transaction`);
-      try {
-        await aptInstall(aptPkgs);
-      } catch (err) {
-        aptError = (err as Error).message;
-      }
+      aptError = await runAptBatch(aptPkgs, observer);
     }
 
     for (const tool of tools) {
@@ -138,7 +176,12 @@ export async function converge(
         // rather than claiming a per-tool install that never ran.
         if (aptError) finish("failed", aptError);
         else if (isInstalled(tool)) finish("installed");
-        else finish("failed", "apt reported success but the binary is absent");
+        else if (installState(tool) === "outdated") {
+          // Present and runnable, just too old — the archive has nothing
+          // newer. Saying "absent" here sends the reader hunting for a
+          // missing binary that is sitting right there on PATH.
+          finish("failed", `apt has nothing newer than ${tool.minVersion} for ${tool.name}`);
+        } else finish("failed", "apt reported success but the binary is absent");
         continue;
       }
 

--- a/src/dotfiles-targets.test.ts
+++ b/src/dotfiles-targets.test.ts
@@ -1,0 +1,56 @@
+/**
+ * A Windows machine running WSL has two homes, and the shell config is
+ * the pair that drifts without anything failing.
+ *
+ * Converging from inside the distro wrote the distro's copy only, so the
+ * Git Bash side kept whatever it had from the last time red-dev ran as a
+ * native Windows binary. On the machine this was written for that was
+ * eight days of skew, with a prompt.sh still missing the TERM=dumb
+ * guard: the mode you were not in was quietly older, and `doctor` had
+ * nothing to say about it because the side it looked at was correct.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { deployTargets } from "./dotfiles.ts";
+
+const WSL_HOME = "/home/cyber";
+const WIN_HOME = "/mnt/c/Users/filip";
+
+describe("deployTargets", () => {
+  test("from the distro, both homes are written", () => {
+    const t = deployTargets("wsl", WSL_HOME, WIN_HOME);
+    expect(t.map((x) => x.dir)).toEqual([WSL_HOME, WIN_HOME]);
+  });
+
+  test("the distro's own home comes first", () => {
+    // If the crossing fails halfway, the side the user is actually in
+    // has already been converged.
+    expect(deployTargets("wsl", WSL_HOME, WIN_HOME)[0]?.dir).toBe(WSL_HOME);
+  });
+
+  test("an unreachable Windows profile leaves one target, not an error", () => {
+    // Interop switched off, or a C: that did not mount. That machine has
+    // no second home to converge; it is not a broken install of the
+    // first one.
+    expect(deployTargets("wsl", WSL_HOME, null)).toHaveLength(1);
+  });
+
+  test("native Windows writes only its own home", () => {
+    // Its distro is reached by wsl-sync, which runs a full install in
+    // there rather than reaching into its filesystem. Writing both from
+    // here would be the same crossing owned by two different steps.
+    expect(deployTargets("windows", "C:/Users/filip", WIN_HOME)).toHaveLength(1);
+  });
+
+  test("a Linux desktop has no other side", () => {
+    expect(deployTargets("desktop", WSL_HOME, null)).toHaveLength(1);
+    expect(deployTargets("server", WSL_HOME, null)).toHaveLength(1);
+  });
+
+  test("the same directory twice is one target", () => {
+    // Guards a %USERPROFILE% that resolves back to where we already
+    // wrote: the second pass would re-read and re-hook the same
+    // .bashrc, and the backup would be of our own edit.
+    expect(deployTargets("wsl", WIN_HOME, WIN_HOME)).toHaveLength(1);
+  });
+});

--- a/src/dotfiles.ts
+++ b/src/dotfiles.ts
@@ -84,18 +84,18 @@ async function writeIfChanged(path: string, content: string): Promise<boolean> {
  * only when our marker is absent — keeps a re-run harmless and keeps a
  * pre-existing configuration intact.
  */
-async function wireShellRc(): Promise<void> {
-  const bashrc = `${home()}/.bashrc`;
+async function wireShellRc(homeDir: string, label: string): Promise<void> {
+  const bashrc = `${homeDir}/.bashrc`;
   const existing = existsSync(bashrc) ? await Bun.file(bashrc).text() : "";
 
   if (existing.includes(MARKER)) {
-    log.skip("~/.bashrc already sources red-dev");
+    log.skip(`${label} .bashrc already sources red-dev`);
     return;
   }
 
   if (existing.length > 0) {
     await Bun.write(`${bashrc}.red-dev-backup`, existing);
-    log.step(`backed up ~/.bashrc to ~/.bashrc.red-dev-backup`);
+    log.step(`backed up ${label} .bashrc to .bashrc.red-dev-backup`);
   }
 
   const block = [
@@ -108,11 +108,17 @@ async function wireShellRc(): Promise<void> {
   ].join("\n");
 
   await Bun.write(bashrc, block);
-  log.ok("~/.bashrc now sources red-dev");
+  log.ok(`${label} .bashrc now sources red-dev`);
 }
 
-export async function installDotfiles(p: Platform): Promise<void> {
-  const dest = `${home()}/.local/share/red-dev/config/bash`;
+/**
+ * Render the bash config into one home and hook that home's .bashrc.
+ *
+ * Takes the home rather than asking for it, because there are two. See
+ * installDotfiles.
+ */
+async function deployTo(homeDir: string, label: string): Promise<void> {
+  const dest = `${homeDir}/.local/share/red-dev/config/bash`;
   // node:fs rather than shelling out to mkdir, which native Windows
   // does not have. Git Bash understands the forward-slash HOME it
   // reports, so the path itself needs no translation.
@@ -123,13 +129,70 @@ export async function installDotfiles(p: Platform): Promise<void> {
     if (await writeIfChanged(`${dest}/${name}`, content)) changed++;
   }
 
-  if (changed > 0) {
-    log.ok(`dotfiles: ${changed} file(s) written to ${dest}`);
-  } else {
-    log.skip("dotfiles already current");
+  if (changed > 0) log.ok(`dotfiles: ${changed} file(s) written to ${dest}`);
+  else log.skip(`dotfiles already current in ${label}`);
+
+  await wireShellRc(homeDir, label);
+}
+
+/**
+ * The Windows profile, as this distro reaches it — or null.
+ *
+ * Null rather than throwing: a distro with interop switched off, or a
+ * C: that did not mount, is a machine that simply has no second home to
+ * converge. That is not a reason to fail the install of the first one.
+ */
+async function windowsHomeFromWsl(): Promise<string | null> {
+  try {
+    const { windowsUserProfile } = await import("./wsl.ts");
+    const { localPath } = await import("./shared-root.ts");
+    const dir = localPath(await windowsUserProfile(), "wsl");
+    return existsSync(dir) ? dir : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Both homes, one converge.
+ *
+ * A Windows machine running WSL has two of everything, and the shell
+ * config is the pair that silently drifts. Converging from inside the
+ * distro used to write the distro's copy only, so the Git Bash side kept
+ * whatever it had from the last time red-dev happened to run as a native
+ * Windows binary — on this machine, dotfiles from eight days earlier,
+ * with a prompt.sh still missing the TERM=dumb guard. Nothing failed.
+ * The mode you were not in was just quietly older.
+ *
+ * wsl-sync.ts crosses the same boundary the other way and states the
+ * rule this follows: whoever is converging owns the crossing. The files
+ * are byte-identical by construction, so the second write is a no-op
+ * whenever the two sides already agree — which is the point.
+ */
+export function deployTargets(
+  env: Platform["env"],
+  ownHome: string,
+  windowsHome: string | null,
+): { dir: string; label: string }[] {
+  const targets = [{ dir: ownHome, label: "this" }];
+  // Only from the distro outwards. Native Windows reaches its distro
+  // through wsl-sync, which runs a full install in there rather than
+  // reaching into its filesystem, and a Linux desktop has no other side.
+  if (env === "wsl" && windowsHome && windowsHome !== ownHome) {
+    targets.push({ dir: windowsHome, label: "the Windows profile" });
+  }
+  return targets;
+}
+
+export async function installDotfiles(p: Platform): Promise<void> {
+  const winHome = p.env === "wsl" ? await windowsHomeFromWsl() : null;
+  const targets = deployTargets(p.env, home(), winHome);
+
+  for (const t of targets) await deployTo(t.dir, t.label);
+  if (p.env === "wsl" && targets.length === 1) {
+    log.skip("no reachable Windows profile — Git Bash side left as it is");
   }
 
-  await wireShellRc();
   await installZellijConfig(p);
   await wireDelta();
   await primeTldr();

--- a/src/drift.ts
+++ b/src/drift.ts
@@ -467,7 +467,63 @@ export async function collectDrift(p: Platform): Promise<DriftCheck[]> {
   checks.push(await checkToolchainParity(p));
   checks.push(await checkBlesh());
   checks.push(await checkSharedRoot(p));
+  checks.push(await checkHotkeys(p));
   return checks;
+}
+
+/**
+ * The shortcut exists — but does the key still reach it?
+ *
+ * Writing the .lnk was treated as the whole job, and it is only half.
+ * The file keeps its HotKey property forever; the *registration* is
+ * Explorer's and happens at runtime, first come first served. Anything
+ * that starts earlier and claims Ctrl+Alt+T takes it, Explorer's claim
+ * fails, and the shortcut goes dead with no error anywhere — converge
+ * still reports it written, because it is.
+ *
+ * The probe can prove the dead case and not the stolen one: Windows
+ * answers "somebody holds this" and never says who. So a free key is
+ * reported as drift, and a held key is reported as ok with the caveat
+ * stated rather than implied.
+ */
+async function checkHotkeys(p: Platform): Promise<DriftCheck> {
+  const name = "windows hotkeys";
+
+  if (p.env !== "wsl" && p.env !== "windows") {
+    return { name, status: "n/a", detail: "a Windows host claims these" };
+  }
+
+  const { WINDOWS_HOTKEYS, probeHotkeys, hotkeyVerdict } = await import("./hotkeys.ts");
+  const states = await probeHotkeys(p);
+  const claimed = WINDOWS_HOTKEYS.filter((h) => h.combo);
+
+  const dead: string[] = [];
+  let unknown = 0;
+  for (const h of claimed) {
+    const state = states[h.combo as string] ?? "unknown";
+    if (state === "unknown") unknown++;
+    // Shortcut presence is not re-checked here: installWindowsHotkeys
+    // writes them and its own step reports failure. What it cannot see
+    // is whether the key was accepted afterwards.
+    else if (hotkeyVerdict(true, state) === "drift") dead.push(h.combo as string);
+  }
+
+  if (unknown === claimed.length) {
+    return { name, status: "n/a", detail: "could not ask Windows which keys are taken" };
+  }
+  if (dead.length > 0) {
+    return {
+      name,
+      status: "drift",
+      detail: `${dead.join(", ")} registered by nothing — the shortcut will not fire`,
+      fix: "restart Explorer, then: red-dev install desktop",
+    };
+  }
+  return {
+    name,
+    status: "ok",
+    detail: `${claimed.length} claimed and held (Windows does not say by whom)`,
+  };
 }
 
 /**

--- a/src/drift.ts
+++ b/src/drift.ts
@@ -542,7 +542,7 @@ async function checkSharedRoot(p: Platform): Promise<DriftCheck> {
     return { name, status: "n/a", detail: "spans WSL and Windows; this machine is neither" };
   }
 
-  const { sharedRootFor, adoptableTools } = await import("./shared-root.ts");
+  const { sharedRootFor, sharedTools } = await import("./shared-root.ts");
   const root = sharedRootFor(p);
   if (!root) {
     return {
@@ -583,8 +583,13 @@ async function checkSharedRoot(p: Platform): Promise<DriftCheck> {
     }
   };
 
+  // sharedTools, not adoptableTools: alacritty's config is written
+  // straight into the share and has no ~/.config original to adopt, so
+  // listing only the adoptable ones reported "sharing zellij, atuin,
+  // bat" over a directory that also held the theme, font and keys the
+  // terminal was reading at that moment.
   const cfg = `${root.local}/config`;
-  const shared = adoptableTools().filter(
+  const shared = sharedTools().filter(
     (t) =>
       hasContent(`${cfg}/${t}`) ||
       hasContent(`${cfg}/${t}.toml`) ||

--- a/src/hotkey-probe.test.ts
+++ b/src/hotkey-probe.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Writing the .lnk is half the job.
+ *
+ * The file keeps its HotKey property forever; the registration belongs
+ * to Explorer, happens at runtime, and is first come first served. An
+ * application that starts earlier and claims Ctrl+Alt+T takes it,
+ * Explorer's claim fails, and the shortcut goes dead with no error
+ * anywhere — converge keeps reporting it written, because it is.
+ *
+ * This was found the hard way: Ctrl+Alt+T stopped opening the terminal
+ * on a machine whose shortcut, target and hotkey property were all
+ * correct.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { hotkeyArgs, hotkeyVerdict, WINDOWS_HOTKEYS } from "./hotkeys.ts";
+
+describe("hotkeyArgs", () => {
+  test("encodes the combos this project actually claims", () => {
+    // MOD_ALT 1 | MOD_CONTROL 2 = 3, 'T' = 0x54.
+    expect(hotkeyArgs("CTRL+ALT+T")).toEqual({ mods: 3, vk: 0x54 });
+    // ...plus MOD_SHIFT 4 = 7.
+    expect(hotkeyArgs("CTRL+ALT+SHIFT+T")).toEqual({ mods: 7, vk: 0x54 });
+  });
+
+  test("every claimed combo can be probed", () => {
+    // A combo the encoder cannot express is a key the check silently
+    // skips, which is the same blind spot this file exists to close.
+    for (const h of WINDOWS_HOTKEYS) {
+      if (h.combo) expect(hotkeyArgs(h.combo)).not.toBeNull();
+    }
+  });
+
+  test("a combo with no modifier is rejected", () => {
+    // RegisterHotKey accepts it, and taking a bare letter system-wide
+    // would break typing it everywhere else.
+    expect(hotkeyArgs("T")).toBeNull();
+  });
+
+  test("a combo with no key is rejected", () => {
+    expect(hotkeyArgs("CTRL+ALT")).toBeNull();
+  });
+
+  test("something it does not understand is rejected, not guessed", () => {
+    expect(hotkeyArgs("CTRL+ALT+F13")).toBeNull();
+  });
+});
+
+describe("hotkeyVerdict", () => {
+  test("free is the unambiguous failure", () => {
+    // Our shortcut declares the key and nothing holds it, so nothing
+    // happens when it is pressed.
+    expect(hotkeyVerdict(true, "free")).toBe("drift");
+  });
+
+  test("held is reported ok, because Windows never says who holds it", () => {
+    // A working shortcut and a stolen one are indistinguishable through
+    // this API. Calling held "drift" would cry wolf on every healthy
+    // machine; the ambiguity is stated in the detail line instead.
+    expect(hotkeyVerdict(true, "held")).toBe("ok");
+  });
+
+  test("a probe that could not run is not evidence of a fault", () => {
+    expect(hotkeyVerdict(true, "unknown")).toBe("ok");
+  });
+
+  test("a missing shortcut is drift whatever the key says", () => {
+    // Somebody else holding Ctrl+Alt+T does not mean we installed ours.
+    expect(hotkeyVerdict(false, "held")).toBe("drift");
+    expect(hotkeyVerdict(false, "free")).toBe("drift");
+  });
+});

--- a/src/hotkeys.ts
+++ b/src/hotkeys.ts
@@ -24,6 +24,7 @@
  * that still carries an old one.
  */
 
+import type { DriftStatus } from "./drift.ts";
 import { log, RedError } from "./log.ts";
 import type { Platform } from "./platform.ts";
 
@@ -45,6 +46,52 @@ export const WINDOWS_HOTKEYS: Hotkey[] = [
   { label: "Terminal", combo: "CTRL+ALT+T", note: "bash inside WSL, through Alacritty when it is there" },
   { label: "PowerShell (Administrator)", combo: "CTRL+ALT+SHIFT+T", note: "elevated" },
 ];
+
+export type HotkeyState = "held" | "free" | "unknown";
+
+/**
+ * Translate a combo into RegisterHotKey's arguments.
+ *
+ * MOD_ALT 1, MOD_CONTROL 2, MOD_SHIFT 4, MOD_WIN 8. Only the letter keys
+ * this project claims are supported, because that is all it claims.
+ */
+export function hotkeyArgs(combo: string): { mods: number; vk: number } | null {
+  const parts = combo.toUpperCase().split("+").map((s) => s.trim()).filter(Boolean);
+  let mods = 0;
+  let key: string | null = null;
+  for (const part of parts) {
+    if (part === "ALT") mods |= 1;
+    else if (part === "CTRL" || part === "CONTROL") mods |= 2;
+    else if (part === "SHIFT") mods |= 4;
+    else if (part === "WIN") mods |= 8;
+    else if (/^[A-Z]$/.test(part)) key = part;
+    else return null;
+  }
+  if (!key || mods === 0) return null;
+  return { mods, vk: key.charCodeAt(0) };
+}
+
+/**
+ * What a probe result means for a shortcut we wrote.
+ *
+ * A .lnk carries its hotkey forever, but the *registration* belongs to
+ * Explorer and happens at runtime — and RegisterHotKey is first come,
+ * first served. An application that starts early and claims Ctrl+Alt+T
+ * wins it, Explorer's own claim fails, and the shortcut stops working
+ * with nothing anywhere reporting a fault. That is the failure this
+ * exists to name.
+ *
+ * "held" is honestly ambiguous and says so. The API answers "somebody
+ * has this", never who, so a working shortcut and a stolen one are
+ * indistinguishable from here. "free" is the unambiguous one: our
+ * shortcut declares the key, nothing holds it, so nothing will happen
+ * when it is pressed.
+ */
+export function hotkeyVerdict(shortcutExists: boolean, state: HotkeyState): DriftStatus {
+  if (!shortcutExists) return "drift";
+  if (state === "free") return "drift";
+  return "ok";
+}
 
 /**
  * Everything is resolved on the Windows side, deliberately.
@@ -132,4 +179,66 @@ export async function installWindowsHotkeys(p: Platform): Promise<void> {
   for (const line of lines) log.plain(`       ${line}`);
   log.plain("       the elevated one prompts for consent when it opens");
   log.ok(`${lines.length} hotkey(s) in the Start Menu`);
+}
+
+/**
+ * Ask Windows whether each combo is spoken for.
+ *
+ * RegisterHotKey succeeding means nobody holds the key, so the probe
+ * takes it for an instant and gives it straight back. Failing with 1409
+ * — ERROR_HOTKEY_ALREADY_REGISTERED — means somebody does. The API
+ * never says who, which is the whole reason a stolen hotkey is so quiet:
+ * there is no list to look at and nothing logs the loss.
+ *
+ * Every other failure is reported as unknown rather than as held. A
+ * probe that cannot run is not evidence about the machine, and calling
+ * it "held" would turn a broken check into a clean bill of health.
+ */
+export async function probeHotkeys(p: Platform): Promise<Record<string, HotkeyState>> {
+  const out: Record<string, HotkeyState> = {};
+  if (p.os !== "windows" && p.env !== "wsl") return out;
+
+  const probes = WINDOWS_HOTKEYS.map((h) => (h.combo ? hotkeyArgs(h.combo) : null));
+  const script = `
+Add-Type @"
+using System;
+using System.Runtime.InteropServices;
+public class RedHK {
+  [DllImport("user32.dll", SetLastError=true)]
+  public static extern bool RegisterHotKey(IntPtr hWnd, int id, uint fsModifiers, uint vk);
+  [DllImport("user32.dll", SetLastError=true)]
+  public static extern bool UnregisterHotKey(IntPtr hWnd, int id);
+}
+"@
+${WINDOWS_HOTKEYS.map((h, i) => {
+  const a = probes[i];
+  if (!h.combo || !a) return "";
+  return `if ([RedHK]::RegisterHotKey([IntPtr]::Zero, ${9100 + i}, ${a.mods}, ${a.vk})) {
+  [RedHK]::UnregisterHotKey([IntPtr]::Zero, ${9100 + i}) | Out-Null
+  '${h.combo}=free'
+} else { '${h.combo}=held' }`;
+}).join("\n")}
+`.trim();
+
+  try {
+    const exe = p.os === "windows" ? "powershell.exe" : (Bun.which("powershell.exe") ?? "powershell.exe");
+    const proc = Bun.spawn([exe, "-NoProfile", "-Command", script], {
+      stdout: "pipe",
+      stderr: "ignore",
+      stdin: "ignore",
+    });
+    const text = (await new Response(proc.stdout).text()).replace(/\r/g, "");
+    if ((await proc.exited) !== 0) throw new Error("probe failed");
+    for (const line of text.split("\n")) {
+      const [combo, state] = line.trim().split("=");
+      if (combo && (state === "free" || state === "held")) out[combo] = state;
+    }
+  } catch {
+    // Left empty; the caller reads a missing entry as unknown.
+  }
+
+  for (const h of WINDOWS_HOTKEYS) {
+    if (h.combo && !(h.combo in out)) out[h.combo] = "unknown";
+  }
+  return out;
 }

--- a/src/local-overrides.test.ts
+++ b/src/local-overrides.test.ts
@@ -1,0 +1,73 @@
+/**
+ * The one place a personal setting can actually live.
+ *
+ * Everything in config/bash is regenerated on every converge, so an
+ * alias added to any of it survives until the next install and then
+ * quietly does not. Until local.sh there was nowhere in this project to
+ * put one and have it stay.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const rc = readFileSync("config/bash/rc.sh", "utf8");
+const sharedRoot = readFileSync("src/shared-root.ts", "utf8");
+
+describe("rc.sh sources the override files", () => {
+  test("both of them", () => {
+    expect(rc).toContain("$RED_SHARE/config/bash/local.sh");
+    expect(rc).toContain("$HOME/.config/red-dev/local.sh");
+  });
+
+  test("after the generated files, so an override actually overrides", () => {
+    // Sourced before them, every alias here would be replaced by the
+    // generated aliases.sh a moment later — present in the file and
+    // absent from the shell, which is the worst of both.
+    const loop = rc.indexOf("for _red_part in path shared zellij");
+    const mine = rc.indexOf("for _red_mine in");
+    expect(loop).toBeGreaterThan(-1);
+    expect(mine).toBeGreaterThan(loop);
+  });
+
+  test("the machine-local one is sourced after the shared one", () => {
+    // Shared travels to every machine; local is what is true here and
+    // nowhere else. This machine gets the last word about itself.
+    const line = rc.slice(rc.indexOf("for _red_mine in"));
+    const shared = line.indexOf("RED_SHARE");
+    const local = line.indexOf(".config/red-dev/local.sh");
+    expect(shared).toBeGreaterThan(-1);
+    expect(local).toBeGreaterThan(shared);
+  });
+
+  test("the shared one is skipped when there is no share", () => {
+    // ${RED_SHARE:+...} expands to the empty string with no share, and
+    // the loop body drops an empty entry. Without the guard the loop
+    // would try to read "/config/bash/local.sh" at the filesystem root.
+    expect(rc).toContain('"${RED_SHARE:+$RED_SHARE/config/bash/local.sh}"');
+    expect(rc).toContain('[ -n "$_red_mine" ]');
+  });
+
+  test("a missing file is not an error", () => {
+    // Neither is created on a machine that never opted into a share,
+    // and an unreadable one must not break every shell on the box.
+    expect(rc).toContain('[ -r "$_red_mine" ]');
+  });
+});
+
+describe("the template red-dev leaves behind", () => {
+  test("is created once and never rewritten", () => {
+    // The whole value of the file is that converge does not touch it.
+    expect(sharedRoot).toContain("if (existsSync(file)) return;");
+  });
+
+  test("carries content, so it can be found at all", () => {
+    // An empty directory is not discoverable, and nobody guesses a path
+    // they were never shown.
+    expect(sharedRoot).toContain("LOCAL_TEMPLATE");
+    expect(sharedRoot).toContain("red-dev created this file once");
+  });
+
+  test("points at the machine-local file for machine-local things", () => {
+    expect(sharedRoot).toContain("~/.config/red-dev/local.sh instead");
+  });
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -69,6 +69,24 @@ async function cmdDoctor(p: Platform, inv: Invocation): Promise<number> {
   let missing = 0;
   let outdated = 0;
 
+  // Which of the two this machine currently is.
+  //
+  // Everything below is answered per-target, and reading a report
+  // without knowing which target it describes is how "the theme did not
+  // apply" turns into an hour of looking at the wrong side.
+  if (p.os === "windows" || p.env === "wsl") {
+    log.plain("\n[mode]");
+    const { resolveTerminalShell, readPreferences } = await import("./preferences.ts");
+    const prefs = await readPreferences(p);
+    const mode = await resolveTerminalShell(p);
+    const where = mode === "wsl" ? (prefs.distro ?? "WSL") : "Git Bash";
+    // A recorded choice and an inferred one look identical afterwards,
+    // and only one of them is an answer.
+    const how = prefs.terminalShell ? "recorded" : "defaulted, never chosen";
+    log.ok(`a new terminal opens into ${where} — ${how}`);
+    log.plain("       change it with: red-dev shell");
+  }
+
   log.plain("\n[tools]");
   for (const scope of resolveScopes(p, inv.scope)) {
     for (const tool of toolsInScope(scope)) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,8 @@ import { log } from "./log.ts";
 import {
   applicableScopes,
   describeProvider,
+  installedVersion,
+  installState,
   isInstalled,
   providerFor,
   toolsInScope,
@@ -54,7 +56,9 @@ async function cmdPlan(p: Platform, inv: Invocation): Promise<number> {
             ? " (managed)"
             : isInstalled(tool)
               ? " (present)"
-              : "";
+              : installState(tool) === "outdated"
+                ? ` (outdated, wants ${tool.minVersion})`
+                : "";
       log.plain(`  ${tool.name.padEnd(17)}${describeProvider(pr)}${state}`);
     }
   }
@@ -63,6 +67,7 @@ async function cmdPlan(p: Platform, inv: Invocation): Promise<number> {
 
 async function cmdDoctor(p: Platform, inv: Invocation): Promise<number> {
   let missing = 0;
+  let outdated = 0;
 
   log.plain("\n[tools]");
   for (const scope of resolveScopes(p, inv.scope)) {
@@ -76,6 +81,14 @@ async function cmdDoctor(p: Platform, inv: Invocation): Promise<number> {
         continue;
       } else if (isInstalled(tool)) {
         log.ok(tool.name);
+      } else if (installState(tool) === "outdated") {
+        // Named apart from missing because the fix is different: an
+        // absent tool needs installing, this one needs a source that
+        // carries something newer. Reporting it as missing sent someone
+        // looking for a binary that was sitting on PATH the whole time.
+        const found = installedVersion(tool) ?? "unknown";
+        log.err(`${tool.name} ${found} — older than ${tool.minVersion} (${describeProvider(pr)})`);
+        outdated++;
       } else {
         log.err(`${tool.name} missing (${describeProvider(pr)})`);
         missing++;
@@ -103,8 +116,11 @@ async function cmdDoctor(p: Platform, inv: Invocation): Promise<number> {
   }
 
   log.plain("");
-  if (missing > 0 || drifted > 0) {
-    log.warn(`${missing} tool(s) missing, ${drifted} config drift(s)`);
+  if (missing > 0 || outdated > 0 || drifted > 0) {
+    const parts = [`${missing} tool(s) missing`];
+    if (outdated > 0) parts.push(`${outdated} outdated`);
+    parts.push(`${drifted} config drift(s)`);
+    log.warn(parts.join(", "));
     return 1;
   }
   log.ok("no drift");

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -101,6 +101,7 @@ export type Provider =
         | "dotfiles"
         | "alacritty"
         | "wsl-interop"
+        | "wsl-runtime-dir"
         | "blesh"
         | "runtimes"
         | "shared-root"
@@ -152,6 +153,22 @@ export interface Tool {
    * a process per check.
    */
   signature?: RegExp;
+  /**
+   * Below this, present is not installed.
+   *
+   * Probing for a name answers "is something here", which is the wrong
+   * question whenever the archive ships a version the rest of the stack
+   * has moved past. noble's neovim is 0.9.5; LazyVim refuses to start
+   * under 0.11.2 and exits with a message. Since red-dev also sets
+   * EDITOR=nvim, that is not a degraded editor, it is every caller of
+   * $EDITOR broken — and converge reported `present` on every run,
+   * because a binary was there.
+   *
+   * Only worth declaring where a floor is known and enforced by
+   * something downstream. Compared numerically, segment by segment; no
+   * prerelease ordering, because no tool here needs it.
+   */
+  minVersion?: string;
   scope: Scope;
   /**
    * True when presence cannot be answered by probing for a command —
@@ -207,6 +224,7 @@ const builtin = (
     | "dotfiles"
     | "alacritty"
     | "wsl-interop"
+    | "wsl-runtime-dir"
     | "wsl-sync"
     | "blesh"
     | "runtimes"
@@ -416,11 +434,18 @@ export const TOOLS: Tool[] = [
   {
     name: "neovim",
     cmd: ["nvim"],
+    // LazyVim's own floor. Below it nvim starts, prints "LazyVim
+    // requires Neovim >= 0.11.2" and exits.
+    minVersion: "0.11.2",
     scope: "core",
-    // The archive ships 0.9.5 on noble. LazyVim runs on it but the
-    // ecosystem has moved on, and the upstream tarball is not a drop-in
-    // either: nvim needs its runtime tree, so installing just the
-    // binary produces a broken editor. The PPA packages both properly.
+    // The archive ships 0.9.5 on noble, and LazyVim refuses to start on
+    // it — it requires 0.11.2 or newer and exits with a message. Since
+    // red-dev also sets EDITOR=nvim, an archive nvim does not degrade
+    // the editor, it breaks every caller of $EDITOR: git commit, zellij's
+    // EditScrollback, Claude Code's external editor. The upstream tarball
+    // is not a drop-in either: nvim needs its runtime tree, so installing
+    // just the binary produces a broken editor. The PPA packages both
+    // properly.
     u24: ppa("neovim-ppa/unstable", "neovim"),
     win: winget("Neovim.Neovim"),
   },
@@ -760,6 +785,17 @@ export const TOOLS: Tool[] = [
     win: skip("native Windows needs no interop shim"),
   },
   {
+    // WSL exports XDG_RUNTIME_DIR but never creates it, and the parent
+    // is root-owned — so the programs that trust the variable get EACCES
+    // rather than a fallback. zellij is the visible casualty.
+    name: "wsl-runtime-dir",
+    about: "XDG_RUNTIME_DIR that exists, so zellij can start",
+    scope: "wsl",
+    managed: true,
+    u24: builtin("wsl-runtime-dir"),
+    win: skip("native Windows has no XDG runtime dir"),
+  },
+  {
     name: "nerd-font",
     scope: "desktop",
     managed: true,
@@ -856,12 +892,85 @@ export function applicableScopes(p: Platform): Scope[] {
   return scopes;
 }
 
-export function isInstalled(tool: Tool): boolean {
-  if (tool.managed) return false; // the provider decides; see Tool.managed
+/**
+ * The three answers, kept apart so a report can tell them apart.
+ *
+ * "absent" and "outdated" both mean there is work to do, but they fail
+ * differently and a converge that says "the binary is absent" about a
+ * binary sitting on PATH sends whoever reads it looking in the wrong
+ * place.
+ */
+export type InstallState = "ok" | "absent" | "outdated";
+
+export function installState(tool: Tool): InstallState {
+  if (tool.managed) return "absent"; // the provider decides; see Tool.managed
   const candidates = tool.cmd ?? [tool.name];
-  if (!candidates.some(present)) return false;
+  if (!candidates.some(present)) return "absent";
   // A name on PATH is not proof it is the right program — see Tool.signature.
-  return tool.signature ? identify(candidates, tool.signature) : true;
+  if (tool.signature && !identify(candidates, tool.signature)) return "absent";
+  if (tool.minVersion && versionBelow(candidates, tool.minVersion)) return "outdated";
+  return "ok";
+}
+
+export function isInstalled(tool: Tool): boolean {
+  return installState(tool) === "ok";
+}
+
+/**
+ * On the machine at all, at whatever version.
+ *
+ * What removal cares about, and the reason it cannot reuse isInstalled:
+ * once a version floor exists, "not installed" stops meaning "not
+ * there". A tool below its floor would vanish from the uninstall list
+ * while still sitting on disk — offering no way to remove the very thing
+ * the doctor is complaining about.
+ */
+export function isPresent(tool: Tool): boolean {
+  return installState(tool) !== "absent";
+}
+
+/**
+ * The version this machine actually has, or null when it cannot be read.
+ *
+ * For reporting only. The decision is installState's; this exists so a
+ * message can say which version is the problem instead of leaving the
+ * reader to run --version themselves.
+ */
+export function installedVersion(tool: Tool): string | null {
+  for (const c of tool.cmd ?? [tool.name]) {
+    if (!commandExists(c)) continue;
+    return parseVersion(versionOutput(c) ?? "");
+  }
+  return null;
+}
+
+/** The first dotted numeric run in --version output: "NVIM v0.9.5" -> "0.9.5". */
+export function parseVersion(output: string): string | null {
+  const m = /(\d+)\.(\d+)(?:\.(\d+))?/.exec(output);
+  return m ? `${m[1]}.${m[2]}.${m[3] ?? "0"}` : null;
+}
+
+/** -1, 0 or 1, comparing segment by segment with missing segments as zero. */
+export function compareVersions(a: string, b: string): number {
+  const pa = a.split(".").map(Number);
+  const pb = b.split(".").map(Number);
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const d = (pa[i] ?? 0) - (pb[i] ?? 0);
+    if (d !== 0) return d < 0 ? -1 : 1;
+  }
+  return 0;
+}
+
+function versionBelow(candidates: string[], min: string): boolean {
+  for (const c of candidates) {
+    if (!commandExists(c)) continue;
+    const found = parseVersion(versionOutput(c) ?? "");
+    // Unreadable output is not evidence of an old version, and treating
+    // it as one would reinstall the tool on every single converge with
+    // no run ever reaching a fixed point. Fail open and say nothing.
+    return found === null ? false : compareVersions(found, min) < 0;
+  }
+  return false;
 }
 
 /**
@@ -892,28 +1001,35 @@ function present(candidate: string): boolean {
  * go on. Failure to run at all counts as "not ours": a program that
  * cannot answer `--version` is not one we can claim is installed.
  */
+/**
+ * Whatever `<cmd> --version` prints, both streams, or null if it will not run.
+ *
+ * stdin detached, and that is not defensive tidiness.
+ *
+ * The command being probed is by definition one whose name we do not
+ * trust. /usr/bin/red is GNU ed, and an editor handed a terminal it can
+ * read will sit on it forever — which is exactly what happened: the
+ * converge stopped dead at step 13 with no child process and no output,
+ * because the probe itself was waiting for someone to type.
+ */
+function versionOutput(cmd: string): string | null {
+  try {
+    const proc = Bun.spawnSync([cmd, "--version"], {
+      stdout: "pipe",
+      stderr: "pipe",
+      stdin: "ignore",
+    });
+    return `${proc.stdout?.toString() ?? ""}${proc.stderr?.toString() ?? ""}`;
+  } catch {
+    return null;
+  }
+}
+
 function identify(candidates: string[], signature: RegExp): boolean {
   for (const c of candidates) {
     if (!commandExists(c)) continue;
-    try {
-      // stdin detached, and that is not defensive tidiness.
-      //
-      // The command being probed is by definition one whose name we do
-      // not trust. /usr/bin/red is GNU ed, and an editor handed a
-      // terminal it can read will sit on it forever — which is exactly
-      // what happened: the converge stopped dead at step 13 with no
-      // child process and no output, because the probe itself was
-      // waiting for someone to type.
-      const proc = Bun.spawnSync([c, "--version"], {
-        stdout: "pipe",
-        stderr: "pipe",
-        stdin: "ignore",
-      });
-      const out = `${proc.stdout?.toString() ?? ""}${proc.stderr?.toString() ?? ""}`;
-      if (signature.test(out)) return true;
-    } catch {
-      // Unrunnable; try the next candidate.
-    }
+    const out = versionOutput(c);
+    if (out !== null && signature.test(out)) return true;
   }
   return false;
 }

--- a/src/migrations.ts
+++ b/src/migrations.ts
@@ -22,6 +22,7 @@
  *    machine does not look like it silently did something.
  */
 
+import { existsSync } from "node:fs";
 import { log } from "./log.ts";
 import type { Platform } from "./platform.ts";
 import { readPreferences, writePreferences } from "./preferences.ts";
@@ -123,6 +124,65 @@ export const MIGRATIONS: Migration[] = [
       const { installNerdFont } = await import("./wsl.ts");
       const prefs = await readPreferences(p);
       await installNerdFont(prefs.font ?? "firacode");
+    },
+  },
+  {
+    id: "2026-08-06-share-root-namespace",
+    describe: "move the shared root out of .reddev and into .red\\dev",
+    /**
+     * The share was a flat `.reddev` in the profile, which put it outside
+     * the `.red` namespace everything else in the toolchain writes into.
+     * Machines set up before the rename have a working root at the old
+     * spelling, so nothing looks broken and converge has no reason to
+     * touch it — which is exactly the shape a migration exists for.
+     */
+    applies: async (p) => {
+      if (p.env !== "wsl" && p.env !== "windows") return false;
+      const { namespaceMove, recordedShareRoot, windowsHome, localPath } = await import(
+        "./shared-root.ts"
+      );
+      const move = namespaceMove(recordedShareRoot(), await windowsHome(p));
+      if (!move) return false;
+      // A recorded root whose directory is gone is a different problem,
+      // and copying nothing over it would not fix that one either.
+      return existsSync(localPath(move.from, p.env));
+    },
+    /**
+     * Copied, not moved, and the old tree is left where it is.
+     *
+     * This runs unattended during install, across a filesystem boundary,
+     * over the directory holding every config the user has. A copy that
+     * half-finishes leaves both trees intact; a move that half-finishes
+     * leaves neither. The old one costs a few hundred kilobytes and is
+     * removed by hand, once, by someone who can see both.
+     */
+    run: async (p) => {
+      const { namespaceMove, recordedShareRoot, windowsHome, localPath, ensureSharedRoot } =
+        await import("./shared-root.ts");
+      const { recordShellEnv } = await import("./firstrun.ts");
+
+      const move = namespaceMove(recordedShareRoot(), await windowsHome(p));
+      if (!move) return;
+
+      const from = localPath(move.from, p.env);
+      const to = localPath(move.to, p.env);
+
+      if (existsSync(to)) {
+        log.skip(`${move.to} already exists — leaving it as it is`);
+      } else {
+        const { cpSync, mkdirSync } = await import("node:fs");
+        mkdirSync(to, { recursive: true });
+        cpSync(from, to, { recursive: true });
+        log.ok(`copied the share to ${move.to}`);
+      }
+
+      // Recorded before ensureSharedRoot, which reads it back.
+      await recordShellEnv({ RED_SHARE_WIN: move.to });
+      process.env["RED_SHARE_WIN"] = move.to;
+      await ensureSharedRoot(p);
+
+      log.plain(`       ${move.from} is left in place and is no longer read —`);
+      log.plain(`       delete it yourself once you have looked inside both`);
     },
   },
 ];

--- a/src/min-version.test.ts
+++ b/src/min-version.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Version floors: present is not installed when the version is below one.
+ *
+ * The case that motivated this is neovim. noble's archive ships 0.9.5,
+ * LazyVim refuses to start under 0.11.2, and converge reported `present`
+ * on every run because a binary named nvim existed. A probe that only
+ * asks "is something here" cannot see that.
+ *
+ * parseVersion and compareVersions are tested directly; installState is
+ * covered through the manifest entries rather than by spawning a real
+ * binary at a version this machine may or may not have.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  compareVersions,
+  installState,
+  isInstalled,
+  isPresent,
+  parseVersion,
+  TOOLS,
+  type Tool,
+} from "./manifest.ts";
+
+describe("parseVersion", () => {
+  test("reads the version out of real --version output", () => {
+    expect(parseVersion("NVIM v0.9.5")).toBe("0.9.5");
+    expect(parseVersion("nvim 0.11.2\nBuild type: Release")).toBe("0.11.2");
+    expect(parseVersion("git version 2.43.0")).toBe("2.43.0");
+  });
+
+  test("pads a two-segment version rather than rejecting it", () => {
+    expect(parseVersion("zellij 0.44")).toBe("0.44.0");
+  });
+
+  test("returns null when there is no version to find", () => {
+    expect(parseVersion("")).toBeNull();
+    expect(parseVersion("command not found")).toBeNull();
+  });
+});
+
+describe("compareVersions", () => {
+  test("orders by numeric segment, not lexically", () => {
+    expect(compareVersions("0.9.5", "0.11.2")).toBe(-1);
+    expect(compareVersions("0.11.2", "0.9.5")).toBe(1);
+    expect(compareVersions("0.11.2", "0.11.2")).toBe(0);
+  });
+
+  test("treats a missing segment as zero", () => {
+    expect(compareVersions("1.2", "1.2.0")).toBe(0);
+    expect(compareVersions("1.2", "1.2.1")).toBe(-1);
+  });
+
+  test("does not stop at the first differing digit count", () => {
+    expect(compareVersions("1.10.0", "1.9.0")).toBe(1);
+  });
+});
+
+/**
+ * `bun` rather than a manifest tool: these assertions need a binary that
+ * is certainly present and certainly prints a version, and the process
+ * running the test is exactly that.
+ */
+function bunWithFloor(min: string): Tool {
+  return {
+    name: "bun",
+    cmd: ["bun"],
+    minVersion: min,
+    scope: "core",
+    u24: { kind: "apt", pkg: "bun" },
+    win: { kind: "skip", reason: "not under test" },
+  };
+}
+
+describe("installState", () => {
+  test("a version above the floor is ok", () => {
+    expect(installState(bunWithFloor("0.0.1"))).toBe("ok");
+    expect(isInstalled(bunWithFloor("0.0.1"))).toBe(true);
+  });
+
+  test("a version below the floor is outdated, not absent", () => {
+    expect(installState(bunWithFloor("999.0.0"))).toBe("outdated");
+  });
+
+  test("a command that does not exist is absent", () => {
+    const ghost = { ...bunWithFloor("0.0.1"), cmd: ["red-dev-no-such-binary"] };
+    expect(installState(ghost)).toBe("absent");
+    expect(isPresent(ghost)).toBe(false);
+  });
+});
+
+describe("isPresent vs isInstalled", () => {
+  test("an outdated tool is not installed but is still present", () => {
+    // The uninstall list is built from isPresent. Were it built from
+    // isInstalled, a tool below its floor would disappear from it while
+    // sitting on disk — no way to remove the thing the doctor flags.
+    const stale = bunWithFloor("999.0.0");
+    expect(isInstalled(stale)).toBe(false);
+    expect(isPresent(stale)).toBe(true);
+  });
+});
+
+describe("the neovim floor", () => {
+  test("is declared, and is LazyVim's", () => {
+    const nvim = TOOLS.find((t) => t.name === "neovim");
+    expect(nvim?.minVersion).toBe("0.11.2");
+  });
+
+  test("rejects what the noble archive ships", () => {
+    expect(compareVersions("0.9.5", "0.11.2")).toBeLessThan(0);
+  });
+});

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -825,6 +825,10 @@ export async function applyProvider(pr: Provider, ctx: ApplyContext): Promise<vo
         await wsl.ensureWslInterop();
         return;
       }
+      if (pr.name === "wsl-runtime-dir") {
+        await wsl.ensureUserRuntimeDir();
+        return;
+      }
       if (pr.name === "nerd-font") {
         await wsl.installNerdFont(ctx.font, ctx.platform);
       } else {

--- a/src/shared-root.test.ts
+++ b/src/shared-root.test.ts
@@ -5,19 +5,25 @@
 
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
-import { adoptableTools, defaultRoot, localPath } from "./shared-root.ts";
+import {
+  adoptableTools,
+  defaultRoot,
+  legacyRoot,
+  localPath,
+  namespaceMove,
+} from "./shared-root.ts";
 
 describe("localPath", () => {
-  const win = "C:\\Users\\filip\\.reddev";
+  const win = "C:\\Users\\filip\\.red\\dev";
 
   test("WSL reaches it under /mnt", () => {
-    expect(localPath(win, "wsl")).toBe("/mnt/c/Users/filip/.reddev");
+    expect(localPath(win, "wsl")).toBe("/mnt/c/Users/filip/.red/dev");
   });
 
   test("on Windows the binary gets the native path, not the Git Bash one", () => {
     // The bug this replaces: `/c/Users/...` is right for Git Bash and
     // wrong for a native process, and handing it here made red-dev
-    // create C:\c\Users\filip\.reddev — a phantom tree beside the real
+    // create C:\c\Users\filip\.red\dev — a phantom tree beside the real
     // one, reported as "7 new" on a share that already existed. The
     // Git Bash spelling belongs to config/bash/rc.sh and nowhere else.
     expect(localPath(win, "windows")).toBe(win);
@@ -32,7 +38,7 @@ describe("localPath", () => {
   });
 
   test("forward slashes survive, since Windows accepts both", () => {
-    expect(localPath("C:/Users/filip/.reddev", "wsl")).toBe("/mnt/c/Users/filip/.reddev");
+    expect(localPath("C:/Users/filip/.red/dev", "wsl")).toBe("/mnt/c/Users/filip/.red/dev");
   });
 
   test("something that is not a Windows path is returned unchanged", () => {
@@ -60,10 +66,69 @@ describe("the share tree", () => {
 
 describe("defaultRoot", () => {
   test("inside the profile, so it goes when the profile goes", () => {
-    expect(defaultRoot("C:\\Users\\filip")).toBe("C:\\Users\\filip\\.reddev");
+    expect(defaultRoot("C:\\Users\\filip")).toBe("C:\\Users\\filip\\.red\\dev");
   });
 
   test("a trailing separator does not double up", () => {
-    expect(defaultRoot("C:\\Users\\filip\\")).toBe("C:\\Users\\filip\\.reddev");
+    expect(defaultRoot("C:\\Users\\filip\\")).toBe("C:\\Users\\filip\\.red\\dev");
+  });
+
+  test("lives under the .red namespace the rest of the toolchain uses", () => {
+    // The point of the move: one dotfile per namespace, not one per
+    // product. A future red-* tool gets .red\<name> for free.
+    expect(defaultRoot("C:\\Users\\filip")).toContain("\\.red\\");
+  });
+
+  test("the legacy spelling is still spelled out, for the migration", () => {
+    // The migration needs to recognise the old root to move it. Losing
+    // this constant would leave those machines silently on the old tree.
+    expect(legacyRoot("C:\\Users\\filip")).toBe("C:\\Users\\filip\\.reddev");
+    expect(legacyRoot("C:\\Users\\filip")).not.toBe(defaultRoot("C:\\Users\\filip"));
+  });
+});
+
+/**
+ * This decides whether a migration copies someone's whole config
+ * directory somewhere else, unattended, during an install. The tests
+ * that matter here are the ones that say *no*.
+ */
+describe("namespaceMove", () => {
+  const profile = "C:\\Users\\filip";
+
+  test("the old default is moved into the namespace", () => {
+    expect(namespaceMove("C:\\Users\\filip\\.reddev", profile)).toEqual({
+      from: "C:\\Users\\filip\\.reddev",
+      to: "C:\\Users\\filip\\.red\\dev",
+    });
+  });
+
+  test("a root already in the namespace is left alone", () => {
+    expect(namespaceMove("C:\\Users\\filip\\.red\\dev", profile)).toBeNull();
+  });
+
+  test("a root the user put somewhere else is theirs, even named .reddev", () => {
+    // The spelling is not the trigger; being the default this project
+    // wrote is. Moving D:\work\.reddev because the tail looks familiar
+    // relocates a directory out from under a deliberate choice.
+    expect(namespaceMove("D:\\work\\.reddev", profile)).toBeNull();
+  });
+
+  test("no recorded root means nothing to move", () => {
+    expect(namespaceMove(null, profile)).toBeNull();
+  });
+
+  test("matches case-insensitively, as Windows paths compare", () => {
+    // A root recorded as C:\Users\Filip\... against a profile reported
+    // as C:\Users\filip is one directory, not two.
+    expect(namespaceMove("C:\\Users\\Filip\\.RedDev", profile)?.to).toBe(
+      "C:\\Users\\filip\\.red\\dev",
+    );
+  });
+
+  test("a trailing separator does not defeat the match", () => {
+    expect(namespaceMove("C:\\Users\\filip\\.reddev\\", profile)).toEqual({
+      from: "C:\\Users\\filip\\.reddev",
+      to: "C:\\Users\\filip\\.red\\dev",
+    });
   });
 });

--- a/src/shared-root.ts
+++ b/src/shared-root.ts
@@ -252,13 +252,19 @@ const ADOPTABLE: Record<string, { from: string; to: string; dir?: boolean }> = {
  *
  * alacritty's config does not live in ~/.config at all; on the target
  * that matters it is %APPDATA%\alacritty, on the Windows side of the
- * boundary. bash's is rendered from this repo's config/bash. Claude's
- * keybindings are written by claude-keybindings.ts. `share adopt
- * alacritty` would have nothing to pick up, so it is deliberately not
- * offered — being shared and being adoptable are different questions
- * and conflating them is what put the share behind a migration step.
+ * boundary. bash's shared half is local.sh, which red-dev creates once
+ * and then never touches. `share adopt alacritty` would have nothing to
+ * pick up, so it is deliberately not offered — being shared and being
+ * adoptable are different questions, and conflating them is what put
+ * the share behind a migration step.
+ *
+ * Claude is deliberately absent. Its keybindings are written identically
+ * on both sides by claude-keybindings.ts, and the only indirection
+ * Claude Code offers relocates the whole of ~/.claude — sessions, cache
+ * and projects, hundreds of megabytes — rather than the one file worth
+ * sharing.
  */
-const GENERATED = new Set(["alacritty", "bash", "claude"]);
+const GENERATED = new Set(["alacritty", "bash"]);
 
 /** Tools whose configuration lives in the share, however it got there. */
 export function sharedTools(): string[] {
@@ -377,6 +383,45 @@ export async function adoptConfig(p: Platform, tool: string): Promise<number> {
  */
 const TREE = ["config", "bin", "bin/linux", "bin/windows"];
 
+/**
+ * The one bash file red-dev creates and then never writes again.
+ *
+ * Everything in config/bash is regenerated on every converge, so an
+ * alias added to any of it survives until the next install and then
+ * quietly does not — there was nowhere in this project to put a
+ * personal setting and have it stay. rc.sh sources this last, after the
+ * generated files, so it wins.
+ *
+ * Created with content rather than left as an empty directory. TREE
+ * deliberately avoids pre-creating per-tool directories because an
+ * empty one made "is this shared" unanswerable; this is the opposite
+ * case, where the file has to exist to be found at all. Nobody guesses
+ * a path they were never shown.
+ */
+const LOCAL_TEMPLATE = `# Yours. red-dev created this file once and will not write it again.
+#
+# Sourced last, after everything red-dev generates, so anything here
+# wins. This copy lives in the shared root, so it follows the
+# configuration to every machine that reads the share.
+#
+# For settings true on one machine only — a work proxy, a path to a
+# checkout, a key that exists on this laptop — use
+# ~/.config/red-dev/local.sh instead. That one is sourced after this
+# one, so the machine gets the last word about itself.
+
+# alias k='kubectl'
+# export EDITOR=nvim
+`;
+
+async function ensureLocalTemplate(root: SharedRoot): Promise<void> {
+  const dir = `${root.local}/config/bash`;
+  const file = `${dir}/local.sh`;
+  if (existsSync(file)) return;
+  mkdirSync(dir, { recursive: true });
+  await Bun.write(file, LOCAL_TEMPLATE);
+  log.ok(`created ${root.windows}\\config\\bash\\local.sh — your aliases go there`);
+}
+
 export async function ensureSharedRoot(p: Platform): Promise<void> {
   const root = sharedRootFor(p);
   if (!root) {
@@ -397,6 +442,8 @@ export async function ensureSharedRoot(p: Platform): Promise<void> {
     mkdirSync(dir, { recursive: true });
     created++;
   }
+
+  await ensureLocalTemplate(root);
 
   if (created > 0) log.ok(`shared root ready at ${root.windows} (${created} new)`);
   else log.skip(`shared root already at ${root.windows}`);

--- a/src/shared-root.ts
+++ b/src/shared-root.ts
@@ -86,12 +86,48 @@ export function sharedRootFor(p: Platform): SharedRoot | null {
 /**
  * The default, and the reason for it.
  *
- * Inside the profile rather than at C:\reddev: it disappears with the
+ * Inside the profile rather than at C:\red: it disappears with the
  * profile when a machine is rebuilt, and it does not add a directory to
  * the root of the system drive.
+ *
+ * `.red\dev` and not `.reddev` because `.red` is a namespace the rest of
+ * the toolchain already writes into — .red/adr, .red/CONTEXT.md — and
+ * dev is one product inside it. A flat `.reddev` would be the only thing
+ * sitting outside that namespace, which leaves the next tool to invent
+ * its own spelling and the profile to collect one dotfile per product.
+ * Machines that already have the old root are moved by
+ * 2026-08-06-share-root-namespace rather than left behind.
  */
 export function defaultRoot(windowsHome: string): string {
+  return `${windowsHome.replace(/[\\/]$/, "")}\\.red\\dev`;
+}
+
+/** The pre-namespace spelling, still on every machine set up before it. */
+export function legacyRoot(windowsHome: string): string {
   return `${windowsHome.replace(/[\\/]$/, "")}\\.reddev`;
+}
+
+/**
+ * Whether a recorded root is the old default, and where it should go.
+ *
+ * Matched against the default this project itself wrote, not against any
+ * path that happens to end in `.reddev`. A root the user pointed
+ * somewhere else by hand is a deliberate choice, and relocating it
+ * because the spelling looks familiar is the kind of helpfulness that
+ * moves a directory out from under someone.
+ *
+ * Case-insensitive because Windows paths are, and a root recorded as
+ * `C:\Users\Filip\.reddev` against a profile reported as
+ * `C:\Users\filip` is the same directory.
+ */
+export function namespaceMove(
+  recorded: string | null,
+  profile: string,
+): { from: string; to: string } | null {
+  if (!recorded) return null;
+  const norm = (s: string): string => s.replace(/[\\/]+$/, "").toLowerCase();
+  if (norm(recorded) !== norm(legacyRoot(profile))) return null;
+  return { from: recorded.replace(/[\\/]+$/, ""), to: defaultRoot(profile) };
 }
 
 /**
@@ -171,7 +207,7 @@ async function addWindowsBinToPath(root: string): Promise<void> {
 }
 
 /** The Windows profile directory, whichever side we are asking from. */
-async function windowsHome(p: Platform): Promise<string> {
+export async function windowsHome(p: Platform): Promise<string> {
   if (p.env === "windows") {
     const h = process.env["USERPROFILE"];
     if (h) return h;

--- a/src/shared-root.ts
+++ b/src/shared-root.ts
@@ -241,6 +241,30 @@ const ADOPTABLE: Record<string, { from: string; to: string; dir?: boolean }> = {
   git: { from: "", to: "gitconfig" },
 };
 
+/**
+ * Shared, but with nothing to adopt.
+ *
+ * ADOPTABLE answers "can `share adopt` move a file the user already
+ * has": it names a path under ~/.config to copy from. These have no such
+ * original. red-dev generates them itself, so the only question is which
+ * directory it generates them into — and the answer is the share, from
+ * the first install rather than after a migration.
+ *
+ * alacritty's config does not live in ~/.config at all; on the target
+ * that matters it is %APPDATA%\alacritty, on the Windows side of the
+ * boundary. bash's is rendered from this repo's config/bash. Claude's
+ * keybindings are written by claude-keybindings.ts. `share adopt
+ * alacritty` would have nothing to pick up, so it is deliberately not
+ * offered — being shared and being adoptable are different questions
+ * and conflating them is what put the share behind a migration step.
+ */
+const GENERATED = new Set(["alacritty", "bash", "claude"]);
+
+/** Tools whose configuration lives in the share, however it got there. */
+export function sharedTools(): string[] {
+  return [...Object.keys(ADOPTABLE), ...GENERATED].sort();
+}
+
 export function adoptableTools(): string[] {
   return Object.keys(ADOPTABLE);
 }
@@ -284,7 +308,7 @@ export function configHome(p: Platform, tool?: string): string {
   // config names /home/<user>/.config/btop/themes/... and a gitconfig on
   // this machine calls /usr/bin/gh, both of which exist on exactly one
   // of the two sides.
-  if (tool && !(tool in ADOPTABLE)) return `${home}/.config`;
+  if (tool && !(tool in ADOPTABLE) && !GENERATED.has(tool)) return `${home}/.config`;
   return `${share}/config`;
 }
 

--- a/src/tui-install.ts
+++ b/src/tui-install.ts
@@ -32,7 +32,7 @@ import {
 import { createScrollArea, type ScrollAreaState } from "tuiuiu.js";
 import { VERSION } from "./cli.ts";
 import { converge, countSteps, type StepResult } from "./converge.ts";
-import { captureStart, captureStop } from "./log.ts";
+import { captureStart, captureStop, captureTo } from "./log.ts";
 import { Accented, Header, Screen, Section, StatusLine, Surface } from "./tui-chrome.ts";
 import { muted, subtle, text, ui } from "./tui-theme.ts";
 import type { Scope } from "./manifest.ts";
@@ -162,7 +162,19 @@ export function useInstallModel(
   // creating it during render is the mistake createWizard already taught
   // — signals rebuilt thirty times a second.
 
-  const push = (line: string): void => setLines((prev) => [...prev, line]);
+  // Streaming apt into the log changed what this buffer holds: a step
+  // line per tool is dozens, a hundred-package transaction is thousands,
+  // and every push copies the whole array. Capped at a depth no one
+  // scrolls past by hand — the failures are read at the tail.
+  const MAX_LINES = 2000;
+  const push = (line: string): void =>
+    setLines((prev) => (prev.length < MAX_LINES ? [...prev, line] : [...prev.slice(1), line]));
+
+  /** Closes the batch's log redirect. Non-null only while apt is running. */
+  let releaseBatch: (() => void) | null = null;
+
+  /** Log lines carry colour; the viewer takes plain strings. */
+  const plain = (line: string): string => line.replace(/\x1b\[[0-9;]*m/g, "").trim();
 
   useEffect(() => {
     if (!started()) return;
@@ -176,6 +188,20 @@ export function useInstallModel(
           push(`-- ${s} · ${n} items`);
         },
         note: (m) => push(`   ${m}`),
+        // captureTo rather than captureStart: this transaction runs for
+        // minutes, and holding its output until the end would trade a
+        // corrupted frame for a frozen one. Streaming puts apt's
+        // progress in the log pane, which is where the eye already is.
+        batchStart: (pkgs) => {
+          setCurrent("apt");
+          releaseBatch = captureTo((line) => push(`    ${plain(line)}`));
+          push(`   apt: ${pkgs.length} packages`);
+        },
+        batchEnd: (error) => {
+          releaseBatch?.();
+          releaseBatch = null;
+          if (error) push(`    ${error}`);
+        },
         stepStart: (e) => {
           setCurrent(e.tool);
           // Hold provider chatter so it lands under its own step rather
@@ -189,7 +215,7 @@ export function useInstallModel(
           const glyph =
             r.outcome === "failed" ? "✗" : r.outcome === "present" || r.outcome === "skipped" ? "·" : "✓";
           push(`${glyph} ${r.tool.padEnd(16)} ${r.outcome}${r.ms >= 1000 ? `  ${human(r.ms)}` : ""}`);
-          for (const h of held) push(`    ${h.replace(/\x1b\[[0-9;]*m/g, "").trim()}`);
+          for (const h of held) push(`    ${plain(h)}`);
           if (r.detail && r.outcome === "failed") push(`    ${r.detail}`);
           setResults((prev) => [...prev, r]);
         },

--- a/src/tui-setup-model.ts
+++ b/src/tui-setup-model.ts
@@ -103,7 +103,7 @@ export function questions(
         {
           key: "yes",
           label: "Share configuration",
-          note: "%LOCALAPPDATA%\\..\\.reddev — 43ms per shell, measured",
+          note: "%USERPROFILE%\\.red\\dev — 43ms per shell, measured",
         },
         { key: "no", label: "Keep each side separate", note: "every config stays local" },
       ],

--- a/src/uninstall.ts
+++ b/src/uninstall.ts
@@ -19,7 +19,7 @@
 
 import { existsSync } from "node:fs";
 import { log, RedError } from "./log.ts";
-import { providerFor, toolsInScope, isInstalled, type Tool } from "./manifest.ts";
+import { providerFor, toolsInScope, isPresent, type Tool } from "./manifest.ts";
 import type { Platform } from "./platform.ts";
 
 export interface Removal {
@@ -111,7 +111,9 @@ export function removableTools(p: Platform): { tool: Tool; removal: Removal }[] 
   const out: { tool: Tool; removal: Removal }[] = [];
   for (const scope of ["core", "desktop", "wsl", "optional"] as const) {
     for (const tool of toolsInScope(scope)) {
-      if (tool.managed || !isInstalled(tool)) continue;
+      // isPresent, not isInstalled: a tool below its version floor is
+      // still on disk, and still the user's to remove.
+      if (tool.managed || !isPresent(tool)) continue;
       const removal = removalFor(tool, p);
       if (removal) out.push({ tool, removal });
     }

--- a/src/wsl-runtime-dir.test.ts
+++ b/src/wsl-runtime-dir.test.ts
@@ -1,0 +1,35 @@
+/**
+ * XDG_RUNTIME_DIR triage.
+ *
+ * The case that motivated this is the third one: WSL exports the variable
+ * and systemd-logind never creates the directory, because `wsl.exe` opens
+ * no PAM session. A set-but-absent path is the failure, not an absent
+ * variable — programs that see the variable stop falling back to /tmp and
+ * try to mkdir under root-owned /run/user instead.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { runtimeDirState } from "./wsl.ts";
+
+describe("runtimeDirState", () => {
+  test("an unset variable is nobody's problem", () => {
+    expect(runtimeDirState(undefined, null, 1000)).toBe("unset");
+    expect(runtimeDirState("", null, 1000)).toBe("unset");
+  });
+
+  test("set and owned by us is the working case", () => {
+    expect(runtimeDirState("/run/user/1000", 1000, 1000)).toBe("usable");
+  });
+
+  test("set but absent is the WSL failure", () => {
+    expect(runtimeDirState("/run/user/1000", null, 1000)).toBe("unusable");
+  });
+
+  test("set but owned by another uid is no better than absent", () => {
+    expect(runtimeDirState("/run/user/1000", 0, 1000)).toBe("unusable");
+  });
+
+  test("root running as root still reads its own dir as usable", () => {
+    expect(runtimeDirState("/run/user/0", 0, 0)).toBe("usable");
+  });
+});

--- a/src/wsl.ts
+++ b/src/wsl.ts
@@ -13,7 +13,8 @@
  * which is why config/bash/path.sh prepends instead.
  */
 
-import { copyFileSync, existsSync, mkdirSync, rmSync } from "node:fs";
+import { copyFileSync, existsSync, mkdirSync, rmSync, statSync } from "node:fs";
+import { userInfo } from "node:os";
 import { log, RedError } from "./log.ts";
 import type { Platform } from "./platform.ts";
 import { THEMES, type Theme } from "./themes.ts";
@@ -158,6 +159,104 @@ export async function ensureWslInterop(): Promise<void> {
     log.ok("WSL interop restored");
   } else {
     throw new RedError("could not register WSLInterop; .exe calls will fail");
+  }
+}
+
+// ----------------------------------------------------- runtime dir
+
+/**
+ * What XDG_RUNTIME_DIR is actually doing on this machine.
+ *
+ * Split from the effectful half so the three cases can be tested without
+ * a systemd, a uid or a real /run.
+ */
+export type RuntimeDirState = "unset" | "usable" | "unusable";
+
+/**
+ * `ownerUid` is the directory's owner, or null when it does not exist.
+ *
+ * Ownership rather than existence, because the failure this guards
+ * against is a path that resolves to something we cannot write into. A
+ * runtime dir belonging to another uid is as useless as an absent one.
+ */
+export function runtimeDirState(
+  dir: string | undefined,
+  ownerUid: number | null,
+  selfUid: number,
+): RuntimeDirState {
+  if (!dir) return "unset";
+  if (ownerUid === null) return "unusable";
+  return ownerUid === selfUid ? "usable" : "unusable";
+}
+
+function ownerUid(dir: string): number | null {
+  try {
+    return statSync(dir).uid;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Make XDG_RUNTIME_DIR real, because WSL exports it without creating it.
+ *
+ * With systemd enabled, WSL puts XDG_RUNTIME_DIR=/run/user/<uid> in the
+ * environment of every shell. Nothing creates that directory:
+ * systemd-logind makes it when a login session opens, and `wsl.exe`
+ * starts the shell without going through PAM, so `loginctl
+ * list-sessions` reports none and the path never appears.
+ *
+ * An exported variable pointing at nothing is worse than an unset one.
+ * Programs that would have fallen back to /tmp instead trust the
+ * variable and try to create the directory, whose parent /run/user is
+ * root-owned — so they do not get ENOENT and a fallback, they get EACCES
+ * and a crash. zellij is the one that shows up first here, since
+ * config/bash/zellij.sh starts it for every interactive shell: it
+ * panics, and because that script deliberately does not `exec`, the
+ * terminal silently comes up as a plain shell with no multiplexer and no
+ * explanation.
+ *
+ * enable-linger is the durable half: a lingering user gets user@<uid>.service,
+ * and the runtime dir with it, at boot and without a session. The mkdir is
+ * the fallback for a machine where logind will not do it, and repairs the
+ * running boot either way.
+ */
+export async function ensureUserRuntimeDir(): Promise<void> {
+  const dir = process.env["XDG_RUNTIME_DIR"];
+  const uid = process.getuid?.() ?? -1;
+
+  if (runtimeDirState(dir, dir ? ownerUid(dir) : null, uid) === "unset") {
+    // Nothing points anywhere, so nothing is broken: callers fall back
+    // to /tmp on their own.
+    log.skip("XDG_RUNTIME_DIR not set — nothing to repair");
+    return;
+  }
+
+  const path = dir as string;
+  if (runtimeDirState(path, ownerUid(path), uid) === "usable") {
+    log.skip(`user runtime dir present (${path})`);
+    return;
+  }
+
+  log.step(`XDG_RUNTIME_DIR points at ${path}, which does not exist — repairing`);
+
+  const user = process.env["USER"] ?? userInfo().username;
+  const linger = Bun.spawn(["sudo", "loginctl", "enable-linger", user], {
+    stdout: "ignore",
+    stderr: "ignore",
+  });
+  await linger.exited;
+
+  if (runtimeDirState(path, ownerUid(path), uid) !== "usable") {
+    await run(["sudo", "mkdir", "-p", path]);
+    await run(["sudo", "chown", `${uid}:${process.getgid?.() ?? uid}`, path]);
+    await run(["sudo", "chmod", "700", path]);
+  }
+
+  if (runtimeDirState(path, ownerUid(path), uid) === "usable") {
+    log.ok(`user runtime dir ready (${path}) — zellij can start`);
+  } else {
+    throw new RedError(`could not create ${path}; zellij will not start`);
   }
 }
 


### PR DESCRIPTION
Twelve commits from one session that started as "Ctrl+G opens neovim" and
turned into the boundary between the WSL and native-Windows sides of a
machine.

## Hotkeys, and who actually owns a key

`Ctrl+G` was never zellij's fault. Claude Code binds `chat:externalEditor`
to it by default, and zellij's own `Ctrl+G` never saw the key. red-dev now
unbinds it, alongside the `shift+enter` binding it already managed.

Separately, `Ctrl+Alt+T` stopped opening the terminal on a machine whose
shortcut, target path and hotkey property were all correct. Writing the
.lnk was being treated as the whole job and it is half of one: the file
keeps its HotKey property forever, but the registration belongs to
Explorer, happens at runtime, and is first come first served. Anything
that starts earlier and claims the key takes it, Explorer's claim fails,
and nothing anywhere reports a fault. `doctor` now probes each combo and
says so.

The probe proves the dead case and not the stolen one — Windows answers
"somebody holds this" and never says who — so a free key is drift, a held
key is ok with the ambiguity written into the detail line rather than
implied.

## Present stopped meaning installed

`nvim` was on PATH at 0.9.5 from noble's archive, LazyVim needs 0.11.2,
and the manifest's `ppa:neovim-ppa/unstable` never fired because a binary
named nvim existed. Tools can now declare a `minVersion`, and `doctor`
reports outdated apart from missing — the fix is different for each, and
calling one the other sent someone looking for a binary that was on PATH
the whole time.

`isPresent` exists because of a regression this caused: the uninstall list
filtered on `isInstalled`, so a tool below its floor would drop off the
list while still sitting on disk.

## The shared root

Moved from a flat `.reddev` in the profile to `%USERPROFILE%\.red\dev`,
inside the namespace the rest of the toolchain writes into. The migration
copies rather than moves and leaves the old tree in place: it runs
unattended during install, across the WSL boundary, over the directory
holding every config the user has, and a copy that half-finishes leaves
both trees intact where a move leaves neither.

alacritty's theme, font and keys move into it. They describe a preference
and name nothing local. `shell.toml` deliberately stays local — it names
`wsl.exe` or a path to `bash.exe`, so it *is* the WSL-or-native choice
written down, and sharing it would make two machines fight over which one
they both are.

`repairedImports` now replaces our entries rather than appending. Once
theme.toml moved, appending left both the bare name and the absolute path
in the list with the stale local copy still on disk, and which one won
depended on merge order.

## Both modes, one converge

A Windows machine running WSL has two homes, and the shell config is the
pair that drifts silently. Converging from inside the distro wrote the
distro's copy only, so the Git Bash side kept whatever it had from the
last time red-dev happened to run as a native Windows binary — on the
machine this was found on, eight days of skew, with a `prompt.sh` still
missing the `TERM=dumb` guard. Nothing failed. The mode you were not in
was quietly older.

`wsl-sync.ts` crosses the same boundary the other way and states the rule
this follows: whoever is converging owns the crossing.

## A place for your own aliases

Everything in `config/bash` is regenerated, so an alias added to any of it
survives until the next install and then quietly does not. `local.sh` is
the one bash file red-dev creates and never writes again — a shared copy
that travels with the configuration, and a machine-local one sourced after
it, both after everything generated so an override actually overrides.

## Also

- `XDG_RUNTIME_DIR` is created under WSL. WSL exports the variable and
  never creates the directory, and the parent is root-owned, so zellij got
  EACCES rather than a fallback and silently never started.
- The apt batch is bracketed like a step. It runs between `scopeStart` and
  the first `stepStart`, outside the capture window, so the loudest command
  of the whole run wrote straight over the fullscreen frame.
- `doctor` opens by naming which of the two modes the machine is in, and
  separates a recorded choice from an inferred one.

## Not done, on purpose

bash's generated files and Claude's keybindings are **not** shared. Both
are already byte-identical across the two modes — the manifest converges
`dotfiles` and `claude-keybindings` on `win` as well as `u24` — so sharing
buys nothing and costs. bash is the hottest path in the system, read on
every shell and every zellij pane, and `shared.sh` measures the share at
65ms against 22ms for twenty files. Claude Code's only indirection
relocates all of `~/.claude`, sessions and cache and projects included.

## Verification

370 tests, `tsc --noEmit` clean. Converged on a real WSL machine and
checked on disk rather than in the log: `.red\dev` populated and `.reddev`
untouched, `alacritty.toml` importing absolute share paths, all nine
dotfiles identical across both homes where `prompt.sh` had differed,
zellij reading the moved config, `doctor` reporting no drift. `local.sh`
proven in a real interactive shell, including precedence and the
no-share guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788641723&installation_model_id=20659&pr_number=42&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F42&signature=8d607067b28678bc5a694b0461aaaa3dca4c64967dfcbd984a9d2ccc5bee13f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->