### PR TITLE
chore: #68 doctor reports privileged work left unfinished as drift

### DIFF
--- a/src/drift-privileged.test.ts
+++ b/src/drift-privileged.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Work that needed administrator, and did not get it, has to outlive the
+ * run that gave up on it.
+ *
+ * The converge already says the right thing at the right moment: the
+ * item that could not raise its rights warns, names the remedy, and the
+ * run carries on with everything else — which is correct, because one
+ * item short is not a reason to abandon thirty-five that succeeded. What
+ * was missing is everything after that. The warning scrolls past, the
+ * summary reports success, and from then on the machine's own account of
+ * itself is silent about a port that was never opened.
+ *
+ * doctor is where a machine says what is wrong with it, so that is where
+ * this belongs, and the shape is one the file already uses: a hotkey is
+ * reported on whether Windows *accepted* it, not on whether the shortcut
+ * was written, because writing without effect is the failure worth
+ * catching. Privileged work is the same failure with a different cause.
+ *
+ * What these pin, in the order they would hurt if they broke:
+ *
+ *   Each outstanding item is named. A count sends the reader back to a
+ *   transcript to find out which one, and the whole point is to answer
+ *   that here.
+ *
+ *   Silence is not success. A probe that could not reach the machine
+ *   reports that it could not, rather than inventing either verdict —
+ *   the same discipline the hotkey check keeps around "held".
+ *
+ *   The remedy is asked for, never written. rights.ts owns the sentence;
+ *   a second copy here would be the drift that slice just removed.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { checkPrivilegedWork, privilegedDrift } from "./drift.ts";
+import type { Capabilities, Platform } from "./platform.ts";
+import { missingRights } from "./rights.ts";
+import { readFileSync } from "node:fs";
+
+function platform(over: Partial<Platform> = {}): Platform {
+  const caps: Capabilities = {
+    apt: true,
+    gui: false,
+    systemd: true,
+    winget: false,
+    flatpak: false,
+    ...(over.caps ?? {}),
+  };
+  return {
+    os: "linux",
+    distro: "ubuntu",
+    version: "24.04",
+    codename: "noble",
+    env: "wsl",
+    arch: "x64",
+    ...over,
+    caps,
+  };
+}
+
+const WSL = platform();
+const WINDOWS = platform({
+  os: "windows",
+  env: "windows",
+  distro: null,
+  version: null,
+  caps: { apt: false, gui: true, systemd: false, winget: true, flatpak: false },
+});
+
+describe("privileged work left unfinished", () => {
+  test("is drift, and every outstanding item is named", () => {
+    // Two, because one item can be named by accident — a message that
+    // says "ssh-server" and a message that lists what is outstanding are
+    // indistinguishable until there is a second thing to list.
+    const check = privilegedDrift(["ssh-server", "windows-firewall"], {
+      "ssh-server": "unfinished",
+      "windows-firewall": "unfinished",
+    });
+
+    expect(check.status).toBe("drift");
+    expect(check.detail).toContain("ssh-server");
+    expect(check.detail).toContain("windows-firewall");
+  });
+
+  test("and the finished ones are left out of it", () => {
+    // A report that names an item which is already done teaches the
+    // reader to stop trusting the list.
+    const check = privilegedDrift(["ssh-server", "windows-firewall"], {
+      "ssh-server": "finished",
+      "windows-firewall": "unfinished",
+    });
+
+    expect(check.status).toBe("drift");
+    expect(check.detail).toContain("windows-firewall");
+    expect(check.detail).not.toContain("ssh-server");
+  });
+
+  test("says what the operator must do to clear it", () => {
+    const check = privilegedDrift(["ssh-server"], { "ssh-server": "unfinished" });
+
+    // Asked for rather than written. The operator has already read this
+    // sentence once, in the converge that stopped at the item — hearing
+    // it worded differently here would read as a different problem.
+    expect(check.fix).toBe(missingRights("administrator").remedy);
+  });
+});
+
+describe("privileged work that is done", () => {
+  test("is not drift", () => {
+    const check = privilegedDrift(["ssh-server", "windows-firewall"], {
+      "ssh-server": "finished",
+      "windows-firewall": "finished",
+    });
+
+    expect(check.status).toBe("ok");
+    expect(check.fix).toBeUndefined();
+  });
+
+  test("and a machine whose plan has no privileged items is not drift either", () => {
+    // Every Ubuntu target. Nothing in its plan asks for administrator —
+    // apt goes through sudo, which is a path of its own — so a check
+    // that reported drift here would be permanent noise on the majority
+    // of machines this runs on.
+    expect(privilegedDrift([], {}).status).toBe("n/a");
+  });
+
+  test("and an item nothing could ask about is reported as unasked", () => {
+    // Not drift and not ok. An unreachable host, a probe that failed,
+    // an item this build has no way to verify: all of them mean the
+    // question went unanswered, and answering it anyway is how a doctor
+    // starts lying in one direction or the other.
+    const check = privilegedDrift(["ssh-server"], { "ssh-server": "unknown" });
+
+    expect(check.status).toBe("n/a");
+    expect(check.detail).toContain("ssh-server");
+  });
+});
+
+describe("the check on a real target", () => {
+  test("takes its items from the manifest, so Windows reports its own", async () => {
+    // The states are supplied, so this asks nothing of the machine it
+    // runs on — the item list is the manifest's answer for a Windows
+    // target, which is where the only privileged column lives.
+    const check = await checkPrivilegedWork(WINDOWS, { "ssh-server": "unfinished" });
+
+    expect(check.status).toBe("drift");
+    expect(check.detail).toContain("ssh-server");
+  });
+
+  test("and a WSL target has nothing to report, without asking anything", async () => {
+    // No states passed on purpose: an empty plan must short-circuit
+    // before any probe, or every doctor run on Linux would pay for a
+    // question with no possible answer.
+    expect((await checkPrivilegedWork(WSL)).status).toBe("n/a");
+  });
+
+  test("and doctor actually runs it", () => {
+    // The half that is easy to leave out: a check nothing calls is a
+    // check that passes forever.
+    expect(readFileSync("src/drift.ts", "utf8")).toContain("await checkPrivilegedWork(p)");
+  });
+});

--- a/src/drift.ts
+++ b/src/drift.ts
@@ -14,6 +14,7 @@
 
 import { existsSync, readFileSync } from "node:fs";
 import type { Platform } from "./platform.ts";
+import { missingRights } from "./rights.ts";
 
 export type DriftStatus = "ok" | "drift" | "n/a";
 
@@ -514,6 +515,7 @@ export async function collectDrift(p: Platform): Promise<DriftCheck[]> {
   checks.push(await checkBlesh());
   checks.push(await checkSharedRoot(p));
   checks.push(await checkHotkeys(p));
+  checks.push(await checkPrivilegedWork(p));
   return checks;
 }
 
@@ -579,6 +581,134 @@ async function checkHotkeys(p: Platform): Promise<DriftCheck> {
       `${claimed.length} claimed and held (Windows does not say by whom) — ` +
       `note: they do not fire while an elevated window has focus`,
   };
+}
+
+/**
+ * Whether a privileged item's work is actually on the machine.
+ *
+ * Three values because two would have to lie. "unknown" is the answer
+ * whenever the question could not be put — no host to ask, a probe that
+ * failed, an item this build has no way to verify — and collapsing it
+ * into either of the others turns a doctor into a guess: fold it into
+ * "unfinished" and every machine that cannot be asked grows a permanent
+ * warning, fold it into "finished" and the one failure this exists to
+ * catch is the one it reports as fine.
+ */
+export type PrivilegedState = "finished" | "unfinished" | "unknown";
+
+/** What each privileged item reports, by tool name. */
+export type PrivilegedStates = Record<string, PrivilegedState>;
+
+const PRIVILEGED = "administrator work";
+
+/**
+ * The verdict on privileged work, from names and states alone. PURE.
+ *
+ * Separated from the asking so the reporting can be pinned without a
+ * Windows host, and because the two halves fail differently: a probe
+ * breaks when a machine changes, this breaks when the wording does.
+ *
+ * Every outstanding item is named. The converge already reported a
+ * count — "1 warning" — and the whole cost of that is the reader going
+ * back through a transcript to learn which of thirty-six items it was.
+ */
+export function privilegedDrift(items: string[], states: PrivilegedStates): DriftCheck {
+  if (items.length === 0) {
+    // Every Ubuntu target lands here, and it is not an absence of
+    // information: apt goes through sudo, which is its own path with its
+    // own outcome, so there is genuinely nothing on this machine waiting
+    // on administrator.
+    return { name: PRIVILEGED, status: "n/a", detail: "nothing here needs administrator" };
+  }
+
+  const inState = (state: PrivilegedState): string[] =>
+    items.filter((item) => (states[item] ?? "unknown") === state);
+  const unfinished = inState("unfinished");
+  const finished = inState("finished");
+  const unknown = inState("unknown");
+
+  if (unfinished.length > 0) {
+    return {
+      name: PRIVILEGED,
+      status: "drift",
+      detail: `${unfinished.join(", ")} — administrator work a converge left unfinished`,
+      // Asked for, not written. The operator read this sentence once
+      // already, in the converge that stopped at the item; wording it
+      // differently here would read as a second, unrelated problem.
+      fix: missingRights("administrator").remedy,
+    };
+  }
+
+  if (finished.length === 0) {
+    return {
+      name: PRIVILEGED,
+      status: "n/a",
+      detail: `could not ask this machine about ${unknown.join(", ")}`,
+    };
+  }
+
+  return {
+    name: PRIVILEGED,
+    status: "ok",
+    detail:
+      unknown.length === 0
+        ? `${finished.join(", ")} — done`
+        : `${finished.join(", ")} done; could not ask about ${unknown.join(", ")}`,
+  };
+}
+
+/**
+ * How each privileged item answers for itself, by tool name.
+ *
+ * A registry rather than a branch, and loaded per item rather than up
+ * front, because the module behind each entry is a platform adapter that
+ * a machine without that platform must never import to find out it has
+ * nothing to do. An item with no entry answers "unknown" — the honest
+ * result for a build that cannot verify it, and one that shows up in the
+ * report as unasked rather than as either verdict.
+ */
+const PRIVILEGED_PROBES: Record<string, () => Promise<(p: Platform) => Promise<PrivilegedState>>> =
+  {
+    "ssh-server": async () => (await import("./ssh-server.ts")).probeSshServer,
+  };
+
+async function probePrivileged(items: string[], p: Platform): Promise<PrivilegedStates> {
+  const states: PrivilegedStates = {};
+  for (const item of items) {
+    const load = PRIVILEGED_PROBES[item];
+    if (!load) {
+      states[item] = "unknown";
+      continue;
+    }
+    try {
+      states[item] = await (await load())(p);
+    } catch {
+      // A probe that threw answered nothing, which is a state we have.
+      states[item] = "unknown";
+    }
+  }
+  return states;
+}
+
+/**
+ * What this target needs administrator for, and how much of it is done.
+ *
+ * The item list comes from the manifest's declarations, so it is the
+ * same set `plan` announces before a converge starts — a machine cannot
+ * be told one thing beforehand and reported against another afterwards.
+ *
+ * `states` is injectable for tests only; nothing in the product passes
+ * it. An empty plan short-circuits before any probe runs, which is what
+ * keeps this free on the majority of machines.
+ */
+export async function checkPrivilegedWork(
+  p: Platform,
+  states?: PrivilegedStates,
+): Promise<DriftCheck> {
+  const { itemsNeedingAdmin } = await import("./manifest.ts");
+  const items = itemsNeedingAdmin(p).map((t) => t.name);
+  if (items.length === 0) return privilegedDrift([], {});
+  return privilegedDrift(items, states ?? (await probePrivileged(items, p)));
 }
 
 /**

--- a/src/rights.test.ts
+++ b/src/rights.test.ts
@@ -171,7 +171,11 @@ describe("it lives in one place", () => {
     // The other direction. Without this, deleting a call site and its
     // message together would pass the check above by saying nothing at
     // all — which is the second failure mode the spec names.
-    for (const file of ["providers.ts", "ssh-server.ts", "wsl-provision.ts"]) {
+    // drift.ts is here for the same reason as the three that converge:
+    // it hands the operator a remedy after the run rather than during
+    // it, which is precisely where a second wording would be hardest to
+    // notice and easiest to justify.
+    for (const file of ["providers.ts", "ssh-server.ts", "wsl-provision.ts", "drift.ts"]) {
       expect([file, codeOf(file).includes('from "./rights.ts"')]).toEqual([file, true]);
     }
   });

--- a/src/ssh-server.ts
+++ b/src/ssh-server.ts
@@ -30,6 +30,7 @@
  * the log says what happened rather than reporting a silent `ok`.
  */
 
+import type { PrivilegedState } from "./drift.ts";
 import { log } from "./log.ts";
 import type { Platform } from "./platform.ts";
 import { classifyRights, missingRights } from "./rights.ts";
@@ -200,6 +201,59 @@ export async function installSshServerWindows(p: Platform): Promise<void> {
     log.plain(`       ${line}`);
   }
   log.ok("OpenSSH server configured on the Windows host");
+}
+
+/**
+ * The same three steps, asked rather than performed.
+ *
+ * Read-only by construction, and that is the constraint the script is
+ * written around: an unelevated doctor is exactly the machine worth
+ * asking, since it is the one whose converge could not finish this. So
+ * the capability is not queried at all — `Get-WindowsCapability -Online`
+ * needs the rights we are trying to find out are missing — and the
+ * service it creates is asked instead. No sshd service means the
+ * capability was never added, which is the same answer arrived at from
+ * outside.
+ *
+ * Every condition mirrors one the install performs, in the same order,
+ * because a check that verifies less than the work did will call a
+ * half-configured machine done: the capability alone leaves the service
+ * Manual and stopped, and Manual survives exactly until the next reboot.
+ */
+const WINDOWS_PROBE = `
+$svc = Get-Service sshd -ErrorAction SilentlyContinue
+if (-not $svc) { 'unfinished'; exit 0 }
+if ($svc.StartType -ne 'Automatic') { 'unfinished'; exit 0 }
+if ($svc.Status -ne 'Running') { 'unfinished'; exit 0 }
+if (-not (Get-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -ErrorAction SilentlyContinue)) {
+  'unfinished'; exit 0
+}
+'finished'
+`.trim();
+
+/**
+ * Whether the privileged half of this item is actually in place.
+ *
+ * "unknown" is a real answer here and is returned generously: a machine
+ * with no Windows host to ask, a PowerShell that is not reachable, a
+ * word this build did not print itself. Guessing in either direction is
+ * worse than saying the question went unanswered — doctor reports it as
+ * unasked, and nobody is sent to elevate a shell over a probe that
+ * simply could not run.
+ */
+export async function probeSshServer(p: Platform): Promise<PrivilegedState> {
+  if (p.os !== "windows" && p.env !== "wsl") return "unknown";
+
+  const exe =
+    p.os === "windows" ? "powershell.exe" : (Bun.which("powershell.exe") ?? "powershell.exe");
+  try {
+    const { ok, out } = await run([exe, "-NoProfile", "-Command", WINDOWS_PROBE]);
+    if (!ok) return "unknown";
+    const answer = out.replace(/\r/g, "").trim();
+    return answer === "finished" || answer === "unfinished" ? answer : "unknown";
+  } catch {
+    return "unknown";
+  }
 }
 
 /** The manifest entry point; picks the half this platform has. */


### PR DESCRIPTION
Automated AFK landing for #68. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #68

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788808292&installation_model_id=20659&pr_number=83&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F83&signature=7dc9b5f84a43f004bf721840c838e5251cdd5eb2360c03d55f380b891eb4b299"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->