### PR TITLE
chore: #69 Report deferred-for-rights as its own outcome, not a failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,6 +460,43 @@ warn alacritty: ENOEXEC: unknown error, posix_spawn 'cmd.exe'
  ok  converged — restart your shell
 ```
 
+### Work it was not allowed to do
+
+Some items need rights the run does not have: the Windows OpenSSH server needs
+administrator, and sudo on a machine that will not grant it without a password
+cannot be answered from inside a converge. Those items are *deferred*, which is
+its own outcome — the work never started, nothing is broken, and every item that
+needed no rights converged as usual.
+
+```console
+── summary ──────────────────────────────────────────────────────────
+  installed        18
+  already present   9
+  deferred          1
+  failed            0
+  elapsed          2m 4s
+
+  deferred
+    ssh-server        this needs administrator and nothing here can raise it.
+
+    Start an elevated PowerShell first, then re-run red-dev — re-running is safe.
+
+  Nothing here broke — this work is waiting, not lost.
+```
+
+Each deferred item is named, so nobody has to go back through the log to find
+out which one it was, and the exit status says the same thing to a script:
+
+| | |
+| --- | --- |
+| `0` | converged |
+| `1` | something failed |
+| `2` | converged, except work waiting on rights |
+
+So a wrapper can tell "done" from "done except the privileged part" without
+reading the summary, and without treating a healthy machine as a broken one.
+`red-dev doctor` reports the same outstanding work afterwards.
+
 ### Reading the log while it is being written
 
 A converge inside the fullscreen interface follows the tail, which is right until

--- a/src/converge.ts
+++ b/src/converge.ts
@@ -13,6 +13,7 @@
  */
 
 import { transcribeStep } from "./transcript.ts";
+import { refusedRights } from "./rights.ts";
 import { aptInstall, applyProvider, type ApplyContext } from "./providers.ts";
 import {
   describeProvider,
@@ -25,7 +26,22 @@ import {
 } from "./manifest.ts";
 import type { Platform } from "./platform.ts";
 
-export type StepOutcome = "installed" | "applied" | "present" | "skipped" | "failed";
+/**
+ * `deferred` is the one that is not a verdict on the work.
+ *
+ * An item that needs rights this run does not have did not fail: it was
+ * never attempted, nothing is broken, and the machine around it
+ * converged. Reporting it as a failure makes a healthy, partly-converged
+ * machine read as a broken one, and after enough of those a red summary
+ * stops being read at all.
+ */
+export type StepOutcome =
+  | "installed"
+  | "applied"
+  | "present"
+  | "skipped"
+  | "deferred"
+  | "failed";
 
 export interface StepEvent {
   scope: Scope;
@@ -39,6 +55,16 @@ export interface StepResult extends StepEvent {
   outcome: StepOutcome;
   ms: number;
   detail?: string;
+  /**
+   * What the operator has to do to finish this item, when something is.
+   *
+   * Kept apart from `detail` rather than folded into it because they are
+   * printed at different rates: the cause belongs on the item's own row,
+   * the remedy belongs once per gate — three items behind the same
+   * locked door share one key, and printing it three times reads as
+   * three separate problems.
+   */
+  remedy?: string;
 }
 
 export interface ConvergeObserver {
@@ -75,6 +101,39 @@ export interface ConvergeOptions {
 export interface ConvergeSummary {
   results: StepResult[];
   failed: number;
+  /** Items that ran out of rights. Not a subset of `failed`. */
+  deferred: number;
+}
+
+/**
+ * What an error message means for the item that raised it. PURE.
+ *
+ * The whole classification, in one place and testable without a package
+ * manager: both callers below reach it holding nothing but a string,
+ * because that is all an exception and a failed batch leave behind.
+ */
+export function outcomeForError(message: string): {
+  outcome: StepOutcome;
+  detail: string;
+  remedy?: string;
+} {
+  const denied = refusedRights(message);
+  if (!denied) return { outcome: "failed", detail: message };
+  return { outcome: "deferred", detail: denied.cause, remedy: denied.remedy };
+}
+
+/**
+ * The three answers a script wrapping a converge has to tell apart.
+ *
+ * 0 converged, 1 something failed, 2 converged except work that needs
+ * rights this run did not have. The third exists so "done" and "done
+ * except the privileged part" are not the same byte — a wrapper can act
+ * on the difference without parsing a summary, and neither of them has
+ * to be reported as a failure to be noticed.
+ */
+export function convergeExit(summary: { failed: number; deferred: number }): 0 | 1 | 2 {
+  if (summary.failed > 0) return 1;
+  return summary.deferred > 0 ? 2 : 0;
 }
 
 /** Total steps across every scope, so a progress bar has a denominator. */
@@ -148,12 +207,13 @@ export async function converge(
       observer.stepStart?.(event);
       const started = Date.now();
 
-      const finish = (outcome: StepOutcome, detail?: string): void => {
+      const finish = (outcome: StepOutcome, detail?: string, remedy?: string): void => {
         const result: StepResult = {
           ...event,
           outcome,
           ms: Date.now() - started,
           ...(detail ? { detail } : {}),
+          ...(remedy ? { remedy } : {}),
         };
         results.push(result);
         observer.stepEnd?.(result);
@@ -168,6 +228,18 @@ export async function converge(
         // with it, still leaves the rows up to the point it stopped,
         // which is the run most likely to be worth reading.
         transcribeStep(result);
+      };
+
+      /**
+       * Close a step that raised, as whichever of the two things it was.
+       *
+       * Both paths below arrive holding a message and nothing else, and
+       * the difference between "this broke" and "this was not allowed to
+       * run" is entirely inside it.
+       */
+      const finishError = (message: string): void => {
+        const { outcome, detail, remedy } = outcomeForError(message);
+        finish(outcome, detail, remedy);
       };
 
       if (pr.kind === "skip") {
@@ -186,7 +258,11 @@ export async function converge(
       if (pr.kind === "apt") {
         // Attempted in the batch above; report what is actually true
         // rather than claiming a per-tool install that never ran.
-        if (aptError) finish("failed", aptError);
+        // A batch that never ran because sudo said no defers every
+        // package in it: one refusal at the transaction is not twenty
+        // broken packages, and reporting it as twenty is how a whole
+        // summary turns red over a single missing password.
+        if (aptError) finishError(aptError);
         else if (isInstalled(tool)) finish("installed");
         else if (installState(tool) === "outdated") {
           // Present and runnable, just too old — the archive has nothing
@@ -204,11 +280,15 @@ export async function converge(
         finish(tool.managed ? "applied" : "installed");
       } catch (err) {
         // One tool failing must not abort the run: re-running and
-        // picking up the rest is the point of a converge tool.
-        finish("failed", (err as Error).message);
+        // picking up the rest is the point of a converge tool. Nor does
+        // an item that ran out of rights — it is reported as deferred
+        // and the run carries on to everything that needs none.
+        finishError((err as Error).message);
       }
     }
   }
 
-  return { results, failed: results.filter((r) => r.outcome === "failed").length };
+  const count = (outcome: StepOutcome): number =>
+    results.filter((r) => r.outcome === outcome).length;
+  return { results, failed: count("failed"), deferred: count("deferred") };
 }

--- a/src/deferred.test.ts
+++ b/src/deferred.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Work deferred for lack of rights is its own outcome, not a failure.
+ *
+ * The summary already told installed, applied, present, skipped and
+ * failed apart. A privileged item on an unelevated run is none of those:
+ * nothing broke, nothing was misconfigured, and a machine that converged
+ * everything it had the rights for is healthy. Calling it a failure
+ * makes that machine read as broken — which is exactly how the SSH
+ * server item read.
+ *
+ * Four properties, in the order they would hurt if they drifted:
+ *
+ *   A refusal is recognised. The gate's wording is written once in
+ *   rights.ts, so a message carrying it came from the gate rather than
+ *   from a provider that happened to fail.
+ *
+ *   A genuine failure is still a failure. The half that keeps the
+ *   outcome honest: an outcome that swallows real breakage is worse than
+ *   the one it replaced.
+ *
+ *   Every deferred item is named. A count sends the reader back through
+ *   a transcript to learn which of thirty-six items it was.
+ *
+ *   The exit status tells the three apart, so a script wrapping the
+ *   converge knows "done" from "done except the privileged part"
+ *   without parsing any of the above.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { convergeExit, outcomeForError } from "./converge.ts";
+import { summaryLines, type Entry } from "./report.ts";
+import { missingRights, refusedRights } from "./rights.ts";
+
+/** Without the colour, which depends on whether a terminal is watching. */
+const plain = (lines: string[]): string[] =>
+  lines.map((l) => l.replace(/\x1b\[[0-9;]*m/g, ""));
+
+function entry(name: string, over: Partial<Entry> = {}): Entry {
+  return { scope: "core", name, outcome: "installed", ms: 10, ...over };
+}
+
+function deferredEntry(name: string, gate: Parameters<typeof missingRights>[0]): Entry {
+  const denied = missingRights(gate);
+  return entry(name, { outcome: "deferred", detail: denied.cause, remedy: denied.remedy });
+}
+
+describe("recognising a refusal", () => {
+  test("a message the gate wrote is a deferral, and names its remedy", () => {
+    // The inverse of missingRights, and the reason it can be one: every
+    // refusal in this program is worded in the one place, so the bytes
+    // coming back are bytes it produced.
+    for (const gate of ["sudo", "administrator"] as const) {
+      const denied = refusedRights(missingRights(gate).message);
+      expect(denied?.gate).toBe(gate);
+      expect(denied?.remedy).toBe(missingRights(gate).remedy);
+    }
+  });
+
+  test("anything else is not", () => {
+    expect(refusedRights("apt-get install failed (100)")).toBeNull();
+    expect(refusedRights("")).toBeNull();
+  });
+});
+
+describe("the outcome an error earns", () => {
+  test("a gate that refused defers the item", () => {
+    const result = outcomeForError(missingRights("administrator").message);
+    expect(result.outcome).toBe("deferred");
+    // The cause on the row and the remedy beside it, kept apart so the
+    // summary can print one per item and the other once per gate.
+    expect(result.detail).toBe(missingRights("administrator").cause);
+    expect(result.remedy).toBe(missingRights("administrator").remedy);
+  });
+
+  test("a genuine failure is still a failure, with its own message", () => {
+    const result = outcomeForError("apt has nothing newer than 1.2 for eza");
+    expect(result.outcome).toBe("failed");
+    expect(result.detail).toBe("apt has nothing newer than 1.2 for eza");
+    expect(result.remedy).toBeUndefined();
+  });
+});
+
+describe("the summary", () => {
+  const lines = (entries: Entry[]): string[] => plain(summaryLines(entries, 1_000));
+
+  test("counts deferred work apart from failures", () => {
+    const out = lines([
+      entry("git"),
+      deferredEntry("ssh-server", "administrator"),
+      entry("docker", { outcome: "failed", detail: "exit 1" }),
+    ]);
+    expect(out.some((l) => /^\s*deferred\s+1$/.test(l))).toBe(true);
+    expect(out.some((l) => /^\s*failed\s+1$/.test(l))).toBe(true);
+  });
+
+  test("says nothing about deferral when there was none", () => {
+    // A permanent "deferred 0" on every Ubuntu run is noise that trains
+    // people to stop reading the block that matters.
+    expect(lines([entry("git")]).some((l) => l.includes("deferred"))).toBe(false);
+  });
+
+  test("names each deferred item, rather than counting them", () => {
+    const out = lines([
+      deferredEntry("ssh-server", "administrator"),
+      deferredEntry("windows-terminal", "administrator"),
+    ]).join("\n");
+    expect(out).toContain("ssh-server");
+    expect(out).toContain("windows-terminal");
+  });
+
+  test("and the remedy once per gate, not once per item", () => {
+    // Two items behind the same locked door share one key. Printing it
+    // twice reads as two separate problems.
+    const out = lines([
+      deferredEntry("ssh-server", "administrator"),
+      deferredEntry("windows-terminal", "administrator"),
+    ]);
+    const remedy = missingRights("administrator").remedy;
+    expect(out.filter((l) => l.includes(remedy))).toHaveLength(1);
+  });
+
+  test("keeps a deferred item out of the failures", () => {
+    const out = lines([
+      deferredEntry("ssh-server", "administrator"),
+      entry("docker", { outcome: "failed", detail: "exit 1" }),
+    ]);
+    const failedBlock = out.slice(out.findIndex((l) => /^\s*failed$/.test(l)));
+    expect(failedBlock.join("\n")).toContain("docker");
+    expect(failedBlock.join("\n")).not.toContain("ssh-server");
+  });
+});
+
+describe("the exit status", () => {
+  test("tells a full converge from one with deferred work", () => {
+    // The whole point of the third answer: a wrapper script can act on
+    // "done except the privileged part" without reading the summary,
+    // and without treating a healthy machine as a broken one.
+    expect(convergeExit({ failed: 0, deferred: 0 })).toBe(0);
+    expect(convergeExit({ failed: 0, deferred: 1 })).toBe(2);
+  });
+
+  test("and a failure still outranks both", () => {
+    expect(convergeExit({ failed: 1, deferred: 0 })).toBe(1);
+    expect(convergeExit({ failed: 1, deferred: 2 })).toBe(1);
+  });
+});
+
+describe("the item that made this necessary", () => {
+  const source = readFileSync("src/ssh-server.ts", "utf8");
+
+  test("the SSH server hands its refusal to the converge", () => {
+    // It used to warn and return, which the converge reads as applied:
+    // the one item that regularly runs out of rights was reporting
+    // success and printing a warning nobody could act on afterwards.
+    expect(source).toContain("throw new RedError(denied.message)");
+  });
+
+  test("and still fails when apt itself failed", () => {
+    // `sudo -n` refusing and apt refusing are different answers. The
+    // first has a remedy; treating the second as one sends an operator
+    // to elevate a shell that changes nothing.
+    expect(source).toContain('classifyRights(install.out, "sudo")');
+  });
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -202,10 +202,9 @@ async function cmdInstall(
   // CI, in a pipe, over a dumb SSH session and on a narrow window.
   if (!inv.dryRun && interactive() && (process.stdout.columns ?? 0) >= 60) {
     const { runInstallTui } = await import("./tui-install.ts");
-    const { failed } = await runInstallTui({ platform: p, ctx, scopes });
-    if (failed > 0) return 1;
-    log.ok("converged — restart your shell");
-    return 0;
+    const { convergeExit } = await import("./converge.ts");
+    const outcome = await runInstallTui({ platform: p, ctx, scopes });
+    return endInstall(convergeExit(outcome), outcome.deferred);
   }
 
   log.step(summary(p).split("\n")[0] ?? "");
@@ -218,8 +217,10 @@ async function cmdInstall(
   // into a line. The fullscreen view subscribes to the same events and
   // draws them instead — one ordering, one apt batch, one failure
   // policy, two presentations.
-  let close: ((outcome: StepOutcome, detail?: string) => void) | null = null;
-  const { failed } = await converge(
+  let close:
+    | ((outcome: StepOutcome, detail?: string, remedy?: string) => void)
+    | null = null;
+  const summaryOf = await converge(
     { platform: p, ctx, scopes: scopes, dryRun: inv.dryRun },
     {
       scopeStart: (scope, total) => report.scope(scope, total),
@@ -228,7 +229,7 @@ async function cmdInstall(
         close = report.begin(e.tool, e.provider || "—");
       },
       stepEnd: (r) => {
-        close?.(r.outcome, r.detail);
+        close?.(r.outcome, r.detail, r.remedy);
         close = null;
       },
     },
@@ -240,9 +241,30 @@ async function cmdInstall(
     log.ok("dry run — nothing changed");
     return 0;
   }
-  if (failed > 0) return 1;
-  log.ok("converged — restart your shell");
-  return 0;
+  const { convergeExit } = await import("./converge.ts");
+  return endInstall(convergeExit(summaryOf), summaryOf.deferred);
+}
+
+/**
+ * The last line of a converge, and the status the shell gets.
+ *
+ * Shared by both presentations so they cannot disagree about what a run
+ * was, and separate from either so the third answer is stated once: 2
+ * means every item that could run did, and the ones that needed rights
+ * this run did not have are still waiting. Not 0, because something is
+ * outstanding and a wrapper script has to be able to see it; not 1,
+ * because nothing about this machine is broken.
+ */
+function endInstall(code: 0 | 1 | 2, deferred = 0): number {
+  if (code === 0) log.ok("converged — restart your shell");
+  else if (code === 2) {
+    log.warn(
+      deferred === 1
+        ? "converged, except one item that needs rights this run did not have"
+        : `converged, except ${deferred} items that need rights this run did not have`,
+    );
+  }
+  return code;
 }
 
 async function cmdUpdate(p: Platform, inv: Invocation): Promise<number> {
@@ -647,8 +669,14 @@ async function cmdUi(p: Platform, inv: Invocation): Promise<number> {
   switch (result.action) {
     case "theme":
       return result.theme ? await cmdTheme(p, inv, result.theme) : 0;
-    case "installed":
-      return (result.failed ?? 0) > 0 ? 1 : 0;
+    case "installed": {
+      // The same three answers as the line report. A converge watched
+      // from the menu is still a converge, and a script that started
+      // this way reads the status the same way.
+      const { convergeExit } = await import("./converge.ts");
+      const deferred = result.deferred ?? 0;
+      return endInstall(convergeExit({ failed: result.failed ?? 0, deferred }), deferred);
+    }
     case "doctor":
       return await cmdDoctor(p, inv);
     case "apps":

--- a/src/report.ts
+++ b/src/report.ts
@@ -10,7 +10,8 @@
  *
  * What this reports instead: where in the run you are, what is
  * happening right now, how long each step took, and a summary that
- * names the failures rather than counting them.
+ * names the failures rather than counting them — and, apart from them,
+ * names the work that was never allowed to run.
  *
  * Written to survive a pipe. No cursor movement, no redraw, no spinner
  * — the prefix is written when a step starts and the line is completed
@@ -31,22 +32,32 @@ const paint = (code: string, s: string): string =>
  * changes nothing, and reporting that as an install is the kind of
  * confident-and-wrong output this whole file is meant to remove.
  */
-export type Outcome = "installed" | "applied" | "present" | "skipped" | "failed";
+/**
+ * `deferred` is the outcome for work this run was not allowed to do.
+ *
+ * Amber rather than red, and lower-case rather than shouted, because
+ * that is what it is: an item waiting on rights, on a machine where
+ * everything else converged. See converge.ts, which decides it.
+ */
+export type Outcome = "installed" | "applied" | "present" | "skipped" | "deferred" | "failed";
 
 const MARK: Record<Outcome, string> = {
   installed: paint("1;32", "installed"),
   applied: paint("1;32", "applied"),
   present: paint("1;90", "present"),
   skipped: paint("1;90", "skipped"),
+  deferred: paint("1;33", "deferred"),
   failed: paint("1;31", "FAILED"),
 };
 
-interface Entry {
+export interface Entry {
   scope: string;
   name: string;
   outcome: Outcome;
   ms: number;
   detail?: string;
+  /** What to do about it, for the outcomes where there is something. */
+  remedy?: string;
 }
 
 function human(ms: number): string {
@@ -87,7 +98,10 @@ export class Reporter {
    * The prefix goes out immediately so a long install shows which tool
    * it is on rather than looking hung behind apt's own output.
    */
-  begin(name: string, provider: string): (outcome: Outcome, detail?: string) => void {
+  begin(
+    name: string,
+    provider: string,
+  ): (outcome: Outcome, detail?: string, remedy?: string) => void {
     this.closeLine();
     this.index++;
     const started = Date.now();
@@ -99,7 +113,7 @@ export class Reporter {
     this.openLine = true;
     captureStart();
 
-    return (outcome: Outcome, detail?: string) => {
+    return (outcome: Outcome, detail?: string, remedy?: string) => {
       const held = captureStop();
       const ms = Date.now() - started;
       // Timing only where it is information: a sub-second skip is
@@ -113,10 +127,16 @@ export class Reporter {
       for (const line of held) {
         console.log(`          ${paint("1;90", line.replace(/\x1b\[[0-9;]*m/g, "").trim())}`);
       }
+      // Said at the item as well as in the summary, for both outcomes
+      // that have something to say. A deferral whose cause appears only
+      // at the end leaves the row itself unexplained, which is where
+      // somebody watching the run is actually looking.
       if (detail && outcome === "failed") {
         console.log(`          ${paint("1;31", detail)}`);
+      } else if (detail && outcome === "deferred") {
+        console.log(`          ${paint("1;33", detail)}`);
       }
-      this.entries.push({ scope: this.scopeName, name, outcome, ms, detail });
+      this.entries.push({ scope: this.scopeName, name, outcome, ms, detail, remedy });
     };
   }
 
@@ -136,57 +156,95 @@ export class Reporter {
   /**
    * Close the run.
    *
-   * Failures are re-listed by name here. Counting them and leaving the
-   * detail sixty lines up is what makes people re-run instead of read.
+   * The lines themselves are built by summaryLines, which is where the
+   * decisions about what a summary says now live — this prints them.
    */
-  finish(): { failed: number } {
+  finish(): { failed: number; deferred: number } {
     this.closeLine();
-    const by = (o: Outcome) => this.entries.filter((e) => e.outcome === o);
-    const failed = by("failed");
 
     console.log("");
     console.log(rule("summary"));
-
-    const rows: [string, number][] = [
-      ["installed", by("installed").length],
-      ["applied", by("applied").length],
-      ["already present", by("present").length],
-      ["skipped", by("skipped").length],
-      ["failed", failed.length],
-    ];
-    for (const [label, n] of rows) {
-      if (n === 0 && label !== "failed") continue;
-      const painted = label === "failed" && n > 0 ? paint("1;31", String(n)) : String(n);
-      console.log(`  ${label.padEnd(16)} ${painted}`);
-    }
-    console.log(`  ${"elapsed".padEnd(16)} ${human(Date.now() - this.started)}`);
-
-    // The three slowest steps, when anything took real time. On a fresh
-    // machine this is the difference between "it was slow" and "docker
-    // took four minutes".
-    const slow = this.entries
-      .filter((e) => e.ms >= 3000)
-      .sort((a, b) => b.ms - a.ms)
-      .slice(0, 3);
-    if (slow.length > 0) {
-      console.log("");
-      console.log(`  ${paint("1;90", "slowest")}`);
-      for (const e of slow) {
-        console.log(`  ${" ".repeat(2)}${e.name.padEnd(17)} ${human(e.ms)}`);
-      }
-    }
-
-    if (failed.length > 0) {
-      console.log("");
-      console.log(`  ${paint("1;31", "failed")}`);
-      for (const e of failed) {
-        console.log(`    ${e.name.padEnd(17)} ${e.detail ?? ""}`);
-      }
-      console.log("");
-      console.log(`  ${paint("1;90", "Re-running is safe: every provider is idempotent.")}`);
+    for (const line of summaryLines(this.entries, Date.now() - this.started)) {
+      console.log(line);
     }
     console.log("");
 
-    return { failed: failed.length };
+    const count = (o: Outcome): number => this.entries.filter((e) => e.outcome === o).length;
+    return { failed: count("failed"), deferred: count("deferred") };
   }
+}
+
+/**
+ * The summary, as lines. PURE.
+ *
+ * A function rather than more of `finish` because what a summary claims
+ * is the whole point of the file, and a claim nothing can check is a
+ * preference: this is the only piece a test can hold without a terminal,
+ * a package manager and half an hour.
+ *
+ * Deferred work is listed apart from failures and named item by item.
+ * Both halves matter. Folded into the failures, a machine that converged
+ * everything it had the rights for reads as broken; reduced to a count,
+ * the reader goes back through a transcript to learn which of thirty-six
+ * items the number was about.
+ */
+export function summaryLines(entries: Entry[], elapsedMs: number): string[] {
+  const by = (o: Outcome): Entry[] => entries.filter((e) => e.outcome === o);
+  const deferred = by("deferred");
+  const failed = by("failed");
+  const out: string[] = [];
+
+  const rows: [string, number][] = [
+    ["installed", by("installed").length],
+    ["applied", by("applied").length],
+    ["already present", by("present").length],
+    ["skipped", by("skipped").length],
+    ["deferred", deferred.length],
+    ["failed", failed.length],
+  ];
+  for (const [label, n] of rows) {
+    // `failed` is printed at zero because a zero there is the news. The
+    // rest, deferred included, stay silent: a permanent "deferred 0" on
+    // every machine that needs no rights is noise, and noise is what
+    // teaches people to skip the block that matters.
+    if (n === 0 && label !== "failed") continue;
+    const colour = label === "failed" ? "1;31" : label === "deferred" ? "1;33" : "";
+    const painted = colour && n > 0 ? paint(colour, String(n)) : String(n);
+    out.push(`  ${label.padEnd(16)} ${painted}`);
+  }
+  out.push(`  ${"elapsed".padEnd(16)} ${human(elapsedMs)}`);
+
+  // The three slowest steps, when anything took real time. On a fresh
+  // machine this is the difference between "it was slow" and "docker
+  // took four minutes".
+  const slow = entries
+    .filter((e) => e.ms >= 3000)
+    .sort((a, b) => b.ms - a.ms)
+    .slice(0, 3);
+  if (slow.length > 0) {
+    out.push("", `  ${paint("1;90", "slowest")}`);
+    for (const e of slow) out.push(`    ${e.name.padEnd(17)} ${human(e.ms)}`);
+  }
+
+  if (deferred.length > 0) {
+    out.push("", `  ${paint("1;33", "deferred")}`);
+    for (const e of deferred) out.push(`    ${e.name.padEnd(17)} ${e.detail ?? ""}`);
+    // Once per remedy, not once per item: several items can be waiting
+    // on the same gate, and repeating one instruction beside each of
+    // them reads as several unrelated things to go and do.
+    const remedies = [...new Set(deferred.map((e) => e.remedy).filter(Boolean))];
+    if (remedies.length > 0) {
+      out.push("");
+      for (const remedy of remedies) out.push(`    ${remedy}`);
+    }
+    out.push("", `  ${paint("1;90", "Nothing here broke — this work is waiting, not lost.")}`);
+  }
+
+  if (failed.length > 0) {
+    out.push("", `  ${paint("1;31", "failed")}`);
+    for (const e of failed) out.push(`    ${e.name.padEnd(17)} ${e.detail ?? ""}`);
+    out.push("", `  ${paint("1;90", "Re-running is safe: every provider is idempotent.")}`);
+  }
+
+  return out;
 }

--- a/src/rights.ts
+++ b/src/rights.ts
@@ -84,6 +84,30 @@ export function missingRights(gate: Gate): MissingRights {
 }
 
 /**
+ * The refusal behind one of our own error messages, if that is what it is.
+ *
+ * The inverse of missingRights, and the reason it can be an inverse at
+ * all: every gate refusal in this program is worded above, so a message
+ * carrying one of those causes came from here rather than from a
+ * provider inventing its own wording for a failure.
+ *
+ * The converge needs it because an exception flattens both into the same
+ * string. Work that was deferred for lack of rights and work that broke
+ * arrive at the same catch, and telling them apart there is what lets a
+ * healthy, partly-converged machine stop reporting as a broken one.
+ *
+ * classifyRights asks the same question of a *command's* output, where
+ * the tells are whatever Windows felt like printing that day. This one
+ * asks it of a message whose bytes are known exactly, which is why it
+ * matches on the cause rather than on a list of guesses.
+ */
+export function refusedRights(message: string): MissingRights | null {
+  const gates = Object.keys(WORDING) as Gate[];
+  const gate = gates.find((g) => message.includes(WORDING[g].cause));
+  return gate ? missingRights(gate) : null;
+}
+
+/**
  * How each gate spells a refusal, lower-cased for comparison.
  *
  * Windows has no single spelling. One product, several components, and

--- a/src/ssh-server.ts
+++ b/src/ssh-server.ts
@@ -31,9 +31,9 @@
  */
 
 import type { PrivilegedState } from "./drift.ts";
-import { log } from "./log.ts";
+import { log, RedError } from "./log.ts";
 import type { Platform } from "./platform.ts";
-import { classifyRights, missingRights } from "./rights.ts";
+import { classifyRights } from "./rights.ts";
 
 /** Ran, and what it printed. */
 interface Ran {
@@ -77,14 +77,23 @@ async function linuxUnit(): Promise<string | null> {
 export async function installSshServerLinux(p: Platform): Promise<void> {
   const install = await run(["sudo", "-n", "apt-get", "install", "-y", "openssh-server"]);
   if (!install.ok) {
-    // Same wording as the rest of the converge, and now literally the
-    // same wording: sudo that needs a password cannot be answered from
-    // here, and that is not a bug. `sudo -n` is the same non-blocking
-    // probe the shared gate uses, so a failure here means the gate.
-    const denied = missingRights("sudo");
-    log.warn(`openssh-server: ${denied.cause}`);
-    log.plain(`       ${denied.remedy}`);
-    return;
+    // Raised rather than warned past, and this is the item that made
+    // the distinction necessary. Warning and returning left the converge
+    // recording an `applied` it had not applied: the one item that
+    // regularly runs out of rights reported success, and the sentence
+    // explaining why it had not scrolled away with everything else.
+    // Thrown, it reaches the loop, which reads the wording back and
+    // reports the item as deferred — beside the failures, not among
+    // them.
+    const denied = classifyRights(install.out, "sudo");
+    if (denied) throw new RedError(denied.message);
+
+    // sudo refusing and apt refusing are different answers. `sudo -n`
+    // says so in its own words, so anything else here is apt's — a
+    // package that does not exist on this release, an archive that is
+    // unreachable — and it has no remedy involving elevation. Calling it
+    // one sends an operator to raise a shell that changes nothing.
+    throw new RedError(`openssh-server: ${install.out.split("\n")[0] ?? "apt-get failed"}`);
   }
 
   if (!p.caps.systemd) {
@@ -184,17 +193,15 @@ export async function installSshServerWindows(p: Platform): Promise<void> {
     // mistake. Asked of the one classifier so this reads exactly like
     // every other item that runs out of rights, instead of handing the
     // operator the first line of a DISM stack trace to decode.
+    // Raised so the converge can report it as deferred rather than as
+    // done: an unelevated run has not configured this, and a warning
+    // under an `applied` row is a claim the machine cannot back up.
     const denied = classifyRights(err, "administrator");
-    if (denied) {
-      log.warn(`the OpenSSH server: ${denied.cause}`);
-      log.plain(`       ${denied.remedy}`);
-      return;
-    }
+    if (denied) throw new RedError(denied.message);
 
-    // Anything else really is a failure, and keeps its own reporting.
+    // Anything else really is a failure, and is raised as one.
     const first = err.split("\n")[0] ?? "unknown";
-    log.warn(`could not configure the OpenSSH server: ${first}`);
-    return;
+    throw new RedError(`could not configure the OpenSSH server: ${first}`);
   }
 
   for (const line of out.split("\n").map((l) => l.trim()).filter(Boolean)) {

--- a/src/tui-install.ts
+++ b/src/tui-install.ts
@@ -183,7 +183,7 @@ export function handleInstallScroll(
 export function useInstallModel(
   opts: InstallTuiOptions,
   logScroll: ScrollAreaState,
-  onFinish: (failed: number) => void,
+  onFinish: (outcome: { failed: number; deferred: number }) => void,
 ): InstallModel {
   const total = countSteps(opts.scopes);
 
@@ -271,11 +271,26 @@ export function useInstallModel(
           const held = captureStop();
           // LogViewer takes plain strings, so the glyph is chosen here
           // rather than by a component.
+          // A deferral gets its own glyph rather than the failure's: it
+          // is the row an operator scans for afterwards, and an ✗ beside
+          // it is the thing this outcome exists to stop saying.
           const glyph =
-            r.outcome === "failed" ? "✗" : r.outcome === "present" || r.outcome === "skipped" ? "·" : "✓";
+            r.outcome === "failed"
+              ? "✗"
+              : r.outcome === "deferred"
+                ? "!"
+                : r.outcome === "present" || r.outcome === "skipped"
+                  ? "·"
+                  : "✓";
           push(`${glyph} ${r.tool.padEnd(16)} ${r.outcome}${r.ms >= 1000 ? `  ${human(r.ms)}` : ""}`);
           for (const h of held) push(`    ${plain(h)}`);
-          if (r.detail && r.outcome === "failed") push(`    ${r.detail}`);
+          if (r.detail && (r.outcome === "failed" || r.outcome === "deferred")) {
+            push(`    ${r.detail}`);
+          }
+          // The remedy under the item, in the pane the eye is already
+          // on. The right-hand column has room to name what deferred,
+          // never room to say what to do about it.
+          if (r.remedy) push(`    ${r.remedy}`);
           setResults((prev) => [...prev, r]);
         },
       },
@@ -283,7 +298,7 @@ export function useInstallModel(
       setFinishedAt(Date.now());
       setFinished(true);
       const setupFailed = setupResults().filter((result) => result.outcome === "failed").length;
-      onFinish(summary.failed + setupFailed);
+      onFinish({ failed: summary.failed + setupFailed, deferred: summary.deferred });
     });
   });
 
@@ -371,8 +386,10 @@ export function InstallLayout(m: InstallModel, width: number, height: number) {
 
   const by = (o: string): number => results.filter((r) => r.outcome === o).length;
   const failures = results.filter((r) => r.outcome === "failed");
+  const deferrals = results.filter((r) => r.outcome === "deferred");
   const elapsedMs = m.elapsedMs();
-  const rightRows = 14 + Math.min(failures.length, 6) + (finished ? 4 : 0);
+  const rightRows =
+    14 + Math.min(failures.length, 6) + Math.min(deferrals.length, 6) + (finished ? 4 : 0);
 
   return Screen(
     width,
@@ -443,6 +460,7 @@ export function InstallLayout(m: InstallModel, width: number, height: number) {
             segments: [
               { value: by("installed") + by("applied"), color: ui.ok },
               { value: by("present"), color: subtle },
+              { value: by("deferred"), color: ui.warn },
               { value: by("failed"), color: ui.danger },
             ],
             total,
@@ -462,6 +480,19 @@ export function InstallLayout(m: InstallModel, width: number, height: number) {
           ),
           Section("Elapsed", { text: human(elapsedMs), color: text }),
 
+          // Named, not counted, and above the failures rather than
+          // among them: "1 deferred" sends the reader back through the
+          // log to find out which item it was, which is the whole cost
+          // this block exists to remove.
+          ...(deferrals.length > 0
+            ? [
+                Text({ color: ui.warn, bold: true }, "Deferred"),
+                ...deferrals
+                  .slice(0, 6)
+                  .map((d) => ListItem({ primary: d.tool, status: "warning" })),
+              ]
+            : []),
+
           ...(failures.length > 0
             ? [
                 Text({ color: ui.danger, bold: true }, "Failed"),
@@ -471,14 +502,25 @@ export function InstallLayout(m: InstallModel, width: number, height: number) {
 
           // Wrapped by hand to the column, not by hope: "Finished with
           // failures" rendered as "Finished with failu".
+          //
+          // Three endings, because there are three. A run whose only
+          // outstanding work needed rights it did not have is neither
+          // "Incomplete" — nothing broke — nor "Converged", since the
+          // items above are still waiting for an elevated session.
           ...(finished
             ? [
                 Text({}, ""),
                 Section(
-                  failures.length > 0 ? "Incomplete" : "Converged",
+                  failures.length > 0
+                    ? "Incomplete"
+                    : deferrals.length > 0
+                      ? "Deferred"
+                      : "Converged",
                   ...(failures.length > 0
                     ? ["Fix the cause and re-run;", "it resumes from here."]
-                    : ["Restart your shell to", "pick up the changes."]),
+                    : deferrals.length > 0
+                      ? ["Nothing broke. Re-run with", "the rights to finish these."]
+                      : ["Restart your shell to", "pick up the changes."]),
                 ),
               ]
             : []),
@@ -503,15 +545,17 @@ export function InstallLayout(m: InstallModel, width: number, height: number) {
  * still owns. Reaching the converge from the menu no longer comes
  * through here — see useInstallModel for why that mattered.
  */
-export async function runInstallTui(opts: InstallTuiOptions): Promise<{ failed: number }> {
-  let outcome = { failed: 0 };
+export async function runInstallTui(
+  opts: InstallTuiOptions,
+): Promise<{ failed: number; deferred: number }> {
+  let outcome = { failed: 0, deferred: 0 };
   const logScroll = createScrollArea({ height: 10, content: [], autoScroll: true });
 
   function App() {
     const { exit } = useApp();
     const size = useTerminalSize();
-    const model = useInstallModel(opts, logScroll, (failed) => {
-      outcome = { failed };
+    const model = useInstallModel(opts, logScroll, (finished) => {
+      outcome = finished;
     });
 
     useEffect(() => model.begin());

--- a/src/tui-theme.ts
+++ b/src/tui-theme.ts
@@ -78,5 +78,8 @@ export const outcomeColor: Record<string, string> = {
   applied: ui.ok,
   present: ui.fg3,
   skipped: ui.fg3,
+  // Amber, and deliberately not the danger colour: an item waiting on
+  // rights is the one outcome that is neither done nor broken.
+  deferred: ui.warn,
   failed: ui.danger,
 };

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -126,6 +126,14 @@ export interface TuiResult {
   theme?: string;
   /** Failures, when the converge ran inside the interface. */
   failed?: number;
+  /**
+   * Items that ran out of rights, counted apart from the failures.
+   *
+   * Carried separately all the way out because the caller turns it into
+   * an exit status, and the whole point of the outcome is that these two
+   * numbers are not the same news.
+   */
+  deferred?: number;
 }
 
 
@@ -225,8 +233,8 @@ export async function runTui(
     // between frames; the converge does not begin until begin() is
     // called, which is what the Enter key does.
     const model = install
-      ? useInstallModel(install, logScroll, (failed) => {
-          result = { action: "installed", failed };
+      ? useInstallModel(install, logScroll, ({ failed, deferred }) => {
+          result = { action: "installed", failed, deferred };
         })
       : null;
 


### PR DESCRIPTION
Automated AFK landing for #69. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #69

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788809665&installation_model_id=20659&pr_number=86&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F86&signature=7858d5ccad304e8ec8f70fbcf5790dc7669efd4f9dc3480314a0ea8fe0a74aaa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->