### PR TITLE
fix: isolate RED_ZELLIJ so the opt-out does not redden the suite

### DIFF
--- a/src/zellij-autostart.test.ts
+++ b/src/zellij-autostart.test.ts
@@ -76,11 +76,20 @@ function run(env: Record<string, string>, interactive: boolean): Run {
     env: {
       ...process.env,
       PATH: `${dir}:${process.env["PATH"]}`,
-      // Inherited from whatever ran the test suite, and both would
-      // otherwise make every case look like "already inside one".
+      // Inherited from whatever ran the test suite. The first three
+      // would make every case look like "already inside one"; RED_ZELLIJ
+      // is the opt-out, and a maintainer who set it in env.sh — the
+      // documented way to stop the autostart — turned ten of these red
+      // on their own machine and nowhere else.
+      //
+      // Empty rather than deleted, because `${RED_ZELLIJ:-1}` reads an
+      // empty value as unset and lands on the default. The cases that
+      // exercise the opt-out set it through `env`, which is spread after
+      // this and still wins.
       ZELLIJ: "",
       ZELLIJ_SESSION_NAME: "",
       RED_IN_ZELLIJ: "",
+      RED_ZELLIJ: "",
       TERM: "xterm-256color",
       XDG_STATE_HOME: stateHome,
       ...env,


### PR DESCRIPTION
`zellij-autostart.test.ts` neutralises `ZELLIJ`, `ZELLIJ_SESSION_NAME` and `RED_IN_ZELLIJ` before spawning each case, but not `RED_ZELLIJ`.

`RED_ZELLIJ=0` in `~/.config/red-dev/env.sh` is the documented way to stop the autostart — `config/bash/zellij.sh` says so in its own header. A maintainer who takes that route inherits it into the test process, every case falls through the opt-out guard, and ten tests go red on their machine and nowhere else. Nothing is wrong with the code they are testing.

Set to empty rather than deleted: `${RED_ZELLIJ:-1}` reads an empty value as unset and lands on the default. The cases that deliberately exercise the opt-out pass it through `env`, which is spread after this and still wins.

## Checks

- `bun test` with `RED_ZELLIJ=0` exported — 598 pass, 0 fail (was 588/10 before)
- `bun test` with a clean environment — 598 pass, 0 fail
- `tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhSZ5GCX26PgTZLNRpWmtv

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788784144&installation_model_id=20659&pr_number=49&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F49&signature=fc1776d4e17412838f2d4833b4b32354ed2eccc86e1d6074485d36754e46d5ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->