### PR TITLE
chore: declare the AFK validation moments this repo already runs in CI

### DIFF
--- a/.red/config.yaml
+++ b/.red/config.yaml
@@ -1,0 +1,27 @@
+# Project-level RedSkills policy for red-dev.
+#
+# The AFK validation block is the only authority on what runs and when.
+# An undeclared moment is skipped loudly rather than guessed at, and the
+# engine never discovers a suite on its own — so before this file existed
+# a drain would have written code, run nothing, and left every failure
+# for the PR checks to find one red build at a time.
+#
+# The commands are the ones package.json already defines and CI already
+# runs, so a worker's local verdict and the merge queue's cannot drift.
+plugins:
+  dev:
+    afk:
+      validation:
+        # Handed to the inner agent while it writes, so it stays the fast
+        # half: the type checker runs at the two moments below, where a
+        # few extra seconds buy a verdict nobody has to re-derive.
+        iteration:
+          - bun test
+        # At the branch's fork point, once the agent reports done.
+        post_done:
+          - bun run typecheck
+          - bun test
+        # Before push, PR and queue — the last local word before CI's.
+        landing:
+          - bun run typecheck
+          - bun test


### PR DESCRIPTION
The repo had no `.red/config.yaml`, so every AFK validation moment resolved as undeclared and the daemon reported `iteration: skip`, `post_done: skip`, `landing: skip`.

That is not a soft default. `plugins.dev.afk.validation` is the sole local validation authority and the engine never discovers a suite on its own — so a drain would have written code, run nothing locally, and pushed. The PR checks would still have caught the failures, one red build at a time, each one becoming `blocked:ci` and escalating to a human. With six tickets queued whose acceptance criteria all read "bun test passes and tsc --noEmit is clean", that is a slow way to find out.

Declared with the commands `package.json` already defines and CI already runs, so a worker's local verdict and the merge queue's cannot drift.

`iteration` carries only the test run, because it is handed to the inner agent while it writes and wants to stay fast. `post_done` and `landing` carry the type check too.

Landed as a PR rather than committed straight to main because AFK workers branch from `origin/main` — a declaration that exists only in a working tree is invisible to every worker that would use it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhSZ5GCX26PgTZLNRpWmtv

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788805924&installation_model_id=20659&pr_number=74&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F74&signature=73fd308fe16d18351e5c2ea4e679ad935cb2ac7d8edb9043abb9a7e376800800"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->