### PR TITLE
chore: #55 Read host-state for the Worker count, degrading on unknown versions

### DIFF
--- a/src/fixtures/redskilled-host-state.json
+++ b/src/fixtures/redskilled-host-state.json
@@ -1,0 +1,419 @@
+{
+  "version": 1,
+  "protocol_version": 1,
+  "daemon_version": "3.12.6",
+  "machine_id_hash": "9f2c1a0b3d4e",
+  "session_key_hash": "7a6b5c4d3e2f",
+  "pid": 1417835,
+  "started_at": "2026-08-08T18:00:13.071Z",
+  "ceiling": {
+    "memory_bytes": 16417174323,
+    "worker_count": 6,
+    "interactive_reservation": 1,
+    "memory_source": "derived-default",
+    "worker_source": "home-config",
+    "source": "host-fraction",
+    "validation_count": 6,
+    "validation_source": "derived-default"
+  },
+  "scope": {
+    "kind": "machine",
+    "claim_path": "/tmp/redskilled-9f2c1a0b3d4e/redskilled.machine.claim.toon",
+    "owner_uid": 1000,
+    "machine_id_hash": "9f2c1a0b3d4e",
+    "session_key_hash": "7a6b5c4d3e2f",
+    "socket_path": "/run/user/1000/red-skills/0123456789abcdef0123/redskilled.sock"
+  },
+  "workers": [
+    {
+      "worker_id": "hO7UE",
+      "project_label": "reddb-io/design-system",
+      "pid": 1534418,
+      "started_at": "2026-08-08T18:30:45.795Z",
+      "workspace_path": "/home/dev/workspace/design-system",
+      "log_path": "/home/dev/workspace/design-system/.red/tmp/workers/hO7UE/worker.log.toonl",
+      "isolated": true,
+      "unit": "red-worker-reddb-io-design-system-ho7ue.service",
+      "applied_budget": {
+        "memory_max": "2736195720"
+      },
+      "memory_ceiling": "2736195720",
+      "memory_ceiling_reason": "derived from this host's memory ceiling of 16417174323 bytes shared across its 6 Worker slot(s) (ceiling source: host-fraction)",
+      "warnings": [],
+      "fork_sha": "2b8eff05331d7bee47b4abffe5ea448c88d9e1ef",
+      "cpu": {
+        "cpu_seconds": 658.67325,
+        "sampled_at": "2026-08-08T18:37:44.996Z"
+      },
+      "base_head_sha": "7df5d542ad991c7f9411c20ce7ba86e7cbf019b7",
+      "base_commits_ahead": 33
+    },
+    {
+      "worker_id": "hUK3Z",
+      "project_label": "reddb-io/design-system",
+      "pid": 1562395,
+      "started_at": "2026-08-08T18:33:23.082Z",
+      "workspace_path": "/home/dev/workspace/design-system",
+      "log_path": "/home/dev/workspace/design-system/.red/tmp/workers/hUK3Z/worker.log.toonl",
+      "isolated": true,
+      "unit": "red-worker-reddb-io-design-system-huk3z.service",
+      "applied_budget": {
+        "memory_max": "2736195720"
+      },
+      "memory_ceiling": "2736195720",
+      "memory_ceiling_reason": "derived from this host's memory ceiling of 16417174323 bytes shared across its 6 Worker slot(s) (ceiling source: host-fraction)",
+      "warnings": [],
+      "fork_sha": "7df5d542ad991c7f9411c20ce7ba86e7cbf019b7",
+      "base_head_sha": "7df5d542ad991c7f9411c20ce7ba86e7cbf019b7",
+      "base_commits_ahead": 0,
+      "cpu": {
+        "cpu_seconds": 332.376289,
+        "sampled_at": "2026-08-08T18:37:44.996Z"
+      }
+    },
+    {
+      "worker_id": "h9998",
+      "project_label": "reddb-io/red-dev",
+      "pid": 1563827,
+      "started_at": "2026-08-08T18:33:38.207Z",
+      "workspace_path": "/home/dev/workspace/red-dev",
+      "log_path": "/home/dev/workspace/red-dev/.red/tmp/workers/h9998/worker.log.toonl",
+      "isolated": true,
+      "unit": "red-worker-reddb-io-red-dev-h9998.service",
+      "applied_budget": {
+        "memory_max": "2736195720"
+      },
+      "memory_ceiling": "2736195720",
+      "memory_ceiling_reason": "derived from this host's memory ceiling of 16417174323 bytes shared across its 6 Worker slot(s) (ceiling source: host-fraction)",
+      "warnings": [],
+      "fork_sha": "52206606e76a605e8ead205eda83473938914293",
+      "base_head_sha": "52206606e76a605e8ead205eda83473938914293",
+      "base_commits_ahead": 0,
+      "cpu": {
+        "cpu_seconds": 131.748422,
+        "sampled_at": "2026-08-08T18:37:44.996Z"
+      }
+    },
+    {
+      "worker_id": "hDAL5",
+      "project_label": "reddb-io/red-dev",
+      "pid": 1563828,
+      "started_at": "2026-08-08T18:33:38.212Z",
+      "workspace_path": "/home/dev/workspace/red-dev",
+      "log_path": "/home/dev/workspace/red-dev/.red/tmp/workers/hDAL5/worker.log.toonl",
+      "isolated": true,
+      "unit": "red-worker-reddb-io-red-dev-hdal5.service",
+      "applied_budget": {
+        "memory_max": "2736195720"
+      },
+      "memory_ceiling": "2736195720",
+      "memory_ceiling_reason": "derived from this host's memory ceiling of 16417174323 bytes shared across its 6 Worker slot(s) (ceiling source: host-fraction)",
+      "warnings": [],
+      "fork_sha": "52206606e76a605e8ead205eda83473938914293",
+      "base_head_sha": "52206606e76a605e8ead205eda83473938914293",
+      "base_commits_ahead": 0,
+      "cpu": {
+        "cpu_seconds": 42.70361,
+        "sampled_at": "2026-08-08T18:37:44.996Z"
+      }
+    },
+    {
+      "worker_id": "hNH5J",
+      "project_label": "reddb-io/red-dev",
+      "pid": 1563830,
+      "started_at": "2026-08-08T18:33:38.217Z",
+      "workspace_path": "/home/dev/workspace/red-dev",
+      "log_path": "/home/dev/workspace/red-dev/.red/tmp/workers/hNH5J/worker.log.toonl",
+      "isolated": true,
+      "unit": "red-worker-reddb-io-red-dev-hnh5j.service",
+      "applied_budget": {
+        "memory_max": "2736195720"
+      },
+      "memory_ceiling": "2736195720",
+      "memory_ceiling_reason": "derived from this host's memory ceiling of 16417174323 bytes shared across its 6 Worker slot(s) (ceiling source: host-fraction)",
+      "warnings": [],
+      "fork_sha": "52206606e76a605e8ead205eda83473938914293",
+      "base_head_sha": "52206606e76a605e8ead205eda83473938914293",
+      "base_commits_ahead": 0,
+      "cpu": {
+        "cpu_seconds": 52.052544,
+        "sampled_at": "2026-08-08T18:37:44.996Z"
+      }
+    },
+    {
+      "worker_id": "hLFTB",
+      "project_label": "reddb-io/red-dev",
+      "pid": 1563831,
+      "started_at": "2026-08-08T18:33:38.222Z",
+      "workspace_path": "/home/dev/workspace/red-dev",
+      "log_path": "/home/dev/workspace/red-dev/.red/tmp/workers/hLFTB/worker.log.toonl",
+      "isolated": true,
+      "unit": "red-worker-reddb-io-red-dev-hlftb.service",
+      "applied_budget": {
+        "memory_max": "2736195720"
+      },
+      "memory_ceiling": "2736195720",
+      "memory_ceiling_reason": "derived from this host's memory ceiling of 16417174323 bytes shared across its 6 Worker slot(s) (ceiling source: host-fraction)",
+      "warnings": [],
+      "fork_sha": "52206606e76a605e8ead205eda83473938914293",
+      "base_head_sha": "52206606e76a605e8ead205eda83473938914293",
+      "base_commits_ahead": 0,
+      "cpu": {
+        "cpu_seconds": 37.468866,
+        "sampled_at": "2026-08-08T18:37:44.996Z"
+      }
+    }
+  ],
+  "projects": [
+    {
+      "project_label": "reddb-io/design-system",
+      "worker_count": 2
+    },
+    {
+      "project_label": "reddb-io/red-dev",
+      "worker_count": 4
+    }
+  ],
+  "registrations": [
+    {
+      "version": 1,
+      "project_label": "reddb-io/design-system",
+      "selector": "repo:reddb-io/design-system is:issue is:open label:\"ready-for-agent\"",
+      "queue_poll": {
+        "owner": "reddb-io",
+        "repo": "design-system",
+        "labels": [
+          "ready-for-agent"
+        ]
+      },
+      "argv": [
+        "npx",
+        "-y",
+        "-p",
+        "@reddb-io/red-skills@3.12.6",
+        "red-skills-dev",
+        "run",
+        "--once",
+        "--runner",
+        "codex"
+      ],
+      "workspace_path": "/home/dev/workspace/design-system",
+      "trunk": {
+        "remote": "origin",
+        "branch": "main"
+      },
+      "env": {
+        "REDSKILLED_WORKER_ID": "{{worker_id}}",
+        "RED_AFK_SLOT": "{{slot}}",
+        "RED_AFK_RUNNER_ORIGIN": "project_start",
+        "RED_AFK_RUNNER": "codex",
+        "RED_AFK_WORKER_ID": "{{worker_id}}"
+      },
+      "target": 2,
+      "registered_at": "2026-08-08T12:10:43.261Z",
+      "renew_within_ms": 300000,
+      "renew_by": "2026-08-08T18:42:52.738Z",
+      "renewed_at": "2026-08-08T18:36:58.141Z",
+      "renewals": 5194,
+      "session_renewals": 349,
+      "launch_revision": 1,
+      "sustained_at": "2026-08-08T18:37:52.738Z",
+      "sustains": 4845,
+      "sustained_by": "open-work",
+      "log_path": "/home/dev/workspace/design-system/.red/tmp/workers/{{worker_id}}/worker.log.toonl",
+      "renewal": "renewing",
+      "last_poll": {
+        "at": "2026-08-08T18:37:38.144Z",
+        "outcome": "counted",
+        "depth": 26,
+        "request_count": 3,
+        "detail": "project \"reddb-io/design-system\" has 26 item(s) matching its selector"
+      }
+    },
+    {
+      "version": 1,
+      "project_label": "reddb-io/red-dev",
+      "selector": "repo:reddb-io/red-dev is:issue is:open label:\"ready-for-agent\"",
+      "queue_poll": {
+        "owner": "reddb-io",
+        "repo": "red-dev",
+        "labels": [
+          "ready-for-agent"
+        ]
+      },
+      "argv": [
+        "/home/dev/.local/share/mise/installs/node/24.18.0/bin/node",
+        "/home/dev/.cache/red-skills/bundles/dev-3.12.6.bundle.min.mjs",
+        "run",
+        "--once",
+        "--runner",
+        "claude"
+      ],
+      "workspace_path": "/home/dev/workspace/red-dev",
+      "trunk": {
+        "remote": "origin",
+        "branch": "main"
+      },
+      "env": {
+        "REDSKILLED_WORKER_ID": "{{worker_id}}",
+        "RED_AFK_SLOT": "{{slot}}",
+        "RED_AFK_RUNNER_ORIGIN": "project_start",
+        "RED_AFK_RUNNER": "claude",
+        "RED_AFK_WORKER_ID": "{{worker_id}}"
+      },
+      "target": 4,
+      "registered_at": "2026-08-08T18:33:15.924Z",
+      "renew_within_ms": 300000,
+      "renew_by": "2026-08-08T18:42:52.738Z",
+      "renewed_at": "2026-08-08T18:37:05.582Z",
+      "renewals": 152,
+      "session_renewals": 6,
+      "launch_revision": 0,
+      "sustained_at": "2026-08-08T18:37:52.738Z",
+      "sustains": 146,
+      "sustained_by": "open-work",
+      "log_path": "/home/dev/workspace/red-dev/.red/tmp/workers/{{worker_id}}/worker.log.toonl",
+      "renewal": "renewing",
+      "last_poll": {
+        "at": "2026-08-08T18:37:38.144Z",
+        "outcome": "counted",
+        "depth": 2,
+        "request_count": 3,
+        "detail": "project \"reddb-io/red-dev\" has 2 item(s) matching its selector"
+      }
+    },
+    {
+      "version": 1,
+      "project_label": "reddb-io/red-skills",
+      "selector": "repo:reddb-io/red-skills is:issue is:open label:\"ready-for-agent\"",
+      "queue_poll": {
+        "owner": "reddb-io",
+        "repo": "red-skills",
+        "labels": [
+          "ready-for-agent"
+        ]
+      },
+      "argv": [
+        "/home/dev/.local/share/mise/installs/node/24.18.0/bin/node",
+        "/home/dev/.cache/red-skills/bundles/dev-3.12.6.bundle.min.mjs",
+        "run",
+        "--once",
+        "--runner",
+        "codex"
+      ],
+      "workspace_path": "/home/dev/workspace/red-skills",
+      "trunk": {
+        "remote": "origin",
+        "branch": "main"
+      },
+      "env": {
+        "REDSKILLED_WORKER_ID": "{{worker_id}}",
+        "RED_AFK_SLOT": "{{slot}}",
+        "RED_AFK_RUNNER_ORIGIN": "project_start",
+        "RED_AFK_RUNNER": "codex",
+        "RED_AFK_WORKER_ID": "{{worker_id}}"
+      },
+      "target": 3,
+      "registered_at": "2026-08-08T18:32:10.790Z",
+      "renew_within_ms": 300000,
+      "renew_by": "2026-08-08T18:42:52.738Z",
+      "renewed_at": "2026-08-08T18:35:58.908Z",
+      "renewals": 196,
+      "session_renewals": 2,
+      "launch_revision": 0,
+      "sustained_at": "2026-08-08T18:37:52.738Z",
+      "sustains": 194,
+      "sustained_by": "open-work",
+      "log_path": "/home/dev/workspace/red-skills/.red/tmp/workers/{{worker_id}}/worker.log.toonl",
+      "renewal": "renewing",
+      "last_poll": {
+        "at": "2026-08-08T18:37:38.144Z",
+        "outcome": "counted",
+        "depth": 6,
+        "request_count": 3,
+        "detail": "project \"reddb-io/red-skills\" has 6 item(s) matching its selector"
+      }
+    }
+  ],
+  "demand": {
+    "version": 1,
+    "at": "2026-08-08T18:37:44.999Z",
+    "requested": 0,
+    "granted": [],
+    "shortfall": 0,
+    "refusal": null,
+    "retry_after": null,
+    "projects": [
+      {
+        "project_label": "reddb-io/design-system",
+        "queue_depth": 26,
+        "target": 2,
+        "live": 2,
+        "outcome": "at-target",
+        "wanted": 0,
+        "detail": "project \"reddb-io/design-system\" holds 2 Worker(s) against a target of 2 and a queue of 26, so it asks for none"
+      },
+      {
+        "project_label": "reddb-io/red-dev",
+        "queue_depth": 2,
+        "target": 4,
+        "live": 4,
+        "outcome": "at-target",
+        "wanted": 0,
+        "detail": "project \"reddb-io/red-dev\" holds 4 Worker(s) against a target of 4 and a queue of 2, so it asks for none"
+      },
+      {
+        "project_label": "reddb-io/red-skills",
+        "queue_depth": 6,
+        "target": 3,
+        "live": 0,
+        "outcome": "birth-halted",
+        "wanted": 0,
+        "detail": "project \"reddb-io/red-skills\" lost 3 Workers in a row inside 60000ms of birth, so it is not asked for another before 2026-08-08T18:42:38.290Z \u2014 a Worker that cannot survive boot will not survive the next one either, and every birth spends host quota shared with every project"
+      }
+    ]
+  },
+  "birth_latches": [
+    {
+      "name": "project-birth-breaker",
+      "project_label": "reddb-io/red-skills",
+      "state": "open",
+      "opened_at": "2026-08-08T18:32:38.290Z",
+      "reason": "3 Workers from this project died before surviving 60000ms",
+      "closes": "the cooldown ends at 2026-08-08T18:42:38.290Z, then one probe Worker is admitted; surviving the short-life window closes the latch",
+      "probe_worker_id": null,
+      "repair": {
+        "tool": "project_reset",
+        "args": {
+          "latch": "project-birth-breaker"
+        },
+        "why": "clear the project's birth-breaker history and allow the next demand tick to birth normally"
+      }
+    }
+  ],
+  "budget_accounting": {
+    "version": 1,
+    "worker_count": 6,
+    "memory_high_bytes": 0,
+    "memory_max_bytes": 16417174320,
+    "cpu_weight_total": 0,
+    "unaccounted_workers": [],
+    "unisolated_workers": [],
+    "memory_ceiling_bytes": 16417174323,
+    "over_committed_bytes": 0,
+    "over_commitment_reason": null
+  },
+  "upgrade": {
+    "running_version": "3.12.6",
+    "published_version": "3.12.6",
+    "published_unknown": 0,
+    "newer_published": 0,
+    "replacement": "none",
+    "checked_at": "2026-08-08T18:31:01.037Z",
+    "checks": 3,
+    "hold_reason": "no-newer-version",
+    "newest_published_version": "3.12.6",
+    "major_held": 0,
+    "major_hold": null
+  }
+}

--- a/src/host-state.test.ts
+++ b/src/host-state.test.ts
@@ -1,0 +1,113 @@
+/**
+ * The daemon's host-state, read for the one number Redwall draws from it.
+ *
+ * Three of these tests are the same rule stated three ways: a Worker count
+ * that cannot be trusted is dropped, and nothing else is. A daemon that is
+ * not running, a payload this build cannot read, and a version skew all end
+ * in `null` — never in a throw, because the caller composing a Redwall still
+ * has an address to draw and must not lose it to an absent daemon.
+ *
+ * The fourth is the one that makes the other three worth anything: a host
+ * with no Workers reports `{ workers: 0 }`, which is a different value from
+ * `null`. Collapsing them would make "the queue drained" and "the daemon is
+ * gone" the same picture on the wallpaper.
+ *
+ * The payload is a real capture from `redskilled host-state`, with the
+ * machine's own identifiers and paths replaced. What it pins is the shape
+ * the daemon actually emits — a shape with sixteen top-level keys, of which
+ * this module reads three.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import {
+  HOST_STATE_PROTOCOL_VERSION,
+  HOST_STATE_VERSION,
+  hostStateFrom,
+  parseHostState,
+  readHostState,
+} from "./host-state.ts";
+
+// Read as text rather than imported as a module, so what the parser is given
+// is the bytes the daemon printed — an import would hand it a document
+// TypeScript had already decided the shape of.
+const fixture = readFileSync("src/fixtures/redskilled-host-state.json", "utf8");
+const captured = JSON.parse(fixture) as Record<string, unknown>;
+
+function payload(over: Record<string, unknown> = {}): Record<string, unknown> {
+  return { ...captured, ...over };
+}
+
+describe("a payload the daemon really emitted", () => {
+  test("yields the Worker count it declares", () => {
+    const workers = captured["workers"] as unknown[];
+    // Both numbers come from the capture rather than from a literal, so the
+    // assertion cannot drift from the fixture it is reading.
+    expect(workers.length).toBeGreaterThan(0);
+    expect(hostStateFrom(captured)).toEqual({ workers: workers.length });
+  });
+
+  test("counts Workers, not the slots the host would allow", () => {
+    // The ceiling is the machine's capacity and the demand block is what the
+    // daemon wants; neither is what is running. A reader that took either
+    // would draw a full machine on an idle one.
+    const state = hostStateFrom(payload({ workers: [], projects: [] }));
+    expect(state).toEqual({ workers: 0 });
+  });
+
+  test("is read the same way from its JSON text", () => {
+    expect(parseHostState(fixture)).toEqual(hostStateFrom(captured));
+  });
+});
+
+describe("a version this build does not understand", () => {
+  test("drops the Worker count rather than reading it anyway", () => {
+    expect(hostStateFrom(payload({ version: HOST_STATE_VERSION + 1 }))).toBeNull();
+  });
+
+  test("drops it on a protocol skew too", () => {
+    expect(hostStateFrom(payload({ protocol_version: HOST_STATE_PROTOCOL_VERSION + 1 }))).toBeNull();
+  });
+
+  test("throws nothing on the way", () => {
+    // Stated separately from the value, because the caller's other half — the
+    // address — is lost to an exception just as surely as to a wrong number.
+    expect(() => hostStateFrom(payload({ version: "1" }))).not.toThrow();
+    expect(() => parseHostState("{ not json")).not.toThrow();
+    expect(parseHostState("{ not json")).toBeNull();
+  });
+
+  test("drops it when the Worker set is missing or malformed", () => {
+    expect(hostStateFrom(payload({ workers: 6 }))).toBeNull();
+    expect(hostStateFrom({ version: 1, protocol_version: 1 })).toBeNull();
+    expect(hostStateFrom(null)).toBeNull();
+    expect(hostStateFrom([captured])).toBeNull();
+  });
+});
+
+describe("a daemon that is not running", () => {
+  test("yields no Worker count and no error", async () => {
+    expect(await readHostState(async () => null)).toBeNull();
+  });
+
+  test("is not distinguishable from one that answered with nothing", async () => {
+    expect(await readHostState(async () => "")).toBeNull();
+  });
+
+  test("survives a reader that fails outright", async () => {
+    // Spawning a command that is not installed rejects rather than returning
+    // nothing, and an absent red-skills checkout is the common case on a
+    // machine that only ever wanted the wallpaper.
+    expect(
+      await readHostState(async () => {
+        throw new Error("ENOENT");
+      }),
+    ).toBeNull();
+  });
+
+  test("is distinguishable from a host with no Workers", async () => {
+    const idle = JSON.stringify(payload({ workers: [], projects: [] }));
+    expect(await readHostState(async () => idle)).toEqual({ workers: 0 });
+    expect(await readHostState(async () => null)).toBeNull();
+  });
+});

--- a/src/host-state.ts
+++ b/src/host-state.ts
@@ -1,0 +1,136 @@
+/**
+ * The daemon's host-state, reduced to what Redwall draws from it.
+ *
+ * `redskilled host-state` answers with everything the RedSkills daemon knows
+ * about this machine — ceilings, budgets, registrations, birth latches, the
+ * version it is holding at. Redwall wants one number out of that document:
+ * how many Workers are running right now. Everything else is read past.
+ *
+ * ## Absent is a value, not a failure
+ *
+ * The whole of this module is one rule: **never withhold half the
+ * information because the other half is unavailable.** Redwall composes a
+ * Worker count and a LAN address over the theme's art, and the address is
+ * resolved without the daemon's help. So a daemon that is not running, a
+ * document this build cannot parse, and a document whose version it does not
+ * recognise all produce the same thing — `null`, meaning "no Worker count" —
+ * and none of them throws. The Redwall that results carries the address
+ * alone, which is the picture the Spec settled on twice.
+ *
+ * `null` is therefore load-bearing, and it is not the same value as
+ * `{ workers: 0 }`. A host whose queue has drained reports zero; a host
+ * whose daemon is gone reports nothing. Collapsing the two would draw the
+ * same wallpaper for "the work is done" and "the machine went quiet", which
+ * is the one distinction the daemon's own document was built to preserve.
+ *
+ * ## Why the version is checked at all
+ *
+ * The daemon's contract is frozen and serves checkouts pinned to different
+ * bundle versions, so a red-dev built today will meet daemons older and
+ * newer than itself. `version` and `protocol_version` are how the document
+ * says which contract it was written against, and this build understands
+ * exactly one of each. Reading a document that declares another would be
+ * guessing that a field kept its meaning across a release that said it did
+ * not — and a guess that is wrong draws a confident, false number on
+ * someone's desktop.
+ */
+
+import { existsSync } from "node:fs";
+
+/** The document shape this build reads. Not a floor: an exact match. */
+export const HOST_STATE_VERSION = 1;
+
+/** The wire contract this build reads. Exact for the same reason. */
+export const HOST_STATE_PROTOCOL_VERSION = 1;
+
+/** What Redwall takes from the daemon. `null` in place of this is "unknown". */
+export interface HostState {
+  /** Workers running on this machine right now; zero is a real answer. */
+  readonly workers: number;
+}
+
+/**
+ * The Worker count in a parsed host-state document, or null. PURE.
+ *
+ * Fail-closed by construction: every path that is not a document of the
+ * exact version this build understands, carrying a Worker array, returns
+ * null. `workers.length` rather than the `projects` block, because
+ * `projects` is that same array grouped by label — one source, so the two
+ * can never be seen to disagree — and rather than `ceiling.worker_count`,
+ * which is what the machine would allow and not what it is running.
+ */
+export function hostStateFrom(value: unknown): HostState | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return null;
+  const state = value as Record<string, unknown>;
+  if (state["version"] !== HOST_STATE_VERSION) return null;
+  if (state["protocol_version"] !== HOST_STATE_PROTOCOL_VERSION) return null;
+  const workers = state["workers"];
+  if (!Array.isArray(workers)) return null;
+  return { workers: workers.length };
+}
+
+/**
+ * The same, from the JSON text the daemon printed. PURE.
+ *
+ * Text that is not JSON is a daemon that answered with something else — an
+ * error line, a truncated write, a stub on a machine where the bundle was
+ * never built. All of it means the same thing here, and none of it is worth
+ * an exception the caller would have to catch to keep its address.
+ */
+export function parseHostState(text: string | null | undefined): HostState | null {
+  if (text == null || text.trim() === "") return null;
+  try {
+    return hostStateFrom(JSON.parse(text));
+  } catch {
+    return null;
+  }
+}
+
+/** Produces the host-state document as text, or null when there is none. */
+export type HostStateSource = () => Promise<string | null>;
+
+/**
+ * Ask for host-state and reduce it, or answer null.
+ *
+ * The source is injected so the two cases that matter — a daemon that is not
+ * running and a daemon whose document this build cannot read — are testable
+ * without a machine in either state. A source that rejects is caught here
+ * rather than at the caller, because "the command is not installed" is the
+ * ordinary condition on a machine that only ever wanted the wallpaper, and
+ * an ordinary condition must not travel as an exception.
+ */
+export async function readHostState(
+  source: HostStateSource = askRedskilled,
+): Promise<HostState | null> {
+  try {
+    return parseHostState(await source());
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The default source: the `redskilled` entry point in the red-skills checkout.
+ *
+ * A read and only a read. `host-state` reaches for the daemon's socket and
+ * never starts it, which is the property that lets a wallpaper regenerate
+ * without a cosmetic feature becoming what births a machine-wide singleton.
+ *
+ * A checkout that is absent, or present without its built bundle, exits
+ * non-zero or prints nothing — and both arrive here as null, which is the
+ * same answer a stopped daemon gives. That is deliberate: red-dev has no
+ * repair to offer for either, and the Redwall it draws is identical.
+ */
+async function askRedskilled(): Promise<string | null> {
+  const home = (process.env["HOME"] ?? process.env["USERPROFILE"] ?? "").replace(/\\/g, "/");
+  if (home === "") return null;
+  const bin = `${home}/.red-skills/current/packaging/npm/bin/red-skills-redskilled.mjs`;
+  if (!existsSync(bin)) return null;
+  const proc = Bun.spawn(["node", bin, "host-state"], {
+    stdout: "pipe",
+    stderr: "ignore",
+    stdin: "ignore",
+  });
+  const out = await new Response(proc.stdout).text();
+  return (await proc.exited) === 0 ? out : null;
+}


### PR DESCRIPTION
Automated AFK landing for #55. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #55

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788806505&installation_model_id=20659&pr_number=76&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F76&signature=62568e7993ae0efca88503b4275eeeb18c9bb62ee6b450fc3faba0c9e36b1268"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->