### PR TITLE
chore: #58 red-dev redwall: generate and write the image

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ red-dev install [scope]      # converge toward the manifest
 red-dev install --dry-run    # print the plan, touch nothing
 red-dev update               # upgrade what the package managers own
 red-dev theme [name]         # dark | light | obsidian | marble | cobalt | flare
+red-dev redwall              # redraw the wallpaper carrying this machine's state
 red-dev apps                 # choose optional tools
 red-dev lang                 # choose runtimes for mise to manage
 red-dev lang node@lts,bun@latest # unattended runtime selection

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -113,6 +113,14 @@ export function buildCli(): CLI {
           },
         ],
       },
+      redwall: {
+        // No positional, and no flag to force it on. What it draws comes
+        // from the machine and whether it draws at all comes from the
+        // preference, so there is nothing here for a caller to decide —
+        // which is what lets a hook invoke it with no arguments and no
+        // knowledge of how the feature is configured.
+        description: "regenerate the wallpaper that carries this machine's state",
+      },
       apps: {
         description: "choose optional tools to install",
       },

--- a/src/main.ts
+++ b/src/main.ts
@@ -347,6 +347,52 @@ async function cmdTheme(p: Platform, inv: Invocation, name?: string): Promise<nu
 }
 
 /**
+ * Regenerate this machine's Redwall.
+ *
+ * A command of its own rather than another thing `red-dev theme` does,
+ * because it is fired by something outside the program — a state change
+ * the RedSkills daemon reports — and a command that runs on its own
+ * schedule must not be reachable only through one a person types.
+ *
+ * Zero when the preference is off, and zero when there is no desktop
+ * here. The trigger should not have to know which machine it is on or
+ * what the user decided, and a non-zero exit for a feature nobody asked
+ * for is an error line in a log about nothing.
+ */
+async function cmdRedwall(p: Platform): Promise<number> {
+  const { generateRedwall } = await import("./redwall.ts");
+
+  let outcome: Awaited<ReturnType<typeof generateRedwall>>;
+  try {
+    outcome = await generateRedwall(p);
+  } catch (err) {
+    // Composing failed, which is a real fault rather than a state: the
+    // art, the face and the arithmetic all ship in this binary.
+    log.err(`redwall: ${(err as Error).message}`);
+    return 1;
+  }
+
+  if (outcome.skipped === "off") {
+    log.skip("redwall is off — `red-dev menu` turns it on");
+    return 0;
+  }
+  if (outcome.skipped === "headless") {
+    log.skip("redwall: no desktop on this machine");
+    return 0;
+  }
+
+  if (outcome.removed.length > 0) {
+    log.plain(`       removed ${outcome.removed.length} superseded redwall(s)`);
+  }
+  // The path is the useful half of this command's output: it is what the
+  // step that applies it reads, and what a person checks when a desktop
+  // shows something unexpected.
+  if (outcome.written) log.ok(`redwall: ${outcome.path}`);
+  else log.ok(`redwall: ${outcome.path} (unchanged)`);
+  return 0;
+}
+
+/**
  * Choose optional tools.
  *
  * `install` stays silent on purpose — it runs in CI and in scripts,
@@ -1007,6 +1053,8 @@ async function main(): Promise<number> {
       return await cmdUpdate(p, inv);
     case "theme":
       return await cmdTheme(p, inv, inv.scope);
+    case "redwall":
+      return await cmdRedwall(p);
     case "apps":
       return await cmdApps(p, inv);
     case "agents":

--- a/src/redwall-generate.test.ts
+++ b/src/redwall-generate.test.ts
@@ -1,0 +1,264 @@
+/**
+ * The command that writes the image, checked on a machine that has none.
+ *
+ * Everything here is about the file system and the two questions asked
+ * before anything touches it. What the overlay looks like is
+ * `redwall-render.test.ts`'s subject and is deliberately not re-asserted;
+ * what is asserted is that the image arrives, that it arrives somewhere
+ * that cannot confuse the wallpaper sweep, and that a trigger firing on
+ * every state change does not turn an idle machine into a directory full
+ * of 4K PNGs.
+ *
+ * The seams matter as much as the assertions. Both defaults reach for a
+ * process — `redskilled` for the Worker count, `ip` or PowerShell for
+ * the address, `gsettings` for what is on screen — so a test that let
+ * them run would be asserting against the machine running CI. Injecting
+ * state is also what makes "the same state twice" and "a different
+ * state" expressible at all.
+ */
+
+import { existsSync, mkdtempSync, readdirSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { describe, expect, test } from "bun:test";
+import { buildCli, parseArgs } from "./cli.ts";
+import type { Platform } from "./platform.ts";
+import { writePreferences } from "./preferences.ts";
+import type { RedwallState } from "./redwall-render.ts";
+import { generateRedwall, redwallDir } from "./redwall.ts";
+import {
+  expectedWallpaperNames,
+  materialise,
+  sweepRetiredWallpapers,
+  wallpaperDir,
+} from "./wallpaper.ts";
+import { THEMES } from "./themes.ts";
+
+const desktop: Platform = {
+  os: "linux",
+  distro: "ubuntu",
+  version: "24.04",
+  codename: "noble",
+  env: "desktop",
+  arch: "x64",
+  caps: { apt: true, gui: true, systemd: true, winget: false, flatpak: true },
+};
+
+const server: Platform = { ...desktop, env: "server", caps: { ...desktop.caps, gui: false } };
+
+const running: RedwallState = { workers: 3, address: "192.168.1.42" };
+
+/** A machine with nothing on it, torn down with the process. */
+async function onFreshMachine<T>(run: (home: string) => Promise<T>): Promise<T> {
+  const previous = process.env["HOME"];
+  const home = mkdtempSync(`${tmpdir()}/red-dev-redwall-write-`);
+  process.env["HOME"] = home;
+  try {
+    return await run(home);
+  } finally {
+    if (previous === undefined) delete process.env["HOME"];
+    else process.env["HOME"] = previous;
+  }
+}
+
+/**
+ * Generate with the machine's own questions answered for it. `inUse`
+ * says nothing is on screen, which is true of a temporary directory and
+ * keeps `gsettings` out of the run.
+ */
+function generate(p: Platform, state: RedwallState = running) {
+  return generateRedwall(p, { state: async () => state, inUse: async () => null });
+}
+
+const listing = (dir: string): string[] => (existsSync(dir) ? readdirSync(dir).sort() : []);
+
+describe("with the preference off", () => {
+  test("the command succeeds and writes nothing at all", async () => {
+    await onFreshMachine(async (home) => {
+      // No preference written: absent is off, and that is the state a
+      // machine that has never been asked is in.
+      const outcome = await generate(desktop);
+
+      expect(outcome.skipped).toBe("off");
+      expect(outcome.path).toBeNull();
+      expect(outcome.written).toBe(false);
+      // Not merely "no image": the directory itself is never created,
+      // so a machine that declined leaves no trace of the feature.
+      expect(existsSync(await redwallDir(desktop))).toBe(false);
+      expect(existsSync(`${home}/.local/share/red-dev`)).toBe(false);
+    });
+  });
+
+  test("and the trigger does not have to know that — it is not an error", async () => {
+    await onFreshMachine(async () => {
+      await writePreferences(desktop, { redwall: false, theme: "dark" });
+      expect((await generate(desktop)).skipped).toBe("off");
+    });
+  });
+});
+
+describe("with the preference on", () => {
+  test("an image is written, and the command reports where", async () => {
+    await onFreshMachine(async () => {
+      await writePreferences(desktop, { redwall: true, theme: "dark" });
+      const outcome = await generate(desktop);
+
+      expect(outcome.skipped).toBeNull();
+      expect(outcome.written).toBe(true);
+      expect(outcome.path).not.toBeNull();
+      expect(existsSync(outcome.path!)).toBe(true);
+
+      // A path is only a report if what is at the end of it is an
+      // image. A truncated or mangled write still has a length.
+      const bytes = await Bun.file(outcome.path!).bytes();
+      expect([...bytes.slice(0, 8)]).toEqual([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    });
+  });
+
+  test("the image lands outside the wallpapers directory", async () => {
+    await onFreshMachine(async () => {
+      await writePreferences(desktop, { redwall: true, theme: "dark" });
+      const outcome = await generate(desktop);
+
+      const wallpapers = await wallpaperDir(desktop);
+      expect(outcome.path!.startsWith(`${wallpapers}/`)).toBe(false);
+      expect(outcome.path!.startsWith(`${await redwallDir(desktop)}/`)).toBe(true);
+      // And the wallpapers directory is not merely free of this image —
+      // generating one does not bring it into existence.
+      expect(existsSync(wallpapers)).toBe(false);
+    });
+  });
+
+  test("it follows the theme the machine is actually set to", async () => {
+    await onFreshMachine(async () => {
+      await writePreferences(desktop, { redwall: true, theme: "flare" });
+      const outcome = await generate(desktop);
+      expect(outcome.path!.split("/").pop()!.startsWith("flare-")).toBe(true);
+    });
+  });
+
+  test("a headless machine is skipped, because nothing there will show it", async () => {
+    await onFreshMachine(async () => {
+      await writePreferences(server, { redwall: true, theme: "dark" });
+      const outcome = await generate(server);
+
+      expect(outcome.skipped).toBe("headless");
+      expect(existsSync(await redwallDir(server))).toBe(false);
+    });
+  });
+});
+
+describe("the wallpaper sweep", () => {
+  test("expects the same six names whether or not a Redwall was generated", async () => {
+    // The criterion this file exists for. `expectedWallpaperNames()` is
+    // what tells a retired wallpaper from one somebody chose by hand,
+    // and it can only do that while it stays finite — a generated image
+    // admitted to that set would make it unbounded.
+    const before = await expectedWallpaperNames();
+
+    await onFreshMachine(async () => {
+      await writePreferences(desktop, { redwall: true, theme: "dark" });
+      await generate(desktop);
+      await generate(desktop, { workers: 9, address: "10.0.0.7" });
+    });
+
+    const after = await expectedWallpaperNames();
+    expect([...after].sort()).toEqual([...before].sort());
+    expect(after.size).toBe(Object.keys(THEMES).length);
+  });
+
+  test("does not reach the generated image, and the image does not confuse it", async () => {
+    await onFreshMachine(async () => {
+      await writePreferences(desktop, { redwall: true, theme: "dark" });
+      const wallpaper = await materialise(THEMES.dark, "dark", desktop);
+      const outcome = await generate(desktop);
+
+      // A wallpaper red-dev no longer writes, which the sweep should
+      // take — the control that proves the sweep ran at all.
+      const stale = `${await wallpaperDir(desktop)}/dark-0badcafe.png`;
+      writeFileSync(stale, "not really a png");
+
+      const removed = await sweepRetiredWallpapers(desktop);
+
+      expect(removed).toEqual(["dark-0badcafe.png"]);
+      expect(existsSync(wallpaper)).toBe(true);
+      expect(existsSync(outcome.path!)).toBe(true);
+    });
+  });
+});
+
+describe("running it again", () => {
+  test("with unchanged state leaves the directory exactly as it was", async () => {
+    await onFreshMachine(async () => {
+      await writePreferences(desktop, { redwall: true, theme: "dark" });
+      const dir = await redwallDir(desktop);
+
+      const first = await generate(desktop);
+      const stamp = statSync(first.path!).mtimeMs;
+      const before = listing(dir);
+
+      const second = await generate(desktop);
+
+      expect(second.path).toBe(first.path!);
+      // Not rewritten, which is the sharper claim: identical bytes
+      // written again would move the timestamp on every hook that fires
+      // while nothing was happening.
+      expect(second.written).toBe(false);
+      expect(second.removed).toEqual([]);
+      expect(statSync(second.path!).mtimeMs).toBe(stamp);
+      expect(listing(dir)).toEqual(before);
+      expect(before).toHaveLength(1);
+    });
+  });
+
+  test("with changed state writes a new image and clears the old one", async () => {
+    await onFreshMachine(async () => {
+      await writePreferences(desktop, { redwall: true, theme: "dark" });
+      const dir = await redwallDir(desktop);
+
+      const first = await generate(desktop);
+      const second = await generate(desktop, { ...running, workers: 4 });
+
+      expect(second.path).not.toBe(first.path!);
+      expect(second.written).toBe(true);
+      expect(second.removed).toEqual([first.path!.split("/").pop()!]);
+      // A derived image is regenerated for as long as the machine
+      // works, so the directory has to be bounded by what is current
+      // rather than by how many times the state moved.
+      expect(listing(dir)).toEqual([second.path!.split("/").pop()!]);
+    });
+  });
+
+  test("but never removes the image the desktop is currently showing", async () => {
+    await onFreshMachine(async () => {
+      await writePreferences(desktop, { redwall: true, theme: "dark" });
+      const dir = await redwallDir(desktop);
+
+      const first = await generateRedwall(desktop, {
+        state: async () => running,
+        inUse: async () => null,
+      });
+      const second = await generateRedwall(desktop, {
+        state: async () => ({ ...running, workers: 4 }),
+        // The desktop is pointed at the previous Redwall — deleting it
+        // is how the background goes black in the gap before something
+        // repoints it.
+        inUse: async () => first.path,
+      });
+
+      expect(second.removed).toEqual([]);
+      expect(existsSync(first.path!)).toBe(true);
+      expect(listing(dir)).toHaveLength(2);
+    });
+  });
+});
+
+describe("the command line", () => {
+  test("accepts `redwall` with no arguments and nothing to configure", () => {
+    // The hook invokes this with no knowledge of the machine, so a
+    // required argument here would be a trigger that has to be taught
+    // something before it can fire.
+    const inv = parseArgs(buildCli(), ["redwall"]);
+    expect(inv.command).toBe("redwall");
+    expect(inv.errors).toEqual([]);
+  });
+});

--- a/src/redwall.ts
+++ b/src/redwall.ts
@@ -1,0 +1,242 @@
+/**
+ * Generate the Redwall and put it where the machine that displays it can
+ * read it.
+ *
+ * `redwall-render.ts` is the pure half: art plus state in, PNG bytes
+ * out, no disk and no daemon. This is the half with effects — it asks
+ * the daemon what it knows, asks the routing table where this machine
+ * answers, hands both to the renderer, and writes the result down. The
+ * split is what lets every claim about the image be tested without a
+ * desktop, and it is why nothing in here decides what the overlay looks
+ * like.
+ *
+ * ## Why a directory of its own
+ *
+ * Not `wallpapers/`. The wallpapers are immutable per theme and named
+ * after their contents, and `expectedWallpaperNames()` is the finite set
+ * that lets the sweep say "red-dev wrote this and no longer would" about
+ * one file and "somebody chose this" about another. A Redwall changes
+ * whenever the state it draws changes, so a Redwall in that directory
+ * would make the expected set unbounded — and an unbounded expected set
+ * is no set at all: the sweep would either delete a wallpaper someone
+ * picked by hand or stop deleting anything.
+ *
+ * The two directories are siblings under one root, so the rule about
+ * where images live on a WSL machine is stated once, in `wallpaper.ts`,
+ * and both obey it.
+ *
+ * ## Why the name carries a digest
+ *
+ * The same reason the wallpapers do, and it matters more here. GNOME
+ * repaints when `picture-uri` changes, not when the bytes behind an
+ * unchanged URI change; a fixed filename would leave the desktop showing
+ * last hour's Worker count with the right image sitting on disk. New
+ * bytes are a new path, so there is no cache to invalidate.
+ *
+ * It also makes the run cheap in the case that will be the common one.
+ * A hook that fires on every state change fires often, and most of those
+ * changes are invisible to a Redwall — the file name is a function of
+ * the bytes, so an unchanged Redwall is an `existsSync` and nothing
+ * else. That is what makes running this twice on unchanged state leave
+ * the directory exactly as it was.
+ *
+ * ## Why it sweeps
+ *
+ * Because a derived image with a content-addressed name accumulates. Six
+ * wallpapers are six files forever; a Worker count that moves between 0
+ * and 8 through a working day is a new 4K PNG every time it moves. So
+ * the images this generation superseded go, and the one the desktop is
+ * currently pointed at is spared — deleting the file the OS has open is
+ * how you get a black desktop for the moment between the delete and the
+ * next apply.
+ *
+ * ## Doing nothing, successfully
+ *
+ * With the preference off this writes nothing and reports success. The
+ * trigger — a RedSkills hook, and later `red-dev theme` — must not have
+ * to know whether the feature is enabled, and a non-zero exit for "the
+ * user did not ask for this" would turn an ordinary state into an error
+ * in somebody's logs. A headless machine is the same answer for the same
+ * reason: nothing there will ever display it.
+ */
+
+import { existsSync, mkdirSync, readdirSync, rmSync } from "node:fs";
+import { readHostState } from "./host-state.ts";
+import { resolveRedwallAddress } from "./lan-address.ts";
+import type { Platform } from "./platform.ts";
+import { readPreferences, resolveRedwall } from "./preferences.ts";
+import { REDWALL_SUBSET } from "./redwall-font.ts";
+import { renderRedwall, type RedwallState } from "./redwall-render.ts";
+import { resolveThemeSlug, THEMES } from "./themes.ts";
+import { imageRoot, shortDigest, wallpaperBytes, wallpaperPathInUse } from "./wallpaper.ts";
+
+/** Where the generated images live. A sibling of `wallpapers/`, never inside it. */
+export async function redwallDir(p: Platform): Promise<string> {
+  return `${await imageRoot(p)}/redwall`;
+}
+
+/** Why nothing was generated, when nothing was. */
+export type RedwallSkip =
+  /** The preference is off, which is its default. */
+  | "off"
+  /** No desktop here, so no surface to show it on. */
+  | "headless";
+
+export interface RedwallOutcome {
+  /** Where the image is, or null when none was generated. */
+  readonly path: string | null;
+  /** Null when an image was generated. */
+  readonly skipped: RedwallSkip | null;
+  /** False when those exact bytes were already on disk under that name. */
+  readonly written: boolean;
+  /** Names of the superseded images removed once the new one had landed. */
+  readonly removed: string[];
+}
+
+/**
+ * The seams a test replaces, and the two things this module asks the
+ * machine about that a build server cannot answer.
+ *
+ * Both defaults reach for a process — `redskilled`, `ip`, `gsettings` —
+ * so a test that did not replace them would assert against whatever the
+ * machine running CI happened to be. Injected here rather than deeper,
+ * because "what does this machine say about itself" is exactly the
+ * question this module exists to ask, and the layers below already have
+ * their own seams for their own halves of it.
+ */
+export interface RedwallSeams {
+  /** What to draw. Defaults to asking the daemon and the routing table. */
+  readonly state?: () => Promise<RedwallState>;
+  /** Which image the desktop is pointed at, so the sweep can spare it. */
+  readonly inUse?: () => Promise<string | null>;
+}
+
+/**
+ * What this machine currently says about itself.
+ *
+ * Both halves are asked at once and neither can withhold the other: a
+ * daemon that is not running costs the Worker count, and `host-state.ts`
+ * turns every way that can happen into `null` rather than a throw. The
+ * address is resolved without the daemon's help precisely so that it
+ * survives.
+ */
+export async function redwallState(p: Platform): Promise<RedwallState> {
+  const [host, address] = await Promise.all([readHostState(), resolveRedwallAddress(p)]);
+  return { workers: host?.workers ?? null, address };
+}
+
+/**
+ * Compose this machine's Redwall and write it, or explain why it did
+ * not.
+ *
+ * Everything that can be answered without doing work is answered first:
+ * the preference, then the target. Only then does anything read a
+ * daemon, spawn a route lookup, or touch a 4K PNG.
+ */
+export async function generateRedwall(
+  p: Platform,
+  seams: RedwallSeams = {},
+): Promise<RedwallOutcome> {
+  if (!(await resolveRedwall(p))) return skipped("off");
+  // Not a failure, and not a thing to warn about either: a server is a
+  // machine that never had a desktop to write on.
+  if (p.env === "server") return skipped("headless");
+
+  // Through resolveThemeSlug, so a machine still carrying one of the
+  // retired slugs draws its Redwall on the art it is actually themed
+  // with rather than failing to find a wallpaper for a name nothing
+  // holds any more.
+  const slug = resolveThemeSlug((await readPreferences(p)).theme);
+  const state = await (seams.state ?? (() => redwallState(p)))();
+
+  const bytes = renderRedwall({
+    art: await wallpaperBytes(slug),
+    font: await Bun.file(REDWALL_SUBSET).bytes(),
+    theme: THEMES[slug],
+    state,
+  });
+
+  const dir = await redwallDir(p);
+  mkdirSync(dir, { recursive: true });
+  const path = `${dir}/${slug}-${shortDigest(bytes)}.png`;
+
+  // The skip is the point, not an optimisation: rewriting identical
+  // bytes would move the file's timestamp, and a hook that fires on
+  // every tick would leave a directory that looks freshly churned on a
+  // machine where nothing changed.
+  const written = !existsSync(path);
+  if (written) await Bun.write(path, bytes);
+
+  const removed = await sweepSupersededRedwalls(p, path, seams.inUse);
+  return { path, skipped: null, written, removed };
+}
+
+/**
+ * Delete the Redwalls this one replaced.
+ *
+ * Only inside red-dev's own Redwall directory, and only after the new
+ * image is on disk — the same ordering `sweepRetiredWallpapers` keeps,
+ * for the same reason. `keep` is the image just written; the image the
+ * desktop is currently pointed at is spared as well, because removing
+ * what the OS has a handle on is how a desktop goes black in the gap
+ * before something repoints it.
+ *
+ * A machine that cannot say what it is displaying spares nothing. That
+ * is the deliberate choice: the cost is a moment of black on a desktop
+ * that was about to be repainted anyway, and the alternative — never
+ * sweeping when the question cannot be answered — is a directory of 4K
+ * PNGs that grows for as long as the machine works.
+ */
+export async function sweepSupersededRedwalls(
+  p: Platform,
+  keep: string,
+  inUse: (() => Promise<string | null>) | undefined = undefined,
+): Promise<string[]> {
+  const dir = await redwallDir(p);
+  if (!existsSync(dir)) return [];
+
+  const displayed = await currentlyDisplayed(p, inUse);
+  const removed: string[] = [];
+  for (const name of readdirSync(dir)) {
+    if (!name.endsWith(".png")) continue;
+    const path = `${dir}/${name}`;
+    if (samePath(path, keep) || samePath(path, displayed)) continue;
+    rmSync(path, { force: true });
+    removed.push(name);
+  }
+  return removed;
+}
+
+async function currentlyDisplayed(
+  p: Platform,
+  inUse: (() => Promise<string | null>) | undefined,
+): Promise<string | null> {
+  try {
+    return await (inUse ?? (() => wallpaperPathInUse(p)))();
+  } catch {
+    // The OS was asked and did not answer. Same as "nothing is
+    // displayed" for this purpose, and never worth failing a
+    // regeneration over.
+    return null;
+  }
+}
+
+/**
+ * Whether two paths name the same file, as far as this comparison needs
+ * to be right.
+ *
+ * Windows is why this is not `===`. This module joins with `/` and the
+ * registry answers with `\`, and the drive letter's case is not the
+ * file's identity either — so the one place the sweep must not get a
+ * false "different" is exactly the one where a naive compare gives one,
+ * and the file it would then delete is the one on screen.
+ */
+function samePath(a: string, b: string | null): boolean {
+  if (b === null) return false;
+  const normalise = (value: string): string => value.replace(/\\/g, "/").toLowerCase();
+  return normalise(a) === normalise(b);
+}
+
+function skipped(reason: RedwallSkip): RedwallOutcome {
+  return { path: null, skipped: reason, written: false, removed: [] };
+}

--- a/src/wallpaper.ts
+++ b/src/wallpaper.ts
@@ -60,20 +60,56 @@ function home(): string {
 }
 
 /**
- * Where the image has to live for the machine that will display it.
+ * Where images have to live for the machine that will display them.
  *
  * Under WSL this must be the Windows filesystem, not the distro's. A
  * wallpaper at \\wsl.localhost\... only renders while the distro is
  * running: shut WSL down and the desktop goes black, and every login
  * reads it across the 9p bridge. The host's own disk has neither
  * problem.
+ *
+ * The root rather than the wallpaper directory, because Redwall writes
+ * beside it under the same rule and a second copy of this reasoning is a
+ * second chance for one of them to be wrong about WSL.
  */
-export async function wallpaperDir(p: Platform): Promise<string> {
+export async function imageRoot(p: Platform): Promise<string> {
   if (p.env === "wsl") {
     const { windowsLocalAppData } = await import("./wsl.ts");
-    return `${await windowsLocalAppData()}/red-dev/wallpapers`;
+    return `${await windowsLocalAppData()}/red-dev`;
   }
-  return `${home()}/.local/share/red-dev/wallpapers`;
+  return `${home()}/.local/share/red-dev`;
+}
+
+/** Where the theme's own art is copied to, and nothing else. */
+export async function wallpaperDir(p: Platform): Promise<string> {
+  return `${await imageRoot(p)}/wallpapers`;
+}
+
+/**
+ * Eight hex of a sha256, which is how red-dev names an image after its
+ * contents.
+ *
+ * Shared with Redwall rather than spelled twice, because the two
+ * directories name files for the same reason — new bytes must be a new
+ * path, or a desktop that caches by path goes on showing the old image —
+ * and a convention that is written down once cannot drift.
+ */
+export function shortDigest(bytes: Uint8Array): string {
+  return new Bun.CryptoHasher("sha256").update(bytes).digest("hex").slice(0, 8);
+}
+
+/**
+ * The theme's sheet, as bytes, from the binary.
+ *
+ * Exported for Redwall, which composes over the same art the desktop
+ * would otherwise carry. Reading it back out of the wallpapers directory
+ * would make the overlay depend on a converge having run first; the
+ * embedded bytes are the source and the file on disk is a copy of them.
+ */
+export async function wallpaperBytes(key: string): Promise<Uint8Array> {
+  const source = EMBEDDED[key as ThemeSlug];
+  if (!source) throw new Error(`no wallpaper for theme '${key}'`);
+  return await Bun.file(source).bytes();
 }
 
 /**
@@ -90,11 +126,8 @@ export async function wallpaperDir(p: Platform): Promise<string> {
  */
 export async function materialise(theme: Theme, key: string, p: Platform): Promise<string> {
   void theme;
-  const source = EMBEDDED[key as ThemeSlug];
-  if (!source) throw new Error(`no wallpaper for theme '${key}'`);
-
-  const bytes = await Bun.file(source).bytes();
-  const digest = new Bun.CryptoHasher("sha256").update(bytes).digest("hex").slice(0, 8);
+  const bytes = await wallpaperBytes(key);
+  const digest = shortDigest(bytes);
 
   const dir = await wallpaperDir(p);
   mkdirSync(dir, { recursive: true });
@@ -109,13 +142,17 @@ export async function materialise(theme: Theme, key: string, p: Platform): Promi
  * Used to tell a retired image from one somebody chose by hand: the
  * sweep below deletes the first and doctor reports it, while a wallpaper
  * outside red-dev's own directory is a decision and is left alone.
+ *
+ * The set is finite — six themes, six names — and that is the property
+ * the whole scheme rests on. It is also why a Redwall is written
+ * somewhere else: a generated image changes whenever the state it shows
+ * changes, so admitting one here would make this set unbounded and
+ * leave the sweep unable to tell either kind of image apart.
  */
 export async function expectedWallpaperNames(): Promise<Set<string>> {
   const names = new Set<string>();
   for (const slug of THEME_SLUGS) {
-    const bytes = await Bun.file(EMBEDDED[slug]).bytes();
-    const digest = new Bun.CryptoHasher("sha256").update(bytes).digest("hex").slice(0, 8);
-    names.add(`${slug}-${digest}.png`);
+    names.add(`${slug}-${shortDigest(await wallpaperBytes(slug))}.png`);
   }
   return names;
 }


### PR DESCRIPTION
Automated AFK landing for #58. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #58

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788809102&installation_model_id=20659&pr_number=85&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F85&signature=f156aaceb6e61fa1803a90fe57b5f45ee8bf57ef774305fae4a9348e212a0256"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->