### PR TITLE
fix: declare bash-completion, which init.sh has always sourced

### DIFF
--- a/src/manifest.test.ts
+++ b/src/manifest.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
 import {
   TOOLS,
   applicableScopes,
@@ -121,6 +122,25 @@ describe("the manifest itself", () => {
     const tool = TOOLS.find((t) => t.name === "wl-clipboard");
     expect(tool?.scope).toBe("desktop");
     expect(providerFor(tool!, DESKTOP)).toEqual({ kind: "apt", pkg: "wl-clipboard" });
+  });
+
+  test("what init.sh sources, the manifest installs", () => {
+    // The gap this closes: init.sh sourced bash_completion from the
+    // first version and nothing ever declared the package. On a desktop
+    // Ubuntu it arrives as somebody else's dependency, so the `[ -r ]`
+    // guard around the source line always passed and the omission was
+    // invisible — until a trimmed WSL image, where bash silently loses
+    // completion for git, apt and ssh.
+    //
+    // Asserted against init.sh rather than as a bare name, so deleting
+    // the source line and leaving the package, or the reverse, is what
+    // fails here.
+    const init = readFileSync("config/bash/init.sh", "utf8");
+    expect(init).toContain("/usr/share/bash-completion/bash_completion");
+
+    const tool = TOOLS.find((t) => t.name === "bash-completion");
+    expect(tool?.scope).toBe("core");
+    expect(providerFor(tool!, WSL24)).toEqual({ kind: "apt", pkg: "bash-completion" });
   });
 
   test("webm2mp4's ffmpeg dependency is declared", () => {

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -273,6 +273,22 @@ export const TOOLS: Tool[] = [
     win: winget("sharkdp.bat"),
   },
   { name: "eza", scope: "core", u24: apt("eza"), win: winget("eza-community.eza") },
+  {
+    // Sourced by config/bash/init.sh since before it was ever declared
+    // here, which is the whole reason it is now. It arrives as somebody
+    // else's dependency on a desktop Ubuntu, so the guard around the
+    // source line never fired and the gap stayed invisible — until a
+    // trimmed WSL image or a container, where nothing pulls it in and
+    // bash loses tab-completion for git, apt, ssh and the rest without
+    // saying so.
+    //
+    // No `win`: Git Bash carries its own copy, and there is no winget
+    // package that would put one where MSYS bash reads from.
+    name: "bash-completion",
+    scope: "core",
+    u24: apt("bash-completion"),
+    win: skip("Git Bash ships its own bash-completion"),
+  },
   { name: "zoxide", scope: "core", u24: apt("zoxide"), win: winget("ajeetdsouza.zoxide") },
   { name: "fzf", scope: "core", u24: apt("fzf"), win: winget("junegunn.fzf") },
   { name: "btop", scope: "core", u24: apt("btop"), win: winget("aristocratos.btop4win") },


### PR DESCRIPTION
`config/bash/init.sh` has sourced `/usr/share/bash-completion/bash_completion` since it was written, and no tool in the manifest ever installed it.

On a desktop Ubuntu the package arrives as somebody else's dependency, so the `[ -r … ]` guard around the source line always passed and the omission stayed invisible. On a trimmed WSL image or a container nothing pulls it in, the guard fails silently, and bash loses tab-completion for git, apt and ssh without saying why.

Declared `core`, so a plain converge installs it. No `win` provider: Git Bash ships its own copy and no winget package would put one where MSYS bash reads from.

## Test

`what init.sh sources, the manifest installs` asserts against the text of `init.sh` rather than a bare name, so deleting the source line and leaving the package — or the reverse — is what fails. Verified non-vacuous: renaming the manifest entry makes it fail.

## Checks

- `bun test` — 598 pass, 0 fail
- `tsc --noEmit` — clean
- `red-dev plan` on a WSL host lists `bash-completion apt:bash-completion` as the only item not `(present)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhSZ5GCX26PgTZLNRpWmtv

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788783622&installation_model_id=20659&pr_number=48&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F48&signature=54db848186610d6b1a4a0addada98cbc37fddf408b1e3fd1cae72a1a80807703"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->