### PR TITLE
chore: #57 Render a Redwall: compose live state over the theme's wallpaper

### DIFF
--- a/src/brand.ts
+++ b/src/brand.ts
@@ -125,11 +125,26 @@ function channel(v: number): number {
   return c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
 }
 
-export function luminance(hex: Hex): number {
+/**
+ * The three channels of a brand colour, 0–255.
+ *
+ * Exported because Redwall paints with these rather than measuring them,
+ * and a second hex parser written beside this one is a second place for
+ * `#f4f5f7` to become something else.
+ */
+export function rgb(hex: Hex): [number, number, number] {
   const m = /^#?([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i.exec(hex.trim());
   if (!m) throw new Error(`not a hex colour: ${hex}`);
-  const [r, g, b] = [m[1], m[2], m[3]].map((h) => channel(Number.parseInt(h as string, 16)));
-  return 0.2126 * (r as number) + 0.7152 * (g as number) + 0.0722 * (b as number);
+  return [
+    Number.parseInt(m[1] as string, 16),
+    Number.parseInt(m[2] as string, 16),
+    Number.parseInt(m[3] as string, 16),
+  ];
+}
+
+export function luminance(hex: Hex): number {
+  const [r, g, b] = rgb(hex).map(channel) as [number, number, number];
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
 }
 
 /**

--- a/src/png.test.ts
+++ b/src/png.test.ts
@@ -1,0 +1,109 @@
+/**
+ * The codec, checked against the only images that matter here.
+ *
+ * A PNG reader is easy to write and easy to write *nearly* right: an
+ * off-by-one in the unfilter shifts a row and the result still opens in
+ * every viewer, still has the right dimensions, and is wrong. So the
+ * round trip is not the interesting assertion — the interesting one is
+ * that the six vendored wallpapers decode to what their own headers say
+ * they are, including the palette sheet, which travels through a
+ * different branch to the other five and would otherwise never be read.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { decodePng, encodePng, type Raster } from "./png.ts";
+import { THEME_SLUGS } from "./themes.ts";
+
+const root = `${import.meta.dir}/..`;
+
+/** A raster with a different value in every channel of every pixel. */
+function ramp(width: number, height: number): Raster {
+  const data = new Uint8Array(width * height * 4);
+  for (let i = 0; i < width * height; i++) {
+    data[i * 4] = (i * 7) & 0xff;
+    data[i * 4 + 1] = (i * 13) & 0xff;
+    data[i * 4 + 2] = (i * 29) & 0xff;
+    data[i * 4 + 3] = 0xff;
+  }
+  return { width, height, data };
+}
+
+describe("a raster that has been through a PNG", () => {
+  test("comes back with every byte it went in with", () => {
+    const before = ramp(37, 19);
+    const after = decodePng(encodePng(before));
+    expect(after.width).toBe(before.width);
+    expect(after.height).toBe(before.height);
+    expect([...after.data]).toEqual([...before.data]);
+  });
+
+  test("keeps its alpha, which is the channel a wallpaper never exercises", () => {
+    const data = new Uint8Array([0, 0, 0, 0, 255, 255, 255, 128, 12, 34, 56, 255]);
+    const after = decodePng(encodePng({ width: 3, height: 1, data }));
+    expect([...after.data]).toEqual([...data]);
+  });
+
+  test("survives a single row and a single column", () => {
+    // Both are where a stride calculation goes wrong without anything
+    // else noticing, and neither is a shape a wallpaper ever has.
+    for (const [w, h] of [[1, 40], [40, 1], [1, 1]] as const) {
+      const before = ramp(w, h);
+      expect([...decodePng(encodePng(before)).data]).toEqual([...before.data]);
+    }
+  });
+});
+
+describe("encoding", () => {
+  test("is deterministic, which is what the whole Redwall rests on", () => {
+    const raster = ramp(64, 64);
+    expect([...encodePng(raster)]).toEqual([...encodePng(raster)]);
+  });
+
+  test("refuses a raster whose data does not match its dimensions", () => {
+    expect(() => encodePng({ width: 4, height: 4, data: new Uint8Array(12) })).toThrow();
+  });
+});
+
+describe("the vendored wallpapers", () => {
+  test.each([...THEME_SLUGS])("%s decodes to the size its header declares", async (slug) => {
+    const raster = decodePng(await Bun.file(`${root}/assets/wallpapers/${slug}.png`).bytes());
+    expect(raster.width).toBe(3840);
+    expect(raster.height).toBe(2160);
+    expect(raster.data.length).toBe(3840 * 2160 * 4);
+  });
+
+  test("obsidian is the palette sheet, and its colours survive the indirection", async () => {
+    // Colour type 3. The other five are type 2 and never touch the PLTE
+    // branch, so without this the palette path ships unread.
+    const raster = decodePng(await Bun.file(`${root}/assets/wallpapers/obsidian.png`).bytes());
+    const distinct = new Set<string>();
+    let translucent = 0;
+    for (let i = 0; i < raster.data.length; i += 4) {
+      distinct.add(`${raster.data[i]},${raster.data[i + 1]},${raster.data[i + 2]}`);
+      if (raster.data[i + 3] !== 255) translucent++;
+    }
+    // Counted rather than asserted per pixel: eight million assertions
+    // say the same thing as one and take a hundred times as long.
+    expect(translucent).toBe(0);
+    // A palette holds at most 256 entries; a decoder that read the index
+    // as a grey value would produce greys and nothing else.
+    expect(distinct.size).toBeGreaterThan(1);
+    expect(distinct.size).toBeLessThanOrEqual(256);
+  });
+});
+
+describe("what is not a PNG", () => {
+  test("is refused by its signature rather than misread", () => {
+    expect(() => decodePng(new Uint8Array(64))).toThrow(/signature/);
+    expect(() => decodePng(new Uint8Array(4))).toThrow();
+  });
+
+  test("and a PNG with a byte flipped in it is refused by its checksum", () => {
+    const bytes = encodePng(ramp(16, 16));
+    // Into the IDAT payload: past the signature, the IHDR chunk and the
+    // IDAT header. Corrupting the header instead would be caught by
+    // length arithmetic, which is a weaker claim.
+    bytes[8 + 25 + 12] = bytes[8 + 25 + 12]! ^ 0xff;
+    expect(() => decodePng(bytes)).toThrow(/corrupt/);
+  });
+});

--- a/src/png.ts
+++ b/src/png.ts
@@ -1,0 +1,312 @@
+/**
+ * PNG, read and written, because composing over one needs both halves.
+ *
+ * Redwall draws state over the theme's wallpaper. The wallpapers are
+ * PNGs, what the desktop wants back is a PNG, and there is nothing in
+ * Bun or in this project's two dependencies that turns one into pixels.
+ * So this is the codec — the whole of it, and no more of it than the six
+ * vendored sheets need.
+ *
+ * ## What it reads
+ *
+ * Eight bits a channel, non-interlaced, in all five colour types. That
+ * covers the sheets as vendored (five are truecolour, obsidian is
+ * palette) and leaves room for a re-vendor that arrives with an alpha
+ * channel or a greyscale one. Sixteen-bit and interlaced files throw a
+ * sentence naming what they are, which is the useful failure: a decoder
+ * that quietly halves a 16-bit channel produces an image that looks
+ * right until someone measures it.
+ *
+ * ## What it writes
+ *
+ * One shape — eight-bit RGBA, non-interlaced — because there is exactly
+ * one caller and it always has an alpha channel to write. Choosing the
+ * narrowest colour type that fits the pixels would shave a few bytes off
+ * a file the desktop reads once, at the price of an encoder with modes,
+ * and modes are where "the same input produces the same bytes" goes to
+ * die.
+ *
+ * Every row is filtered with Paeth rather than by the usual adaptive
+ * heuristic. The heuristic makes five passes over a 33 MB raster to pick
+ * a filter per row, and on smooth gradient art it picks Paeth almost
+ * everywhere anyway; one pass is a second of wall clock the regenerator
+ * gets to keep. It is a fixed choice, so it is also a deterministic one.
+ *
+ * ## Why node:zlib rather than Bun's own
+ *
+ * `Bun.inflateSync` fails with "invalid stored block lengths" on every
+ * one of the vendored sheets — they arrive as six 32 KB IDAT chunks and
+ * it does not reassemble the stream the way the spec's concatenation
+ * requires. `node:zlib` reads all six in 48 ms. This is not a preference
+ * between two working libraries; one of them cannot read the images this
+ * module exists to read.
+ */
+
+import { deflateSync, inflateSync } from "node:zlib";
+
+/** Eight-bit RGBA, row-major. `data.length === width * height * 4`. */
+export interface Raster {
+  readonly width: number;
+  readonly height: number;
+  readonly data: Uint8Array;
+}
+
+const SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a] as const;
+
+/** Bytes per pixel in the raw stream, by colour type. */
+const CHANNELS: Record<number, number> = { 0: 1, 2: 3, 3: 1, 4: 2, 6: 4 };
+
+// ------------------------------------------------------------- checksum
+
+let table: Uint32Array | null = null;
+
+/**
+ * CRC-32 as the PNG spec defines it, which is the ordinary one.
+ *
+ * Verified on the way in and not merely written on the way out. The
+ * wallpapers travel inside a compiled binary through an import mechanism
+ * that has already been observed to mangle a file while leaving its
+ * length plausible — see `scripts/embed-smoke.ts` — and a mangled IDAT
+ * decodes to noise rather than to an error.
+ */
+function crc32(data: Uint8Array): number {
+  if (table === null) {
+    table = new Uint32Array(256);
+    for (let n = 0; n < 256; n++) {
+      let c = n;
+      for (let k = 0; k < 8; k++) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+      table[n] = c >>> 0;
+    }
+  }
+  let crc = 0xffffffff;
+  for (let i = 0; i < data.length; i++) {
+    crc = table[(crc ^ data[i]!) & 0xff]! ^ (crc >>> 8);
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+// --------------------------------------------------------------- decode
+
+export function decodePng(bytes: Uint8Array): Raster {
+  if (bytes.length < 8 + 25) throw new Error(`not a PNG: ${bytes.length} bytes is shorter than a header`);
+  for (let i = 0; i < SIGNATURE.length; i++) {
+    if (bytes[i] !== SIGNATURE[i]) throw new Error("not a PNG: signature mismatch");
+  }
+
+  const dv = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  let header: Uint8Array | null = null;
+  let palette: Uint8Array | null = null;
+  let transparency: Uint8Array | null = null;
+  const parts: Uint8Array[] = [];
+
+  let at = 8;
+  while (at + 12 <= bytes.length) {
+    const length = dv.getUint32(at);
+    const end = at + 12 + length;
+    if (end > bytes.length) throw new Error("PNG is truncated: a chunk runs past the end of the file");
+
+    const tag = String.fromCharCode(bytes[at + 4]!, bytes[at + 5]!, bytes[at + 6]!, bytes[at + 7]!);
+    // The checksum covers the tag and the payload, not the length.
+    if (crc32(bytes.subarray(at + 4, at + 8 + length)) !== dv.getUint32(at + 8 + length)) {
+      throw new Error(`PNG chunk '${tag}' is corrupt: the checksum does not match its bytes`);
+    }
+
+    const body = bytes.subarray(at + 8, at + 8 + length);
+    if (tag === "IHDR") header = body;
+    else if (tag === "PLTE") palette = body;
+    else if (tag === "tRNS") transparency = body;
+    else if (tag === "IDAT") parts.push(body);
+    else if (tag === "IEND") break;
+
+    at = end;
+  }
+
+  if (header === null) throw new Error("PNG has no IHDR");
+  if (parts.length === 0) throw new Error("PNG has no image data");
+
+  const head = new DataView(header.buffer, header.byteOffset, header.byteLength);
+  const width = head.getUint32(0);
+  const height = head.getUint32(4);
+  const depth = header[8]!;
+  const colour = header[9]!;
+  const interlace = header[12]!;
+
+  if (width === 0 || height === 0) throw new Error(`PNG is ${width}x${height}, which has no pixels`);
+  if (depth !== 8) throw new Error(`PNG is ${depth} bits a channel; this reader handles 8`);
+  if (interlace !== 0) throw new Error("PNG is interlaced; this reader handles the progressive-free form");
+  const channels = CHANNELS[colour];
+  if (channels === undefined) throw new Error(`PNG declares colour type ${colour}, which is not one of the five`);
+  if (colour === 3 && palette === null) throw new Error("PNG is palette-indexed and carries no PLTE");
+
+  // One IDAT is the common case; several is the common case for anything
+  // large, and the stream is the concatenation rather than each part
+  // being its own deflate stream.
+  const joined = parts.length === 1 ? parts[0]! : concat(parts);
+  const raw = new Uint8Array(inflateSync(joined));
+
+  const stride = width * channels;
+  if (raw.length < (stride + 1) * height) {
+    throw new Error(`PNG decompressed to ${raw.length} bytes, short of the ${(stride + 1) * height} its size needs`);
+  }
+
+  return {
+    width,
+    height,
+    data: toRgba(unfilter(raw, height, stride, channels), width * height, colour, palette, transparency),
+  };
+}
+
+function concat(parts: readonly Uint8Array[]): Uint8Array {
+  let total = 0;
+  for (const part of parts) total += part.length;
+  const out = new Uint8Array(total);
+  let at = 0;
+  for (const part of parts) {
+    out.set(part, at);
+    at += part.length;
+  }
+  return out;
+}
+
+/** The one non-obvious predictor: PNG §9.4, unchanged. */
+function paeth(a: number, b: number, c: number): number {
+  const p = a + b - c;
+  const pa = Math.abs(p - a);
+  const pb = Math.abs(p - b);
+  const pc = Math.abs(p - c);
+  if (pa <= pb && pa <= pc) return a;
+  return pb <= pc ? b : c;
+}
+
+/**
+ * Undo the per-row filters, in place of the leading type byte.
+ *
+ * `bpp` is a byte offset, not a pixel one, and at eight bits a channel
+ * the two happen to be the same number — which is exactly why this reader
+ * refuses other depths rather than growing a case for them.
+ */
+function unfilter(raw: Uint8Array, height: number, stride: number, bpp: number): Uint8Array {
+  const out = new Uint8Array(stride * height);
+  let read = 0;
+
+  for (let y = 0; y < height; y++) {
+    const type = raw[read++]!;
+    const row = y * stride;
+    const prior = row - stride;
+
+    for (let x = 0; x < stride; x++) {
+      const value = raw[read + x]!;
+      const a = x >= bpp ? out[row + x - bpp]! : 0;
+      const b = y > 0 ? out[prior + x]! : 0;
+      let recon: number;
+      switch (type) {
+        case 0: recon = value; break;
+        case 1: recon = value + a; break;
+        case 2: recon = value + b; break;
+        case 3: recon = value + ((a + b) >> 1); break;
+        case 4: recon = value + paeth(a, b, x >= bpp && y > 0 ? out[prior + x - bpp]! : 0); break;
+        default: throw new Error(`PNG row ${y} uses filter ${type}, which is not one of the five`);
+      }
+      out[row + x] = recon & 0xff;
+    }
+    read += stride;
+  }
+  return out;
+}
+
+function toRgba(
+  pixels: Uint8Array,
+  count: number,
+  colour: number,
+  palette: Uint8Array | null,
+  transparency: Uint8Array | null,
+): Uint8Array {
+  if (colour === 6) return pixels;
+
+  const out = new Uint8Array(count * 4);
+  for (let i = 0; i < count; i++) {
+    const o = i * 4;
+    if (colour === 0 || colour === 4) {
+      const grey = pixels[i * (colour === 4 ? 2 : 1)]!;
+      out[o] = grey;
+      out[o + 1] = grey;
+      out[o + 2] = grey;
+      out[o + 3] = colour === 4 ? pixels[i * 2 + 1]! : 255;
+    } else if (colour === 2) {
+      out[o] = pixels[i * 3]!;
+      out[o + 1] = pixels[i * 3 + 1]!;
+      out[o + 2] = pixels[i * 3 + 2]!;
+      out[o + 3] = 255;
+    } else {
+      const index = pixels[i]!;
+      out[o] = palette![index * 3]!;
+      out[o + 1] = palette![index * 3 + 1]!;
+      out[o + 2] = palette![index * 3 + 2]!;
+      // tRNS on a palette is a prefix: entries past its end are opaque.
+      out[o + 3] = transparency?.[index] ?? 255;
+    }
+  }
+  return out;
+}
+
+// --------------------------------------------------------------- encode
+
+export function encodePng(raster: Raster): Uint8Array {
+  const { width, height, data } = raster;
+  if (width <= 0 || height <= 0) throw new Error(`cannot encode a ${width}x${height} raster`);
+  if (data.length !== width * height * 4) {
+    throw new Error(`raster is ${data.length} bytes, not the ${width * height * 4} a ${width}x${height} RGBA image is`);
+  }
+
+  const header = new Uint8Array(13);
+  const head = new DataView(header.buffer);
+  head.setUint32(0, width);
+  head.setUint32(4, height);
+  header[8] = 8; // bit depth
+  header[9] = 6; // truecolour with alpha
+  // compression 0, filter 0, interlace 0 — the zeroed buffer already
+  // says all three, and there is no other legal value for any of them.
+
+  const idat = deflateSync(filtered(data, width, height), { level: 9 });
+
+  const chunks = [chunk("IHDR", header), chunk("IDAT", idat), chunk("IEND", new Uint8Array(0))];
+  const out = new Uint8Array(8 + chunks.reduce((n, c) => n + c.length, 0));
+  out.set(SIGNATURE, 0);
+  let at = 8;
+  for (const part of chunks) {
+    out.set(part, at);
+    at += part.length;
+  }
+  return out;
+}
+
+/** Every row Paeth-filtered, each behind the type byte that says so. */
+function filtered(data: Uint8Array, width: number, height: number): Uint8Array {
+  const stride = width * 4;
+  const out = new Uint8Array((stride + 1) * height);
+
+  for (let y = 0; y < height; y++) {
+    const row = y * stride;
+    const prior = row - stride;
+    const write = y * (stride + 1);
+    out[write] = 4;
+
+    for (let x = 0; x < stride; x++) {
+      const a = x >= 4 ? data[row + x - 4]! : 0;
+      const b = y > 0 ? data[prior + x]! : 0;
+      const c = x >= 4 && y > 0 ? data[prior + x - 4]! : 0;
+      out[write + 1 + x] = (data[row + x]! - paeth(a, b, c)) & 0xff;
+    }
+  }
+  return out;
+}
+
+function chunk(tag: string, body: Uint8Array): Uint8Array {
+  const out = new Uint8Array(12 + body.length);
+  const dv = new DataView(out.buffer);
+  dv.setUint32(0, body.length);
+  for (let i = 0; i < 4; i++) out[4 + i] = tag.charCodeAt(i);
+  out.set(body, 8);
+  dv.setUint32(8 + body.length, crc32(out.subarray(4, 8 + body.length)));
+  return out;
+}

--- a/src/redwall-render.test.ts
+++ b/src/redwall-render.test.ts
@@ -1,0 +1,226 @@
+/**
+ * The composer, checked the way a desktop cannot check it.
+ *
+ * Every claim Spec #52 makes about a Redwall is a claim about bytes, and
+ * that is the whole design: purity is what makes "did the state change"
+ * answerable by comparison, and it is what lets a build with no desktop
+ * attached have an opinion at all.
+ *
+ * Two of these are the same assertion pointing opposite ways —
+ * identical inputs must produce identical output, and a different Worker
+ * count must produce different output. Either one alone passes for a
+ * renderer that ignores its arguments.
+ *
+ * The legibility half lives in `theme-contrast.test.ts`, beside every
+ * other pair this project measures, because that is the table a colour
+ * change has to get past. What is here is the pixels: that the two
+ * colours the theme declares are the two colours that actually landed.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { contrast } from "./brand.ts";
+import { decodePng, encodePng, type Raster } from "./png.ts";
+import { REDWALL_SUBSET } from "./redwall-font.ts";
+import {
+  redwallBox,
+  redwallInk,
+  redwallLines,
+  renderRedwall,
+  type RedwallState,
+} from "./redwall-render.ts";
+import { THEMES, THEME_SLUGS, type ThemeSlug } from "./themes.ts";
+import { readFont } from "./ttf.ts";
+
+const root = `${import.meta.dir}/..`;
+const fontBytes = await Bun.file(REDWALL_SUBSET).bytes();
+const font = readFont(fontBytes);
+
+/**
+ * Stand-in art: a two-way gradient, so that a pixel moved by one in
+ * either direction is a pixel with a different value.
+ */
+function sheet(width = 1280, height = 720): Raster {
+  const data = new Uint8Array(width * height * 4);
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const at = (y * width + x) * 4;
+      data[at] = x & 0xff;
+      data[at + 1] = y & 0xff;
+      data[at + 2] = (x + y) & 0xff;
+      data[at + 3] = 255;
+    }
+  }
+  return { width, height, data };
+}
+
+const art = encodePng(sheet());
+const running: RedwallState = { workers: 3, address: "192.168.1.42" };
+
+function render(state: RedwallState, slug: ThemeSlug = "dark"): Uint8Array {
+  return renderRedwall({ art, font: fontBytes, theme: THEMES[slug], state });
+}
+
+describe("the same inputs", () => {
+  test("produce byte-identical output", () => {
+    // Not "an equivalent image". The regenerator decides whether the
+    // desktop needs rewriting by comparing what it just composed with
+    // what is already there, and a renderer that varied by a compression
+    // timestamp would rewrite the wallpaper on every tick.
+    expect([...render(running)]).toEqual([...render(running)]);
+  });
+
+  test("and a state that says nothing hands back the art it was given", () => {
+    // A machine with no daemon and no route is a machine Redwall has
+    // nothing to add to, and the honest picture of it is the wallpaper.
+    expect(render({ workers: null, address: null })).toBe(art);
+  });
+});
+
+describe("a different state", () => {
+  test("is a different image when the Worker count changes", () => {
+    expect([...render(running)]).not.toEqual([...render({ ...running, workers: 4 })]);
+  });
+
+  test("including when the count goes to zero, which is not the same as unknown", () => {
+    // `host-state.ts` exists to keep these two apart: a drained queue
+    // reports zero, a stopped daemon reports nothing. A renderer that
+    // drew them the same would undo that distinction at the last step.
+    const drained = render({ ...running, workers: 0 });
+    const unknown = render({ ...running, workers: null });
+    expect([...drained]).not.toEqual([...unknown]);
+  });
+
+  test("and when the address changes", () => {
+    expect([...render(running)]).not.toEqual([...render({ ...running, address: "10.0.0.1" })]);
+  });
+
+  test("and when the theme changes, because the ink and the plate do", () => {
+    expect([...render(running, "dark")]).not.toEqual([...render(running, "light")]);
+  });
+});
+
+describe("the brand art underneath", () => {
+  test("is present unmodified outside the region the overlay occupies", () => {
+    const before = sheet();
+    const after = decodePng(render(running));
+    const box = redwallBox(before, font, redwallLines(running))!;
+
+    let moved = 0;
+    let insideBox = 0;
+    for (let y = 0; y < before.height; y++) {
+      for (let x = 0; x < before.width; x++) {
+        const inside =
+          x >= box.x && x < box.x + box.width && y >= box.y && y < box.y + box.height;
+        if (inside) {
+          insideBox++;
+          continue;
+        }
+        const at = (y * before.width + x) * 4;
+        for (let c = 0; c < 4; c++) {
+          if (before.data[at + c] !== after.data[at + c]) moved++;
+        }
+      }
+    }
+
+    expect(moved).toBe(0);
+    // And the region is a region: an overlay that occupied nothing would
+    // pass the assertion above without drawing anything.
+    expect(insideBox).toBeGreaterThan(0);
+    expect(insideBox).toBeLessThan(before.width * before.height);
+  });
+
+  test("survives a real sheet, at the size a real desktop asks for", async () => {
+    // The synthetic art above is 1280x720 and has no mark on it. The
+    // vendored sheets are 3840x2160 and are the actual subject, and the
+    // scale arithmetic is the part that only shows up at their size.
+    const real = await Bun.file(`${root}/assets/wallpapers/dark.png`).bytes();
+    const before = decodePng(real);
+    const after = decodePng(
+      renderRedwall({ art: real, font: fontBytes, theme: THEMES.dark, state: running }),
+    );
+    const box = redwallBox(before, font, redwallLines(running))!;
+
+    expect(after.width).toBe(before.width);
+    expect(after.height).toBe(before.height);
+    // The overlay is a corner of the desktop, not a banner across it.
+    expect(box.width).toBeLessThan(before.width / 3);
+    expect(box.height).toBeLessThan(before.height / 6);
+
+    let moved = 0;
+    for (let y = 0; y < before.height; y++) {
+      if (y >= box.y && y < box.y + box.height) continue;
+      for (let x = 0; x < before.width * 4; x++) {
+        if (before.data[y * before.width * 4 + x] !== after.data[y * before.width * 4 + x]) moved++;
+      }
+    }
+    expect(moved).toBe(0);
+  });
+});
+
+describe("what actually landed inside the region", () => {
+  test.each([...THEME_SLUGS])("%s writes its declared ink on its declared plate", (slug) => {
+    const ink = redwallInk(THEMES[slug]);
+    const after = decodePng(render(running, slug));
+    const box = redwallBox(after, font, redwallLines(running))!;
+
+    const tally = new Map<string, number>();
+    for (let y = box.y; y < box.y + box.height; y++) {
+      for (let x = box.x; x < box.x + box.width; x++) {
+        const at = (y * after.width + x) * 4;
+        const hex = `#${[0, 1, 2].map((c) => after.data[at + c]!.toString(16).padStart(2, "0")).join("")}`;
+        tally.set(hex, (tally.get(hex) ?? 0) + 1);
+      }
+    }
+
+    // Both colours present as themselves, not merely as something near
+    // them: the plate is flat and the strokes are wide enough to have
+    // solid interiors, so antialiasing accounts for edges and nothing
+    // else. This is the pixel-level half of the contrast claim that
+    // theme-contrast.test.ts measures as a ratio.
+    expect(tally.get(ink.plate) ?? 0).toBeGreaterThan(0);
+    expect(tally.get(ink.text) ?? 0).toBeGreaterThan(0);
+    expect(contrast(ink.text, ink.plate)).toBeGreaterThanOrEqual(4.5);
+  });
+
+  test("and the ink follows the appearance rather than the palette", () => {
+    // obsidian and marble are the pair that makes this checkable: they
+    // are the same design in opposite appearances and share no accent to
+    // confuse the question.
+    expect(redwallInk(THEMES.obsidian).text).not.toBe(redwallInk(THEMES.marble).text);
+    for (const slug of THEME_SLUGS) {
+      const theme = THEMES[slug];
+      expect(redwallInk(theme).text, slug).toBe(
+        redwallInk(THEMES[theme.appearance === "light" ? "light" : "dark"]).text,
+      );
+    }
+  });
+});
+
+describe("the lines", () => {
+  test("carry both facts when both are known, in a fixed order", () => {
+    expect(redwallLines(running)).toEqual(["WORKERS 3", "LAN 192.168.1.42"]);
+  });
+
+  test("keep the half that is known when the other is not", () => {
+    expect(redwallLines({ workers: 2, address: null })).toEqual(["WORKERS 2"]);
+    expect(redwallLines({ workers: null, address: "10.1.2.3" })).toEqual(["LAN 10.1.2.3"]);
+    expect(redwallLines({ workers: null, address: null })).toEqual([]);
+  });
+
+  test("drop an address the embedded face was never cut for", () => {
+    // Nothing produces an IPv6 address today. When something does, the
+    // failure has to be one missing line rather than a wallpaper that
+    // stops regenerating — and the charset test is what will say so.
+    expect(redwallLines({ workers: 1, address: "fe80::1" })).toEqual(["WORKERS 1"]);
+  });
+
+  test("drop a count that has no digits-only decimal form", () => {
+    for (const workers of [-1, 1.5, Number.NaN, 1e21, Number.POSITIVE_INFINITY]) {
+      expect(redwallLines({ workers, address: null }), String(workers)).toEqual([]);
+    }
+  });
+
+  test("and there is no box to draw when there are no lines", () => {
+    expect(redwallBox({ width: 100, height: 100 }, font, [])).toBeNull();
+  });
+});

--- a/src/redwall-render.ts
+++ b/src/redwall-render.ts
@@ -1,0 +1,232 @@
+/**
+ * Compose a Redwall: the theme's art, with this machine's state on it.
+ *
+ * One function, and it is a pure one — the same art, the same state and
+ * the same theme produce the same bytes. That is not a stylistic
+ * preference. A Redwall is regenerated every time the state it displays
+ * changes, so "did anything actually change" has to be answerable by
+ * comparing bytes; and a renderer that could be tested only by looking
+ * at a desktop could not be tested at all in CI.
+ *
+ * ## What it draws, and what it never touches
+ *
+ * The art underneath is unchanged. This composes *on top of* the brand
+ * sheet, never in place of it, which is what keeps Redwall compatible
+ * with the decision `wallpaper.ts` records: the desktop carries the
+ * mark, and a generator that could not draw one is why the old gradient
+ * was retired. Outside the overlay's rectangle the output is the input,
+ * pixel for pixel.
+ *
+ * ## Why there is a plate at all
+ *
+ * The overlay puts an opaque rectangle down and writes on that, rather
+ * than writing straight onto the art. The reason is `flare`: its sheet
+ * is a field of red.500, and paper text on red.500 measures 3.75 — a
+ * failure by the brand's own guardrail. Text laid directly on art is
+ * legible only if something checked the art, and checking the art means
+ * sampling pixels, which Spec #52 ruled out for a reason worth keeping:
+ * a sampled colour is a colour nobody declared, so nothing can assert
+ * about it before the image exists.
+ *
+ * With a plate, the ground is a colour the *theme* declares, the ink is
+ * a colour the theme's *appearance* declares, and the pair can be
+ * measured in `theme-contrast.test.ts` alongside every other pair this
+ * project draws. Legibility becomes arithmetic instead of a look.
+ *
+ * ## Where it sits
+ *
+ * Bottom right. The top left is where both GNOME and Windows put desktop
+ * icons, the left edge is where GNOME's dock lives, and both lock
+ * screens set their clock along the top. What is left is the corner
+ * nothing else claims.
+ */
+
+import { brand, rgb } from "./brand.ts";
+import { decodePng, encodePng, type Raster } from "./png.ts";
+import { REDWALL_CHARSET } from "./redwall-charset.ts";
+import type { Hex, Theme } from "./themes.ts";
+import { readFont, type Font } from "./ttf.ts";
+import { typeset, type Mask } from "./typeset.ts";
+
+/**
+ * What the overlay reports, with `null` meaning "not known".
+ *
+ * Both halves are independently absent, and that is load-bearing: see
+ * `host-state.ts`, which exists to make sure a daemon that is not
+ * running costs the Worker count and not the address as well.
+ */
+export interface RedwallState {
+  /** Workers running here. Zero is a real answer; null is no answer. */
+  readonly workers: number | null;
+  /** The address this machine answers on, as a dotted quad. */
+  readonly address: string | null;
+}
+
+export interface RedwallInput {
+  /** The theme's wallpaper, as PNG bytes. */
+  readonly art: Uint8Array;
+  /** The face to rasterise with — the bytes at `REDWALL_SUBSET`. */
+  readonly font: Uint8Array;
+  readonly theme: Theme;
+  readonly state: RedwallState;
+}
+
+/** The rectangle the overlay occupies. Everything outside it is art. */
+export interface RedwallBox {
+  readonly x: number;
+  readonly y: number;
+  readonly width: number;
+  readonly height: number;
+}
+
+/** The two colours the overlay is painted in. */
+export interface RedwallInk {
+  /** The plate the text is set on. */
+  readonly plate: Hex;
+  /** The text itself. */
+  readonly text: Hex;
+}
+
+/**
+ * The overlay's colours, from what the theme declares about itself.
+ *
+ * The plate is the theme's own deepest ground — the colour `themes.ts`
+ * describes as the wallpaper's base — so the block reads as part of the
+ * desktop rather than as a sticker on it. The ink is chosen from
+ * `appearance` and nothing else: a dark theme takes paper, a light one
+ * takes ink. No pixel is consulted, which is what makes the pair
+ * knowable, and therefore assertable, before anything is drawn.
+ */
+export function redwallInk(theme: Theme): RedwallInk {
+  return {
+    plate: theme.surface.bg,
+    text: theme.appearance === "light" ? brand.ink : brand.paper,
+  };
+}
+
+/**
+ * The lines the overlay writes, in the order it writes them.
+ *
+ * A value the embedded face cannot draw is dropped rather than
+ * substituted or thrown over. The face covers `REDWALL_CHARSET` and no
+ * more (see `redwall-charset.ts`), so an IPv6 address — which nothing
+ * here produces today and a future `lan-address.ts` might — must not be
+ * able to turn a wallpaper regeneration into a crash. What is dropped is
+ * one line; what is kept is the other, which is the same rule
+ * `host-state.ts` states for a missing daemon.
+ */
+export function redwallLines(state: RedwallState): string[] {
+  const lines: string[] = [];
+  // A count that is not a plain non-negative integer has no decimal form
+  // made only of digits — 1e21 and NaN both stringify into characters
+  // this face has never been cut for.
+  if (state.workers !== null && Number.isSafeInteger(state.workers) && state.workers >= 0) {
+    lines.push(`WORKERS ${state.workers}`);
+  }
+  if (state.address !== null && state.address !== "") {
+    const line = `LAN ${state.address}`;
+    if ([...line].every((ch) => REDWALL_CHARSET.includes(ch))) lines.push(line);
+  }
+  return lines;
+}
+
+/** Text height in pixels, and the space around it, for art this tall. */
+function scaleFor(height: number): { size: number; pad: number; margin: number } {
+  // A fortieth of the height puts about forty lines of text on any
+  // screen, so a 4K sheet and a 1080p one carry the same overlay at
+  // different resolutions rather than the same overlay at different
+  // apparent sizes. The floor is what keeps a thumbnail legible.
+  const size = Math.max(12, Math.round(height / 40));
+  return { size, pad: Math.round(size * 0.75), margin: Math.round(size * 2) };
+}
+
+/**
+ * Where the overlay lands on art of a given size, or null for no lines.
+ *
+ * Exported so a test can say "everything outside this rectangle is
+ * untouched" without re-deriving the layout from the same constants the
+ * renderer used — a check written against its own subject's arithmetic
+ * proves only that the arithmetic was copied correctly.
+ */
+export function redwallBox(
+  art: { readonly width: number; readonly height: number },
+  font: Font,
+  lines: readonly string[],
+): RedwallBox | null {
+  if (lines.length === 0) return null;
+  const { size, pad, margin } = scaleFor(art.height);
+  const mask = typeset(font, lines, size);
+
+  const width = mask.width + pad * 2;
+  const height = mask.height + pad * 2;
+  // Clamped rather than allowed to run off the edge: art smaller than
+  // the overlay is a thumbnail, and a thumbnail should show what it can.
+  return {
+    x: Math.max(0, art.width - margin - width),
+    y: Math.max(0, art.height - margin - height),
+    width,
+    height,
+  };
+}
+
+/**
+ * The art with the state drawn on it, as PNG bytes.
+ *
+ * State with nothing sayable in it returns the art it was given, byte
+ * for byte and without a re-encode. A Redwall of an unknown machine is
+ * the wallpaper, and saying so by returning the input is both cheaper
+ * and more obviously true than encoding an image nothing was drawn on.
+ */
+export function renderRedwall(input: RedwallInput): Uint8Array {
+  const lines = redwallLines(input.state);
+  if (lines.length === 0) return input.art;
+
+  const raster = decodePng(input.art);
+  const font = readFont(input.font);
+  const box = redwallBox(raster, font, lines)!;
+  const { size, pad } = scaleFor(raster.height);
+
+  paint(raster, box, pad, typeset(font, lines, size), redwallInk(input.theme));
+  return encodePng(raster);
+}
+
+/**
+ * Lay the plate down and pour the ink through the mask.
+ *
+ * The blend is against the plate rather than against the art, because
+ * the plate is opaque and already covers every pixel this touches. That
+ * is what makes the measured contrast of an antialiased edge a value
+ * between the two declared colours and never a third one taken from
+ * whatever the sheet happened to have there.
+ */
+function paint(raster: Raster, box: RedwallBox, pad: number, mask: Mask, ink: RedwallInk): void {
+  const [pr, pg, pb] = rgb(ink.plate);
+  const [tr, tg, tb] = rgb(ink.text);
+  const { data, width } = raster;
+
+  for (let y = 0; y < box.height; y++) {
+    const row = box.y + y;
+    if (row < 0 || row >= raster.height) continue;
+    const my = y - pad;
+
+    for (let x = 0; x < box.width; x++) {
+      const column = box.x + x;
+      if (column < 0 || column >= width) continue;
+      const mx = x - pad;
+      const covered =
+        mx >= 0 && mx < mask.width && my >= 0 && my < mask.height
+          ? mask.alpha[my * mask.width + mx]!
+          : 0;
+
+      const at = (row * width + column) * 4;
+      data[at] = mix(pr, tr, covered);
+      data[at + 1] = mix(pg, tg, covered);
+      data[at + 2] = mix(pb, tb, covered);
+      data[at + 3] = 255;
+    }
+  }
+}
+
+function mix(under: number, over: number, coverage: number): number {
+  return Math.round((over * coverage + under * (255 - coverage)) / 255);
+}

--- a/src/theme-contrast.test.ts
+++ b/src/theme-contrast.test.ts
@@ -15,10 +15,17 @@
  * src/brand-guardrail.test.ts is the other half: it pins this checker
  * against the brand's published numbers, so a luminance function that
  * drifted would be caught before it started passing bad themes.
+ *
+ * The Redwall overlay joins the table at the bottom. It is the one pair
+ * here that is not a theme role against another theme role — the ink
+ * comes from the theme's declared appearance and the plate from its
+ * ground — and it is drawn on somebody's desktop rather than inside a
+ * window, so an unreadable one is the least recoverable of the lot.
  */
 
 import { describe, expect, test } from "bun:test";
-import { contrast, neutral, red } from "./brand.ts";
+import { brand, contrast, neutral, red } from "./brand.ts";
+import { redwallInk } from "./redwall-render.ts";
 import { THEME_SLUGS, THEMES } from "./themes.ts";
 
 /** WCAG AA for normal text, and what audit-contrast.mjs uses. */
@@ -70,6 +77,14 @@ describe.each([...THEME_SLUGS])("%s", (slug) => {
     expect(contrast(t.surface.edge, t.surface.bg)).toBeGreaterThanOrEqual(HAIRLINE);
   });
 
+  test("the Redwall overlay reads on the plate Redwall draws it on", () => {
+    // Held to the text bar and not the secondary one. This is a Worker
+    // count and an address — the two things the overlay exists so that
+    // somebody can read from across the room without unlocking.
+    const ink = redwallInk(t);
+    expect(contrast(ink.text, ink.plate)).toBeGreaterThanOrEqual(BODY);
+  });
+
   test("the accent is a fill that can be seen, carrying text that can be read", () => {
     if (t.accent.kind !== "colour") return;
     // As a fill: the non-text bar. The accent is never text — the type
@@ -91,6 +106,20 @@ describe("the rule the whole exercise exists for", () => {
       const accent = THEMES[slug].accent;
       if (accent.kind !== "colour") continue;
       expect(contrast(accent.on, accent.value), slug).toBeGreaterThanOrEqual(BODY);
+    }
+  });
+
+  test("and the Redwall ink is a choice this table would refuse to have wrong", () => {
+    // The check above passes for every theme, which on its own says
+    // nothing about whether the check has teeth. So: swap each theme's
+    // ink for the other appearance's — the single-character change
+    // somebody would make in `redwallInk` — and every one of the six
+    // fails. Paper on paper is 1.00 and ink on cobalt's grey is 1.74.
+    for (const slug of THEME_SLUGS) {
+      const theme = THEMES[slug];
+      const wrong = theme.appearance === "light" ? brand.paper : brand.ink;
+      expect(wrong, slug).not.toBe(redwallInk(theme).text);
+      expect(contrast(wrong, redwallInk(theme).plate), slug).toBeLessThan(BODY);
     }
   });
 

--- a/src/ttf-outline.test.ts
+++ b/src/ttf-outline.test.ts
@@ -1,0 +1,109 @@
+/**
+ * The outline reader, checked against the face it was written for.
+ *
+ * There is no fixture font here and there should not be one: the
+ * embedded subset is the only face Redwall will ever draw with, it is
+ * pinned by digest in `vendor/font/font.lock.json`, and a hand-built
+ * fixture would prove the reader agrees with whatever the fixture's
+ * author believed about `glyf`.
+ *
+ * What is checkable without a picture is shape rather than pixels: a
+ * glyph's points must land inside the box its own header declares, a
+ * monospaced face must advance by one width for every character, and the
+ * blank must be blank. Each of those fails loudly under the coordinate
+ * bugs that otherwise render as "the text looks a bit wrong".
+ */
+
+import { describe, expect, test } from "bun:test";
+import { REDWALL_CHARSET } from "./redwall-charset.ts";
+import { REDWALL_SUBSET } from "./redwall-font.ts";
+import { readFont, view, requireTable, type Font } from "./ttf.ts";
+
+const bytes = await Bun.file(REDWALL_SUBSET).bytes();
+const font: Font = readFont(bytes);
+
+/** Every character the overlay may draw, minus the one with no ink. */
+const drawn = [...REDWALL_CHARSET].filter((ch) => ch !== " ");
+
+function glyph(ch: string): number {
+  const gid = font.glyphFor(ch.codePointAt(0)!);
+  if (gid === undefined) throw new Error(`the subset does not map '${ch}'`);
+  return gid;
+}
+
+describe("the face as a whole", () => {
+  test("declares an em square and one glyph per character plus .notdef", () => {
+    expect(font.unitsPerEm).toBeGreaterThan(0);
+    expect(font.glyphCount).toBe(REDWALL_CHARSET.length + 1);
+  });
+
+  test("is monospaced, which is what lets a pen advance without measuring", () => {
+    const widths = [...new Set(drawn.map((ch) => font.advanceOf(glyph(ch))))];
+    expect(widths).toHaveLength(1);
+    // The space is a character with an advance and no outline. A face
+    // where it advanced by zero would set every line on top of itself.
+    expect(font.advanceOf(glyph(" "))).toBe(widths[0]!);
+  });
+});
+
+describe("every glyph the overlay can draw", () => {
+  test.each(drawn)("'%s' has an outline inside the box its header declares", (ch) => {
+    const gid = glyph(ch);
+    const contours = font.contoursOf(gid);
+    expect(contours.length).toBeGreaterThan(0);
+
+    // The glyph header's own bounding box, read straight out of `glyf`
+    // rather than from the reader under test. A sign error in the delta
+    // decoding puts points outside it; nothing else does.
+    const dv = view(bytes);
+    const glyf = requireTable(bytes, "glyf");
+    const loca = requireTable(bytes, "loca");
+    const at = glyf.offset + dv.getUint32(loca.offset + gid * 4);
+    const box = {
+      xMin: dv.getInt16(at + 2),
+      yMin: dv.getInt16(at + 4),
+      xMax: dv.getInt16(at + 6),
+      yMax: dv.getInt16(at + 8),
+    };
+
+    for (const contour of contours) {
+      for (const point of contour) {
+        expect(point.x).toBeGreaterThanOrEqual(box.xMin);
+        expect(point.x).toBeLessThanOrEqual(box.xMax);
+        expect(point.y).toBeGreaterThanOrEqual(box.yMin);
+        expect(point.y).toBeLessThanOrEqual(box.yMax);
+      }
+    }
+  });
+
+  test("'0' and 'O' are different shapes, which is the whole point of a face", () => {
+    // Not in the charset together — 'O' is only there because WORKERS
+    // has one — but this is the pair a subsetter renumbering glyphs gets
+    // wrong, and the pair a reader would be most embarrassed to confuse.
+    const zero = font.contoursOf(glyph("0"));
+    const oh = font.contoursOf(glyph("O"));
+    expect(JSON.stringify(zero)).not.toBe(JSON.stringify(oh));
+  });
+});
+
+describe("the blank", () => {
+  test("has no contours at all, rather than an empty one", () => {
+    // A zero-length `loca` entry means "no outline", and the format
+    // stores no header for it. A reader that parsed one anyway would
+    // read the next glyph's bytes as this glyph's contour count.
+    expect(font.contoursOf(glyph(" "))).toEqual([]);
+  });
+});
+
+describe("what the reader refuses", () => {
+  test("a glyph index the face does not have", () => {
+    expect(() => font.contoursOf(font.glyphCount)).toThrow(/no glyph/);
+    expect(() => font.contoursOf(-1)).toThrow(/no glyph/);
+  });
+
+  test("a codepoint the subset was not cut for", () => {
+    // Undefined rather than a throw: an unmapped character is a question
+    // the caller has to answer, and .notdef is one of the answers.
+    expect(font.glyphFor("Z".codePointAt(0)!)).toBeUndefined();
+  });
+});

--- a/src/ttf.ts
+++ b/src/ttf.ts
@@ -12,9 +12,12 @@
  * font's own cmap or it can be believed, and a claim nobody can check is
  * the failure mode `brand-lock.test.ts` was written to close.
  *
- * Deliberately absent: `glyf` outlines, kerning, `GSUB`. Nothing draws
- * yet, and a parser written ahead of a caller is a parser written
- * against a guess.
+ * `glyf` outlines arrived when the caller did — `readFont` below is what
+ * the Redwall rasteriser reads glyphs through. Still deliberately absent:
+ * kerning and `GSUB`. The subset is a monospaced face with the ligature
+ * machinery cut out of it (see `ttf-subset.ts`), so a pen that advances
+ * by `hmtx` and nothing else is not an approximation of what the face
+ * does — it is what the face does.
  */
 
 export type TableRecord = {
@@ -153,4 +156,270 @@ function readFormat12(dv: DataView, at: number): Map<number, number> {
     }
   }
   return map;
+}
+
+// ------------------------------------------------------------- outlines
+
+/**
+ * A point on a glyph's outline, in font units with y pointing up.
+ *
+ * `on` is the TrueType distinction: an on-curve point is somewhere the
+ * outline passes through, an off-curve point is the control point of a
+ * quadratic between its neighbours. Two off-curve points in a row have
+ * an on-curve point implied at their midpoint, and the format stores
+ * neither it nor any note that it is missing.
+ *
+ * The sequence is handed over as the file stores it, implications and
+ * all. Reconstructing them here would mean this module deciding what a
+ * curve is before anything asks it to draw one; the rasteriser is where
+ * that belongs, and it is the only caller.
+ */
+export interface GlyphPoint {
+  readonly x: number;
+  readonly y: number;
+  readonly on: boolean;
+}
+
+/** One closed loop of a glyph. The last point joins back to the first. */
+export type GlyphContour = readonly GlyphPoint[];
+
+/** A face, with its tables located once instead of on every glyph. */
+export interface Font {
+  /** The em square's side in font units — the divisor for any size. */
+  readonly unitsPerEm: number;
+  /**
+   * `hhea`'s vertical metrics, in font units: how far above the baseline
+   * the face reaches, how far below (negative), and the extra leading it
+   * asks for between two lines. Read from `hhea` rather than `OS/2`
+   * because `hhea` is the table every TrueType file must carry, and the
+   * subsetter copies it through unchanged.
+   */
+  readonly ascender: number;
+  readonly descender: number;
+  readonly lineGap: number;
+  readonly glyphCount: number;
+  /** The glyph for a codepoint, or undefined where the face has none. */
+  glyphFor(codepoint: number): number | undefined;
+  /** How far the pen moves after drawing it, in font units. */
+  advanceOf(gid: number): number;
+  /** Its outline, composites already resolved into their parts. */
+  contoursOf(gid: number): GlyphContour[];
+}
+
+/** Simple-glyph flags, from the `glyf` spec. */
+const ON_CURVE = 0x01;
+const X_SHORT = 0x02;
+const Y_SHORT = 0x04;
+const REPEAT = 0x08;
+const X_SAME_OR_POSITIVE = 0x10;
+const Y_SAME_OR_POSITIVE = 0x20;
+
+/** Composite-glyph flags. The subsetter names the ones it needs too. */
+const ARG_1_AND_2_ARE_WORDS = 0x0001;
+const ARGS_ARE_XY_VALUES = 0x0002;
+const WE_HAVE_A_SCALE = 0x0008;
+const MORE_COMPONENTS = 0x0020;
+const WE_HAVE_AN_X_AND_Y_SCALE = 0x0040;
+const WE_HAVE_A_TWO_BY_TWO = 0x0080;
+
+/**
+ * Read a face once, then ask it for glyphs.
+ *
+ * The tables are found up front and the cmap is walked up front, because
+ * the alternative is doing both per character of every line drawn — and
+ * `cmapCoverage` expands every mapped codepoint into a Map, which is
+ * cheap over a twenty-two character subset and absurd per glyph.
+ *
+ * Nothing is cached beyond that. A Redwall draws two short lines and the
+ * whole face is 4.9 KB; a glyph cache here would be a lifetime question
+ * asked on behalf of a cost nobody has measured.
+ */
+export function readFont(bytes: Uint8Array): Font {
+  const dv = view(bytes);
+  const head = requireTable(bytes, "head");
+  const hhea = requireTable(bytes, "hhea");
+  const hmtx = requireTable(bytes, "hmtx");
+  const locaTable = requireTable(bytes, "loca");
+  const glyf = requireTable(bytes, "glyf");
+
+  const unitsPerEm = dv.getUint16(head.offset + 18);
+  if (unitsPerEm === 0) throw new Error("font declares an em square of zero units");
+  const longLoca = dv.getInt16(head.offset + 50) === 1;
+  const glyphCount = numGlyphs(bytes);
+  const metrics = dv.getUint16(hhea.offset + 34);
+  const coverage = cmapCoverage(bytes);
+
+  const loca = (gid: number): number =>
+    longLoca
+      ? dv.getUint32(locaTable.offset + gid * 4)
+      : dv.getUint16(locaTable.offset + gid * 2) * 2;
+
+  const contoursOf = (gid: number, depth = 0): GlyphContour[] => {
+    if (gid < 0 || gid >= glyphCount) throw new Error(`no glyph ${gid} in a face of ${glyphCount}`);
+    // A composite that reaches itself would otherwise recurse until the
+    // stack gave out. Five is past anything a real face nests.
+    if (depth > 5) throw new Error(`glyph ${gid} nests composites more than five deep`);
+
+    const start = glyf.offset + loca(gid);
+    const end = glyf.offset + loca(gid + 1);
+    // A zero-length glyph is a blank one — the space character — and has
+    // no header at all, let alone contours.
+    if (end <= start) return [];
+
+    const contours = dv.getInt16(start);
+    return contours >= 0
+      ? simpleGlyph(dv, start, contours)
+      : compositeGlyph(dv, start, (part) => contoursOf(part, depth + 1));
+  };
+
+  return {
+    unitsPerEm,
+    ascender: dv.getInt16(hhea.offset + 4),
+    descender: dv.getInt16(hhea.offset + 6),
+    lineGap: dv.getInt16(hhea.offset + 8),
+    glyphCount,
+    glyphFor: (codepoint) => coverage.get(codepoint),
+    advanceOf: (gid) => dv.getUint16(hmtx.offset + Math.min(gid, metrics - 1) * 4),
+    contoursOf: (gid) => contoursOf(gid),
+  };
+}
+
+/**
+ * The point stream, with the implied on-curve points put back.
+ *
+ * The three coordinate arrays are read in the order the format stores
+ * them — all the flags, then all the x deltas, then all the y deltas —
+ * so the x pass has to run to completion before the y pass knows where
+ * to start. That is why the flags are materialised into an array rather
+ * than streamed.
+ */
+function simpleGlyph(dv: DataView, start: number, contours: number): GlyphContour[] {
+  const ends: number[] = [];
+  for (let i = 0; i < contours; i++) ends.push(dv.getUint16(start + 10 + i * 2));
+  const count = contours === 0 ? 0 : ends[contours - 1]! + 1;
+  if (count === 0) return [];
+
+  let at = start + 10 + contours * 2;
+  at += 2 + dv.getUint16(at); // the hinting instructions, read past
+
+  const flags = new Uint8Array(count);
+  for (let i = 0; i < count; ) {
+    const flag = dv.getUint8(at++);
+    flags[i++] = flag;
+    if (flag & REPEAT) {
+      let repeats = dv.getUint8(at++);
+      while (repeats-- > 0 && i < count) flags[i++] = flag;
+    }
+  }
+
+  const xs = new Int32Array(count);
+  let x = 0;
+  for (let i = 0; i < count; i++) {
+    const flag = flags[i]!;
+    if (flag & X_SHORT) {
+      const delta = dv.getUint8(at++);
+      x += flag & X_SAME_OR_POSITIVE ? delta : -delta;
+    } else if (!(flag & X_SAME_OR_POSITIVE)) {
+      // Without the short flag, the "same" bit means the coordinate did
+      // not change and nothing is stored for it at all.
+      x += dv.getInt16(at);
+      at += 2;
+    }
+    xs[i] = x;
+  }
+
+  const ys = new Int32Array(count);
+  let y = 0;
+  for (let i = 0; i < count; i++) {
+    const flag = flags[i]!;
+    if (flag & Y_SHORT) {
+      const delta = dv.getUint8(at++);
+      y += flag & Y_SAME_OR_POSITIVE ? delta : -delta;
+    } else if (!(flag & Y_SAME_OR_POSITIVE)) {
+      y += dv.getInt16(at);
+      at += 2;
+    }
+    ys[i] = y;
+  }
+
+  const out: GlyphContour[] = [];
+  let from = 0;
+  for (const last of ends) {
+    const points: GlyphPoint[] = [];
+    for (let i = from; i <= last; i++) {
+      points.push({ x: xs[i]!, y: ys[i]!, on: (flags[i]! & ON_CURVE) !== 0 });
+    }
+    if (points.length > 0) out.push(points);
+    from = last + 1;
+  }
+  return out;
+}
+
+/**
+ * A glyph assembled out of other glyphs, each under its own transform.
+ *
+ * Point-matching placement — the form where the arguments are point
+ * indices rather than offsets — throws rather than being guessed at. It
+ * is used by hand-built accented faces and by nothing in a subset of
+ * digits and capitals, and placing a component at the wrong offset draws
+ * a glyph that is confidently wrong.
+ */
+function compositeGlyph(
+  dv: DataView,
+  start: number,
+  partOf: (gid: number) => GlyphContour[],
+): GlyphContour[] {
+  const out: GlyphContour[] = [];
+  let at = start + 10;
+
+  for (;;) {
+    const flags = dv.getUint16(at);
+    const component = dv.getUint16(at + 2);
+    at += 4;
+
+    let dx: number;
+    let dy: number;
+    if (flags & ARG_1_AND_2_ARE_WORDS) {
+      dx = dv.getInt16(at);
+      dy = dv.getInt16(at + 2);
+      at += 4;
+    } else {
+      dx = dv.getInt8(at);
+      dy = dv.getInt8(at + 1);
+      at += 2;
+    }
+    if (!(flags & ARGS_ARE_XY_VALUES)) {
+      throw new Error("composite glyph places a component by point matching, which this reader does not do");
+    }
+
+    // F2Dot14: a signed 16-bit fixed-point value with two integer bits.
+    const f2dot14 = (offset: number): number => dv.getInt16(offset) / 16384;
+    let a = 1;
+    let b = 0;
+    let c = 0;
+    let d = 1;
+    if (flags & WE_HAVE_A_SCALE) {
+      a = d = f2dot14(at);
+      at += 2;
+    } else if (flags & WE_HAVE_AN_X_AND_Y_SCALE) {
+      a = f2dot14(at);
+      d = f2dot14(at + 2);
+      at += 4;
+    } else if (flags & WE_HAVE_A_TWO_BY_TWO) {
+      a = f2dot14(at);
+      b = f2dot14(at + 2);
+      c = f2dot14(at + 4);
+      d = f2dot14(at + 6);
+      at += 8;
+    }
+
+    for (const contour of partOf(component)) {
+      out.push(
+        contour.map((p) => ({ x: a * p.x + c * p.y + dx, y: b * p.x + d * p.y + dy, on: p.on })),
+      );
+    }
+
+    if (!(flags & MORE_COMPONENTS)) break;
+  }
+  return out;
 }

--- a/src/typeset.test.ts
+++ b/src/typeset.test.ts
@@ -1,0 +1,109 @@
+/**
+ * The rasteriser, checked without anybody looking at the output.
+ *
+ * A mask cannot be asserted pixel by pixel against a reference without
+ * committing a reference, and a committed reference is a test that fails
+ * whenever the renderer improves. So what is measured here is what stays
+ * true across any correct rasteriser: ink lands where the glyphs are and
+ * nowhere else, a blank has no ink, wider text is wider, and the same
+ * call twice is the same bytes.
+ *
+ * The last one is the load-bearing one. `redwall-render.ts` is pure only
+ * if this is, and everything downstream of that — comparing a composed
+ * Redwall against the one already on disk to decide whether to write —
+ * rests on it.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { REDWALL_SUBSET } from "./redwall-font.ts";
+import { readFont } from "./ttf.ts";
+import { measure, typeset } from "./typeset.ts";
+
+const font = readFont(await Bun.file(REDWALL_SUBSET).bytes());
+
+/** How much ink a mask carries, as a fraction of its own area. */
+function inked(text: string, size = 32): number {
+  const mask = typeset(font, [text], size);
+  let total = 0;
+  for (const value of mask.alpha) total += value;
+  return total / (mask.alpha.length * 255);
+}
+
+describe("the same call twice", () => {
+  test("produces the same coverage, byte for byte", () => {
+    const first = typeset(font, ["WORKERS 12", "LAN 10.0.0.1"], 24);
+    const second = typeset(font, ["WORKERS 12", "LAN 10.0.0.1"], 24);
+    expect(first.width).toBe(second.width);
+    expect(first.height).toBe(second.height);
+    expect([...first.alpha]).toEqual([...second.alpha]);
+  });
+});
+
+describe("what lands in the mask", () => {
+  test("is ink for a character with an outline", () => {
+    // A number rather than a threshold on any one pixel: a rasteriser
+    // that filled with the wrong winding rule would draw the counter of
+    // an '0' solid, and one that flipped y would still draw something.
+    expect(inked("0")).toBeGreaterThan(0.1);
+    expect(inked("0")).toBeLessThan(0.9);
+  });
+
+  test("and nothing at all for a line of blanks", () => {
+    // The space is a glyph with an advance and no contours. It is the
+    // one character whose correct rendering is an empty mask, and a
+    // reader that parsed its absent header would put noise here.
+    expect(inked("   ")).toBe(0);
+  });
+
+  test("with the counters of the letters left open", () => {
+    // 'O' is a contour inside a contour wound the other way. Non-zero
+    // winding leaves the middle empty; a rasteriser that ignored
+    // direction fills it, and 'O' then carries more ink than '0'.
+    const mask = typeset(font, ["O"], 64);
+    const centre = mask.alpha[Math.floor(mask.height / 2) * mask.width + Math.floor(mask.width / 2)]!;
+    expect(centre).toBe(0);
+  });
+});
+
+describe("the geometry", () => {
+  test("advances by the same width for every character, because the face is one", () => {
+    const one = measure(font, ["0"], 40).width;
+    const four = measure(font, ["0000"], 40).width;
+    expect(four).toBeCloseTo(one * 4, 6);
+    // The blank advances too. A face where it did not would set the
+    // address hard against its label.
+    expect(measure(font, ["0 0"], 40).width).toBeCloseTo(one * 3, 6);
+  });
+
+  test("scales linearly with the size asked for", () => {
+    expect(measure(font, ["WORKERS"], 60).width).toBeCloseTo(measure(font, ["WORKERS"], 30).width * 2, 6);
+  });
+
+  test("stacks lines rather than overprinting them", () => {
+    const one = measure(font, ["LAN"], 32);
+    const three = measure(font, ["LAN", "LAN", "LAN"], 32);
+    expect(three.height).toBeCloseTo(one.height + one.lineHeight * 2, 6);
+    // And the mask is as tall as the measurement says, so a caller can
+    // position the block without knowing where a baseline is.
+    expect(typeset(font, ["LAN", "LAN", "LAN"], 32).height).toBe(Math.ceil(three.height));
+  });
+
+  test("is a widest-line measurement, not a last-line one", () => {
+    expect(measure(font, ["0", "000"], 32).width).toBeCloseTo(measure(font, ["000"], 32).width, 6);
+    expect(measure(font, ["000", "0"], 32).width).toBeCloseTo(measure(font, ["000"], 32).width, 6);
+  });
+
+  test("and nothing at all is a block of no height", () => {
+    expect(measure(font, [], 32).height).toBe(0);
+  });
+});
+
+describe("a character the face was not cut for", () => {
+  test("is a refusal naming it, not a row of empty boxes", () => {
+    // .notdef is deliberately not the fallback: a subset and a charset
+    // that have drifted apart is a re-vendor, and the failure has to say
+    // so rather than shipping tofu to somebody's desktop.
+    expect(() => typeset(font, ["Z"], 32)).toThrow(/U\+005A/);
+    expect(() => measure(font, ["%"], 32)).toThrow(/no glyph/);
+  });
+});

--- a/src/typeset.ts
+++ b/src/typeset.ts
@@ -1,0 +1,310 @@
+/**
+ * Lines of text turned into coverage, one glyph outline at a time.
+ *
+ * This is the rasteriser Spec #52 chose over an embedded bitmap atlas.
+ * The reason is in `redwall-font.ts`: the overlay has to look the same
+ * on a machine whose owner picked a different terminal font, and a
+ * bitmap atlas would have fixed the size at vendor time — a 4K desktop
+ * and a 1080p one would then get the same pixel height of text, which is
+ * half the size on one of them.
+ *
+ * What comes out is a mask, not an image. Coverage says how much of each
+ * pixel the letterforms cover and says nothing about colour; the caller
+ * decides what to pour through it. That is what keeps the ink colour a
+ * decision `redwall-render.ts` makes from the theme, in one place, where
+ * the contrast table can see it.
+ *
+ * ## Determinism
+ *
+ * Every number here is IEEE double arithmetic on inputs that are
+ * integers from the font file, so the same text at the same size is the
+ * same mask, byte for byte, on every machine. Nothing samples, nothing
+ * consults a clock, and the curve flattening subdivides by a count
+ * derived from the control polygon rather than by an error tolerance
+ * loop — a loop would still be deterministic, but a count is obviously
+ * so.
+ *
+ * ## Fill rule
+ *
+ * Non-zero winding, which is what TrueType specifies: a counter is
+ * incremented on downward crossings and decremented on upward ones, and
+ * anything not at zero is inside. The even-odd rule would hollow out the
+ * bowl of an 'O' correctly by accident and get an overlapping contour
+ * wrong, and overlapping contours are ordinary in a real face.
+ */
+
+import type { Font, GlyphContour } from "./ttf.ts";
+
+/** Coverage, 0 (bare) to 255 (solid), row-major, `width * height` bytes. */
+export interface Mask {
+  readonly width: number;
+  readonly height: number;
+  readonly alpha: Uint8Array;
+}
+
+/**
+ * How many sub-scanlines each pixel row is sampled at.
+ *
+ * Vertical coverage is sampled and horizontal coverage is exact — the
+ * span arithmetic below counts the fraction of a pixel a span covers
+ * rather than testing its centre — so four rows buys most of what
+ * sixteen would. Text this size is read at a glance from across a room,
+ * not measured.
+ */
+const SAMPLES = 4;
+
+interface Vertex {
+  readonly x: number;
+  readonly y: number;
+}
+
+interface Edge {
+  readonly x0: number;
+  readonly y0: number;
+  readonly x1: number;
+  readonly y1: number;
+}
+
+/** Where a set of lines will sit, before any of it is drawn. */
+export interface Metrics {
+  /** The widest line, in pixels. */
+  readonly width: number;
+  /** Every line's box stacked, in pixels. */
+  readonly height: number;
+  /** Baseline to baseline. */
+  readonly lineHeight: number;
+  /** Baseline of the first line, measured from the top of the box. */
+  readonly ascent: number;
+}
+
+export function measure(font: Font, lines: readonly string[], size: number): Metrics {
+  const scale = size / font.unitsPerEm;
+  const ascent = font.ascender * scale;
+  const lineHeight = (font.ascender - font.descender + font.lineGap) * scale;
+
+  let width = 0;
+  for (const line of lines) width = Math.max(width, lineWidth(font, line, scale));
+
+  // The last line needs its descender, not another whole line box, or
+  // every block would carry a strip of nothing along its bottom edge.
+  const height = lines.length === 0 ? 0 : lineHeight * (lines.length - 1) + ascent - font.descender * scale;
+  return { width, height, lineHeight, ascent };
+}
+
+function lineWidth(font: Font, line: string, scale: number): number {
+  let width = 0;
+  for (const ch of line) width += font.advanceOf(glyphOf(font, ch)) * scale;
+  return width;
+}
+
+/**
+ * The glyph for a character, or a refusal naming the character.
+ *
+ * `.notdef` is deliberately not the fallback. The subset is cut from the
+ * character set Redwall declares (`redwall-charset.ts`), so a character
+ * outside it means the two have drifted apart — and the failure mode
+ * that matters is the silent one, where a machine's address renders as a
+ * row of empty boxes on somebody's desktop and nothing says why.
+ */
+function glyphOf(font: Font, ch: string): number {
+  const gid = font.glyphFor(ch.codePointAt(0)!);
+  if (gid === undefined) {
+    throw new Error(`the embedded face has no glyph for '${ch}' (U+${ch.codePointAt(0)!.toString(16).toUpperCase().padStart(4, "0")})`);
+  }
+  return gid;
+}
+
+/**
+ * Set the lines and fill them, left-aligned, at `size` pixels to the em.
+ *
+ * The mask is exactly as large as `measure` says the block is, so the
+ * caller positions one rectangle rather than reasoning about baselines.
+ */
+export function typeset(font: Font, lines: readonly string[], size: number): Mask {
+  const metrics = measure(font, lines, size);
+  const width = Math.max(1, Math.ceil(metrics.width));
+  const height = Math.max(1, Math.ceil(metrics.height));
+  if (lines.length === 0) return { width: 1, height: 1, alpha: new Uint8Array(1) };
+
+  const scale = size / font.unitsPerEm;
+  const edges: Edge[] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const baseline = metrics.ascent + i * metrics.lineHeight;
+    let pen = 0;
+    for (const ch of lines[i]!) {
+      const gid = glyphOf(font, ch);
+      for (const contour of font.contoursOf(gid)) {
+        // Font space has y pointing up from the baseline; a raster has
+        // it pointing down from the top. The flip is the subtraction.
+        addContour(edges, contour, (x, y) => ({ x: pen + x * scale, y: baseline - y * scale }));
+      }
+      pen += font.advanceOf(gid) * scale;
+    }
+  }
+
+  return { width, height, alpha: fill(edges, width, height) };
+}
+
+// -------------------------------------------------------------- outlines
+
+/**
+ * One contour, flattened into the polyline that approximates it.
+ *
+ * The awkward part is the format's implied points: two off-curve points
+ * in a row have an on-curve point at their midpoint that is not stored,
+ * and a contour may have no stored on-curve point at all — in which case
+ * the start is the midpoint of the last and first controls. Both cases
+ * are ordinary, and both draw garbage if assumed away.
+ */
+function addContour(
+  edges: Edge[],
+  contour: GlyphContour,
+  place: (x: number, y: number) => Vertex,
+): void {
+  const n = contour.length;
+  if (n < 2) return;
+
+  const points = contour.map((p) => ({ ...place(p.x, p.y), on: p.on }));
+  const onCurve = points.findIndex((p) => p.on);
+  const start: Vertex = onCurve >= 0 ? points[onCurve]! : midpoint(points[n - 1]!, points[0]!);
+
+  // With a stored start, that point is already placed and the walk
+  // continues past it. Without one, the walk begins at the first control.
+  const from = onCurve >= 0 ? onCurve + 1 : 0;
+  const count = onCurve >= 0 ? n - 1 : n;
+
+  const line: Vertex[] = [start];
+  let current = start;
+  let control: Vertex | null = null;
+
+  for (let k = 0; k < count; k++) {
+    const point = points[(from + k) % n]!;
+    if (point.on) {
+      if (control === null) line.push(point);
+      else curve(line, current, control, point);
+      current = point;
+      control = null;
+    } else if (control === null) {
+      control = point;
+    } else {
+      const implied = midpoint(control, point);
+      curve(line, current, control, implied);
+      current = implied;
+      control = point;
+    }
+  }
+
+  // Closing the loop, through a final control if one is still open.
+  if (control === null) line.push(start);
+  else curve(line, current, control, start);
+
+  for (let i = 0; i + 1 < line.length; i++) {
+    const a = line[i]!;
+    const b = line[i + 1]!;
+    if (a.y !== b.y) edges.push({ x0: a.x, y0: a.y, x1: b.x, y1: b.y });
+  }
+}
+
+function midpoint(a: Vertex, b: Vertex): Vertex {
+  return { x: (a.x + b.x) / 2, y: (a.y + b.y) / 2 };
+}
+
+/**
+ * A quadratic, subdivided into segments no longer than about a pixel.
+ *
+ * The count comes from the control polygon's length, which is an upper
+ * bound on the curve's own — so the segments are never coarser than
+ * asked for, and a curve two pixels across costs two segments rather
+ * than the thirty-two a fixed count would spend on it.
+ */
+function curve(line: Vertex[], p0: Vertex, control: Vertex, p1: Vertex): void {
+  const span = distance(p0, control) + distance(control, p1);
+  const steps = Math.max(2, Math.min(32, Math.ceil(span)));
+  for (let i = 1; i <= steps; i++) {
+    const t = i / steps;
+    const u = 1 - t;
+    line.push({
+      x: u * u * p0.x + 2 * u * t * control.x + t * t * p1.x,
+      y: u * u * p0.y + 2 * u * t * control.y + t * t * p1.y,
+    });
+  }
+}
+
+function distance(a: Vertex, b: Vertex): number {
+  return Math.hypot(b.x - a.x, b.y - a.y);
+}
+
+// ------------------------------------------------------------------ fill
+
+function fill(edges: readonly Edge[], width: number, height: number): Uint8Array {
+  const coverage = new Float64Array(width * height);
+  const crossings: Array<{ x: number; winding: number }> = [];
+  const weight = 1 / SAMPLES;
+
+  for (let row = 0; row < height; row++) {
+    const at = row * width;
+    for (let sample = 0; sample < SAMPLES; sample++) {
+      const y = row + (sample + 0.5) / SAMPLES;
+
+      crossings.length = 0;
+      for (const edge of edges) {
+        const top = Math.min(edge.y0, edge.y1);
+        const bottom = Math.max(edge.y0, edge.y1);
+        // Half-open in y: an edge that ends exactly on this scanline
+        // belongs to the edge that starts there, and counting both would
+        // wind twice at every horizontal join.
+        if (y < top || y >= bottom) continue;
+        crossings.push({
+          x: edge.x0 + ((y - edge.y0) * (edge.x1 - edge.x0)) / (edge.y1 - edge.y0),
+          winding: edge.y1 > edge.y0 ? 1 : -1,
+        });
+      }
+      if (crossings.length < 2) continue;
+
+      crossings.sort((a, b) => a.x - b.x);
+      let winding = 0;
+      for (let i = 0; i + 1 < crossings.length; i++) {
+        winding += crossings[i]!.winding;
+        if (winding !== 0) span(coverage, at, crossings[i]!.x, crossings[i + 1]!.x, weight, width);
+      }
+    }
+  }
+
+  const alpha = new Uint8Array(width * height);
+  for (let i = 0; i < alpha.length; i++) {
+    alpha[i] = Math.min(255, Math.round(coverage[i]! * 255));
+  }
+  return alpha;
+}
+
+/**
+ * Add one sub-scanline's worth of coverage between two x positions.
+ *
+ * The two ends are fractional and the middle is not, which is where the
+ * horizontal antialiasing comes from: a span covering a fifth of a pixel
+ * adds a fifth of this sample's weight to it.
+ */
+function span(
+  coverage: Float64Array,
+  at: number,
+  from: number,
+  to: number,
+  weight: number,
+  width: number,
+): void {
+  const left = Math.max(from, 0);
+  const right = Math.min(to, width);
+  if (right <= left) return;
+
+  const first = Math.floor(left);
+  const last = Math.floor(right);
+  if (first === last) {
+    coverage[at + first] = coverage[at + first]! + (right - left) * weight;
+    return;
+  }
+
+  coverage[at + first] = coverage[at + first]! + (first + 1 - left) * weight;
+  for (let x = first + 1; x < last; x++) coverage[at + x] = coverage[at + x]! + weight;
+  if (last < width) coverage[at + last] = coverage[at + last]! + (right - last) * weight;
+}


### PR DESCRIPTION
Automated AFK landing for #57. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #57

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788808510&installation_model_id=20659&pr_number=84&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F84&signature=86f7b84ae0989a96e29e16ee8ffb25f237cc22f34bf34910594a521e2197cfa9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->