### PR TITLE
chore: #66 Classify missing rights beside the existing sudo case

### DIFF
--- a/src/fixtures/powershell-access-denied.txt
+++ b/src/fixtures/powershell-access-denied.txt
@@ -1,0 +1,6 @@
+Add-WindowsCapability : Access to the path is denied.
+At line:1 char:3
++   Add-WindowsCapability -Online -Name $cap.Name | Out-Null
++   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    + CategoryInfo          : NotSpecified: (:) [Add-WindowsCapability], UnauthorizedAccessException
+    + FullyQualifiedErrorId : Microsoft.Dism.Commands.AddWindowsCapabilityCommand

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -13,6 +13,7 @@ import { copyFileSync, existsSync, mkdirSync, rmSync } from "node:fs";
 import { log, logIsCaptured, RedError } from "./log.ts";
 import type { Provider } from "./manifest.ts";
 import type { Platform } from "./platform.ts";
+import { missingRights } from "./rights.ts";
 
 /**
  * Inheriting stdin is only safe when there is a real terminal behind it.
@@ -150,11 +151,11 @@ export async function requireSudo(): Promise<void> {
     stderr: "ignore",
     stdin: "ignore",
   });
+  // The wording lives in rights.ts, where the Windows sibling of this
+  // refusal lives too. Same bytes as before — this branch is where the
+  // shared classification came from, not somewhere it was applied.
   if ((await probe.exited) !== 0) {
-    throw new RedError(
-      "sudo needs a password and nothing here can supply one.\n" +
-        "      Run `sudo -v` first, then re-run red-dev — or run it as root.",
-    );
+    throw new RedError(missingRights("sudo").message);
   }
   sudoChecked = true;
 }

--- a/src/rights.test.ts
+++ b/src/rights.test.ts
@@ -1,0 +1,188 @@
+/**
+ * The one place that says "this could not run because it lacked rights".
+ *
+ * What is worth pinning here is not the shape of the code but what an
+ * operator ends up reading. Three things, in order of how badly each one
+ * would hurt if it drifted:
+ *
+ *   The Linux message. It already worked, it is what a person has
+ *   learned to look for, and this slice widened the branch rather than
+ *   rewriting it — so the bytes are asserted literally rather than
+ *   described.
+ *
+ *   The Windows message exists at all. A converge on an unelevated shell
+ *   used to surface whatever PowerShell said, which for this case is six
+ *   lines of DISM stack trace ending in UnauthorizedAccessException.
+ *   That is a generic failure. The named outcome is the fix.
+ *
+ *   There is exactly one of each. Eleven modules invoke PowerShell, and
+ *   the reason to centralise is that eleven wordings teach the same rule
+ *   eleven times — so a second copy has to fail a test, not a review.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+import { classifyRights, missingRights } from "./rights.ts";
+
+const denied = readFileSync("src/fixtures/powershell-access-denied.txt", "utf8");
+
+/**
+ * A module's code with its comments removed.
+ *
+ * Borrowed from manifest.test.ts, and for the same reason: prose about
+ * elevation is not a second copy of the classification. hotkeys.ts
+ * explains which shortcut opens an elevated PowerShell, and a module
+ * that documents the problem must not be charged with re-implementing
+ * it.
+ */
+function codeOf(file: string): string {
+  return readFileSync(`src/${file}`, "utf8")
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/^\s*\/\/.*$/gm, "");
+}
+
+function modules(): string[] {
+  return readdirSync("src")
+    .filter((f) => f.endsWith(".ts") && !f.endsWith(".test.ts") && !f.endsWith(".d.ts"))
+    .sort();
+}
+
+describe("the Linux sudo outcome", () => {
+  test("is byte-for-byte what it has always been", () => {
+    // Literal on purpose. Composing the expectation from the same parts
+    // the code composes it from would assert nothing at all, and this
+    // string is the one thing in this slice that must not move.
+    expect(missingRights("sudo").message).toBe(
+      "sudo needs a password and nothing here can supply one.\n" +
+        "      Run `sudo -v` first, then re-run red-dev — or run it as root.",
+    );
+  });
+
+  test("and the gate that produces it behaves as before", () => {
+    // The behaviour beside the message: root needs no probe, the probe
+    // is the non-blocking `sudo -n`, the answer is remembered for the
+    // rest of the run, and the outcome is still a RedError rather than
+    // a warning — a converge that cannot use sudo stops.
+    const providers = codeOf("providers.ts");
+    expect(providers).toContain("process.getuid?.() === 0");
+    expect(providers).toContain('["sudo", "-n", "true"]');
+    expect(providers).toContain("sudoChecked = true");
+    expect(providers).toContain('throw new RedError(missingRights("sudo").message)');
+  });
+});
+
+describe("the Windows administrator outcome", () => {
+  test("a fixture where elevation is unavailable is named, not generic", () => {
+    // The bytes a real unelevated Add-WindowsCapability writes to
+    // stderr. Before this, they reached the operator as their own first
+    // line; now they resolve to the outcome that has a remedy attached.
+    const outcome = classifyRights(denied, "administrator");
+    expect(outcome?.gate).toBe("administrator");
+    expect(outcome?.message).toBe(missingRights("administrator").message);
+  });
+
+  test("every spelling Windows uses for the same refusal", () => {
+    // One product, several components, no agreement on wording. Missing
+    // one of these is what sends an operator back to a stack trace.
+    for (const output of [
+      "Set-Service : Service 'sshd' cannot be configured due to the following error: Access is denied",
+      "New-NetFirewallRule : PermissionDenied",
+      "The requested operation requires elevation.",
+      "Requested registry access is not allowed.",
+    ]) {
+      expect(classifyRights(output, "administrator")?.gate).toBe("administrator");
+    }
+  });
+
+  test("a failure for any other reason stays a failure", () => {
+    // The half that keeps the outcome honest. Claiming missing rights
+    // for an unrelated error would send the operator to elevate a shell
+    // that changes nothing, and hide the real cause behind a remedy.
+    expect(classifyRights("openssh-capability-missing", "administrator")).toBeNull();
+    expect(classifyRights("", "administrator")).toBeNull();
+  });
+
+  test("sudo has tells of its own, and they are not shared", () => {
+    // The two gates answer the same question, and they do not answer it
+    // with the same words.
+    expect(classifyRights("sudo: a password is required", "sudo")?.gate).toBe("sudo");
+    expect(classifyRights("sudo: no tty present and no askpass program specified", "sudo")).not
+      .toBeNull();
+    expect(classifyRights("Access is denied.", "sudo")).toBeNull();
+  });
+});
+
+describe("both messages", () => {
+  test("name what the operator must do to finish", () => {
+    // The property that makes this an outcome rather than an error: a
+    // person reading it knows the next thing to type, and knows that
+    // doing it costs them nothing already done.
+    for (const gate of ["sudo", "administrator"] as const) {
+      const outcome = missingRights(gate);
+      expect(outcome.remedy).toContain("re-run red-dev");
+      expect(outcome.message).toBe(`${outcome.cause}\n      ${outcome.remedy}`);
+    }
+    expect(missingRights("sudo").remedy).toContain("sudo -v");
+    expect(missingRights("administrator").remedy).toContain("elevated PowerShell");
+  });
+
+  test("are the same shape, so the rule is learned once", () => {
+    for (const gate of ["sudo", "administrator"] as const) {
+      const outcome = missingRights(gate);
+      expect(outcome.cause.split("\n")).toHaveLength(1);
+      expect(outcome.remedy.split("\n")).toHaveLength(1);
+      expect(outcome.cause.endsWith(".")).toBe(true);
+    }
+  });
+});
+
+describe("it lives in one place", () => {
+  /**
+   * The wording the classification owns.
+   *
+   * A module that contains any of these has written the outcome itself
+   * instead of asking for it, which is exactly the state this slice
+   * ended: a converge whose answer to "why did this stop" depends on
+   * which module happened to stop.
+   *
+   * All of them are remedy vocabulary — the sentence telling an operator
+   * what to run. Saying that an item *needs* administrator is not on the
+   * list and must not be: announcing the requirement before anything
+   * happens is the other half of the spec, and the prompt offering to
+   * install WSL says so in the question it asks.
+   */
+  const OWNED = [
+    "sudo -v",
+    "nothing here can supply one",
+    "run it as root",
+    "re-run red-dev",
+    "elevated PowerShell",
+    "PowerShell as Administrator",
+  ];
+
+  test("no second copy of the wording exists", () => {
+    const offenders = modules()
+      .filter((f) => f !== "rights.ts")
+      .filter((f) => OWNED.some((phrase) => codeOf(f).includes(phrase)));
+    expect(offenders).toEqual([]);
+  });
+
+  test("and the modules that hit it ask for the outcome", () => {
+    // The other direction. Without this, deleting a call site and its
+    // message together would pass the check above by saying nothing at
+    // all — which is the second failure mode the spec names.
+    for (const file of ["providers.ts", "ssh-server.ts", "wsl-provision.ts"]) {
+      expect([file, codeOf(file).includes('from "./rights.ts"')]).toEqual([file, true]);
+    }
+  });
+
+  test("and nothing else classifies a refusal by hand", () => {
+    // The tells belong to rights.ts too. A module matching on
+    // access-denied text is a second classifier even when it borrows
+    // the message from here.
+    const offenders = modules()
+      .filter((f) => f !== "rights.ts")
+      .filter((f) => /access is denied|requires elevation|unauthorizedaccess/i.test(codeOf(f)));
+    expect(offenders).toEqual([]);
+  });
+});

--- a/src/rights.ts
+++ b/src/rights.ts
@@ -1,0 +1,132 @@
+/**
+ * One place that turns "this could not run because it lacked rights"
+ * into a single named, actionable outcome.
+ *
+ * Two platforms asking the same question, and until now only one of them
+ * had an answer. Ubuntu asks it through `sudo`, which can be probed
+ * without blocking, and the branch that handles the refusal already read
+ * well: one line naming the cause, one line naming the single command to
+ * run first, and the promise that re-running costs nothing. Windows asks
+ * it through UAC, which cannot be answered at all once a run is under
+ * way — the prompt lands on the secure desktop, where a remote session
+ * cannot reach it — and eleven modules invoke PowerShell, each inventing
+ * its own wording for the refusal or saying nothing at all.
+ *
+ * So the Windows case becomes the Linux one's sibling: same shape, same
+ * place, different instruction. The sudo strings here are the exact
+ * bytes providers.ts used to hold, and a test pins them as such; this is
+ * a widening of a branch that works, not a rewrite of it.
+ *
+ * The reason to centralise is the operator, not us. Eleven wordings for
+ * the same outcome teach the same rule eleven times, one failure at a
+ * time. One wording teaches it once.
+ *
+ * This is deliberately a classification and nothing more. It does not
+ * elevate, prompt, or decide what to skip — a provider that raises its
+ * own consent prompt is how the single-prompt guarantee gets broken
+ * quietly, and that machinery belongs to the batch, not here.
+ */
+
+/** Which gate the work could not pass. */
+export type Gate = "sudo" | "administrator";
+
+/**
+ * A named outcome, not a failure.
+ *
+ * Kept in three pieces because callers lay it out differently: a gate
+ * that stops the run throws `message`, while an item that carries on
+ * without its privileged half prints `cause` beside its own name and
+ * `remedy` under it, at whatever indent that log already uses.
+ */
+export interface MissingRights {
+  /** The gate that refused. */
+  gate: Gate;
+  /** One line naming why the work stopped, with no remedy in it. */
+  cause: string;
+  /** One line naming what the operator must do to finish. */
+  remedy: string;
+  /** Both, laid out the way the converge prints a two-line message. */
+  message: string;
+}
+
+/**
+ * The continuation indent of a converge message.
+ *
+ * Six spaces, matching the width of the `warn`/`fail` badge the log
+ * puts in front of a first line, so the second line starts under the
+ * first word rather than under the badge.
+ */
+const INDENT = "      ";
+
+/**
+ * The wording, and the only copy of it.
+ *
+ * Both halves say the same three things in the same order: what could
+ * not happen, the one command that fixes it, and that coming back is
+ * safe. The sudo pair is load-bearing text rather than a phrasing
+ * choice — it is what the Linux path has always printed.
+ */
+const WORDING: Record<Gate, { cause: string; remedy: string }> = {
+  sudo: {
+    cause: "sudo needs a password and nothing here can supply one.",
+    remedy: "Run `sudo -v` first, then re-run red-dev — or run it as root.",
+  },
+  administrator: {
+    cause: "this needs administrator and nothing here can raise it.",
+    remedy: "Start an elevated PowerShell first, then re-run red-dev — re-running is safe.",
+  },
+};
+
+/** The outcome for a gate that is known to have refused. */
+export function missingRights(gate: Gate): MissingRights {
+  const { cause, remedy } = WORDING[gate];
+  return { gate, cause, remedy, message: `${cause}\n${INDENT}${remedy}` };
+}
+
+/**
+ * How each gate spells a refusal, lower-cased for comparison.
+ *
+ * Windows has no single spelling. One product, several components, and
+ * a capability, a service and a firewall rule each report the same
+ * missing right differently — which is precisely why deciding this once
+ * beats deciding it at eleven call sites.
+ *
+ * The list is matched loosely on purpose in one direction only: a tell
+ * that is missing here yields the generic failure the caller would have
+ * produced anyway, while a tell that is too eager would send an operator
+ * to elevate a shell that changes nothing and bury the real cause under
+ * a remedy. Erring towards the first is recoverable; the second is not.
+ */
+const REFUSALS: Record<Gate, string[]> = {
+  sudo: [
+    "a password is required",
+    "no tty present",
+    "a terminal is required",
+    "is not in the sudoers file",
+    "may not run",
+  ],
+  administrator: [
+    "access is denied",
+    "access to the path is denied",
+    "requires elevation",
+    "permissiondenied",
+    "unauthorizedaccessexception",
+    "registry access is not allowed",
+    "run as administrator",
+    "securityexception",
+  ],
+};
+
+/**
+ * Did this command fail for lack of rights, or for some other reason?
+ *
+ * `null` is the important answer. A converge that blames elevation for
+ * every non-zero exit is no more useful than one that never mentions
+ * it, so the caller keeps its own reporting for everything else and
+ * only defers to the shared outcome when the output says so.
+ */
+export function classifyRights(output: string, gate: Gate): MissingRights | null {
+  const haystack = output.toLowerCase();
+  const refused = REFUSALS[gate].some((tell) => haystack.includes(tell));
+  return refused ? missingRights(gate) : null;
+}

--- a/src/ssh-server.ts
+++ b/src/ssh-server.ts
@@ -32,6 +32,7 @@
 
 import { log } from "./log.ts";
 import type { Platform } from "./platform.ts";
+import { classifyRights, missingRights } from "./rights.ts";
 
 /** Ran, and what it printed. */
 interface Ran {
@@ -75,9 +76,13 @@ async function linuxUnit(): Promise<string | null> {
 export async function installSshServerLinux(p: Platform): Promise<void> {
   const install = await run(["sudo", "-n", "apt-get", "install", "-y", "openssh-server"]);
   if (!install.ok) {
-    // Same wording as the rest of the converge: sudo that needs a
-    // password cannot be answered from here, and that is not a bug.
-    log.warn("openssh-server: apt needs sudo — run `sudo -v` first, then re-run red-dev");
+    // Same wording as the rest of the converge, and now literally the
+    // same wording: sudo that needs a password cannot be answered from
+    // here, and that is not a bug. `sudo -n` is the same non-blocking
+    // probe the shared gate uses, so a failure here means the gate.
+    const denied = missingRights("sudo");
+    log.warn(`openssh-server: ${denied.cause}`);
+    log.plain(`       ${denied.remedy}`);
     return;
   }
 
@@ -172,12 +177,22 @@ export async function installSshServerWindows(p: Platform): Promise<void> {
 
   if ((await proc.exited) !== 0) {
     const err = (await new Response(proc.stderr).text()).trim();
+
     // Adding a capability is an administrator operation, and a converge
     // started from an unelevated shell is the common case rather than a
-    // mistake. Named as the cause instead of surfacing an access-denied.
+    // mistake. Asked of the one classifier so this reads exactly like
+    // every other item that runs out of rights, instead of handing the
+    // operator the first line of a DISM stack trace to decode.
+    const denied = classifyRights(err, "administrator");
+    if (denied) {
+      log.warn(`the OpenSSH server: ${denied.cause}`);
+      log.plain(`       ${denied.remedy}`);
+      return;
+    }
+
+    // Anything else really is a failure, and keeps its own reporting.
     const first = err.split("\n")[0] ?? "unknown";
     log.warn(`could not configure the OpenSSH server: ${first}`);
-    log.plain("       Add-WindowsCapability needs an elevated PowerShell");
     return;
   }
 

--- a/src/wsl-provision.ts
+++ b/src/wsl-provision.ts
@@ -18,6 +18,7 @@
 
 import { log } from "./log.ts";
 import type { Platform } from "./platform.ts";
+import { missingRights } from "./rights.ts";
 import { readWindowsOutput } from "./windows-output.ts";
 
 export interface WslState {
@@ -179,10 +180,15 @@ export async function isElevated(): Promise<boolean> {
  */
 export async function installWsl(distro = "Ubuntu-24.04"): Promise<boolean> {
   if (!(await isElevated())) {
-    log.err("installing WSL needs Administrator");
-    log.plain("     Open PowerShell as Administrator and run:");
-    log.plain(`       wsl --install -d ${distro}`);
-    log.plain("     Then re-run red-dev. It will pick up from there.");
+    // The same named outcome every other item reports when it runs out
+    // of rights; only the sentence naming what is left differs. Telling
+    // the operator to type `wsl --install` themselves was the old
+    // advice and it is one step too many — from an elevated shell this
+    // function runs it, which is the promise the shared remedy makes.
+    const denied = missingRights("administrator");
+    log.err(`installing WSL: ${denied.cause}`);
+    log.plain(`     ${denied.remedy}`);
+    log.plain(`     From there red-dev installs ${distro} itself.`);
     return false;
   }
 


### PR DESCRIPTION
Automated AFK landing for #66. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #66

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788807698&installation_model_id=20659&pr_number=81&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F81&signature=a4a80d5cde5bb278bd06771880e6754c2c7d08e66abb60896328e27dd8ecfdca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->