### PR TITLE
chore: #62 Pin a specific interface for the address Redwall reports

### DIFF
--- a/src/lan-address.test.ts
+++ b/src/lan-address.test.ts
@@ -1,11 +1,17 @@
+import { mkdirSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { describe, expect, test } from "bun:test";
 import type { Platform } from "./platform.ts";
+import { writePreferences } from "./preferences.ts";
 import {
+  addressFor,
   addressFromRoutes,
   parseLinuxAddresses,
   parseLinuxDefaultRoutes,
   parseWindowsNetState,
   resolveLanAddress,
+  resolveRedwallAddress,
+  routableInterfaces,
 } from "./lan-address.ts";
 
 /**
@@ -171,6 +177,88 @@ describe("reading what Linux reports", () => {
   });
 });
 
+/**
+ * A pin is an override, so every test here is written as a comparison
+ * with what the default route would have said. A pin that happens to
+ * agree with the route proves nothing about either.
+ */
+describe("pinning an interface", () => {
+  const linuxState = {
+    routes: parseLinuxDefaultRoutes(LINUX_ROUTES),
+    addresses: parseLinuxAddresses(LINUX_ADDRESSES),
+  };
+  const roamed = parseWindowsNetState(WINDOWS_ROAMED);
+
+  test("nothing pinned leaves the default route in charge", () => {
+    expect(addressFor(linuxState, null)).toBe("192.168.1.42");
+    expect(addressFor(roamed, null)).toBe("192.168.4.77");
+  });
+
+  test("a pinned interface is reported even though the route points elsewhere", () => {
+    // The route leaves by enp3s0; this machine is reached on the Wi-Fi.
+    expect(addressFor(linuxState, "wlp2s0")).toBe("10.42.0.19");
+    // And the Windows shape of the same case: the LAN answers on Wi-Fi,
+    // the person wants the address the VM network can see.
+    expect(addressFor(roamed, "vEthernet (WSL)")).toBe("172.28.16.1");
+  });
+
+  test("a pin naming an interface that is gone falls back to the default route", () => {
+    // The VPN was up when the pin was made and is not up now.
+    expect(addressFor(linuxState, "tun0")).toBe("192.168.1.42");
+    expect(addressFor(roamed, "Ethernet 9")).toBe("192.168.4.77");
+  });
+
+  test("a pin naming an interface with no usable address falls back too", () => {
+    // Present, and holding nothing another machine could reach:
+    // loopback never leaves the host, and the unplugged adapter's APIPA
+    // address means DHCP found nobody.
+    expect(addressFor(linuxState, "lo")).toBe("192.168.1.42");
+    expect(addressFor(roamed, "Ethernet")).toBe("192.168.4.77");
+  });
+
+  test("the name is matched the way a person would have typed it", () => {
+    // "vEthernet (WSL)" is an adapter alias read off a screen, and the
+    // case it is read in is not the pin's meaning.
+    expect(addressFor(roamed, "  VETHERNET (WSL)  ")).toBe("172.28.16.1");
+  });
+
+  test("an empty pin is not a pin", () => {
+    expect(addressFor(linuxState, "")).toBe("192.168.1.42");
+    expect(addressFor(linuxState, "   ")).toBe("192.168.1.42");
+  });
+
+  test("a pin invents no answer on a machine that has none", () => {
+    // Falling back to the default route is falling back to nothing here,
+    // and nothing is the honest answer — an unreachable address looks
+    // exactly like one that works.
+    const offline = parseWindowsNetState(WINDOWS_OFFLINE);
+    expect(addressFor(offline, "Ethernet")).toBeNull();
+    expect(addressFor(offline, "Wi-Fi")).toBeNull();
+  });
+});
+
+describe("the interfaces worth offering as a pin", () => {
+  test("are the ones holding an address another machine could reach", () => {
+    // Loopback and the disconnected adapter are left out: pinning them
+    // is pinning the fallback, which is a menu entry that does nothing.
+    expect(routableInterfaces(parseWindowsNetState(WINDOWS_MEASURED))).toEqual([
+      { name: "vEthernet (WSL)", address: "172.28.16.1" },
+      { name: "Ethernet", address: "192.168.1.42" },
+    ]);
+  });
+
+  test("are listed once each, however many addresses they hold", () => {
+    const twice = {
+      routes: [],
+      addresses: [
+        { interfaceName: "eth0", interfaceIndex: 2, address: "192.168.1.42" },
+        { interfaceName: "eth0", interfaceIndex: 2, address: "10.0.0.5" },
+      ],
+    };
+    expect(routableInterfaces(twice)).toEqual([{ name: "eth0", address: "192.168.1.42" }]);
+  });
+});
+
 describe("resolving on a real machine", () => {
   test("a Linux desktop asks the local route table", async () => {
     const { capture, asked } = fakeCapture([
@@ -207,5 +295,54 @@ describe("resolving on a real machine", () => {
     const { capture, asked } = fakeCapture([[/./, { out: LINUX_ROUTES }]]);
     expect(await resolveLanAddress(platform({ os: "darwin" }), capture)).toBeNull();
     expect(asked).toEqual([]);
+  });
+});
+
+/**
+ * `addressFor` proves the rule; these prove the stored preference is the
+ * thing the rule is given. A pin nothing reads is a setting that lies,
+ * and it lies in the direction of "I already told you which interface".
+ */
+describe("the address Redwall reports", () => {
+  const desktop = platform({ env: "desktop" });
+
+  /** A machine with no preferences, torn down with the process. */
+  async function onFreshMachine<T>(run: () => Promise<T>): Promise<T> {
+    const previous = process.env["HOME"];
+    const home = mkdtempSync(`${tmpdir()}/red-dev-pin-`);
+    mkdirSync(`${home}/.config/alacritty`, { recursive: true });
+    process.env["HOME"] = home;
+    try {
+      return await run();
+    } finally {
+      if (previous === undefined) delete process.env["HOME"];
+      else process.env["HOME"] = previous;
+    }
+  }
+
+  const machine = () =>
+    fakeCapture([
+      [/^ip -4 route show default$/, { out: LINUX_ROUTES }],
+      [/^ip -o -4 addr show$/, { out: LINUX_ADDRESSES }],
+    ]).capture;
+
+  test("is the default route's when nothing is pinned", async () => {
+    await onFreshMachine(async () => {
+      expect(await resolveRedwallAddress(desktop, machine())).toBe("192.168.1.42");
+    });
+  });
+
+  test("is the pinned interface's when one is set", async () => {
+    await onFreshMachine(async () => {
+      await writePreferences(desktop, { redwallInterface: "wlp2s0" });
+      expect(await resolveRedwallAddress(desktop, machine())).toBe("10.42.0.19");
+    });
+  });
+
+  test("is the default route's again once the pinned interface is gone", async () => {
+    await onFreshMachine(async () => {
+      await writePreferences(desktop, { redwallInterface: "tun0" });
+      expect(await resolveRedwallAddress(desktop, machine())).toBe("192.168.1.42");
+    });
   });
 });

--- a/src/lan-address.ts
+++ b/src/lan-address.ts
@@ -30,9 +30,25 @@
  *
  * Darwin is deliberately absent, failing closed as it does in
  * `providerFor` and per .red/adr/0001.
+ *
+ * ## When the route is not the answer
+ *
+ * The route is right about how packets leave and can still be wrong
+ * about how a person reaches this machine: a VPN carrying the default
+ * route while the laptop is wanted on the office LAN, a second NIC on
+ * the network everyone else is on. So an interface can be pinned, and a
+ * pin wins over the route.
+ *
+ * It wins only while it can. An interface that has gone away, or that
+ * holds nothing reachable, falls back to the default route rather than
+ * to nothing — a pin is a preference about which of several right
+ * answers to show, and it should not be able to turn into a wrong one
+ * because a VPN dropped. That is why the fallback is the rule above and
+ * not an error.
  */
 
 import type { Platform } from "./platform.ts";
+import { resolveRedwallInterface } from "./preferences.ts";
 import { readWindowsOutput } from "./windows-output.ts";
 
 /** A default route, as either platform describes one. */
@@ -122,6 +138,66 @@ export function addressFromRoutes(
     if (held) return held.address;
   }
   return null;
+}
+
+/**
+ * Interface names are compared the way they are read: off a screen,
+ * out of a menu, into a JSON file by hand. "vEthernet (WSL)" typed as
+ * "vethernet (wsl)" names the same adapter, and a pin that fails on
+ * capitalisation fails silently — it looks exactly like an interface
+ * that has gone away.
+ */
+function sameName(name: string | null, wanted: string): boolean {
+  return name !== null && name.trim().toLowerCase() === wanted;
+}
+
+/**
+ * The reachable address held on a named interface, or null when the
+ * machine has no such interface or it holds nothing worth showing.
+ *
+ * `isRoutable` applies here exactly as it does to the route's answer: an
+ * adapter sitting on its own 169.254 address has no address, whatever
+ * the pin says, and saying so is what lets the caller fall back.
+ */
+export function addressOnInterface(addresses: HostAddress[], name: string): string | null {
+  const wanted = name.trim().toLowerCase();
+  if (wanted === "") return null;
+  const held = addresses.find((a) => sameName(a.interfaceName, wanted) && isRoutable(a.address));
+  return held?.address ?? null;
+}
+
+/**
+ * The whole rule: the pinned interface when there is one and it can
+ * answer, the default route otherwise.
+ */
+export function addressFor(state: NetState, pin: string | null): string | null {
+  if (pin !== null) {
+    const pinned = addressOnInterface(state.addresses, pin);
+    if (pinned !== null) return pinned;
+  }
+  return addressFromRoutes(state.routes, state.addresses);
+}
+
+/**
+ * The interfaces worth offering as a pin: those holding an address
+ * another machine could reach, one entry each.
+ *
+ * Loopback and a disconnected adapter are left out because pinning them
+ * resolves to the default route anyway — a menu entry that does nothing
+ * is worse than an absent one, since choosing it looks like it worked.
+ */
+export function routableInterfaces(state: NetState): Array<{ name: string; address: string }> {
+  const found: Array<{ name: string; address: string }> = [];
+  const seen = new Set<string>();
+  for (const held of state.addresses) {
+    if (held.interfaceName === null || !isRoutable(held.address)) continue;
+    const name = held.interfaceName.trim();
+    const key = name.toLowerCase();
+    if (name === "" || seen.has(key)) continue;
+    seen.add(key);
+    found.push({ name, address: held.address });
+  }
+  return found;
 }
 
 // ----------------------------------------------------------------- linux
@@ -277,17 +353,49 @@ async function spawnCapture(cmd: string[]): Promise<Captured> {
 }
 
 /**
+ * What this machine says about its own addresses. WSL asks the Windows
+ * host; everything else asks itself.
+ *
+ * Exported because the menu offering a pin needs the same list this
+ * resolves against — offering an interface the resolver has never heard
+ * of is offering a pin that cannot work.
+ */
+export async function hostNetState(
+  p: Platform,
+  capture: Capture = spawnCapture,
+): Promise<NetState> {
+  if (p.os === "windows" || p.env === "wsl") return await windowsNetState(capture);
+  if (p.os === "linux") return await linuxNetState(capture);
+  return NOTHING;
+}
+
+/**
  * The address to show for this machine, or null when it has none worth
- * showing. WSL asks the Windows host; everything else asks itself.
+ * showing.
+ *
+ * The pin is a parameter rather than a read, so this stays the pure
+ * question "what does this machine answer on, given this preference" —
+ * `resolveRedwallAddress` is the one that knows where the preference is
+ * kept.
  */
 export async function resolveLanAddress(
   p: Platform,
   capture: Capture = spawnCapture,
+  pin: string | null = null,
 ): Promise<string | null> {
-  let state: NetState;
-  if (p.os === "windows" || p.env === "wsl") state = await windowsNetState(capture);
-  else if (p.os === "linux") state = await linuxNetState(capture);
-  else state = NOTHING;
+  return addressFor(await hostNetState(p, capture), pin);
+}
 
-  return addressFromRoutes(state.routes, state.addresses);
+/**
+ * The address Redwall reports: this machine's, through whatever the
+ * person configured.
+ *
+ * The entry point a caller wants. Reaching for `resolveLanAddress`
+ * without a pin is how a stored preference quietly stops being read.
+ */
+export async function resolveRedwallAddress(
+  p: Platform,
+  capture: Capture = spawnCapture,
+): Promise<string | null> {
+  return await resolveLanAddress(p, capture, await resolveRedwallInterface(p));
 }

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -12,11 +12,12 @@
  * over the commands, never the only way to reach something.
  */
 
+import { hostNetState, routableInterfaces } from "./lan-address.ts";
 import { log } from "./log.ts";
 import type { Platform } from "./platform.ts";
 import { readPreferences, writePreferences } from "./preferences.ts";
 import { resolveThemeSlug, themeFor, themeNames } from "./themes.ts";
-import { banner, number, select } from "./ui.ts";
+import { banner, number, select, text } from "./ui.ts";
 import type { Invocation } from "./cli.ts";
 import { summary } from "./platform.ts";
 
@@ -124,10 +125,9 @@ async function fontMenu(p: Platform, h: Handlers): Promise<void> {
  * is the file's and not a snapshot the menu loop has been holding since
  * it started.
  */
-async function redwallMenu(p: Platform): Promise<void> {
+async function redwallStateStep(p: Platform, current: boolean): Promise<void> {
   const on = "On — draw machine state over the wallpaper";
   const off = "Off — leave the wallpaper as the theme set it";
-  const current = (await readPreferences(p)).redwall === true;
 
   const picked = await select(
     `Redwall? (current: ${current ? "on" : "off"})`,
@@ -139,6 +139,66 @@ async function redwallMenu(p: Platform): Promise<void> {
   const next = picked === on;
   await writePreferences(p, { redwall: next });
   log.ok(`redwall: ${next ? "on" : "off"}`);
+}
+
+/**
+ * Which interface's address Redwall reports.
+ *
+ * Offered as the machine's own list rather than a typed name, because
+ * the name that has to match is the one the OS uses — "vEthernet (WSL)",
+ * "enp3s0" — and a name typed from memory is a pin that silently does
+ * nothing. The typed entry stays for the interface that is down right
+ * now, or a machine whose adapters could not be listed at all.
+ *
+ * Only interfaces holding a reachable address are listed; the rest
+ * resolve to the default route anyway, so offering them would be
+ * offering a choice that changes nothing.
+ */
+async function redwallInterfaceStep(p: Platform, pin: string | null): Promise<void> {
+  const route = "Default route — whichever interface leaves this machine";
+  const other = "Other — type an interface name";
+
+  const held = routableInterfaces(await hostNetState(p));
+  const labels = held.map((i) => `${i.name} — ${i.address}`);
+  const current = labels.find((l) => l.startsWith(`${pin ?? ""} — `)) ?? route;
+
+  const picked = await select(
+    `Report the address of? (current: ${pin ?? "default route"})`,
+    options(route, ...labels, other, BACK),
+    current,
+  );
+  if (picked === BACK) return;
+
+  if (picked === route) {
+    // Written as undefined so the key leaves the file: a pin recorded as
+    // "" is a pin nothing matches, which is not what "default route"
+    // means.
+    await writePreferences(p, { redwallInterface: undefined });
+    log.ok("redwall address: the default route");
+    return;
+  }
+
+  const chosen =
+    picked === other
+      ? (await text("Interface name?", pin ?? "")).trim()
+      : (held[labels.indexOf(picked)]?.name ?? "");
+  if (chosen === "") return;
+
+  await writePreferences(p, { redwallInterface: chosen });
+  log.ok(`redwall address: ${chosen}, falling back to the default route`);
+}
+
+async function redwallMenu(p: Platform): Promise<void> {
+  for (;;) {
+    const prefs = await readPreferences(p);
+    const state = `State — ${prefs.redwall === true ? "on" : "off"}`;
+    const iface = `Interface — ${prefs.redwallInterface ?? "default route"}`;
+
+    const picked = await select("Redwall", options(state, iface, BACK), state);
+    if (picked === BACK) return;
+    if (picked === state) await redwallStateStep(p, prefs.redwall === true);
+    else await redwallInterfaceStep(p, prefs.redwallInterface ?? null);
+  }
 }
 
 export async function runMenu(

--- a/src/preferences.ts
+++ b/src/preferences.ts
@@ -48,6 +48,14 @@ export interface Preferences {
    * agreed to have its desktop written over.
    */
   redwall?: boolean;
+  /**
+   * The interface whose address Redwall reports, for a machine that is
+   * not reached the way its default route leaves — see src/lan-address.ts.
+   *
+   * Absent is the ordinary state and means the default route decides,
+   * which is the answer that keeps working when adapters come and go.
+   */
+  redwallInterface?: string;
   /** Agent keys chosen for this workstation, mirrored into WSL when selected. */
   agents?: string[];
   /** mise runtime ids chosen for this workstation. */
@@ -115,6 +123,23 @@ export async function resolveTerminalShell(p: Platform): Promise<TerminalShell> 
 export async function resolveRedwall(p: Platform): Promise<boolean> {
   const prefs = await readPreferences(p);
   return prefs.redwall === true;
+}
+
+/**
+ * The interface pinned for Redwall's address, or null for "let the
+ * default route decide".
+ *
+ * Blank is not a pin. This is JSON a person opens, and emptying a value
+ * is how someone clears one — reading "" as an interface name would
+ * turn that into a pin that matches nothing, which looks identical to
+ * an interface that has gone away. Trimmed for the same reason a name
+ * copied off a screen deserves: the spaces around it are not the name.
+ */
+export async function resolveRedwallInterface(p: Platform): Promise<string | null> {
+  const pinned = (await readPreferences(p)).redwallInterface;
+  if (typeof pinned !== "string") return null;
+  const trimmed = pinned.trim();
+  return trimmed === "" ? null : trimmed;
 }
 
 export type ApplyContextEntryPath = "plan" | "install" | "update" | "theme";

--- a/src/redwall.test.ts
+++ b/src/redwall.test.ts
@@ -15,7 +15,12 @@
 import { existsSync, mkdirSync, mkdtempSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { describe, expect, test } from "bun:test";
-import { readPreferences, resolveRedwall, writePreferences } from "./preferences.ts";
+import {
+  readPreferences,
+  resolveRedwall,
+  resolveRedwallInterface,
+  writePreferences,
+} from "./preferences.ts";
 import { preferencesFromAnswers } from "./firstrun.ts";
 import type { SetupAnswers } from "./tui-setup-model.ts";
 import type { Platform } from "./platform.ts";
@@ -180,5 +185,79 @@ describe("the menu", () => {
     // The verb the menu switches on is the first word of the entry.
     expect(src).toContain('"Redwall — machine state on the wallpaper"');
     expect(src).toContain('case "Redwall":');
+  });
+
+  test("offers the interface beside the on/off switch", () => {
+    // The pin belongs with the answer it modifies. Somewhere else is a
+    // setting nobody looking at Redwall would find.
+    const src = readFileSync("src/menu.ts", "utf8");
+    const submenu = src.slice(src.indexOf("async function redwallMenu"));
+    expect(submenu.slice(0, submenu.indexOf("export "))).toContain("Interface");
+  });
+});
+
+/**
+ * The pin, which is an override and nothing more: absent is the normal
+ * state of this setting, and the default route is what absent means.
+ */
+describe("the pinned interface", () => {
+  test("is nothing on a machine nobody has pinned one on", async () => {
+    await onFreshMachine(async () => {
+      expect(await resolveRedwallInterface(linux)).toBeNull();
+      await writePreferences(linux, { redwall: true });
+      expect(await resolveRedwallInterface(linux)).toBeNull();
+    });
+  });
+
+  test("is the recorded name once one is set", async () => {
+    await onFreshMachine(async () => {
+      await writePreferences(linux, { redwallInterface: "vEthernet (WSL)" });
+      expect(await resolveRedwallInterface(linux)).toBe("vEthernet (WSL)");
+    });
+  });
+
+  test("survives beside the other answers, and they survive it", async () => {
+    await onFreshMachine(async () => {
+      await writePreferences(linux, preferencesFromAnswers(answers({ redwall: true })));
+      await writePreferences(linux, { redwallInterface: "tun0" });
+
+      const prefs = await readPreferences(linux);
+      expect(prefs).toMatchObject({ redwall: true, redwallInterface: "tun0", theme: "dark" });
+      expect(await resolveRedwall(linux)).toBe(true);
+    });
+  });
+
+  test("is cleared by writing it away, not left behind as an empty string", async () => {
+    // What the menu's "default route" entry does, on the same seam. A
+    // pin cleared to "" is still a pin as far as a JSON file is
+    // concerned, and this is the read that must not treat it as one.
+    await onFreshMachine(async (home) => {
+      await writePreferences(linux, { redwallInterface: "tun0" });
+      await writePreferences(linux, { redwallInterface: undefined });
+
+      expect(await resolveRedwallInterface(linux)).toBeNull();
+      expect(readFileSync(prefsPath(home), "utf8")).not.toContain("redwallInterface");
+    });
+  });
+
+  test("ignores what a person could type into the file by hand", async () => {
+    // Blank is how someone clears a value they can see; a non-string is
+    // what an editor leaves behind. Neither is an interface name.
+    await onFreshMachine(async () => {
+      await writePreferences(linux, { redwallInterface: "   " });
+      expect(await resolveRedwallInterface(linux)).toBeNull();
+    });
+    await onFreshMachine(async (home) => {
+      mkdirSync(`${home}/.config/alacritty`, { recursive: true });
+      await Bun.write(prefsPath(home), JSON.stringify({ redwallInterface: 3 }) + "\n");
+      expect(await resolveRedwallInterface(linux)).toBeNull();
+    });
+  });
+
+  test("is trimmed, because a name read off a screen carries spaces", async () => {
+    await onFreshMachine(async () => {
+      await writePreferences(linux, { redwallInterface: "  wlp2s0 " });
+      expect(await resolveRedwallInterface(linux)).toBe("wlp2s0");
+    });
   });
 });


### PR DESCRIPTION
Automated AFK landing for #62. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #62

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788807044&installation_model_id=20659&pr_number=79&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F79&signature=f25db438cd9bec6d24866ba4ec25700b29c1f7cef724c3ca9bd5c76be3bc2f40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->