### PR TITLE
chore: #54 Resolve the machine's LAN address from the default route

### DIFF
--- a/src/lan-address.test.ts
+++ b/src/lan-address.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, test } from "bun:test";
+import type { Platform } from "./platform.ts";
+import {
+  addressFromRoutes,
+  parseLinuxAddresses,
+  parseLinuxDefaultRoutes,
+  parseWindowsNetState,
+  resolveLanAddress,
+} from "./lan-address.ts";
+
+/**
+ * The measured machine from the Redwall spec: three IPv4 addresses, of
+ * which exactly one is reachable from another host. Index order is the
+ * trap — the LAN adapter is neither first nor last.
+ */
+const WINDOWS_MEASURED = JSON.stringify({
+  routes: [{ index: 12, metric: 0, interfaceMetric: 25 }],
+  addresses: [
+    { index: 1, name: "Loopback Pseudo-Interface 1", address: "127.0.0.1" },
+    { index: 58, name: "vEthernet (WSL)", address: "172.28.16.1" },
+    { index: 12, name: "Ethernet", address: "192.168.1.42" },
+    { index: 21, name: "Ethernet 2", address: "169.254.83.11" },
+  ],
+});
+
+/** The same machine after the cable came out and Wi-Fi took the route. */
+const WINDOWS_ROAMED = JSON.stringify({
+  routes: [{ index: 15, metric: 0, interfaceMetric: 35 }],
+  addresses: [
+    { index: 1, name: "Loopback Pseudo-Interface 1", address: "127.0.0.1" },
+    { index: 58, name: "vEthernet (WSL)", address: "172.28.16.1" },
+    { index: 12, name: "Ethernet", address: "169.254.9.4" },
+    { index: 15, name: "Wi-Fi", address: "192.168.4.77" },
+  ],
+});
+
+/** Airplane mode: adapters and addresses still there, nothing routes. */
+const WINDOWS_OFFLINE = JSON.stringify({
+  routes: [],
+  addresses: [
+    { index: 1, name: "Loopback Pseudo-Interface 1", address: "127.0.0.1" },
+    { index: 58, name: "vEthernet (WSL)", address: "172.28.16.1" },
+    { index: 12, name: "Ethernet", address: "169.254.83.11" },
+  ],
+});
+
+const LINUX_ROUTES = [
+  "default via 192.168.1.1 dev enp3s0 proto dhcp src 192.168.1.42 metric 100",
+  "default via 10.42.0.1 dev wlp2s0 proto dhcp src 10.42.0.19 metric 600",
+].join("\n");
+
+const LINUX_ADDRESSES = [
+  "1: lo    inet 127.0.0.1/8 scope host lo\\       valid_lft forever preferred_lft forever",
+  "2: enp3s0    inet 192.168.1.42/24 brd 192.168.1.255 scope global dynamic noprefixroute enp3s0\\       valid_lft 84559sec preferred_lft 84559sec",
+  "3: wlp2s0    inet 10.42.0.19/24 brd 10.42.0.255 scope global dynamic noprefixroute wlp2s0\\       valid_lft 3421sec preferred_lft 3421sec",
+  "4: docker0    inet 172.17.0.1/16 brd 172.17.255.255 scope global docker0\\       valid_lft forever preferred_lft forever",
+].join("\n");
+
+function platform(over: Partial<Platform>): Platform {
+  return {
+    os: "linux",
+    distro: "ubuntu",
+    version: "24.04",
+    codename: "noble",
+    env: "desktop",
+    arch: "x64",
+    caps: { apt: true, gui: true, systemd: true, winget: false, flatpak: false },
+    ...over,
+  };
+}
+
+/** A capture seam that answers by command and records what was asked. */
+function fakeCapture(answers: Array<[RegExp, { out: string; code?: number }]>) {
+  const asked: string[] = [];
+  const capture = async (cmd: string[]) => {
+    const line = cmd.join(" ");
+    asked.push(line);
+    for (const [pattern, answer] of answers) {
+      if (pattern.test(line)) return { out: answer.out, code: answer.code ?? 0 };
+    }
+    return { out: "", code: 127 };
+  };
+  return { capture, asked };
+}
+
+describe("the default route picks the address", () => {
+  test("a LAN adapter beats a virtual switch and a disconnected APIPA address", () => {
+    const state = parseWindowsNetState(WINDOWS_MEASURED);
+    expect(addressFromRoutes(state.routes, state.addresses)).toBe("192.168.1.42");
+  });
+
+  test("no default route resolves to nothing rather than to a present address", () => {
+    const state = parseWindowsNetState(WINDOWS_OFFLINE);
+    expect(state.addresses.length).toBe(3);
+    expect(addressFromRoutes(state.routes, state.addresses)).toBeNull();
+  });
+
+  test("the answer follows the route when it moves to another adapter", () => {
+    const state = parseWindowsNetState(WINDOWS_ROAMED);
+    expect(addressFromRoutes(state.routes, state.addresses)).toBe("192.168.4.77");
+  });
+
+  test("two default routes are decided by metric, not by order", () => {
+    const routes = [
+      { interfaceName: null, interfaceIndex: 15, metric: 55, source: null },
+      { interfaceName: null, interfaceIndex: 12, metric: 25, source: null },
+    ];
+    const addresses = [
+      { interfaceName: "Wi-Fi", interfaceIndex: 15, address: "192.168.4.77" },
+      { interfaceName: "Ethernet", interfaceIndex: 12, address: "192.168.1.42" },
+    ];
+    expect(addressFromRoutes(routes, addresses)).toBe("192.168.1.42");
+  });
+
+  test("a route whose interface carries no usable address falls to the next one", () => {
+    const routes = [
+      { interfaceName: null, interfaceIndex: 21, metric: 5, source: null },
+      { interfaceName: null, interfaceIndex: 12, metric: 25, source: null },
+    ];
+    const addresses = [
+      { interfaceName: "Ethernet 2", interfaceIndex: 21, address: "169.254.83.11" },
+      { interfaceName: "Ethernet", interfaceIndex: 12, address: "192.168.1.42" },
+    ];
+    expect(addressFromRoutes(routes, addresses)).toBe("192.168.1.42");
+  });
+
+  test("an interface with a route but no address at all invents nothing", () => {
+    const routes = [{ interfaceName: "tun0", interfaceIndex: null, metric: 0, source: null }];
+    expect(addressFromRoutes(routes, [])).toBeNull();
+  });
+});
+
+describe("reading what Windows reports", () => {
+  test("a single route is still a list when PowerShell unrolls it", () => {
+    const unrolled = JSON.stringify({
+      routes: { index: 12, metric: 0, interfaceMetric: 25 },
+      addresses: { index: 12, name: "Ethernet", address: "192.168.1.42" },
+    });
+    const state = parseWindowsNetState(unrolled);
+    expect(state.routes).toEqual([
+      { interfaceName: null, interfaceIndex: 12, metric: 25, source: null },
+    ]);
+    expect(addressFromRoutes(state.routes, state.addresses)).toBe("192.168.1.42");
+  });
+
+  test("output that is not JSON is no answer rather than a crash", () => {
+    expect(parseWindowsNetState("Get-NetRoute : the term is not recognized")).toEqual({
+      routes: [],
+      addresses: [],
+    });
+  });
+});
+
+describe("reading what Linux reports", () => {
+  test("the kernel's own source address is taken from the winning route", () => {
+    const routes = parseLinuxDefaultRoutes(LINUX_ROUTES);
+    expect(routes.length).toBe(2);
+    expect(addressFromRoutes(routes, parseLinuxAddresses(LINUX_ADDRESSES))).toBe("192.168.1.42");
+  });
+
+  test("a route without a source address is matched to its interface", () => {
+    const routes = parseLinuxDefaultRoutes("default via 10.42.0.1 dev wlp2s0 proto dhcp metric 600");
+    expect(routes[0]?.source).toBeNull();
+    expect(addressFromRoutes(routes, parseLinuxAddresses(LINUX_ADDRESSES))).toBe("10.42.0.19");
+  });
+
+  test("non-default routes are not addresses this machine answers on", () => {
+    expect(parseLinuxDefaultRoutes("172.17.0.0/16 dev docker0 proto kernel src 172.17.0.1")).toEqual(
+      [],
+    );
+  });
+});
+
+describe("resolving on a real machine", () => {
+  test("a Linux desktop asks the local route table", async () => {
+    const { capture, asked } = fakeCapture([
+      [/^ip -4 route show default$/, { out: LINUX_ROUTES }],
+      [/^ip -o -4 addr show$/, { out: LINUX_ADDRESSES }],
+    ]);
+    expect(await resolveLanAddress(platform({ env: "desktop" }), capture)).toBe("192.168.1.42");
+    expect(asked.some((cmd) => cmd.startsWith("powershell.exe"))).toBe(false);
+  });
+
+  test("WSL answers with the Windows host's address, not the distro's", async () => {
+    const { capture, asked } = fakeCapture([
+      [/^powershell\.exe /, { out: WINDOWS_MEASURED }],
+      // Present so the test fails loudly if the distro is asked instead:
+      // eth0 behind the NAT is exactly the wrong answer.
+      [/^ip /, { out: "default via 172.28.16.1 dev eth0 src 172.28.30.7 metric 100" }],
+    ]);
+    expect(await resolveLanAddress(platform({ env: "wsl" }), capture)).toBe("192.168.1.42");
+    expect(asked.every((cmd) => cmd.startsWith("powershell.exe"))).toBe(true);
+  });
+
+  test("native Windows asks the same question of the same host", async () => {
+    const { capture } = fakeCapture([[/^powershell\.exe /, { out: WINDOWS_ROAMED }]]);
+    const windows = platform({ os: "windows", env: "windows", distro: null, version: null });
+    expect(await resolveLanAddress(windows, capture)).toBe("192.168.4.77");
+  });
+
+  test("a command that cannot run reports nothing", async () => {
+    const { capture } = fakeCapture([]);
+    expect(await resolveLanAddress(platform({ env: "desktop" }), capture)).toBeNull();
+  });
+
+  test("darwin fails closed, as it does everywhere else", async () => {
+    const { capture, asked } = fakeCapture([[/./, { out: LINUX_ROUTES }]]);
+    expect(await resolveLanAddress(platform({ os: "darwin" }), capture)).toBeNull();
+    expect(asked).toEqual([]);
+  });
+});

--- a/src/lan-address.ts
+++ b/src/lan-address.ts
@@ -1,0 +1,293 @@
+/**
+ * The address this machine answers on.
+ *
+ * Not "an IPv4 address the machine has" — a laptop routinely has three
+ * or four of those and only one of them reaches it from across the
+ * room. The measured case that motivated this: a Windows host reporting
+ * the LAN address on an `Up` Ethernet adapter, the WSL virtual switch,
+ * and a disconnected adapter's APIPA address. Picking by index, by
+ * adapter name, or by "the first one that is not loopback" picks wrong
+ * on that machine, and would keep picking wrong in a different way once
+ * a VPN or a container bridge appears.
+ *
+ * So the rule is the routing table's own answer: whichever interface
+ * carries the default route owns the address, because that is the
+ * interface packets to the rest of the world actually leave by. It
+ * needs no list of virtual adapters to ignore, it follows a laptop from
+ * Ethernet to Wi-Fi without being told, and when there is no default
+ * route it says so instead of guessing — an address nobody can reach is
+ * worse than no address, because it looks like one that works.
+ *
+ * ## The WSL twist
+ *
+ * Under WSL the answer is the *Windows host's* address. The distro sits
+ * behind a NAT: its `eth0` address is real, routable inside the host,
+ * and reaches nothing from another machine — the same reason
+ * `ssh-server.ts` configures sshd on the Windows side. So WSL asks
+ * PowerShell rather than `ip`, which is only a difference in who is
+ * asked. The rule applied to the answer is identical, which is why both
+ * mechanisms parse into one shape and one `addressFromRoutes` decides.
+ *
+ * Darwin is deliberately absent, failing closed as it does in
+ * `providerFor` and per .red/adr/0001.
+ */
+
+import type { Platform } from "./platform.ts";
+import { readWindowsOutput } from "./windows-output.ts";
+
+/** A default route, as either platform describes one. */
+export interface DefaultRoute {
+  /** How Linux names the interface; null when only an index was given. */
+  interfaceName: string | null;
+  /** How Windows names it; null when only a name was given. */
+  interfaceIndex: number | null;
+  /** Lower wins. Windows sums the route and interface metrics. */
+  metric: number;
+  /**
+   * The address the kernel itself would send from over this route.
+   * Linux offers it directly; Windows does not, and leaves it null.
+   */
+  source: string | null;
+}
+
+/** An IPv4 address the machine holds, and where it holds it. */
+export interface HostAddress {
+  interfaceName: string | null;
+  interfaceIndex: number | null;
+  address: string;
+}
+
+export interface NetState {
+  routes: DefaultRoute[];
+  addresses: HostAddress[];
+}
+
+/** Ran, and what it printed. */
+export interface Captured {
+  out: string;
+  code: number;
+}
+
+/** The seam the tests replace: how a question reaches the machine. */
+export type Capture = (cmd: string[]) => Promise<Captured>;
+
+const NOTHING: NetState = { routes: [], addresses: [] };
+
+// ------------------------------------------------------------- the rule
+
+/**
+ * An address that can be reached from another machine.
+ *
+ * Loopback never leaves the host, and 169.254/16 is what an adapter
+ * assigns itself when DHCP found nobody — an address whose presence
+ * means the opposite of connectivity. Both are properties of the
+ * address itself, not adapters named in a list somewhere.
+ */
+function isRoutable(address: string): boolean {
+  if (!/^\d{1,3}(\.\d{1,3}){3}$/.test(address)) return false;
+  if (address.startsWith("127.")) return false;
+  if (address.startsWith("169.254.")) return false;
+  return address !== "0.0.0.0";
+}
+
+/**
+ * Compare on whichever identifier both sides actually carry. Linux
+ * speaks in names, Windows in indices, and neither translates for free.
+ */
+function sameInterface(address: HostAddress, route: DefaultRoute): boolean {
+  if (route.interfaceIndex !== null && address.interfaceIndex !== null) {
+    return route.interfaceIndex === address.interfaceIndex;
+  }
+  if (route.interfaceName !== null && address.interfaceName !== null) {
+    return route.interfaceName === address.interfaceName;
+  }
+  return false;
+}
+
+/**
+ * Follow the route to the address, or return nothing.
+ *
+ * Routes are tried cheapest first, and a route whose interface holds no
+ * usable address falls through to the next rather than ending the
+ * search: a metric-5 adapter sitting on an APIPA address is exactly the
+ * disconnected case, and the machine still answers on the one below it.
+ */
+export function addressFromRoutes(
+  routes: DefaultRoute[],
+  addresses: HostAddress[],
+): string | null {
+  for (const route of [...routes].sort((a, b) => a.metric - b.metric)) {
+    if (route.source !== null && isRoutable(route.source)) return route.source;
+    const held = addresses.find((a) => sameInterface(a, route) && isRoutable(a.address));
+    if (held) return held.address;
+  }
+  return null;
+}
+
+// ----------------------------------------------------------------- linux
+
+function tokenAfter(tokens: string[], key: string): string | null {
+  const at = tokens.indexOf(key);
+  if (at < 0) return null;
+  return tokens[at + 1] ?? null;
+}
+
+/** Parse `ip -4 route show default`. Anything else is not a default route. */
+export function parseLinuxDefaultRoutes(out: string): DefaultRoute[] {
+  const routes: DefaultRoute[] = [];
+  for (const line of out.split(/\r?\n/)) {
+    const tokens = line.trim().split(/\s+/);
+    if (tokens[0] !== "default") continue;
+    routes.push({
+      interfaceName: tokenAfter(tokens, "dev"),
+      interfaceIndex: null,
+      metric: Number(tokenAfter(tokens, "metric") ?? "") || 0,
+      source: tokenAfter(tokens, "src"),
+    });
+  }
+  return routes;
+}
+
+/** Parse `ip -o -4 addr show`, one interface per line by construction. */
+export function parseLinuxAddresses(out: string): HostAddress[] {
+  const addresses: HostAddress[] = [];
+  for (const line of out.split(/\r?\n/)) {
+    const m = /^(\d+):\s+(\S+)\s+inet\s+([\d.]+)/.exec(line.trim());
+    if (!m || m[1] === undefined || m[2] === undefined || m[3] === undefined) continue;
+    addresses.push({
+      interfaceName: m[2],
+      interfaceIndex: Number.parseInt(m[1], 10),
+      address: m[3],
+    });
+  }
+  return addresses;
+}
+
+async function linuxNetState(capture: Capture): Promise<NetState> {
+  const routes = await capture(["ip", "-4", "route", "show", "default"]);
+  if (routes.code !== 0) return NOTHING;
+  const addresses = await capture(["ip", "-o", "-4", "addr", "show"]);
+  return {
+    routes: parseLinuxDefaultRoutes(routes.out),
+    addresses: addresses.code === 0 ? parseLinuxAddresses(addresses.out) : [],
+  };
+}
+
+// --------------------------------------------------------------- windows
+
+/**
+ * One round trip for both halves, because two would be two chances for
+ * the table to change underneath us — an adapter coming up between the
+ * calls yields a route pointing at an interface the address list has
+ * never heard of.
+ *
+ * `RouteMetric` alone does not order Windows routes; the interface
+ * metric is added to it, and it is the sum that decides. Errors are
+ * silenced rather than thrown so a machine missing the NetTCPIP module
+ * produces empty lists, which the rule already reads as "no answer".
+ */
+const WINDOWS_NET_SCRIPT = [
+  "$ErrorActionPreference = 'SilentlyContinue'",
+  "$routes = @(Get-NetRoute -AddressFamily IPv4 -DestinationPrefix '0.0.0.0/0' |" +
+    " ForEach-Object { [pscustomobject]@{ index = [int]$_.InterfaceIndex;" +
+    " metric = [int]$_.RouteMetric; interfaceMetric = [int]$_.InterfaceMetric } })",
+  "$addresses = @(Get-NetIPAddress -AddressFamily IPv4 |" +
+    " ForEach-Object { [pscustomobject]@{ index = [int]$_.InterfaceIndex;" +
+    " name = [string]$_.InterfaceAlias; address = [string]$_.IPAddress } })",
+  "[pscustomobject]@{ routes = $routes; addresses = $addresses } |" +
+    " ConvertTo-Json -Depth 3 -Compress",
+].join("; ");
+
+type Record_ = { [key: string]: unknown };
+
+/** PowerShell serialises a one-element list as a bare object often enough. */
+function records(value: unknown): Record_[] {
+  const many = Array.isArray(value) ? value : [value];
+  return many.filter((v): v is Record_ => typeof v === "object" && v !== null);
+}
+
+function numberOf(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function stringOf(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed === "" ? null : trimmed;
+}
+
+export function parseWindowsNetState(json: string): NetState {
+  let payload: unknown;
+  try {
+    payload = JSON.parse(json);
+  } catch {
+    // PowerShell writes its errors where the JSON was meant to go, and
+    // a machine that cannot answer is not a machine to guess about.
+    return NOTHING;
+  }
+  if (typeof payload !== "object" || payload === null) return NOTHING;
+  const root = payload as Record_;
+
+  const routes: DefaultRoute[] = [];
+  for (const route of records(root["routes"])) {
+    const index = numberOf(route["index"]);
+    if (index === null) continue;
+    routes.push({
+      interfaceName: null,
+      interfaceIndex: index,
+      metric: (numberOf(route["metric"]) ?? 0) + (numberOf(route["interfaceMetric"]) ?? 0),
+      source: null,
+    });
+  }
+
+  const addresses: HostAddress[] = [];
+  for (const address of records(root["addresses"])) {
+    const held = stringOf(address["address"]);
+    if (held === null) continue;
+    addresses.push({
+      interfaceName: stringOf(address["name"]),
+      interfaceIndex: numberOf(address["index"]),
+      address: held,
+    });
+  }
+
+  return { routes, addresses };
+}
+
+async function windowsNetState(capture: Capture): Promise<NetState> {
+  const { out, code } = await capture(["powershell.exe", "-NoProfile", "-Command", WINDOWS_NET_SCRIPT]);
+  if (code !== 0) return NOTHING;
+  return parseWindowsNetState(out);
+}
+
+// ------------------------------------------------------------- the seam
+
+async function spawnCapture(cmd: string[]): Promise<Captured> {
+  try {
+    const proc = Bun.spawn(cmd, { stdout: "pipe", stderr: "ignore", stdin: "ignore" });
+    // PowerShell reached through WSL interop writes UTF-16LE when its
+    // stdout is redirected, which is not JSON until it is decoded.
+    const out = await readWindowsOutput(proc.stdout);
+    return { out, code: await proc.exited };
+  } catch {
+    // A binary that is not there is an answer, not an exception: this
+    // machine cannot be asked, so it reports nothing.
+    return { out: "", code: 127 };
+  }
+}
+
+/**
+ * The address to show for this machine, or null when it has none worth
+ * showing. WSL asks the Windows host; everything else asks itself.
+ */
+export async function resolveLanAddress(
+  p: Platform,
+  capture: Capture = spawnCapture,
+): Promise<string | null> {
+  let state: NetState;
+  if (p.os === "windows" || p.env === "wsl") state = await windowsNetState(capture);
+  else if (p.os === "linux") state = await linuxNetState(capture);
+  else state = NOTHING;
+
+  return addressFromRoutes(state.routes, state.addresses);
+}


### PR DESCRIPTION
Automated AFK landing for #54. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #54

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788806444&installation_model_id=20659&pr_number=75&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F75&signature=0e9ced4777547a3dbbfb2747056353e0790d439a476dcfa7a3c332d3714e7865"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->