### PR TITLE
chore: #61 Show the Redwall on the GNOME lock screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -803,7 +803,7 @@ A theme changes the things nothing else overrides:
 | Windows | dark mode, accent colour, and colour prevalence |
 | GNOME | light/dark preference and accent |
 | VS Code | `workbench.colorTheme`, in a settings file parsed as JSONC so comments and trailing commas survive |
-| Redwall | the new theme's art with this machine's state redrawn over it, then put on the desktop — only where the preference is on, and never on a machine with no screen |
+| Redwall | the new theme's art with this machine's state redrawn over it, then put on the desktop and — on GNOME — the lock screen, so the state reads without unlocking; only where the preference is on, and never on a machine with no screen |
 
 Both steps are written down: [ADR 0002](.red/adr/0002-the-terminal-palette-is-fixed.md)
 made the palette fixed, [ADR 0003](.red/adr/0003-red-dev-does-not-colour-the-terminal.md)

--- a/src/redwall-apply.test.ts
+++ b/src/redwall-apply.test.ts
@@ -20,7 +20,8 @@ import { describe, expect, test } from "bun:test";
 import type { Platform } from "./platform.ts";
 import { writePreferences } from "./preferences.ts";
 import type { RedwallState } from "./redwall-render.ts";
-import { applyRedwall, redwallDir } from "./redwall.ts";
+import { applyRedwall, redwallDir, showRedwall } from "./redwall.ts";
+import { setLockScreenBackground } from "./wallpaper.ts";
 
 const desktop: Platform = {
   os: "linux",
@@ -33,6 +34,8 @@ const desktop: Platform = {
 };
 
 const server: Platform = { ...desktop, env: "server", caps: { ...desktop.caps, gui: false } };
+
+const wsl: Platform = { ...desktop, env: "wsl" };
 
 const running: RedwallState = { workers: 3, address: "192.168.1.42" };
 
@@ -66,6 +69,43 @@ function screen() {
           shown.push(path);
           return true;
         },
+      }),
+  };
+}
+
+/**
+ * Both surfaces a Redwall reaches, watched one at a time.
+ *
+ * `screen()` above replaces the whole of `show`, which is right for
+ * questions about the file and wrong for this one: the lock screen only
+ * becomes assertable when the two writers underneath `show` are separate
+ * values. `showRedwall` is the real default, so what these tests exercise
+ * is the composition the machine runs and not a rehearsal of it.
+ *
+ * `lockTakes` is how a target that has no such key answers — `gsettings`
+ * exits non-zero for a schema it does not know, and the whole question is
+ * what red-dev does next.
+ */
+function screens(lockTakes = true) {
+  const wall: string[] = [];
+  const lock: string[] = [];
+  return {
+    wall,
+    lock,
+    apply: (p: Platform, slug: string) =>
+      applyRedwall(p, slug, {
+        state: async () => running,
+        inUse: async () => wall.at(-1) ?? null,
+        show: showRedwall(p, {
+          desktop: async (path: string) => {
+            wall.push(path);
+            return true;
+          },
+          lock: async (path: string) => {
+            lock.push(path);
+            return lockTakes;
+          },
+        }),
       }),
   };
 }
@@ -176,5 +216,102 @@ describe("applying a Redwall", () => {
       expect(existsSync(outcome.path!)).toBe(true);
       expect(outcome.shown).toBe(false);
     });
+  });
+});
+
+/**
+ * The surface that motivated the feature.
+ *
+ * A Redwall on the desktop is readable by whoever is already sitting at
+ * an unlocked machine, which is the person who least needs it. The lock
+ * screen is where a Worker count and an address are worth having, and it
+ * is the reason the image says anything at all rather than being art.
+ */
+describe("the lock screen", () => {
+  test("is pointed at the same image the desktop is", async () => {
+    await onFreshMachine(async () => {
+      await writePreferences(desktop, { redwall: true, theme: "dark" });
+
+      const s = screens();
+      const outcome = await s.apply(desktop, "marble");
+
+      expect(outcome.shown).toBe(true);
+      // The same path, not merely a path: two surfaces showing different
+      // generations of the same image is the bug that would otherwise
+      // read as working.
+      expect(s.wall).toEqual([outcome.path!]);
+      expect(s.lock).toEqual([outcome.path!]);
+    });
+  });
+
+  test("follows a theme switch rather than keeping the old art", async () => {
+    await onFreshMachine(async () => {
+      await writePreferences(desktop, { redwall: true, theme: "dark" });
+
+      const s = screens();
+      const first = await s.apply(desktop, "obsidian");
+      const second = await s.apply(desktop, "flare");
+
+      expect(s.lock).toEqual([first.path!, second.path!]);
+      // And never at a file the sweep has since removed: the lock screen
+      // is pointed at the survivor, so a machine locked an hour later
+      // still has an image to draw.
+      expect(existsSync(s.lock.at(-1)!)).toBe(true);
+      expect(existsSync(first.path!)).toBe(false);
+    });
+  });
+
+  test("is left alone when the preference is off", async () => {
+    // Not "set back to the plain art", which would be a second decision
+    // red-dev never made: a machine that did not ask for a Redwall has a
+    // lock screen belonging to whoever configured it.
+    await onFreshMachine(async () => {
+      const s = screens();
+      const outcome = await s.apply(desktop, "marble");
+
+      expect(outcome.skipped).toBe("off");
+      expect(s.lock).toEqual([]);
+      expect(s.wall).toEqual([]);
+    });
+  });
+
+  test("a target without the key still shows the desktop, and does not fail", async () => {
+    // GNOME's screensaver schema is not everywhere, and `gsettings set`
+    // exits non-zero for a schema it does not know. That is a surface
+    // this machine does not have, not a failed apply — the desktop is
+    // the claim `shown` makes, and it is still true.
+    await onFreshMachine(async () => {
+      await writePreferences(desktop, { redwall: true, theme: "dark" });
+
+      const s = screens(false);
+      const outcome = await s.apply(desktop, "cobalt");
+
+      expect(outcome.shown).toBe(true);
+      expect(s.wall).toEqual([outcome.path!]);
+    });
+  });
+
+  test("is written once, whatever the shell does with it", async () => {
+    // GNOME Shell has ignored this key since 3.36 and blurs the desktop
+    // wallpaper instead — which is a Redwall either way, and is why the
+    // project accepts the outcome rather than shipping an extension to
+    // override it. What must not happen is red-dev noticing and trying
+    // again: there is no reading back, and no second write.
+    await onFreshMachine(async () => {
+      await writePreferences(desktop, { redwall: true, theme: "dark" });
+
+      const s = screens(false);
+      await s.apply(desktop, "dark");
+
+      expect(s.lock).toHaveLength(1);
+    });
+  });
+
+  test("is a GNOME surface, and is not reached for anywhere else", async () => {
+    // Windows is the case that matters: the lock screen there is not
+    // reachable on Home editions, so the desktop is the whole of it and
+    // this must answer without spawning anything.
+    expect(await setLockScreenBackground("/tmp/red-dev-nowhere.png", wsl)).toBe(false);
+    expect(await setLockScreenBackground("/tmp/red-dev-nowhere.png", server)).toBe(false);
   });
 });

--- a/src/redwall.ts
+++ b/src/redwall.ts
@@ -71,6 +71,7 @@ import { resolveThemeSlug, THEMES } from "./themes.ts";
 import {
   imageRoot,
   setDesktopBackground,
+  setLockScreenBackground,
   shortDigest,
   wallpaperBytes,
   wallpaperPathInUse,
@@ -115,7 +116,10 @@ export interface RedwallSeams {
   readonly state?: () => Promise<RedwallState>;
   /** Which image the desktop is pointed at, so the sweep can spare it. */
   readonly inUse?: () => Promise<string | null>;
-  /** Where the finished image goes. Defaults to this machine's desktop. */
+  /**
+   * Where the finished image goes. Defaults to `showRedwall`, which is
+   * every screen this machine has rather than only the desktop.
+   */
   readonly show?: (path: string) => Promise<boolean>;
 }
 
@@ -195,8 +199,51 @@ export interface RedwallApplied extends RedwallOutcome {
   readonly shown: boolean;
 }
 
+/** The screens a Redwall reaches, replaceable one at a time. */
+export interface ScreenWriters {
+  /** The desktop, which is what `shown` means. */
+  readonly desktop?: (path: string) => Promise<boolean>;
+  /** The lock screen, where a target has one red-dev can write. */
+  readonly lock?: (path: string) => Promise<boolean>;
+}
+
 /**
- * Compose this machine's Redwall for a theme and put it on the desktop.
+ * Put the image on every screen this machine has, and report the desktop.
+ *
+ * The lock screen is the surface that motivated the whole feature: a
+ * Worker count and an address are worth reading without unlocking, and a
+ * Redwall only the person already sitting at an unlocked machine can see
+ * is showing state to the one person who does not need it.
+ *
+ * It is written after the desktop and its answer is dropped, which is the
+ * whole of the tolerance this needs. The lock-screen key is not on every
+ * target — GNOME has it, Windows has nothing red-dev should write — and a
+ * machine that lacks it has still had its desktop repainted, so folding
+ * that absence into `shown` would report a successful apply as a failure
+ * and leave a caller retrying a surface that does not exist. `shown` is a
+ * claim about the desktop, and stays one.
+ *
+ * Both writers are injectable because the defaults repaint the screens of
+ * whoever runs the suite. Injected here rather than as two more seams on
+ * `applyRedwall`: a test that replaced only `show` would otherwise leave
+ * the lock-screen default live and reach for `gsettings` anyway, which is
+ * exactly the accident this seam exists to prevent.
+ */
+export function showRedwall(
+  p: Platform,
+  writers: ScreenWriters = {},
+): (path: string) => Promise<boolean> {
+  return async (path: string): Promise<boolean> => {
+    const shown = await (writers.desktop ?? ((image: string) => setDesktopBackground(image, p)))(
+      path,
+    );
+    await (writers.lock ?? ((image: string) => setLockScreenBackground(image, p)))(path);
+    return shown;
+  };
+}
+
+/**
+ * Compose this machine's Redwall for a theme and put it on the screens.
  *
  * The two halves are one call because they are useless apart. Generating
  * without showing leaves a 4K PNG nothing points at; showing without
@@ -222,7 +269,7 @@ export async function applyRedwall(
   const outcome = await generateRedwall(p, seams, theme);
   if (outcome.path === null) return { ...outcome, shown: false };
 
-  const show = seams.show ?? ((image: string) => setDesktopBackground(image, p));
+  const show = seams.show ?? showRedwall(p);
   const shown = await show(outcome.path);
   // Only when the repaint took. A desktop that refused is still pointed
   // at the previous Redwall, and that file is not this run's to remove.

--- a/src/theme-apply.ts
+++ b/src/theme-apply.ts
@@ -112,10 +112,9 @@ export const THEME_SURFACES: ThemeSurfaceSpec[] = [
     // round would end with the plain art on screen and the overlay in a
     // directory nothing points at.
     //
-    // On Windows that background is the whole of it. The lock screen
-    // there is not reachable on Home editions, and the screensaver route
-    // would greet every new machine with a SmartScreen warning for the
-    // sake of a cosmetic feature.
+    // It has the final word on the lock screen too, where the target has
+    // one red-dev can write — see `setLockScreenBackground`, which is
+    // also where the reason Windows is not such a target is recorded.
     //
     // The slug is passed down rather than re-read: `red-dev theme` does
     // not record the new theme before applying it, so a Redwall that

--- a/src/wallpaper.ts
+++ b/src/wallpaper.ts
@@ -202,6 +202,52 @@ async function setGnome(path: string): Promise<boolean> {
 }
 
 /**
+ * GNOME's lock-screen background, which is a different schema from the
+ * desktop's and not the same promise.
+ *
+ * `org.gnome.desktop.screensaver` is the key GNOME exposes for this, and
+ * setting it is all red-dev does. GNOME Shell has ignored it since 3.36
+ * and blurs the desktop wallpaper instead — which is a Redwall either
+ * way, blurred, so the state is still on the screen the feature exists
+ * for. Making it exact would mean shipping a shell extension: a component
+ * with its own lifecycle, its own version compatibility, and its own
+ * failure mode on every GNOME release. That is a decision belonging to
+ * the program, and red-dev stops where such decisions do.
+ *
+ * So the key is written once and never read back. There is nothing to
+ * verify — a shell that honours it and a shell that ignores it are
+ * indistinguishable from here, and a check that could only ever be
+ * inconclusive would turn into a retry loop against a setting that is
+ * already correct.
+ *
+ * Failure is not fatal for the same reason `picture-uri-dark` is not next
+ * door: on a target where the schema is absent `gsettings` exits non-zero
+ * and that is a surface this machine does not have.
+ */
+async function setGnomeLockScreen(path: string): Promise<boolean> {
+  if (!Bun.which("gsettings")) return false;
+  const uri = `file://${path}`;
+  const ok = await run(["gsettings", "set", "org.gnome.desktop.screensaver", "picture-uri", uri]);
+  await run(["gsettings", "set", "org.gnome.desktop.screensaver", "picture-options", "zoom"]);
+  return ok;
+}
+
+/**
+ * Point the lock screen at an image, on the targets that have one red-dev
+ * can write.
+ *
+ * GNOME only, and deliberately. Windows has a lock screen but it is not
+ * reachable on Home editions, and the route that works everywhere —
+ * registering a screensaver — would greet a new machine with a SmartScreen
+ * warning for the sake of a cosmetic feature. False there is the honest
+ * answer rather than a best effort that half-works on half the machines.
+ */
+export async function setLockScreenBackground(path: string, p: Platform): Promise<boolean> {
+  if (p.env !== "desktop") return false;
+  return await setGnomeLockScreen(path);
+}
+
+/**
  * SystemParametersInfo is the only call that repaints the desktop
  * immediately; writing the registry value alone leaves the old image on
  * screen until the next sign-in.


### PR DESCRIPTION
Automated AFK landing for #61. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #61

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788810491&installation_model_id=20659&pr_number=89&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F89&signature=bdda81548a49d5bf7b903c55d37d4b719848fadcb66cabe0bb2a7885cb26ec04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->