### PR TITLE
chore: #60 Uninstall removes the generated Redwall images

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -552,13 +552,14 @@ async function cmdUninstall(p: Platform): Promise<number> {
   if (what === "Cancel") return 0;
 
   if (what.startsWith("red-dev")) {
-    log.warn("This removes the shipped dotfiles, the ~/.bashrc hook and recorded preferences.");
+    log.warn("This removes the shipped dotfiles, the ~/.bashrc hook, recorded preferences");
+    log.warn("and the generated Redwall images.");
     log.plain("     Installed tools stay. Your pre-red-dev shell backup stays.");
     if (!(await confirm("Remove red-dev's configuration?", false))) {
       log.skip("nothing removed");
       return 0;
     }
-    const removed = await removeConfiguration();
+    const removed = await removeConfiguration(p);
     for (const r of removed) log.ok(`removed ${r}`);
     return 0;
   }

--- a/src/redwall-uninstall.test.ts
+++ b/src/redwall-uninstall.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Turning red-dev off takes the Redwalls with it.
+ *
+ * A content-addressed name is what keeps the directory correct while the
+ * feature is on, and it is exactly what would leave it behind once the
+ * feature is gone: nothing else on the machine knows those names, so an
+ * uninstall that skipped this directory would strand however many 4K PNGs
+ * the day happened to produce, under names no human would recognise as
+ * red-dev's.
+ *
+ * The boundary is the subject of half of these tests. Only red-dev's own
+ * Redwall directory goes. A wallpaper someone chose by hand is a decision
+ * and outlives the tool that was uninstalled around it — the same line
+ * `sweepRetiredWallpapers` draws, held here because uninstall is the one
+ * command with no undo.
+ */
+
+import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { describe, expect, test } from "bun:test";
+import type { Platform } from "./platform.ts";
+import { redwallDir, removeRedwall } from "./redwall.ts";
+import { removeConfiguration } from "./uninstall.ts";
+import { wallpaperDir } from "./wallpaper.ts";
+
+const desktop: Platform = {
+  os: "linux",
+  distro: "ubuntu",
+  version: "24.04",
+  codename: "noble",
+  env: "desktop",
+  arch: "x64",
+  caps: { apt: true, gui: true, systemd: true, winget: false, flatpak: true },
+};
+
+/** A machine with nothing on it, torn down with the process. */
+async function onFreshMachine<T>(run: (home: string) => Promise<T>): Promise<T> {
+  const previous = process.env["HOME"];
+  const home = mkdtempSync(`${tmpdir()}/red-dev-redwall-uninstall-`);
+  process.env["HOME"] = home;
+  try {
+    return await run(home);
+  } finally {
+    if (previous === undefined) delete process.env["HOME"];
+    else process.env["HOME"] = previous;
+  }
+}
+
+/** A machine that used Redwall for a while: several generations of image. */
+async function withRedwalls(p: Platform): Promise<string> {
+  const dir = await redwallDir(p);
+  mkdirSync(dir, { recursive: true });
+  for (const name of ["dark-1a2b3c4d.png", "dark-5e6f7a8b.png", "cobalt-9c0d1e2f.png"]) {
+    writeFileSync(`${dir}/${name}`, "not really a png");
+  }
+  return dir;
+}
+
+/** What somebody picked themselves, nowhere near red-dev's directories. */
+function withChosenWallpaper(home: string): string {
+  mkdirSync(`${home}/Pictures`, { recursive: true });
+  const path = `${home}/Pictures/chosen.png`;
+  writeFileSync(path, "somebody's own wallpaper");
+  return path;
+}
+
+describe("removing the generated images", () => {
+  test("takes the directory and everything in it", async () => {
+    await onFreshMachine(async () => {
+      const dir = await withRedwalls(desktop);
+
+      // The directory itself, not just its contents: an empty
+      // `redwall/` left under a removed tool's root is still a trace of
+      // a feature nobody has any more.
+      expect(await removeRedwall(desktop)).toBe(dir);
+      expect(existsSync(dir)).toBe(false);
+    });
+  });
+
+  test("leaves a wallpaper somebody chose exactly where it is", async () => {
+    await onFreshMachine(async (home) => {
+      await withRedwalls(desktop);
+      const chosen = withChosenWallpaper(home);
+
+      // And the sibling directory too. `wallpapers/` is red-dev's, but
+      // it is not this function's to empty — one destructive step that
+      // reaches past its own directory is the bug this asserts against.
+      const wallpapers = await wallpaperDir(desktop);
+      mkdirSync(wallpapers, { recursive: true });
+      writeFileSync(`${wallpapers}/dark-deadbeef.png`, "the theme's own art");
+
+      await removeRedwall(desktop);
+
+      expect(existsSync(chosen)).toBe(true);
+      expect(existsSync(`${wallpapers}/dark-deadbeef.png`)).toBe(true);
+    });
+  });
+
+  test("succeeds and reports nothing on a machine that never enabled it", async () => {
+    await onFreshMachine(async () => {
+      // Redwall is off by default, so this is the common machine, not
+      // the edge case. Nothing to remove is an ordinary answer.
+      expect(await removeRedwall(desktop)).toBeNull();
+      expect(existsSync(await redwallDir(desktop))).toBe(false);
+    });
+  });
+
+  test("does not create the directory in order to find it missing", async () => {
+    await onFreshMachine(async (home) => {
+      await removeRedwall(desktop);
+      expect(existsSync(`${home}/.local/share/red-dev`)).toBe(false);
+    });
+  });
+});
+
+describe("uninstalling red-dev's configuration", () => {
+  test("names the Redwall directory among what it removed", async () => {
+    await onFreshMachine(async () => {
+      const dir = await withRedwalls(desktop);
+
+      const removed = await removeConfiguration(desktop);
+
+      // Named in its own right rather than swallowed by the root above
+      // it. On this machine the two happen to nest; on WSL the images
+      // live on the Windows disk and nothing else in the list covers
+      // them, so the report has to come from the Redwall step itself.
+      expect(removed).toContain(dir);
+      expect(existsSync(dir)).toBe(false);
+    });
+  });
+
+  test("leaves a wallpaper somebody chose exactly where it is", async () => {
+    await onFreshMachine(async (home) => {
+      await withRedwalls(desktop);
+      const chosen = withChosenWallpaper(home);
+
+      await removeConfiguration(desktop);
+
+      expect(existsSync(chosen)).toBe(true);
+    });
+  });
+
+  test("says nothing about Redwall on a machine that never enabled it", async () => {
+    await onFreshMachine(async () => {
+      mkdirSync(`${await wallpaperDir(desktop)}`, { recursive: true });
+
+      const removed = await removeConfiguration(desktop);
+
+      expect(removed.some((r) => r.endsWith("/redwall"))).toBe(false);
+    });
+  });
+});

--- a/src/redwall.ts
+++ b/src/redwall.ts
@@ -207,6 +207,35 @@ export async function sweepSupersededRedwalls(
   return removed;
 }
 
+/**
+ * Delete the whole Redwall directory, and report whether there was one.
+ *
+ * Uninstall's half of the sweep above. The sweep spares the image on
+ * screen because something is about to replace it; here nothing is, and
+ * a desktop pointed at a file red-dev is removing is the state the user
+ * asked for — the alternative is leaving a 4K PNG behind to keep an
+ * unowned wallpaper setting company.
+ *
+ * The directory rather than its `.png` files, because an empty
+ * `redwall/` under a removed tool's root is still a trace of the
+ * feature, and unlike the sweep there is no next generation that needs
+ * somewhere to land. Nothing outside it is touched: the sibling
+ * `wallpapers/` is a different directory with a different owner, and a
+ * wallpaper somebody chose by hand is a decision that outlives the tool
+ * uninstalled around it.
+ *
+ * Null, not an empty list, when there was nothing here. Redwall is off
+ * by default, so "this machine never generated one" is the common
+ * answer and has to read as success rather than as a thing that failed
+ * to happen.
+ */
+export async function removeRedwall(p: Platform): Promise<string | null> {
+  const dir = await redwallDir(p);
+  if (!existsSync(dir)) return null;
+  rmSync(dir, { recursive: true, force: true });
+  return dir;
+}
+
 async function currentlyDisplayed(
   p: Platform,
   inUse: (() => Promise<string | null>) | undefined,

--- a/src/uninstall.ts
+++ b/src/uninstall.ts
@@ -129,12 +129,34 @@ export function removableTools(p: Platform): { tool: Tool; removal: Removal }[] 
  * intentions. The shipped dotfiles go; the `.bashrc` line is removed;
  * the pre-red-dev backup is left exactly where it is, because that is
  * the only copy of what was there before.
+ *
+ * The generated Redwalls go too, and they need the platform to be found
+ * at all: on WSL the images live on the Windows disk, so none of the
+ * paths below covers them and a machine uninstalled from WSL would keep
+ * every 4K PNG it ever generated, under content-addressed names nothing
+ * left on the machine could explain.
  */
-export async function removeConfiguration(): Promise<string[]> {
+export async function removeConfiguration(p: Platform): Promise<string[]> {
   const home = process.env["HOME"] ?? process.env["USERPROFILE"];
   if (!home) throw new RedError("neither HOME nor USERPROFILE is set");
 
   const removed: string[] = [];
+
+  // Before the roots below, not after. Off WSL the Redwall directory
+  // sits inside `~/.local/share/red-dev`, and removing the root first
+  // would delete the images without ever being able to say it had.
+  //
+  // Isolated, because finding this directory on WSL asks Windows where
+  // LocalAppData is, and a machine where that question fails is still a
+  // machine whose dotfiles and shell hook must come out.
+  try {
+    const { removeRedwall } = await import("./redwall.ts");
+    const dir = await removeRedwall(p);
+    if (dir) removed.push(dir);
+  } catch (err) {
+    log.warn(`redwall: ${(err as Error).message}`);
+  }
+
   const targets = [
     `${home}/.local/share/red-dev`,
     `${home}/.config/red-dev`,


### PR DESCRIPTION
Automated AFK landing for #60. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #60

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788810008&installation_model_id=20659&pr_number=87&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F87&signature=557073aac5a08778b418d1d3c8bab025d32d299d3b1d0c568f0864419e94eedf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->