### PR TITLE
docs: land AFK boot docs sweep

### DIFF
--- a/.red/contexts/visual/CONTEXT.md
+++ b/.red/contexts/visual/CONTEXT.md
@@ -2,6 +2,12 @@
 
 Visual system — themes, fonts, wallpapers, and the ownership of the configs that apply them.
 
+## Redwall
+
+The theme's wallpaper with live machine state drawn over it. The brand art underneath is unchanged — Redwall composes on top of it, never in place of it, which is what keeps it compatible with the decision that the desktop carries the mark. It reaches two surfaces from one image: the desktop background and the lock screen. What it carries is state a person reads at a glance without unlocking — the count of active Workers, and the address this machine answers on.
+
+A Redwall is derived, never authored: the wallpaper is the source and the Redwall is regenerated whenever the state it displays changes. It therefore lives apart from the wallpapers, which are immutable per theme and content-addressed; a Redwall that shared that directory would make "retired" and "chosen by hand" indistinguishable to the sweep.
+
 ## Config ownership modes
 
 Every configuration file touched by an adapter declares a mode: `owned` (red-dev owns and converges it), `merged` (red-dev manages only explicitly-owned fields), `adopted` (pre-existing; red-dev took over management with consent and a plan), or `external` (red-dev never touches it; at most themes it when present). Editors follow the *adoptable starter* model: install when absent, never overwrite what exists.


### PR DESCRIPTION
Automated Docs Sweep landing for stranded .red documentation.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788795004&installation_model_id=20659&pr_number=51&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F51&signature=507a0f4b2bf5b96c8c9a9c6be12325f0ee739930ee9b32cea5854c30b8e03058"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->