### PR TITLE
Every run writes a transcript

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -93,6 +93,16 @@ export function buildCli(): CLI {
       doctor: {
         description: "report drift against the manifest",
       },
+      logs: {
+        description: "show the last run's transcript",
+        positional: [
+          {
+            name: "which",
+            description: "'list' for every kept run, or a number: 2 is the run before last",
+            required: false,
+          },
+        ],
+      },
       theme: {
         description: "apply a colour scheme",
         positional: [
@@ -164,6 +174,12 @@ export interface Invocation {
   shareTarget: string | undefined;
   shareTool: string | undefined;
   /**
+   * `logs [which]` — its own positional, for the same reason share has
+   * two of its own. Reusing `scope` would reject `list` as an invalid
+   * scope, and reusing `name` would reject it as an unknown theme.
+   */
+  logsWhich: string | undefined;
+  /**
    * Parse and validation failures. Strict mode means an unrecognised
    * command lands here too, with the list of real ones — so there is no
    * separate "unknown verb" channel to check.
@@ -212,6 +228,7 @@ export function parseArgs(cli: CLI, argv: string[]): Invocation {
     // `theme <name>` and `plan <scope>` both land in the positional map
     // under their own key; the caller reads whichever applies.
     scope: scope ?? (typeof rawName === "string" ? rawName : undefined),
+    logsWhich: typeof pos["which"] === "string" ? pos["which"] : undefined,
     themeName: typeof opts["theme"] === "string" ? opts["theme"] : DEFAULT_THEME,
     font: typeof opts["font"] === "string" ? opts["font"] : "firacode",
     opacity: clampOpacity(opts["opacity"], errors),

--- a/src/converge.ts
+++ b/src/converge.ts
@@ -12,6 +12,7 @@
  * signal. Neither knows anything about the other.
  */
 
+import { transcribeStep } from "./transcript.ts";
 import { aptInstall, applyProvider, type ApplyContext } from "./providers.ts";
 import {
   describeProvider,
@@ -156,6 +157,17 @@ export async function converge(
         };
         results.push(result);
         observer.stepEnd?.(result);
+        // Written here rather than at the end, and straight to the file
+        // rather than through `log`.
+        //
+        // Straight to the file because the fullscreen view renders these
+        // rows from its own model — they have never passed through the
+        // logger, so a transcript teed off `log` had every provider's
+        // chatter and none of the outcomes it belonged to. Here because
+        // a converge that is killed, or that takes down the terminal
+        // with it, still leaves the rows up to the point it stopped,
+        // which is the run most likely to be worth reading.
+        transcribeStep(result);
       };
 
       if (pr.kind === "skip") {

--- a/src/log.ts
+++ b/src/log.ts
@@ -55,7 +55,42 @@ export function logIsCaptured(): boolean {
   return buffer !== null || stream !== null;
 }
 
+/**
+ * A tee, deliberately not a third sink.
+ *
+ * `buffer` and `stream` compete: each one takes routing away from the
+ * console and from each other. A transcript must not compete with
+ * either, because the runs worth reading afterwards are exactly the ones
+ * where a fullscreen view has already claimed `stream`. So this runs
+ * before the routing decision and changes nothing about it.
+ *
+ * logIsCaptured() deliberately does not count it. That function answers
+ * "would a child process writing to the console damage a frame", and the
+ * answer must not become yes merely because a file is open — a child
+ * that started piping for that reason would lose its progress bar and
+ * its ability to prompt.
+ */
+let transcript: ((line: string) => void) | null = null;
+
+/** Tee every log line into `sink` until the returned function is called. */
+export function transcribeTo(sink: (line: string) => void): () => void {
+  const previous = transcript;
+  transcript = sink;
+  return () => {
+    transcript = previous;
+  };
+}
+
 const emit = (line: string, sink: (s: string) => void): void => {
+  // First, and outside the routing: a line that fails to reach the
+  // console must still reach the log, and the reverse.
+  if (transcript) {
+    try {
+      transcript(line);
+    } catch {
+      // Never let writing the log break the thing being logged.
+    }
+  }
   if (buffer) buffer.push(line);
   else if (stream) stream(line);
   else sink(line);

--- a/src/main.ts
+++ b/src/main.ts
@@ -897,6 +897,8 @@ async function main(): Promise<number> {
       return await cmdPlan(p, inv);
     case "doctor":
       return await cmdDoctor(p, inv);
+    case "logs":
+      return await cmdLogs(inv.logsWhich);
     case "install":
       return await cmdInstall(p, inv);
     case "update":
@@ -939,4 +941,79 @@ async function main(): Promise<number> {
   }
 }
 
-process.exit(await main());
+/**
+ * Show a transcript, or list them.
+ *
+ * The current run's own log is excluded from `red-dev logs` with no
+ * argument: it exists, it is one line long, and printing it instead of
+ * the converge someone is trying to read would be a small joke at their
+ * expense.
+ */
+async function cmdLogs(which?: string): Promise<number> {
+  const { recentTranscripts, transcriptDir, transcriptPath } = await import("./transcript.ts");
+  const mine = transcriptPath();
+  const all = recentTranscripts().filter((f) => f !== mine);
+
+  if (all.length === 0) {
+    log.skip(`no transcripts yet — they are written to ${transcriptDir()}`);
+    return 0;
+  }
+
+  if (which === "list") {
+    log.ok(`${all.length} transcript(s) in ${transcriptDir()}`);
+    for (const [i, f] of all.entries()) {
+      const size = Bun.file(f).size;
+      log.plain(`  ${String(i + 1).padStart(2)}  ${f.split("/").pop()}  ${(size / 1024).toFixed(1)}k`);
+    }
+    return 0;
+  }
+
+  const n = which ? Number.parseInt(which, 10) : 1;
+  if (!Number.isFinite(n) || n < 1) {
+    log.err(`'${which}' is neither 'list' nor a run number`);
+    return 1;
+  }
+  const target = all[n - 1];
+  if (!target) {
+    log.err(`there are only ${all.length} transcript(s)`);
+    return 1;
+  }
+
+  // Written through stdout rather than log.plain: a transcript is
+  // content, not a message about the run, and routing it through the
+  // logger would tee it straight back into the transcript being written.
+  process.stdout.write(await Bun.file(target).text());
+  return 0;
+}
+
+/**
+ * Run, and write down what happened.
+ *
+ * Wrapped around main rather than inside it so a throw is transcribed
+ * too — the run that ends in a stack trace is the one most worth having
+ * a log of, and a try/finally is the only way to be sure the exit line
+ * is written on every path out.
+ *
+ * `--version` and `--help` are excluded by the time this runs only in
+ * the sense that they are cheap; they get a transcript like everything
+ * else, and the rotation keeps that from mattering.
+ */
+async function run(): Promise<number> {
+  const { startTranscript, finishTranscript } = await import("./transcript.ts");
+  const command = process.argv.slice(2).join(" ") || "menu";
+  await startTranscript(command, VERSION, new Date());
+
+  let code = 70;
+  try {
+    code = await main();
+    return code;
+  } finally {
+    const path = finishTranscript(code);
+    // Printed after the interface has released the screen, and only
+    // when something went wrong: a path nobody needs, on every
+    // successful run, is noise that trains people to stop reading.
+    if (path && code !== 0) log.plain(`       log: ${path}`);
+  }
+}
+
+process.exit(await run());

--- a/src/transcript.test.ts
+++ b/src/transcript.test.ts
@@ -1,0 +1,151 @@
+/**
+ * The run, written down.
+ *
+ * Two properties carry this feature and both are easy to break by
+ * accident:
+ *
+ *   1. It is a TEE. log.ts already has `buffer` and `stream`, and each
+ *      takes routing away from the console and from each other. A
+ *      transcript that behaved like a third sink would blank the
+ *      fullscreen view — which is the exact run worth transcribing.
+ *
+ *   2. logIsCaptured() must NOT count it. That function answers "would a
+ *      child writing to the console damage a frame", and if a transcript
+ *      flipped it to true, every child would start piping and lose its
+ *      progress bar and its ability to prompt for a password.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { captureTo, log, logIsCaptured, transcribeTo } from "./log.ts";
+import { prunable, transcriptDir, transcriptName } from "./transcript.ts";
+
+const releases: (() => void)[] = [];
+const track = (r: () => void): void => void releases.push(r);
+afterEach(() => {
+  while (releases.length > 0) releases.pop()?.();
+});
+
+describe("the tee", () => {
+  test("sees a line that also went to the console", () => {
+    const seen: string[] = [];
+    track(transcribeTo((l) => seen.push(l)));
+    log.ok("hello");
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toContain("hello");
+  });
+
+  test("and a line that a fullscreen view claimed", () => {
+    // The property the whole design turns on. captureTo redirects to the
+    // frame; the transcript must still get the line, or every converge
+    // worth reading afterwards is the one that logs nothing.
+    const file: string[] = [];
+    const frame: string[] = [];
+    track(transcribeTo((l) => file.push(l)));
+    track(captureTo((l) => frame.push(l)));
+    log.err("boom");
+    expect(frame).toHaveLength(1);
+    expect(file).toHaveLength(1);
+  });
+
+  test("does not make logIsCaptured true", () => {
+    // If it did, spawnLogged would start piping every child — losing
+    // apt's progress bar and sudo's prompt — to write a nicer log file.
+    expect(logIsCaptured()).toBe(false);
+    track(transcribeTo(() => {}));
+    expect(logIsCaptured()).toBe(false);
+  });
+
+  test("a throwing sink never breaks the thing being logged", () => {
+    // A full disk mid-converge stops the transcript, not the converge.
+    track(
+      transcribeTo(() => {
+        throw new Error("disk full");
+      }),
+    );
+    expect(() => log.ok("still fine")).not.toThrow();
+  });
+
+  test("restores the previous tee, so nesting cannot orphan one", () => {
+    const outer: string[] = [];
+    const release = transcribeTo((l) => outer.push(l));
+    const inner: string[] = [];
+    transcribeTo((l) => inner.push(l))();
+    log.ok("after");
+    expect(outer).toHaveLength(1);
+    expect(inner).toHaveLength(0);
+    release();
+  });
+});
+
+describe("transcriptName", () => {
+  const at = new Date("2026-08-07T09:42:39.212Z");
+
+  test("carries no colon, because NTFS forbids them", () => {
+    // An ISO timestamp as-is fails on Windows and works on Linux, which
+    // is the worst way to discover a filename bug.
+    const name = transcriptName(at, "install core");
+    expect(name).not.toContain(":");
+    expect(name).toMatch(/^2026-08-07T09-42-39-212-install-core\.log$/);
+  });
+
+  test("sorts chronologically as a string", () => {
+    const earlier = transcriptName(new Date("2026-08-07T09:00:00.000Z"), "a");
+    const later = transcriptName(new Date("2026-08-07T10:00:00.000Z"), "a");
+    expect([later, earlier].sort()).toEqual([earlier, later]);
+  });
+
+  test("survives a command full of punctuation", () => {
+    expect(transcriptName(at, "theme --opacity=90")).toMatch(/-theme-opacity-90\.log$/);
+  });
+
+  test("and one that is empty", () => {
+    expect(transcriptName(at, "")).toMatch(/-run\.log$/);
+  });
+});
+
+describe("rotation", () => {
+  const names = Array.from({ length: 25 }, (_, i) => `2026-08-07T00-00-${String(i).padStart(2, "0")}-x.log`);
+
+  test("keeps the newest and lists the rest", () => {
+    const gone = prunable(names, 20);
+    expect(gone).toHaveLength(5);
+    expect(gone[0]).toContain("00-00-00");
+    expect(gone).not.toContain(names[24]);
+  });
+
+  test("removes nothing below the limit", () => {
+    expect(prunable(names.slice(0, 5), 20)).toEqual([]);
+  });
+
+  test("ignores anything that is not a log", () => {
+    // The directory is XDG state and red-dev is not its only possible
+    // occupant; deleting a neighbour's file would be a real bug.
+    expect(prunable(["notes.txt", "a.log"], 0)).toEqual(["a.log"]);
+  });
+});
+
+describe("where transcripts go", () => {
+  test("XDG_STATE_HOME when the platform has one", () => {
+    expect(transcriptDir({ XDG_STATE_HOME: "/x/state", HOME: "/home/me" })).toBe("/x/state/red-dev");
+  });
+
+  test("falls back to ~/.local/state, which is the XDG default", () => {
+    expect(transcriptDir({ HOME: "/home/me" })).toBe("/home/me/.local/state/red-dev");
+  });
+
+  test("LOCALAPPDATA on native Windows", () => {
+    // Per-machine and non-roaming, the same reasoning the wallpapers use.
+    expect(transcriptDir({ LOCALAPPDATA: "C:\\Users\\me\\AppData\\Local" })).toBe(
+      "C:/Users/me/AppData/Local/red-dev/logs",
+    );
+  });
+
+  test("but HOME wins under WSL, where both are set", () => {
+    // Inside the distro LOCALAPPDATA can be inherited across the
+    // boundary; writing the distro's logs onto the Windows side would
+    // interleave two machines' stories in one directory.
+    expect(transcriptDir({ LOCALAPPDATA: "C:\\x", HOME: "/home/me" })).toBe(
+      "/home/me/.local/state/red-dev",
+    );
+  });
+});

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -1,0 +1,202 @@
+/**
+ * Every run, written down, so a converge can be read after it ends.
+ *
+ * The screen is the wrong medium for this and always was. A converge is
+ * forty steps of scrollback inside a fullscreen frame; the interesting
+ * three lines are a failure that happened ninety seconds ago and has
+ * since scrolled past, and the only way to answer "why did that fail"
+ * was to run the whole thing again and watch harder.
+ *
+ * ## A tee, not a sink
+ *
+ * log.ts already has two ways to redirect output — `buffer`, which holds
+ * lines so they land under their own step, and `stream`, which the
+ * fullscreen views use to turn log output into content they can draw.
+ * A third *sink* would have to compete with those. So this is not a
+ * sink: `transcribeTo` tees off `emit` before the routing decision, and
+ * every line reaches the file whether it also reached the console, a
+ * buffer, or a frame. Nothing downstream changes behaviour because a
+ * transcript is open, and `logIsCaptured()` deliberately does not count
+ * it — a child process must not start piping just because a file is
+ * being written.
+ *
+ * ## What is in it, and what is not
+ *
+ * Every `log` call, always. Child process output whenever something is
+ * capturing — which is exactly the fullscreen case this exists for,
+ * since `spawnLogged` pipes into the log there.
+ *
+ * NOT child output on a plain `red-dev install` at a terminal. There
+ * `spawnLogged` inherits the console on purpose, so apt keeps its
+ * progress bar and sudo can still ask for a password, and those bytes
+ * never pass through `emit`. Teeing them would mean piping them, which
+ * would take the interactivity away to improve a log file. The trade is
+ * recorded here rather than hidden: run the fullscreen converge if you
+ * want the child output too.
+ *
+ * ## Where
+ *
+ * State, not config, so deliberately NOT the shared root. A log is about
+ * one machine on one afternoon; shared-root.ts's whole doctrine is that
+ * configuration is shared and everything else is local. Two machines
+ * writing transcripts into one directory would interleave two unrelated
+ * stories.
+ */
+
+import { existsSync, mkdirSync, readdirSync, rmSync } from "node:fs";
+import { appendFileSync } from "node:fs";
+
+/** How many runs to keep. Past this the oldest go. */
+const KEEP = 20;
+
+/** SGR sequences, which are for a terminal and not for a file. */
+const ANSI = /\x1b\[[0-9;]*m/g;
+
+/**
+ * Where transcripts live on this machine.
+ *
+ * XDG_STATE_HOME is the right variable and the one nobody uses: state is
+ * "data that should persist between restarts but is not important enough
+ * for XDG_DATA_HOME", which is a log exactly. On Windows there is no XDG
+ * anything, and LOCALAPPDATA is where a per-machine, non-roaming thing
+ * belongs — the same directory the wallpapers already use.
+ */
+export function transcriptDir(env?: Record<string, string | undefined>): string {
+  const e = env ?? process.env;
+  const local = e["LOCALAPPDATA"];
+  if (local && !e["HOME"]) return `${local.replace(/\\/g, "/")}/red-dev/logs`;
+  const state = e["XDG_STATE_HOME"];
+  if (state) return `${state}/red-dev`;
+  const home = e["HOME"] ?? e["USERPROFILE"] ?? ".";
+  return `${home.replace(/\\/g, "/")}/.local/state/red-dev`;
+}
+
+/**
+ * A filename that sorts chronologically and survives every filesystem.
+ *
+ * Colons are illegal on NTFS, which rules out an ISO timestamp as-is —
+ * and the failure would be silent on Windows and invisible on Linux,
+ * which is the worst way to find out.
+ */
+export function transcriptName(at: Date, command: string): string {
+  const stamp = at.toISOString().replace(/[:.]/g, "-").replace(/Z$/, "");
+  const safe = command.replace(/[^a-z0-9]+/gi, "-").toLowerCase() || "run";
+  return `${stamp}-${safe}.log`;
+}
+
+/**
+ * Keep the newest KEEP files, delete the rest.
+ *
+ * By name rather than by mtime, because the names sort chronologically
+ * by construction and mtime on a /mnt/c path is not something to build
+ * on. Returns what it removed so the caller can say so if it wants to.
+ */
+export function prunable(names: string[], keep = KEEP): string[] {
+  const logs = names.filter((n) => n.endsWith(".log")).sort();
+  return logs.slice(0, Math.max(0, logs.length - keep));
+}
+
+let handle: { path: string; write: (line: string) => void } | null = null;
+
+/** The transcript being written, if one is open. */
+export function transcriptPath(): string | null {
+  return handle?.path ?? null;
+}
+
+/**
+ * Open a transcript for this run and tee every log line into it.
+ *
+ * Failure here is never fatal and never loud. A read-only home, a full
+ * disk or a path that does not resolve must not stop a converge — the
+ * transcript is a convenience, and a tool that refused to install
+ * because it could not write its own log would be absurd.
+ */
+export async function startTranscript(command: string, version: string, at: Date): Promise<void> {
+  try {
+    const dir = transcriptDir();
+    mkdirSync(dir, { recursive: true });
+
+    for (const old of prunable(readdirSync(dir))) {
+      rmSync(`${dir}/${old}`, { force: true });
+    }
+
+    const path = `${dir}/${transcriptName(at, command)}`;
+    const header = [
+      `# red-dev ${version} — ${command}`,
+      `# ${at.toISOString()}`,
+      `# ${process.platform} ${process.arch}`,
+      "",
+    ].join("\n");
+    appendFileSync(path, header);
+
+    handle = {
+      path,
+      // Synchronous on purpose. A converge can exit — or be killed —
+      // between a failure and the next tick, and an async write is
+      // exactly the line that would be missing from the log of the run
+      // that needed one.
+      write: (line: string) => {
+        try {
+          appendFileSync(path, `${line.replace(ANSI, "")}\n`);
+        } catch {
+          // A disk that filled mid-run stops the transcript, not the run.
+          handle = null;
+        }
+      },
+    };
+
+    const { transcribeTo } = await import("./log.ts");
+    transcribeTo((line) => handle?.write(line));
+  } catch {
+    handle = null;
+  }
+}
+
+/** Close the run, and say where it went. */
+export function finishTranscript(exitCode: number): string | null {
+  if (!handle) return null;
+  handle.write("");
+  handle.write(`# exit ${exitCode}`);
+  return handle.path;
+}
+
+/** The transcripts on this machine, newest first. */
+export function recentTranscripts(): string[] {
+  const dir = transcriptDir();
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir)
+    .filter((n) => n.endsWith(".log"))
+    .sort()
+    .reverse()
+    .map((n) => `${dir}/${n}`);
+}
+
+/**
+ * A converge step, written straight to the file.
+ *
+ * Not through `log`, deliberately, and this is the one place that
+ * bypass is correct. The fullscreen view draws these rows from its own
+ * model, so they have never been log lines — teeing off `log` produced a
+ * transcript with every provider's chatter and none of the outcomes it
+ * belonged to, which is precisely backwards for reading a failure.
+ *
+ * Formatted as a fixed-width row so the file can be scanned by eye and
+ * grepped by outcome: `grep failed` on a transcript should be the whole
+ * technique.
+ */
+export function transcribeStep(r: {
+  index: number;
+  total: number;
+  tool: string;
+  provider: string;
+  outcome: string;
+  ms: number;
+  detail?: string;
+}): void {
+  if (!handle) return;
+  const row =
+    `[${String(r.index).padStart(2)}/${r.total}] ` +
+    `${r.tool.padEnd(22)} ${r.provider.padEnd(28)} ` +
+    `${r.outcome.padEnd(9)} ${r.ms}ms`;
+  handle.write(r.detail ? `${row}\n          ${r.detail}` : row);
+}


### PR DESCRIPTION
"Why did red-skills fail?" had no answer that did not involve running the whole
converge again and watching harder. A converge is forty steps of scrollback
inside a fullscreen frame; the three interesting lines happened ninety seconds
ago and have scrolled past.

```
red-dev logs          # the last run
red-dev logs list     # every kept run, with sizes
red-dev logs 2        # the run before last
```

XDG_STATE_HOME on Linux, LOCALAPPDATA on native Windows, twenty kept. The path
is printed at the end of a run **only when the exit code is non-zero** — a path
nobody needs, on every successful run, trains people to stop reading.

## A tee, not a sink

`log.ts` already has two ways to redirect: `buffer`, which holds lines so they
land under their own step, and `stream`, which the fullscreen views use to turn
output into content they can draw. A third *sink* would compete with those, and
it would win exactly when it must not — the runs worth transcribing are the ones
where a frame has already claimed `stream`.

`transcribeTo` tees off `emit` **before** the routing decision. Every line
reaches the file whether it also reached the console, a buffer, or a frame.

`logIsCaptured()` deliberately does not count it. That function answers "would a
child writing to the console damage a frame", and if a transcript flipped it to
true then every child would start piping — losing apt's progress bar and sudo's
ability to prompt — to produce a nicer log file.

## The step rows never were log lines

The first version had every provider's chatter and **none of the outcomes it
belonged to**, which is backwards for reading a failure. The fullscreen view
renders `[19/37] delta apt:git-delta present` from its own model.

`transcribeStep` writes them straight to the file, from inside `converge()`'s
`finish()` rather than at the end — a run that is killed still leaves every row
up to the point it stopped, and that is the run most likely to be worth reading.
Fixed-width, so `grep failed` on a transcript is the whole technique.

```
# red-dev 0.21.0 — install core
# 2026-08-07T09:44:50.134Z
# linux x64
[ 1/37] git                    apt:git                      present   2ms
[ 2/37] curl                   apt:curl                     present   2ms
...
# exit 0
```

## What is deliberately not in it

Child output on a plain `red-dev install` at a terminal. There `spawnLogged`
inherits the console on purpose so apt keeps its progress bar and sudo can
prompt, and those bytes never pass through `emit`. Teeing them would mean piping
them — trading interactivity for a log file. Recorded in the module header
rather than hidden: the fullscreen converge captures child output, and that is
the one to run when you want it.

## Verified

37 step rows and 71 lines in a real `install core` transcript; `logs list` shows
four runs with sizes; a throwing sink does not break the run it is logging.

531 tests, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788687999&installation_model_id=20659&pr_number=47&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F47&signature=db899c0610fcf04572a05889ba69fc809a69dfec30b0ebc3de9093980c370e0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->