### PR TITLE
chore: #67 plan announces which items will require administrator

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -18,6 +18,7 @@ import {
   type Scope,
 } from "./manifest.ts";
 import { detect, summary, type Platform } from "./platform.ts";
+import { administratorNotice } from "./plan.ts";
 import { applyProvider, systemUpdate, type ApplyContext } from "./providers.ts";
 import { applyContextForEntry, type ApplyContextEntryPath } from "./preferences.ts";
 import { themeFor, themeNames } from "./themes.ts";
@@ -42,7 +43,8 @@ function cmdPlatform(p: Platform): number {
 
 async function cmdPlan(p: Platform, inv: Invocation): Promise<number> {
   await contextFor(p, inv, "plan");
-  for (const scope of resolveScopes(p, inv.scope)) {
+  const scopes = resolveScopes(p, inv.scope);
+  for (const scope of scopes) {
     log.plain(`\n[${scope}]`);
     for (const tool of toolsInScope(scope)) {
       const pr = providerFor(tool, p);
@@ -62,6 +64,12 @@ async function cmdPlan(p: Platform, inv: Invocation): Promise<number> {
       log.plain(`  ${tool.name.padEnd(17)}${describeProvider(pr)}${state}`);
     }
   }
+  // Last, where a summary belongs: the rows it names have just been
+  // read, and it is the line the operator acts on — this plan is still
+  // free to abandon in favour of an elevated session, which is the whole
+  // reason for saying it here rather than at the item that needs the
+  // rights.
+  for (const line of administratorNotice(p, scopes)) log.plain(line);
   return 0;
 }
 

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -989,9 +989,12 @@ export function needsAdmin(pr: Provider): boolean {
  * is about to happen rather than everything the manifest could install.
  * On every Linux target the set is empty — sudo is a separate path that
  * already works, and this must not disturb it.
+ *
+ * `scopes` is what `plan core` and `install wsl` need: the caller has
+ * already narrowed the run, and an answer taken from the full matrix
+ * would name an item that run is never going to reach.
  */
-export function itemsNeedingAdmin(p: Platform): Tool[] {
-  const scopes = applicableScopes(p);
+export function itemsNeedingAdmin(p: Platform, scopes: Scope[] = applicableScopes(p)): Tool[] {
   return TOOLS.filter((t) => scopes.includes(t.scope) && needsAdmin(providerFor(t, p)));
 }
 

--- a/src/plan.test.ts
+++ b/src/plan.test.ts
@@ -1,0 +1,123 @@
+/**
+ * What `plan` says about administrator, before anything is touched.
+ *
+ * The run that made this necessary asked for administrator at item 36 of
+ * 38, after half an hour of installs — a session that had to be
+ * abandoned and started again elevated. The manifest already declares
+ * which columns need the rights; this is the command that reads the
+ * declaration out loud while it still costs nothing to act on.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { itemsNeedingAdmin, toolsInScope } from "./manifest.ts";
+import { administratorNotice } from "./plan.ts";
+import type { Capabilities, Platform } from "./platform.ts";
+
+function platform(over: Partial<Platform> = {}): Platform {
+  const caps: Capabilities = {
+    apt: true,
+    gui: false,
+    systemd: true,
+    winget: false,
+    flatpak: false,
+    ...(over.caps ?? {}),
+  };
+  return {
+    os: "linux",
+    distro: "ubuntu",
+    version: "24.04",
+    codename: "noble",
+    env: "wsl",
+    arch: "x64",
+    ...over,
+    caps,
+  };
+}
+
+const WSL24 = platform();
+const WSL26 = platform({ version: "26.04", codename: "resolute" });
+const DESKTOP = platform({ env: "desktop", caps: { gui: true } as Capabilities });
+const SERVER = platform({ env: "server" });
+const WINDOWS = platform({
+  os: "windows",
+  env: "windows",
+  distro: null,
+  version: null,
+  caps: { apt: false, gui: true, systemd: false, winget: true, flatpak: false },
+});
+
+/**
+ * Whether the notice names this item.
+ *
+ * Bounded rather than a plain substring: several manifest items are
+ * short enough to appear inside ordinary English — `gh` inside
+ * "through", `bat` inside "about", `red` inside "required" — and a
+ * check that counts those reports whatever prose the notice happens to
+ * carry as an announced item.
+ */
+function names(notice: string[], name: string): boolean {
+  return new RegExp(`\\b${name}\\b`).test(notice.join("\n"));
+}
+
+describe("the plan's administrator announcement", () => {
+  test("a Windows target names every declared privileged item", () => {
+    const notice = administratorNotice(WINDOWS);
+    const declared = itemsNeedingAdmin(WINDOWS).map((t) => t.name);
+    expect(declared.length).toBeGreaterThan(0);
+    for (const name of declared) expect([name, names(notice, name)]).toEqual([name, true]);
+  });
+
+  test("a Linux target names none", () => {
+    // Silence rather than "nothing needs administrator", because on
+    // Ubuntu the word means the wrong thing: privileged work there goes
+    // through sudo, a path that already works and must not be disturbed
+    // by a line inviting someone to look for elevation that has no
+    // equivalent here.
+    for (const p of [WSL24, WSL26, DESKTOP, SERVER]) {
+      expect(administratorNotice(p)).toEqual([]);
+    }
+  });
+
+  test("an item that does not need administrator is not named", () => {
+    // The half that catches a notice which simply lists the plan: every
+    // other item in scope has to be absent from it, or the operator
+    // learns nothing from reading it.
+    const notice = administratorNotice(WINDOWS);
+    const named = new Set(itemsNeedingAdmin(WINDOWS).map((t) => t.name));
+    const others = toolsInScope("core")
+      .map((t) => t.name)
+      .filter((name) => !named.has(name));
+    expect(others.length).toBeGreaterThan(0);
+    for (const name of others) expect([name, names(notice, name)]).toEqual([name, false]);
+  });
+
+  test("it says what to do about it", () => {
+    // Naming the items is only half an answer. The point of announcing
+    // early is that an elevated session is still a cheap decision, so
+    // the notice has to say that is the move.
+    expect(administratorNotice(WINDOWS).join("\n")).toContain("elevated");
+  });
+
+  test("it answers for the scope being planned", () => {
+    // `plan wsl` must not announce a core item nobody asked about, and
+    // must not hide one it did.
+    expect(administratorNotice(WINDOWS, ["desktop"])).toEqual([]);
+    expect(administratorNotice(WINDOWS, ["core"]).join("\n")).toContain("ssh-server");
+  });
+
+  test("the plan still changes nothing", () => {
+    // The answer above was produced for a Windows target by a test
+    // running on Linux, which is only possible because it comes from
+    // the declarations alone. Pinned at the source too: a notice that
+    // reached for the host — probing a service, asking PowerShell
+    // whether the session is elevated — would turn `plan` into
+    // something that runs, and would stop working on the machine that
+    // most needs to read it before committing to the install.
+    const source = readFileSync("src/plan.ts", "utf8")
+      .replace(/\/\*[\s\S]*?\*\//g, "")
+      .replace(/^\s*\/\/.*$/gm, "");
+    expect(source).not.toMatch(/node:(fs|child_process|os)/);
+    expect(source).not.toMatch(/spawn|exec|writeFile|readFile/);
+  });
+});

--- a/src/plan.ts
+++ b/src/plan.ts
@@ -1,0 +1,45 @@
+/**
+ * What `plan` announces beyond the item list.
+ *
+ * A module of its own rather than another block inside main.ts, because
+ * main.ts ends in `process.exit(await run())` — importing it from a test
+ * runs the CLI and takes the process down with it. The announcement that
+ * matters most here is the one nobody can check by hand from a Linux
+ * machine, so it has to live somewhere a test can call.
+ */
+
+import { applicableScopes, describeProvider, itemsNeedingAdmin, providerFor } from "./manifest.ts";
+import type { Scope } from "./manifest.ts";
+import type { Platform } from "./platform.ts";
+
+/**
+ * The items this plan will ask administrator for, ready to print.
+ *
+ * Read from the manifest's declarations, with nothing executed and no
+ * elevation probed: the whole value of saying this during `plan` is that
+ * `plan` changes nothing, so an operator can still decide to close the
+ * terminal and open an elevated one. Discovering it any later means
+ * discovering it at the item that needs the rights — item 36 of 38, half
+ * an hour in, with the session already spent.
+ *
+ * Empty is the answer for every Linux target, and the notice is silent
+ * rather than reassuring there. Privileged work on Ubuntu goes through
+ * sudo, which already works; a line about administrator would send
+ * someone looking for an elevated session that has no equivalent on the
+ * machine in front of them.
+ */
+export function administratorNotice(
+  p: Platform,
+  scopes: Scope[] = applicableScopes(p),
+): string[] {
+  const items = itemsNeedingAdmin(p, scopes);
+  if (items.length === 0) return [];
+
+  return [
+    "\n[administrator]",
+    // The same two columns as the item list above, so the rows the
+    // operator has just read are the rows being pointed back at.
+    ...items.map((t) => `  ${t.name.padEnd(17)}${describeProvider(providerFor(t, p))}`),
+    `  ${items.length === 1 ? "this item cannot" : "these items cannot"} complete unelevated — start an elevated session before install`,
+  ];
+}


### PR DESCRIPTION
Automated AFK landing for #67. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #67

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788808178&installation_model_id=20659&pr_number=82&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F82&signature=58bcbc956956166053aeb05ac2ebf23a631312ba2ca5bcd6d4ceee3dfadfbc35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->