### PR TITLE
chore: #65 Declare which manifest items need administrator, per platform

### DIFF
--- a/src/manifest.test.ts
+++ b/src/manifest.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, test } from "bun:test";
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
 import {
   TOOLS,
   applicableScopes,
   describeProvider,
   isInstalled,
+  itemsNeedingAdmin,
+  needsAdmin,
   providerFor,
   toolsInScope,
   type Tool,
@@ -229,6 +231,102 @@ describe("the manifest itself", () => {
         if (!provider) continue;
         expect(describeProvider(provider)).not.toContain("undefined");
       }
+    }
+  });
+});
+
+/**
+ * PowerShell an unelevated session cannot run at all.
+ *
+ * Every one of these returns access-denied without administrator, which
+ * is what makes the manifest's declaration checkable instead of a claim
+ * somebody typed. Self-elevation is deliberately not on the list:
+ * `Start-Process -Verb RunAs` runs perfectly well unelevated — raising a
+ * prompt is what it does — so finding it says nothing about whether the
+ * item's own work needs rights.
+ */
+const ADMIN_OPERATIONS = [
+  "Add-WindowsCapability",
+  "Enable-WindowsOptionalFeature",
+  "New-NetFirewallRule",
+  "Set-Service",
+  "Start-Service",
+  "Stop-Service",
+];
+
+/**
+ * Which manifest item each privileged module implements.
+ *
+ * Written down rather than derived from the filename, because only some
+ * builtins are named after their module. Both directions are asserted
+ * below, so this cannot quietly drift from the code it describes.
+ */
+const PRIVILEGED_MODULES: Record<string, string> = {
+  "ssh-server.ts": "ssh-server",
+};
+
+/**
+ * A module's code with its comments removed.
+ *
+ * ssh-server.ts explains Add-WindowsCapability at length before running
+ * it, and a prose mention is not a call — without this, documenting the
+ * problem somewhere would be enough to trip the check.
+ */
+function codeOf(file: string): string {
+  return readFileSync(`src/${file}`, "utf8")
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/^\s*\/\/.*$/gm, "");
+}
+
+function runsPrivilegedOperations(file: string): boolean {
+  const code = codeOf(file);
+  return ADMIN_OPERATIONS.some((op) => code.includes(op));
+}
+
+describe("items that need administrator", () => {
+  test("a Windows target names them", () => {
+    // The answer arrives from data, with nothing executed and no Windows
+    // host in sight — which is the whole point: `plan` has to be able to
+    // announce this before the first install rather than after item 36.
+    expect(itemsNeedingAdmin(WINDOWS).map((t) => t.name)).toEqual(["ssh-server"]);
+  });
+
+  test("a Linux target needs administrator for nothing", () => {
+    // Not symmetrical, and that asymmetry is the reason the declaration
+    // sits on the provider column rather than on the tool: Ubuntu
+    // installs openssh-server through the same sudo path as every other
+    // apt package, and must not be charged for a Windows requirement.
+    for (const p of [DESKTOP, WSL24, WSL26, platform({ env: "server" })]) {
+      expect(itemsNeedingAdmin(p)).toEqual([]);
+    }
+  });
+
+  test("the SSH server declares it on Windows and not on Ubuntu", () => {
+    const tool = TOOLS.find((t) => t.name === "ssh-server");
+    expect(needsAdmin(providerFor(tool!, WINDOWS))).toBe(true);
+    expect(needsAdmin(providerFor(tool!, WSL24))).toBe(false);
+    expect(needsAdmin(providerFor(tool!, WSL26))).toBe(false);
+  });
+
+  test("every module running privileged operations is accounted for", () => {
+    // The half that catches a provider which quietly starts needing
+    // administrator: a new module reaching for one of these cmdlets
+    // fails here until somebody says which item it belongs to, and a
+    // module that stops needing them fails here until it is removed.
+    const found = readdirSync("src")
+      .filter((f) => f.endsWith(".ts") && !f.endsWith(".test.ts"))
+      .filter(runsPrivilegedOperations)
+      .sort();
+    expect(found).toEqual(Object.keys(PRIVILEGED_MODULES).sort());
+  });
+
+  test("and each of them declares it in the manifest", () => {
+    // Delete `admin(...)` from the ssh-server row and this is what goes
+    // red, while the PowerShell that needs the rights sits untouched.
+    for (const [file, name] of Object.entries(PRIVILEGED_MODULES)) {
+      const tool = TOOLS.find((t) => t.name === name);
+      expect(tool).toBeDefined();
+      expect([file, needsAdmin(tool!.win)]).toEqual([file, true]);
     }
   });
 });

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -28,7 +28,13 @@ export type Scope =
    */
   | "optional";
 
-export type Provider =
+/**
+ * The provider shapes, before the flags that apply to all of them.
+ *
+ * Split from `Provider` so a cross-cutting flag is declared once instead
+ * of being repeated on nine members and forgotten on the tenth.
+ */
+type ProviderSpec =
   | { kind: "apt"; pkg: string }
   | { kind: "winget"; id: string }
   /**
@@ -116,6 +122,29 @@ export type Provider =
     }
   /** Not installed here, deliberately. The reason is required. */
   | { kind: "skip"; reason: string };
+
+/** One column of the manifest: how this platform gets this tool. */
+export type Provider = ProviderSpec & {
+  /**
+   * This column cannot complete without administrator rights.
+   *
+   * Declared per column, never per tool, because the need is not
+   * symmetrical. The Windows OpenSSH server is a capability to add, a
+   * service to set Automatic and a firewall rule to open — three
+   * administrator operations — while the same item on Ubuntu is an apt
+   * package taking the ordinary sudo path. A Linux target must not be
+   * asked to elevate for a Windows requirement.
+   *
+   * Data, so `plan` can answer "will this ask for administrator" without
+   * executing anything, and so a test can name the set on each target
+   * with no Windows host in sight.
+   *
+   * `true` only. Absence is the answer for everything else, and a
+   * `needsAdmin: false` sprinkled through the manifest would read as a
+   * checked claim where it is only the default.
+   */
+  needsAdmin?: true;
+};
 
 export interface Tool {
   /** Stable logical name — what the user thinks they have. */
@@ -239,6 +268,14 @@ const builtin = (
     | "ssh-server",
 ): Provider => ({ kind: "builtin", name });
 const skip = (reason: string): Provider => ({ kind: "skip", reason });
+/**
+ * Wraps a column that cannot complete without administrator rights.
+ *
+ * A wrapper rather than a field on every helper, so the declaration
+ * reads as what it is at the call site — `admin(builtin("ssh-server"))`
+ * says the Windows column needs rights and the row above it does not.
+ */
+const admin = (pr: ProviderSpec): Provider => ({ ...pr, needsAdmin: true });
 
 const NO_GUI = "no GUI layer on this target";
 const HOST_PROVIDES = "the Windows host provides this instead";
@@ -286,11 +323,19 @@ export const TOOLS: Tool[] = [
     // `core`, so every converge opens the port. That is a deliberate
     // decision rather than an oversight; src/ssh-server.ts says what it
     // costs, and the converge logs it instead of a silent ok.
+    //
+    // The Windows column is the manifest's first `admin`, and adding the
+    // item is what made the declaration necessary: until it arrived, no
+    // red-dev converge had ever needed administrator, and the run that
+    // discovered otherwise did so at the item itself — a warning buried
+    // in a summary that still reported success. Ubuntu keeps the plain
+    // column: apt-get through sudo is the path every other package here
+    // already takes.
     name: "ssh-server",
     scope: "core",
     managed: true,
     u24: builtin("ssh-server"),
-    win: builtin("ssh-server"),
+    win: admin(builtin("ssh-server")),
   },
   {
     // Sourced by config/bash/init.sh since before it was ever declared
@@ -925,6 +970,29 @@ export function applicableScopes(p: Platform): Scope[] {
   if (p.caps.gui) scopes.push("desktop");
   if (p.env === "wsl") scopes.push("wsl");
   return scopes;
+}
+
+/** Does this column need administrator rights to complete? */
+export function needsAdmin(pr: Provider): boolean {
+  return pr.needsAdmin === true;
+}
+
+/**
+ * The items this target will ask administrator for, in manifest order.
+ *
+ * Answered from the declarations alone: nothing is executed, no
+ * PowerShell is parsed and no Windows host is required, which is what
+ * lets the question be settled before the converge starts rather than at
+ * the item that needs the rights.
+ *
+ * Scoped to what a plain converge touches, so the answer describes what
+ * is about to happen rather than everything the manifest could install.
+ * On every Linux target the set is empty — sudo is a separate path that
+ * already works, and this must not disturb it.
+ */
+export function itemsNeedingAdmin(p: Platform): Tool[] {
+  const scopes = applicableScopes(p);
+  return TOOLS.filter((t) => scopes.includes(t.scope) && needsAdmin(providerFor(t, p)));
 }
 
 /**

--- a/src/ssh-server.test.ts
+++ b/src/ssh-server.test.ts
@@ -43,9 +43,13 @@ describe("the manifest entry", () => {
     const tool = TOOLS.find((t) => t.name === "ssh-server");
     expect(tool?.scope).toBe("core");
     expect(providerFor(tool!, platform())).toEqual({ kind: "builtin", name: "ssh-server" });
+    // Same builtin on both, and one extra word on the Windows column:
+    // the capability, the service and the firewall rule all need
+    // administrator, while Ubuntu's apt-get takes the usual sudo path.
     expect(providerFor(tool!, platform({ os: "windows", env: "windows" }))).toEqual({
       kind: "builtin",
       name: "ssh-server",
+      needsAdmin: true,
     });
   });
 


### PR DESCRIPTION
Automated AFK landing for #65. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #65

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788806994&installation_model_id=20659&pr_number=78&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F78&signature=00ba4a4566037113c177a1f1939a02e50819b4905b404c6e9ec3f3aade518337"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->