### PR TITLE
chore: #56 Redwall preference: first-run question, stored setting, menu entry

### DIFF
--- a/src/firstrun.ts
+++ b/src/firstrun.ts
@@ -55,6 +55,31 @@ type SetupChoices = { agents?: string[]; runtimes: string[]; apps: string[] };
 
 const NON_SKILL_HOSTS = new Set(["claude-desktop", "codex-desktop", "t3code"]);
 
+/**
+ * What the interview's answers mean as recorded preferences.
+ *
+ * Built here rather than at each call site because there are two of
+ * them — the fullscreen menu hosts the same interview `install` runs —
+ * and they were the same object literal written twice. That is the shape
+ * a new answer gets dropped from: adding it to one leaves the other
+ * silently discarding what the person just said.
+ */
+export function preferencesFromAnswers(answers: SetupAnswers): Preferences {
+  return {
+    setupCompleted: true,
+    theme: answers.theme,
+    font: answers.font,
+    blesh: answers.blesh,
+    redwall: answers.redwall,
+    agents: answers.agents,
+    runtimes: answers.runtimes,
+    ...(answers.terminalShell ? { terminalShell: answers.terminalShell } : {}),
+    ...(answers.terminalShell === "wsl" && process.env["WSL_DISTRO_NAME"]
+      ? { distro: process.env["WSL_DISTRO_NAME"] }
+      : {}),
+  };
+}
+
 /** The exact units the pre-converge setup is about to perform. */
 export async function setupPlan(p: Platform, choices: SetupChoices): Promise<SetupPlanStep[]> {
   const { agentInstallMethod, availableAgents } = await import("./agents.ts");
@@ -152,18 +177,7 @@ export async function applySetupAnswers(
     }
   }
 
-  await writePreferences(p, {
-    setupCompleted: true,
-    theme: answers.theme,
-    font: answers.font,
-    blesh: answers.blesh,
-    agents: answers.agents,
-    runtimes: answers.runtimes,
-    ...(answers.terminalShell ? { terminalShell: answers.terminalShell } : {}),
-    ...(answers.terminalShell === "wsl" && process.env["WSL_DISTRO_NAME"]
-      ? { distro: process.env["WSL_DISTRO_NAME"] }
-      : {}),
-  });
+  await writePreferences(p, preferencesFromAnswers(answers));
   await writeShellEnv(p, answers.blesh);
   await carryOutChoices(p, {
     agents: answers.agents,
@@ -342,18 +356,7 @@ export async function askFirstRun(p: Platform): Promise<FirstRunChoices | null> 
       }
     }
 
-    await writePreferences(p, {
-      setupCompleted: true,
-      theme: answers.theme,
-      font: answers.font,
-      blesh: answers.blesh,
-      agents: answers.agents,
-      runtimes: answers.runtimes,
-      ...(answers.terminalShell ? { terminalShell: answers.terminalShell } : {}),
-      ...(answers.terminalShell === "wsl" && process.env["WSL_DISTRO_NAME"]
-        ? { distro: process.env["WSL_DISTRO_NAME"] }
-        : {}),
-    });
+    await writePreferences(p, preferencesFromAnswers(answers));
 
     return {
       theme: answers.theme,
@@ -457,6 +460,16 @@ export async function askFirstRun(p: Platform): Promise<FirstRunChoices | null> 
     DEFAULT_THEME,
   );
 
+  // 7. And whether that wallpaper reports on the machine it is sitting
+  //    on. Asked after the theme because it draws over whatever the
+  //    theme chose, and defaulted to no because a desktop is somebody's
+  //    own — the menu is where anyone who wants it turns it on.
+  log.plain("");
+  log.plain("     Redwall draws live machine state over the theme's wallpaper —");
+  log.plain("     Workers running, and the address this machine answers on —");
+  log.plain("     so the lock screen reports without being unlocked.");
+  const redwall = await confirm("Enable Redwall?", false);
+
   const choices: FirstRunChoices = {
     theme,
     font,
@@ -470,6 +483,7 @@ export async function askFirstRun(p: Platform): Promise<FirstRunChoices | null> 
     theme,
     font,
     blesh,
+    redwall,
     runtimes: choices.runtimes,
     ...(terminalShell ? { terminalShell } : {}),
     ...(terminalShell === "wsl" && process.env["WSL_DISTRO_NAME"]

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -111,6 +111,36 @@ async function fontMenu(p: Platform, h: Handlers): Promise<void> {
   }
 }
 
+/**
+ * Redwall, on or off.
+ *
+ * A preference and nothing else for now: no image is generated or
+ * applied yet, so this submenu records an intent rather than repainting
+ * a desktop. It is still the surface that matters — Redwall is off on
+ * every machine until somebody comes here, which is the trade for not
+ * asking twice at first boot.
+ *
+ * Read fresh on entry rather than passed in, so the current state shown
+ * is the file's and not a snapshot the menu loop has been holding since
+ * it started.
+ */
+async function redwallMenu(p: Platform): Promise<void> {
+  const on = "On — draw machine state over the wallpaper";
+  const off = "Off — leave the wallpaper as the theme set it";
+  const current = (await readPreferences(p)).redwall === true;
+
+  const picked = await select(
+    `Redwall? (current: ${current ? "on" : "off"})`,
+    [on, off, BACK] as const,
+    current ? on : off,
+  );
+  if (picked === BACK) return;
+
+  const next = picked === on;
+  await writePreferences(p, { redwall: next });
+  log.ok(`redwall: ${next ? "on" : "off"}`);
+}
+
 export async function runMenu(
   p: Platform,
   inv: Invocation,
@@ -131,6 +161,7 @@ export async function runMenu(
       "Install — converge this machine",
       "Theme — colour scheme",
       "Font — family and size",
+      "Redwall — machine state on the wallpaper",
       "Apps — optional tools",
       "Languages — runtimes mise manages",
       ...(wslish ? ["Shell — where a terminal lands"] : []),
@@ -154,6 +185,9 @@ export async function runMenu(
         break;
       case "Font":
         await fontMenu(p, h);
+        break;
+      case "Redwall":
+        await redwallMenu(p);
         break;
       case "Apps":
         last = await h.apps();

--- a/src/preferences.ts
+++ b/src/preferences.ts
@@ -39,6 +39,15 @@ export interface Preferences {
   /** Terminal font size in points. omakub offers 7 to 14. */
   fontSize?: number;
   blesh?: boolean;
+  /**
+   * Whether the wallpaper carries live machine state — see Redwall in
+   * .red/contexts/visual/CONTEXT.md.
+   *
+   * Absent means off, and the absence is the setting rather than a gap
+   * waiting to be filled: a machine that has never been asked has not
+   * agreed to have its desktop written over.
+   */
+  redwall?: boolean;
   /** Agent keys chosen for this workstation, mirrored into WSL when selected. */
   agents?: string[];
   /** mise runtime ids chosen for this workstation. */
@@ -89,6 +98,23 @@ export async function resolveTerminalShell(p: Platform): Promise<TerminalShell> 
   const prefs = await readPreferences(p);
   if (prefs.terminalShell) return prefs.terminalShell;
   return p.env === "wsl" ? "wsl" : "gitbash";
+}
+
+/**
+ * Whether Redwall is on for this machine.
+ *
+ * Off unless someone said otherwise. ADR 0003 settled the same question
+ * one surface over — a terminal's colours are not red-dev's to choose —
+ * and a desktop someone looks at all day is no more red-dev's to write
+ * over because a converge happened to run.
+ *
+ * `=== true` rather than a truthy read, because this file is JSON a
+ * person can edit and "off" written as a string should not turn a
+ * desktop into a dashboard.
+ */
+export async function resolveRedwall(p: Platform): Promise<boolean> {
+  const prefs = await readPreferences(p);
+  return prefs.redwall === true;
 }
 
 export type ApplyContextEntryPath = "plan" | "install" | "update" | "theme";

--- a/src/redwall.test.ts
+++ b/src/redwall.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Redwall is off until someone says otherwise.
+ *
+ * The default is the whole of this slice's risk. Nothing generates or
+ * applies an image yet, so a wrong preference costs nothing today — but
+ * the moment something does read it, a default of "on" means red-dev
+ * rewrites a desktop nobody offered it. That is the overreach ADR 0003
+ * reversed one surface over, and it is far easier to keep than to undo.
+ *
+ * So the first three tests are the same assertion approached from three
+ * directions: no file, a file with other answers in it, and a file with
+ * the question answered no. Flipping the default fails all three.
+ */
+
+import { existsSync, mkdirSync, mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { describe, expect, test } from "bun:test";
+import { readPreferences, resolveRedwall, writePreferences } from "./preferences.ts";
+import { preferencesFromAnswers } from "./firstrun.ts";
+import type { SetupAnswers } from "./tui-setup-model.ts";
+import type { Platform } from "./platform.ts";
+
+const linux: Platform = {
+  os: "linux",
+  distro: "ubuntu",
+  version: "24.04",
+  codename: "noble",
+  env: "desktop",
+  arch: "x64",
+  caps: { apt: true, gui: false, systemd: true, winget: false, flatpak: true },
+};
+
+/** A machine with nothing on it, torn down with the process. */
+async function onFreshMachine<T>(run: (home: string) => Promise<T>): Promise<T> {
+  const previous = process.env["HOME"];
+  const home = mkdtempSync(`${tmpdir()}/red-dev-redwall-`);
+  process.env["HOME"] = home;
+  try {
+    return await run(home);
+  } finally {
+    if (previous === undefined) delete process.env["HOME"];
+    else process.env["HOME"] = previous;
+  }
+}
+
+const prefsPath = (home: string): string => `${home}/.config/alacritty/red-dev.json`;
+
+/** The interview answered with everything at its preset. */
+function answers(overrides: Partial<SetupAnswers> = {}): SetupAnswers {
+  return {
+    theme: "dark",
+    font: "firacode",
+    apps: [],
+    runtimes: [],
+    agents: [],
+    blesh: false,
+    redwall: false,
+    share: false,
+    completed: true,
+    ...overrides,
+  };
+}
+
+describe("redwall, before anyone has been asked", () => {
+  test("is off on a machine with no preferences at all", async () => {
+    await onFreshMachine(async (home) => {
+      expect(await resolveRedwall(linux)).toBe(false);
+      // And reading it wrote nothing. A default that has to be
+      // materialised to be read is a decision recorded on somebody's
+      // behalf.
+      expect(existsSync(prefsPath(home))).toBe(false);
+    });
+  });
+
+  test("is off on a machine set up before the question existed", async () => {
+    // Every machine red-dev has already configured has a preferences
+    // file with setupCompleted in it and no redwall key. An upgrade must
+    // not read that silence as consent.
+    await onFreshMachine(async (home) => {
+      mkdirSync(`${home}/.config/alacritty`, { recursive: true });
+      await Bun.write(
+        prefsPath(home),
+        JSON.stringify({ setupCompleted: true, theme: "cobalt", font: "hack" }) + "\n",
+      );
+      expect(await resolveRedwall(linux)).toBe(false);
+    });
+  });
+
+  test("is off for anything recorded that is not the boolean true", async () => {
+    // This file is JSON a person can open and edit, and "off" is a
+    // string. A truthy read would turn a desktop into a dashboard on the
+    // strength of someone writing the word they meant to disable it.
+    await onFreshMachine(async (home) => {
+      mkdirSync(`${home}/.config/alacritty`, { recursive: true });
+      await Bun.write(prefsPath(home), JSON.stringify({ redwall: "off" }) + "\n");
+      expect(await resolveRedwall(linux)).toBe(false);
+    });
+  });
+});
+
+describe("the first-run answer", () => {
+  test("declining leaves it off", async () => {
+    await onFreshMachine(async () => {
+      await writePreferences(linux, preferencesFromAnswers(answers({ redwall: false })));
+      expect(await resolveRedwall(linux)).toBe(false);
+    });
+  });
+
+  test("accepting records it", async () => {
+    await onFreshMachine(async () => {
+      await writePreferences(linux, preferencesFromAnswers(answers({ redwall: true })));
+      expect(await resolveRedwall(linux)).toBe(true);
+    });
+  });
+
+  test("is asked, and asked with declining as the answer enter gives", () => {
+    // A single-choice step commits whatever the cursor is on and the
+    // cursor starts at zero, so the first choice is the real default —
+    // `preset` is what the timeline shows, not what enter selects. Both
+    // are checked, because agreeing with each other is the only way the
+    // interview and its display say the same thing.
+    const src = readFileSync("src/tui-setup-model.ts", "utf8");
+    const block = src.slice(src.indexOf('id: "redwall"'));
+    const step = block.slice(0, block.indexOf("applies:"));
+    expect(step).toContain("Redwall");
+    expect(step.indexOf('key: "no"')).toBeGreaterThan(-1);
+    expect(step.indexOf('key: "no"')).toBeLessThan(step.indexOf('key: "yes"'));
+    expect(step).toContain('preset: ["no"]');
+  });
+
+  test("is carried out of both interviews", () => {
+    // The fullscreen menu and the standalone first run map the wizard's
+    // answers separately. A question only one of them reads is a
+    // question the other silently discards.
+    const model = readFileSync("src/tui-setup-model.ts", "utf8");
+    const tui = readFileSync("src/tui-setup.ts", "utf8");
+    for (const src of [model, tui]) {
+      expect(src).toContain('redwall: get("redwall")[0] === "yes"');
+    }
+  });
+
+  test("the linear fallback asks it too", () => {
+    // Terminals under 60 columns get the prompt sequence rather than the
+    // wizard, and a question that exists on only one of those paths is
+    // one somebody never gets asked.
+    const src = readFileSync("src/firstrun.ts", "utf8");
+    expect(src).toContain('confirm("Enable Redwall?", false)');
+    expect(src).toContain("redwall,");
+  });
+});
+
+describe("the menu", () => {
+  test("changes the preference, and the change survives a reload", async () => {
+    await onFreshMachine(async () => {
+      // What redwallMenu does with the answer, on the same seam it uses.
+      await writePreferences(linux, { redwall: true });
+      expect(await resolveRedwall(linux)).toBe(true);
+
+      // Reloaded, because the point of a preference is that the next
+      // process reads it rather than the current one remembering it.
+      expect((await readPreferences(linux)).redwall).toBe(true);
+
+      await writePreferences(linux, { redwall: false });
+      expect(await resolveRedwall(linux)).toBe(false);
+    });
+  });
+
+  test("turning it on does not disturb the answers beside it", async () => {
+    await onFreshMachine(async () => {
+      await writePreferences(linux, preferencesFromAnswers(answers({ theme: "cobalt" })));
+      await writePreferences(linux, { redwall: true });
+
+      const prefs = await readPreferences(linux);
+      expect(prefs).toMatchObject({ redwall: true, theme: "cobalt", setupCompleted: true });
+    });
+  });
+
+  test("offers it as an entry of its own", () => {
+    const src = readFileSync("src/menu.ts", "utf8");
+    // The verb the menu switches on is the first word of the entry.
+    expect(src).toContain('"Redwall — machine state on the wallpaper"');
+    expect(src).toContain('case "Redwall":');
+  });
+});

--- a/src/tui-setup-model.ts
+++ b/src/tui-setup-model.ts
@@ -37,6 +37,8 @@ export interface SetupAnswers {
   runtimes: string[];
   agents: string[];
   blesh: boolean;
+  /** Whether the wallpaper carries live machine state. Off unless asked for. */
+  redwall: boolean;
   terminalShell?: "wsl" | "gitbash";
   /** Whether to set up the one directory both environments read. */
   share: boolean;
@@ -220,6 +222,30 @@ export function questions(
       preset: [DEFAULT_THEME],
       applies: () => true,
     },
+    {
+      // After Theme, because it composes on the wallpaper that answer
+      // chooses rather than replacing it — and last, because it is the
+      // only question here whose honest default is "no".
+      id: "redwall",
+      title: "Redwall",
+      description:
+        "The theme's wallpaper with live machine state drawn over it: how many " +
+        "Workers are running and the address this machine answers on, readable " +
+        "from the lock screen without unlocking it. The art underneath is " +
+        "unchanged — Redwall composes on top, never in place of it.",
+      multi: false,
+      choices: [
+        // Declining first, and that ordering is load-bearing. A
+        // single-choice step commits whatever the cursor is on, and the
+        // cursor starts at zero — so the answer someone gets for
+        // pressing enter through the interview is the one at the top of
+        // this list, not the one named in `preset`.
+        { key: "no", label: "Leave the wallpaper alone", note: "the default" },
+        { key: "yes", label: "Draw machine state on it", note: "desktop and lock screen" },
+      ],
+      preset: ["no"],
+      applies: () => true,
+    },
   ].filter((q) => q.applies(p));
 }
 
@@ -281,6 +307,7 @@ export function useSetupModel(steps: Question[], wizard: ReturnType<typeof creat
       runtimes: get("runtimes"),
       agents: get("agents"),
       blesh: get("plugins").includes("blesh"),
+      redwall: get("redwall")[0] === "yes",
       share: get("share")[0] === "yes",
       ...(get("shell")[0] ? { terminalShell: get("shell")[0] as "wsl" | "gitbash" } : {}),
       completed: true,

--- a/src/tui-setup.ts
+++ b/src/tui-setup.ts
@@ -91,6 +91,7 @@ export async function runSetupTui(
           runtimes: get("runtimes"),
           agents: get("agents"),
           blesh: get("plugins").includes("blesh"),
+          redwall: get("redwall")[0] === "yes",
           share: get("share")[0] === "yes",
           ...(get("shell")[0] ? { terminalShell: get("shell")[0] as "wsl" | "gitbash" } : {}),
           completed: true,


### PR DESCRIPTION
Automated AFK landing for #56. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #56

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788806520&installation_model_id=20659&pr_number=77&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F77&signature=c56f786f3f55668375c7ed45a6e713d40eb6cd2f3cc1d041866e08518f66bf05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->