### PR TITLE
chore: #59 Apply Redwall as a theme surface, gated on the preference

### DIFF
--- a/README.md
+++ b/README.md
@@ -803,6 +803,7 @@ A theme changes the things nothing else overrides:
 | Windows | dark mode, accent colour, and colour prevalence |
 | GNOME | light/dark preference and accent |
 | VS Code | `workbench.colorTheme`, in a settings file parsed as JSONC so comments and trailing commas survive |
+| Redwall | the new theme's art with this machine's state redrawn over it, then put on the desktop — only where the preference is on, and never on a machine with no screen |
 
 Both steps are written down: [ADR 0002](.red/adr/0002-the-terminal-palette-is-fixed.md)
 made the palette fixed, [ADR 0003](.red/adr/0003-red-dev-does-not-colour-the-terminal.md)

--- a/src/redwall-apply.test.ts
+++ b/src/redwall-apply.test.ts
@@ -1,0 +1,180 @@
+/**
+ * The half of Redwall that reaches a screen.
+ *
+ * `redwall-generate.test.ts` owns the question of whether the image
+ * arrives and where; this owns what happens to it afterwards, which is
+ * the whole difference between a feature and a directory of 4K PNGs
+ * nobody points at.
+ *
+ * The `show` seam is why any of this is assertable. Its default repaints
+ * the desktop of the machine running the test — `gsettings` on a Linux
+ * desk, PowerShell across the WSL boundary — so a suite that let it run
+ * would either do nothing on CI or change the wallpaper of whoever ran
+ * `bun test` at their desk. Replacing it turns "the desktop is now
+ * pointed at this file" into a value.
+ */
+
+import { existsSync, mkdtempSync, readdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { describe, expect, test } from "bun:test";
+import type { Platform } from "./platform.ts";
+import { writePreferences } from "./preferences.ts";
+import type { RedwallState } from "./redwall-render.ts";
+import { applyRedwall, redwallDir } from "./redwall.ts";
+
+const desktop: Platform = {
+  os: "linux",
+  distro: "ubuntu",
+  version: "24.04",
+  codename: "noble",
+  env: "desktop",
+  arch: "x64",
+  caps: { apt: true, gui: true, systemd: true, winget: false, flatpak: true },
+};
+
+const server: Platform = { ...desktop, env: "server", caps: { ...desktop.caps, gui: false } };
+
+const running: RedwallState = { workers: 3, address: "192.168.1.42" };
+
+/** A machine with nothing on it, torn down with the process. */
+async function onFreshMachine<T>(run: (home: string) => Promise<T>): Promise<T> {
+  const previous = process.env["HOME"];
+  const home = mkdtempSync(`${tmpdir()}/red-dev-redwall-apply-`);
+  process.env["HOME"] = home;
+  try {
+    return await run(home);
+  } finally {
+    if (previous === undefined) delete process.env["HOME"];
+    else process.env["HOME"] = previous;
+  }
+}
+
+/**
+ * A desktop that remembers what it was last pointed at, which is also
+ * the honest answer to the sweep's "what is on screen" question.
+ */
+function screen() {
+  const shown: string[] = [];
+  return {
+    shown,
+    current: () => shown.at(-1) ?? null,
+    apply: (p: Platform, slug: string) =>
+      applyRedwall(p, slug, {
+        state: async () => running,
+        inUse: async () => shown.at(-1) ?? null,
+        show: async (path: string) => {
+          shown.push(path);
+          return true;
+        },
+      }),
+  };
+}
+
+const listing = async (p: Platform): Promise<string[]> => {
+  const dir = await redwallDir(p);
+  return existsSync(dir) ? readdirSync(dir).sort() : [];
+};
+
+describe("applying a Redwall", () => {
+  test("draws on the theme it was handed, not the one on file", async () => {
+    // The reason this argument exists. `red-dev theme` applies the new
+    // theme before anything records it, so the preference still names
+    // the old one at the moment the surfaces run — a Redwall that read
+    // it would compose this machine's state over the art the user just
+    // switched away from and then put that on screen.
+    await onFreshMachine(async () => {
+      await writePreferences(desktop, { redwall: true, theme: "dark" });
+
+      const s = screen();
+      const outcome = await s.apply(desktop, "marble");
+
+      expect(outcome.shown).toBe(true);
+      expect(outcome.path).toMatch(/\/marble-[0-9a-f]{8}\.png$/);
+      expect(s.current()).toBe(outcome.path);
+    });
+  });
+
+  test("switching themes replaces what is on screen, and leaves nothing behind", async () => {
+    await onFreshMachine(async () => {
+      await writePreferences(desktop, { redwall: true, theme: "dark" });
+
+      const s = screen();
+      const first = await s.apply(desktop, "obsidian");
+      const second = await s.apply(desktop, "flare");
+
+      // The desktop moved. Not merely "a new file exists": the previous
+      // theme's art was on screen a moment ago and is not now.
+      expect(s.shown).toEqual([first.path!, second.path!]);
+      expect(second.path).not.toBe(first.path);
+
+      // And the superseded image is gone rather than accumulating —
+      // spared only while it was the one being displayed.
+      expect(await listing(desktop)).toEqual([second.path!.split("/").pop()!]);
+      expect(existsSync(first.path!)).toBe(false);
+    });
+  });
+
+  test("switching back and forth does not leave a Redwall per theme", async () => {
+    // A user trying the six themes in a row is six 4K PNGs if the sweep
+    // only ever spares. The one on screen is the only survivor.
+    await onFreshMachine(async () => {
+      await writePreferences(desktop, { redwall: true, theme: "dark" });
+
+      const s = screen();
+      for (const slug of ["dark", "light", "cobalt", "dark"]) {
+        await s.apply(desktop, slug);
+      }
+
+      expect(await listing(desktop)).toHaveLength(1);
+      expect(s.current()).toContain("/dark-");
+    });
+  });
+
+  test("with the preference off nothing is drawn and nothing is shown", async () => {
+    await onFreshMachine(async () => {
+      const s = screen();
+      const outcome = await s.apply(desktop, "marble");
+
+      expect(outcome.skipped).toBe("off");
+      expect(outcome.shown).toBe(false);
+      expect(s.shown).toEqual([]);
+      // The desktop keeps whatever it had: a surface that was not asked
+      // for must not repaint anything, not even back to the plain art.
+      expect(existsSync(await redwallDir(desktop))).toBe(false);
+    });
+  });
+
+  test("a headless machine is never repainted, whatever the preference says", async () => {
+    await onFreshMachine(async () => {
+      await writePreferences(server, { redwall: true, theme: "dark" });
+
+      const s = screen();
+      const outcome = await s.apply(server, "marble");
+
+      expect(outcome.skipped).toBe("headless");
+      expect(outcome.shown).toBe(false);
+      expect(s.shown).toEqual([]);
+    });
+  });
+
+  test("an image that could not be shown does not report that it was", async () => {
+    // A desktop can refuse — no gsettings, a PowerShell that is not
+    // reachable across the boundary. The file is still correct and still
+    // on disk; the claim that anybody can see it is what is false, and
+    // the surface reports skipped rather than applied on the strength of
+    // it.
+    await onFreshMachine(async () => {
+      await writePreferences(desktop, { redwall: true, theme: "dark" });
+
+      const outcome = await applyRedwall(desktop, "dark", {
+        state: async () => running,
+        inUse: async () => null,
+        show: async () => false,
+      });
+
+      expect(outcome.written).toBe(true);
+      expect(existsSync(outcome.path!)).toBe(true);
+      expect(outcome.shown).toBe(false);
+    });
+  });
+});

--- a/src/redwall.ts
+++ b/src/redwall.ts
@@ -68,7 +68,13 @@ import { readPreferences, resolveRedwall } from "./preferences.ts";
 import { REDWALL_SUBSET } from "./redwall-font.ts";
 import { renderRedwall, type RedwallState } from "./redwall-render.ts";
 import { resolveThemeSlug, THEMES } from "./themes.ts";
-import { imageRoot, shortDigest, wallpaperBytes, wallpaperPathInUse } from "./wallpaper.ts";
+import {
+  imageRoot,
+  setDesktopBackground,
+  shortDigest,
+  wallpaperBytes,
+  wallpaperPathInUse,
+} from "./wallpaper.ts";
 
 /** Where the generated images live. A sibling of `wallpapers/`, never inside it. */
 export async function redwallDir(p: Platform): Promise<string> {
@@ -109,6 +115,8 @@ export interface RedwallSeams {
   readonly state?: () => Promise<RedwallState>;
   /** Which image the desktop is pointed at, so the sweep can spare it. */
   readonly inUse?: () => Promise<string | null>;
+  /** Where the finished image goes. Defaults to this machine's desktop. */
+  readonly show?: (path: string) => Promise<boolean>;
 }
 
 /**
@@ -136,6 +144,17 @@ export async function redwallState(p: Platform): Promise<RedwallState> {
 export async function generateRedwall(
   p: Platform,
   seams: RedwallSeams = {},
+  /**
+   * The theme to draw on, for a caller that already knows which one.
+   *
+   * A theme switch is exactly that caller, and it needs this: `red-dev
+   * theme` does not record the new slug before it applies it, so a
+   * Redwall that only ever read the preference would draw the machine's
+   * state over the art the user just switched away from. Omitted, the
+   * recorded preference is the answer — which is what the hook, firing
+   * on a state change rather than a theme change, has to fall back on.
+   */
+  theme?: string,
 ): Promise<RedwallOutcome> {
   if (!(await resolveRedwall(p))) return skipped("off");
   // Not a failure, and not a thing to warn about either: a server is a
@@ -146,7 +165,7 @@ export async function generateRedwall(
   // retired slugs draws its Redwall on the art it is actually themed
   // with rather than failing to find a wallpaper for a name nothing
   // holds any more.
-  const slug = resolveThemeSlug((await readPreferences(p)).theme);
+  const slug = resolveThemeSlug(theme ?? (await readPreferences(p)).theme);
   const state = await (seams.state ?? (() => redwallState(p)))();
 
   const bytes = renderRedwall({
@@ -169,6 +188,48 @@ export async function generateRedwall(
 
   const removed = await sweepSupersededRedwalls(p, path, seams.inUse);
   return { path, skipped: null, written, removed };
+}
+
+export interface RedwallApplied extends RedwallOutcome {
+  /** Whether the desktop is now pointed at the image. */
+  readonly shown: boolean;
+}
+
+/**
+ * Compose this machine's Redwall for a theme and put it on the desktop.
+ *
+ * The two halves are one call because they are useless apart. Generating
+ * without showing leaves a 4K PNG nothing points at; showing without
+ * generating first would point the desktop at the previous theme's
+ * overlay. `generateRedwall` stays separate underneath it because the
+ * hook that fires on a state change wants the first half testable
+ * without a desktop, and because `red-dev redwall` reports the path.
+ *
+ * It sweeps a second time, and that is the point of doing both halves in
+ * one place. The sweep inside `generateRedwall` necessarily runs before
+ * the desktop is repointed, so it has to spare the image on screen — and
+ * on a theme switch the image on screen is precisely the one being
+ * replaced. Left there, a user trying the six themes in turn keeps a 4K
+ * PNG for every theme but the first. Once the desktop has moved, the
+ * same sweep spares the new image instead and the old one goes, which is
+ * the ordering `sweepRetiredWallpapers` has always kept next door.
+ */
+export async function applyRedwall(
+  p: Platform,
+  theme: string,
+  seams: RedwallSeams = {},
+): Promise<RedwallApplied> {
+  const outcome = await generateRedwall(p, seams, theme);
+  if (outcome.path === null) return { ...outcome, shown: false };
+
+  const show = seams.show ?? ((image: string) => setDesktopBackground(image, p));
+  const shown = await show(outcome.path);
+  // Only when the repaint took. A desktop that refused is still pointed
+  // at the previous Redwall, and that file is not this run's to remove.
+  if (!shown) return { ...outcome, shown };
+
+  const removed = await sweepSupersededRedwalls(p, outcome.path, seams.inUse);
+  return { ...outcome, removed: [...outcome.removed, ...removed], shown };
 }
 
 /**

--- a/src/theme-apply.test.ts
+++ b/src/theme-apply.test.ts
@@ -4,9 +4,19 @@ import {
   applyThemeEverywhere,
   themeSurfaceNames,
   THEME_SURFACES,
+  type ThemeSurfaceContext,
   type ThemeSurfaceSpec,
 } from "./theme-apply.ts";
 import { DEFAULT_THEME, THEMES } from "./themes.ts";
+
+/**
+ * The two answers the preference can give, named rather than written
+ * inline. Passed explicitly everywhere below: read from disk instead,
+ * these assertions would say something different on a machine that had
+ * turned Redwall on than they do in CI.
+ */
+const redwallOff: ThemeSurfaceContext = { redwall: false };
+const redwallOn: ThemeSurfaceContext = { redwall: true };
 
 const basePlatform = {
   distro: null,
@@ -34,20 +44,28 @@ const windows = {
   env: "windows",
 } satisfies Platform;
 
+/** No desktop, so nothing here is a surface that can be seen. */
+const server = {
+  ...basePlatform,
+  os: "linux",
+  env: "server",
+  caps: { ...basePlatform.caps, gui: false },
+} satisfies Platform;
+
 describe("theme surfaces", () => {
   test("a theme reaches the desktop and nothing inside the terminal", () => {
     // Nine of the eleven surfaces this used to name were terminal
     // programs. They take the fixed palette now — see
     // src/terminal-surfaces.ts and .red/adr/0003 — so a name reappearing
     // in this list is a theme leaking back into a pane.
-    expect(themeSurfaceNames(windows)).toEqual(["vscode", "wallpaper", "windows"]);
+    expect(themeSurfaceNames(windows, redwallOff)).toEqual(["vscode", "wallpaper", "windows"]);
   });
 
   test("no terminal program is a theme surface any more", () => {
     const inTheTerminal = ["zellij", "btop", "neovim", "bat", "delta", "lazygit", "opencode", "herdr"];
     for (const p of [windows, wsl]) {
       for (const name of inTheTerminal) {
-        expect(themeSurfaceNames(p)).not.toContain(name);
+        expect(themeSurfaceNames(p, redwallOn)).not.toContain(name);
       }
     }
   });
@@ -55,8 +73,8 @@ describe("theme surfaces", () => {
   test("native Windows stays in parity with WSL, apart from GNOME", () => {
     const portable = (name: string) => name !== "gnome";
 
-    expect(themeSurfaceNames(windows).filter(portable)).toEqual(
-      themeSurfaceNames(wsl).filter(portable),
+    expect(themeSurfaceNames(windows, redwallOn).filter(portable)).toEqual(
+      themeSurfaceNames(wsl, redwallOn).filter(portable),
     );
   });
 
@@ -66,10 +84,38 @@ describe("theme surfaces", () => {
     // the try/catch and was reported as a benign "skipped" — invisible.
     // One array cannot disagree with itself, and this says so.
     for (const p of [windows, wsl]) {
-      for (const name of themeSurfaceNames(p)) {
+      for (const name of themeSurfaceNames(p, redwallOn)) {
         expect(THEME_SURFACES.some((s) => s.name === name)).toBe(true);
       }
     }
+  });
+
+  test("Redwall is a surface only where somebody asked for it", () => {
+    // Every other surface is present or absent by what the machine is.
+    // This one is present or absent by what its owner decided, which is
+    // the whole of .red/adr/0003's reasoning applied one surface over:
+    // a desktop is not red-dev's to write over because a converge ran.
+    expect(themeSurfaceNames(windows, redwallOn)).toContain("redwall");
+    expect(themeSurfaceNames(windows, redwallOff)).not.toContain("redwall");
+  });
+
+  test("Redwall draws over the art last, after the surface that installs it", () => {
+    // Not a cosmetic ordering. Redwall composes over the theme's art and
+    // then repoints the desktop at the composite; run before the
+    // wallpaper surface, its work would be immediately overwritten by
+    // the plain art and the overlay would never be seen.
+    const names = themeSurfaceNames(wsl, redwallOn);
+    expect(names.indexOf("redwall")).toBeGreaterThan(names.indexOf("wallpaper"));
+    expect(names.at(-1)).toBe("redwall");
+  });
+
+  test("a headless machine has no Redwall, whatever the preference says", () => {
+    // Two independent gates, and the preference is the weaker one: a
+    // server generating 4K PNGs nothing can display is work done for
+    // nobody, so "yes" from a user who later moved the disk into a rack
+    // does not override the absence of a screen.
+    expect(themeSurfaceNames(server, redwallOn)).not.toContain("redwall");
+    expect(themeSurfaceNames(server, redwallOff)).not.toContain("redwall");
   });
 });
 
@@ -110,7 +156,7 @@ describe("the slug reaches every surface intact", () => {
     if (!slug) throw new Error("no theme whose name and slug differ — the test needs one");
 
     const { seen, surfaces } = spy();
-    await applyThemeEverywhere(slug, wsl, surfaces);
+    await applyThemeEverywhere(slug, wsl, surfaces, redwallOn);
 
     expect(seen.length).toBeGreaterThan(0);
     for (const call of seen) expect(call.slug).toBe(slug);
@@ -118,7 +164,7 @@ describe("the slug reaches every surface intact", () => {
 
   test("the theme handed to a surface is the one the slug names", async () => {
     const { seen, surfaces } = spy();
-    await applyThemeEverywhere(DEFAULT_THEME, wsl, surfaces);
+    await applyThemeEverywhere(DEFAULT_THEME, wsl, surfaces, redwallOn);
     for (const call of seen) expect(call.theme).toBe(THEMES[DEFAULT_THEME].name);
   });
 
@@ -136,8 +182,49 @@ describe("the slug reaches every surface intact", () => {
       { name: "boom", applies: () => true, apply: async () => { throw new Error("nope"); } },
       { name: "fine", applies: () => true, apply: async () => true },
     ];
-    const { applied, skipped } = await applyThemeEverywhere(DEFAULT_THEME, wsl, surfaces);
+    const { applied, skipped } = await applyThemeEverywhere(DEFAULT_THEME, wsl, surfaces, redwallOff);
     expect(applied).toEqual(["fine"]);
     expect(skipped).toEqual(["boom"]);
+  });
+
+  /**
+   * Redwall's gate, watched through the same seam as everything else.
+   *
+   * There is no new test double here on purpose. Whether a surface runs
+   * is `applies`, and the spy above already records every surface that
+   * did — so "invoked with the new theme" and "not invoked at all" are
+   * two readings of one list rather than two mechanisms.
+   */
+  describe("and Redwall is in that list only when it should be", () => {
+    const invoked = (seen: { name: string }[]) => seen.map((call) => call.name);
+
+    test("with the preference on, a theme switch reaches it with the new theme", async () => {
+      const { seen, surfaces } = spy();
+      await applyThemeEverywhere("marble", wsl, surfaces, redwallOn);
+
+      const redwall = seen.filter((call) => call.name === "redwall");
+      expect(redwall).toEqual([
+        { name: "redwall", slug: "marble", theme: THEMES.marble.name },
+      ]);
+    });
+
+    test("with the preference off, it is never reached", async () => {
+      const { seen, surfaces } = spy();
+      const { applied, skipped } = await applyThemeEverywhere("marble", wsl, surfaces, redwallOff);
+
+      expect(invoked(seen)).not.toContain("redwall");
+      // Absent, not failed: a surface nobody asked for must not show up
+      // as a thing that did not work.
+      expect(applied).not.toContain("redwall");
+      expect(skipped).not.toContain("redwall");
+    });
+
+    test("on a headless machine it is never reached, preference or not", async () => {
+      for (const ctx of [redwallOn, redwallOff]) {
+        const { seen, surfaces } = spy();
+        await applyThemeEverywhere("marble", server, surfaces, ctx);
+        expect(invoked(seen)).not.toContain("redwall");
+      }
+    });
   });
 });

--- a/src/theme-apply.ts
+++ b/src/theme-apply.ts
@@ -11,7 +11,8 @@
  * the things you can see at a glance and nothing else overrides.
  *
  * What is left is the desktop: the wallpaper, the system accent and
- * light-dark, and the editor that is a window rather than a pane.
+ * light-dark, the editor that is a window rather than a pane, and — for
+ * the machines that asked for it — the Redwall drawn over the new art.
  *
  * Each writer is independent and failure-tolerant: a missing application
  * is not an error, it is just a surface that does not exist here.
@@ -21,10 +22,32 @@ import { log } from "./log.ts";
 import type { Platform } from "./platform.ts";
 import { themeFor, type Theme } from "./themes.ts";
 
+/**
+ * What a surface needs to know that the platform does not say.
+ *
+ * Redwall is the first surface whose existence is a decision rather than
+ * a property of the machine, and the decision lives in a file. Resolved
+ * once, up front, and handed to every `applies` — rather than read from
+ * disk inside the predicate — for two reasons. A predicate that touches
+ * the filesystem is a predicate whose answer depends on which machine
+ * the test suite is running on, and reading it per surface would spawn
+ * `cmd.exe` once per surface under WSL to find %APPDATA%.
+ */
+export interface ThemeSurfaceContext {
+  /** Whether Redwall is on for this machine. Off unless someone said so. */
+  readonly redwall: boolean;
+}
+
+/** What this machine has decided, for the surfaces that ask. */
+export async function themeSurfaceContext(p: Platform): Promise<ThemeSurfaceContext> {
+  const { resolveRedwall } = await import("./preferences.ts");
+  return { redwall: await resolveRedwall(p) };
+}
+
 export interface ThemeSurfaceSpec {
   name: string;
   /** False on a target that has no such surface at all. */
-  applies: (p: Platform) => boolean;
+  applies: (p: Platform, ctx: ThemeSurfaceContext) => boolean;
   apply: (theme: Theme, slug: string, p: Platform) => Promise<boolean>;
 }
 
@@ -82,10 +105,35 @@ export const THEME_SURFACES: ThemeSurfaceSpec[] = [
       return applyGnomeTheme(p, theme, slug);
     },
   },
+  {
+    // After the wallpaper, and last, because it has the final word on
+    // the background: Redwall composes over the art the surface above
+    // just installed, so a theme change that ran them the other way
+    // round would end with the plain art on screen and the overlay in a
+    // directory nothing points at.
+    //
+    // On Windows that background is the whole of it. The lock screen
+    // there is not reachable on Home editions, and the screensaver route
+    // would greet every new machine with a SmartScreen warning for the
+    // sake of a cosmetic feature.
+    //
+    // The slug is passed down rather than re-read: `red-dev theme` does
+    // not record the new theme before applying it, so a Redwall that
+    // consulted the preference would draw over the art being switched
+    // away from.
+    name: "redwall",
+    applies: (p, ctx) => ctx.redwall && p.env !== "server",
+    apply: async (_theme, slug, p) => {
+      const { applyRedwall } = await import("./redwall.ts");
+      const { shown, removed } = await applyRedwall(p, slug);
+      if (removed.length > 0) log.plain(`       removed ${removed.length} superseded redwall(s)`);
+      return shown;
+    },
+  },
 ];
 
-export function themeSurfaceNames(p: Platform): string[] {
-  return THEME_SURFACES.filter((s) => s.applies(p)).map((s) => s.name);
+export function themeSurfaceNames(p: Platform, ctx: ThemeSurfaceContext): string[] {
+  return THEME_SURFACES.filter((s) => s.applies(p, ctx)).map((s) => s.name);
 }
 
 export interface ApplyThemeResult {
@@ -115,20 +163,28 @@ export interface ApplyThemeResult {
  * to omit it does not compile.
  *
  * `surfaces` is injectable so a test can watch what each one receives.
- * That test could not be written against the old shape at all.
+ * That test could not be written against the old shape at all. `ctx` is
+ * injectable for the same reason one step further out: it is what
+ * decides whether a surface is in the run, so absence is observable
+ * through the same seam as presence.
  */
 export async function applyThemeEverywhere(
   slug: string,
   p: Platform,
   surfaces: ThemeSurfaceSpec[] = THEME_SURFACES,
+  ctx?: ThemeSurfaceContext,
 ): Promise<ApplyThemeResult> {
   const theme = themeFor(slug);
   if (!theme) throw new Error(`unknown theme '${slug}'`);
 
+  // After the slug check, so an unknown theme still fails without having
+  // gone to disk for a preference it will not use.
+  const context = ctx ?? (await themeSurfaceContext(p));
+
   const applied: string[] = [];
   const skipped: string[] = [];
 
-  for (const surface of surfaces.filter((s) => s.applies(p))) {
+  for (const surface of surfaces.filter((s) => s.applies(p, context))) {
     try {
       if (await surface.apply(theme, slug, p)) applied.push(surface.name);
       else skipped.push(surface.name);

--- a/src/wallpaper.ts
+++ b/src/wallpaper.ts
@@ -235,6 +235,22 @@ async function setWindows(path: string, p: Platform): Promise<boolean> {
   return await run([shell, "-NoProfile", "-NonInteractive", "-Command", windowsScript(winPath)]);
 }
 
+/**
+ * Point the desktop at an image, whoever wrote it.
+ *
+ * Split out of `applyWallpaper` because Redwall's last step is this one
+ * and nothing else: it composes its own image and then needs the desktop
+ * repainted exactly the way a theme's own art would be. A second copy of
+ * "how a background is set on GNOME and on Windows" would be a second
+ * place for the WSL path translation to be wrong, and only one of the
+ * two would be the one anybody tested.
+ */
+export async function setDesktopBackground(path: string, p: Platform): Promise<boolean> {
+  if (p.env === "desktop") return await setGnome(path);
+  if (p.os === "windows" || p.env === "wsl") return await setWindows(path, p);
+  return false;
+}
+
 export async function applyWallpaper(
   theme: Theme,
   key: string,
@@ -243,11 +259,7 @@ export async function applyWallpaper(
   // A headless server has no desktop to put an image on.
   if (p.env === "server") return false;
 
-  const path = await materialise(theme, key, p);
-
-  if (p.env === "desktop") return await setGnome(path);
-  if (p.os === "windows" || p.env === "wsl") return await setWindows(path, p);
-  return false;
+  return await setDesktopBackground(await materialise(theme, key, p), p);
 }
 
 /**


### PR DESCRIPTION
Automated AFK landing for #59. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #59

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788810074&installation_model_id=20659&pr_number=88&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F88&signature=2d35aa2866e26e219718a2f96a9deba134e4f335476acd9fbfb192383f9a0fca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->