### PR TITLE
chore: #70 Run all privileged work as one batch behind a single prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,6 +460,26 @@ warn alacritty: ENOEXEC: unknown error, posix_spawn 'cmd.exe'
  ok  converged — restart your shell
 ```
 
+### Everything that needs administrator, asked once
+
+Items that need administrator are lifted out of the converge and run together at
+the end, behind one consent prompt — never one prompt per item, and never in the
+middle of a run. A converge started from an elevated session runs them straight
+away and asks nothing at all, and a machine with no such items produces no batch
+and no prompt, which is every Ubuntu target and most Windows ones after the first
+run.
+
+```console
+  :: 1 item needs administrator — asked for once, here at the end
+ ok  ssh-server        applied
+```
+
+Declining is a real choice. Everything that needed no rights has already
+converged by then, and the items behind the prompt are reported as deferred,
+named, with the one thing to do about them. The batch is safe to run again after
+a partial failure: each item is guarded so repeating it changes nothing, and one
+item failing does not abandon the ones after it.
+
 ### Work it was not allowed to do
 
 Some items need rights the run does not have: the Windows OpenSSH server needs

--- a/src/converge.test.ts
+++ b/src/converge.test.ts
@@ -8,7 +8,8 @@
 
 import { describe, expect, test } from "bun:test";
 import { converge, countSteps, type StepResult } from "./converge.ts";
-import { toolsInScope } from "./manifest.ts";
+import { applicableScopes, toolsInScope } from "./manifest.ts";
+import { privilegedItems } from "./privileged.ts";
 import type { Platform } from "./platform.ts";
 
 const wsl: Platform = {
@@ -19,6 +20,23 @@ const wsl: Platform = {
   env: "wsl",
   arch: "x64",
   caps: { apt: true, gui: false, systemd: true, winget: true, flatpak: true },
+};
+
+/**
+ * The one target with privileged items in it.
+ *
+ * A dry run is the only way to watch a Windows converge from here, and
+ * it is enough for the question this asks: where the privileged items
+ * appear in the run, not what they do when they get there.
+ */
+const windows: Platform = {
+  os: "windows",
+  distro: null,
+  version: null,
+  codename: null,
+  env: "windows",
+  arch: "x64",
+  caps: { apt: false, gui: true, systemd: false, winget: true, flatpak: false },
 };
 
 const ctx = { platform: wsl, theme: "dark", font: "firacode", opacity: 90 };
@@ -114,5 +132,45 @@ describe("converge", () => {
     const { events } = await run(["core", "optional"]);
     const scopes = events.filter((e) => e.startsWith("scope:")).map((e) => e.split(":")[1]);
     expect(scopes).toEqual(["core", "optional"]);
+  });
+});
+
+describe("the privileged batch", () => {
+  const scopes = applicableScopes(windows);
+
+  async function runWindows(): Promise<string[]> {
+    const events: string[] = [];
+    await converge(
+      { platform: windows, ctx: { ...ctx, platform: windows }, scopes, dryRun: true },
+      { stepEnd: (r) => events.push(r.tool) },
+    );
+    return events;
+  }
+
+  test("runs after every unprivileged item, never between them", async () => {
+    // The whole point of batching. An item that needs administrator
+    // interrupts whatever is on the screen, so it interrupts at the end
+    // or it interrupts a run someone is still watching.
+    const order = await runWindows();
+    const batch = privilegedItems(windows, scopes).map((t) => t.name);
+    expect(batch.length).toBeGreaterThan(0);
+    expect(order.slice(-batch.length)).toEqual(batch);
+  });
+
+  test("and each of its items is stepped exactly once", async () => {
+    // Moved to the end, not duplicated there: an item reported twice
+    // makes a converge look like it did the work twice, and the counts
+    // the summary is built from stop adding up.
+    const order = await runWindows();
+    expect(order).toHaveLength(countSteps(scopes));
+    expect(new Set(order).size).toBe(order.length);
+  });
+
+  test("a target with no privileged items is untouched by any of it", async () => {
+    // The common case, and it must stay exactly as it was: same items,
+    // same order, nothing lifted out and nothing appended.
+    const { events } = await run(["core"]);
+    const order = events.filter((e) => e.startsWith("end:")).map((e) => e.split(":")[1]);
+    expect(order).toEqual(toolsInScope("core").map((t) => t.name));
   });
 });

--- a/src/converge.ts
+++ b/src/converge.ts
@@ -14,6 +14,12 @@
 
 import { transcribeStep } from "./transcript.ts";
 import { refusedRights } from "./rights.ts";
+import {
+  batchHost,
+  privilegedItems,
+  runPrivilegedBatch,
+  type BatchHost,
+} from "./privileged.ts";
 import { aptInstall, applyProvider, type ApplyContext } from "./providers.ts";
 import {
   describeProvider,
@@ -87,6 +93,21 @@ export interface ConvergeObserver {
    */
   batchStart?: (packages: string[]) => void;
   batchEnd?: (error: string | null) => void;
+  /**
+   * The privileged batch, bracketed for the same reason the apt one is.
+   *
+   * It runs after the last step has closed, so a view that only
+   * redirects child output between stepStart and stepEnd has already
+   * stopped listening — and an elevated item that prints while nothing
+   * is open writes straight over the frame the renderer believes it
+   * owns.
+   *
+   * privilegedEnd fires however the batch went, refusal included. A
+   * redirect opened here and never closed loses every line after it,
+   * which on this step means the summary.
+   */
+  privilegedStart?: (items: string[]) => void;
+  privilegedEnd?: () => void;
   stepStart?: (event: StepEvent) => void;
   stepEnd?: (result: StepResult) => void;
 }
@@ -96,6 +117,11 @@ export interface ConvergeOptions {
   ctx: ApplyContext;
   scopes: Scope[];
   dryRun: boolean;
+  /**
+   * Where the privileged batch gets its rights. Injected in tests only;
+   * nothing in the product passes it.
+   */
+  host?: BatchHost;
 }
 
 export interface ConvergeSummary {
@@ -175,8 +201,76 @@ export async function converge(
   const total = countSteps(scopes);
   let index = 0;
 
+  /**
+   * Open a step, and hand back the two ways of closing it.
+   *
+   * Lifted out of the loop because the privileged batch below closes
+   * steps too, and a second copy of this is a second place for the
+   * transcript, the numbering or the observer bracket to be wrong in.
+   */
+  const open = (
+    scope: Scope,
+    tool: Tool,
+    provider: string,
+  ): {
+    finish: (outcome: StepOutcome, detail?: string, remedy?: string) => void;
+    finishError: (message: string) => void;
+  } => {
+    index++;
+    const event: StepEvent = { scope, tool: tool.name, provider, index, total };
+    observer.stepStart?.(event);
+    const started = Date.now();
+
+    const finish = (outcome: StepOutcome, detail?: string, remedy?: string): void => {
+      const result: StepResult = {
+        ...event,
+        outcome,
+        ms: Date.now() - started,
+        ...(detail ? { detail } : {}),
+        ...(remedy ? { remedy } : {}),
+      };
+      results.push(result);
+      observer.stepEnd?.(result);
+      // Written here rather than at the end, and straight to the file
+      // rather than through `log`.
+      //
+      // Straight to the file because the fullscreen view renders these
+      // rows from its own model — they have never passed through the
+      // logger, so a transcript teed off `log` had every provider's
+      // chatter and none of the outcomes it belonged to. Here because
+      // a converge that is killed, or that takes down the terminal
+      // with it, still leaves the rows up to the point it stopped,
+      // which is the run most likely to be worth reading.
+      transcribeStep(result);
+    };
+
+    /**
+     * Close a step that raised, as whichever of the two things it was.
+     *
+     * Both callers arrive holding a message and nothing else, and the
+     * difference between "this broke" and "this was not allowed to run"
+     * is entirely inside it.
+     */
+    const finishError = (message: string): void => {
+      const { outcome, detail, remedy } = outcomeForError(message);
+      finish(outcome, detail, remedy);
+    };
+
+    return { finish, finishError };
+  };
+
+  // The privileged half of the plan, lifted out of the loop below and
+  // run after all of it.
+  //
+  // Declared per platform in the manifest, so this is a partition
+  // settled before anything executes rather than a discovery made at the
+  // item that needs the rights. Empty on every Linux target, where it
+  // costs a filter over a list and nothing else.
+  const batch = privilegedItems(p, scopes);
+  const batched = new Set(batch.map((t) => t.name));
+
   for (const scope of scopes) {
-    const tools = toolsInScope(scope);
+    const tools = toolsInScope(scope).filter((t) => !batched.has(t.name));
     observer.scopeStart?.(scope, tools.length);
 
     // apt is batched: twenty sequential apt-get calls is the slowest
@@ -200,47 +294,7 @@ export async function converge(
 
     for (const tool of tools) {
       const pr = providerFor(tool, p);
-      const provider = describeProvider(pr);
-      index++;
-
-      const event: StepEvent = { scope, tool: tool.name, provider, index, total };
-      observer.stepStart?.(event);
-      const started = Date.now();
-
-      const finish = (outcome: StepOutcome, detail?: string, remedy?: string): void => {
-        const result: StepResult = {
-          ...event,
-          outcome,
-          ms: Date.now() - started,
-          ...(detail ? { detail } : {}),
-          ...(remedy ? { remedy } : {}),
-        };
-        results.push(result);
-        observer.stepEnd?.(result);
-        // Written here rather than at the end, and straight to the file
-        // rather than through `log`.
-        //
-        // Straight to the file because the fullscreen view renders these
-        // rows from its own model — they have never passed through the
-        // logger, so a transcript teed off `log` had every provider's
-        // chatter and none of the outcomes it belonged to. Here because
-        // a converge that is killed, or that takes down the terminal
-        // with it, still leaves the rows up to the point it stopped,
-        // which is the run most likely to be worth reading.
-        transcribeStep(result);
-      };
-
-      /**
-       * Close a step that raised, as whichever of the two things it was.
-       *
-       * Both paths below arrive holding a message and nothing else, and
-       * the difference between "this broke" and "this was not allowed to
-       * run" is entirely inside it.
-       */
-      const finishError = (message: string): void => {
-        const { outcome, detail, remedy } = outcomeForError(message);
-        finish(outcome, detail, remedy);
-      };
+      const { finish, finishError } = open(scope, tool, describeProvider(pr));
 
       if (pr.kind === "skip") {
         finish("skipped", pr.reason);
@@ -284,6 +338,59 @@ export async function converge(
         // an item that ran out of rights — it is reported as deferred
         // and the run carries on to everything that needs none.
         finishError((err as Error).message);
+      }
+    }
+  }
+
+  // The privileged batch, after every item that needs no rights and
+  // never between them.
+  //
+  // Last because the consent it raises interrupts whatever is on the
+  // screen, and an interruption at item 12 of 38 stops a run someone is
+  // watching; last, it stops nothing. And because a converge whose
+  // operator walks away still gets everything that needed no permission,
+  // rather than stalling at the first item that did.
+  if (batch.length > 0) {
+    if (dryRun) {
+      // Reported in the position they would actually run in. A dry run
+      // that lists them among their scopes describes an ordering the
+      // real run does not have.
+      for (const tool of batch) {
+        const { finish } = open(tool.scope, tool, describeProvider(providerFor(tool, p)));
+        if (isInstalled(tool)) finish("present");
+        else finish("skipped", "dry run");
+      }
+    } else {
+      observer.note?.(
+        batch.length === 1
+          ? "1 item needs administrator — asked for once, here at the end"
+          : `${batch.length} items need administrator — asked for once, here at the end`,
+      );
+
+      observer.privilegedStart?.(batch.map((t) => t.name));
+      let steps;
+      try {
+        steps = await runPrivilegedBatch(
+          batch,
+          opts.host ?? batchHost(p, (tool) => applyProvider(providerFor(tool, p), ctx)),
+        );
+      } finally {
+        observer.privilegedEnd?.();
+      }
+
+      // Reported per item, the way the apt transaction is: one consent
+      // and one elevated child is how the work ran, but "the batch
+      // failed" is not something an operator can act on, and the report
+      // has to name which of them is still waiting.
+      for (const { tool, present, error } of steps) {
+        const { finish, finishError } = open(
+          tool.scope,
+          tool,
+          describeProvider(providerFor(tool, p)),
+        );
+        if (present) finish("present");
+        else if (error) finishError(error);
+        else finish(tool.managed ? "applied" : "installed");
       }
     }
   }

--- a/src/drift.ts
+++ b/src/drift.ts
@@ -672,7 +672,17 @@ const PRIVILEGED_PROBES: Record<string, () => Promise<(p: Platform) => Promise<P
     "ssh-server": async () => (await import("./ssh-server.ts")).probeSshServer,
   };
 
-async function probePrivileged(items: string[], p: Platform): Promise<PrivilegedStates> {
+/**
+ * Exported for the converge's privileged batch, which asks the same
+ * question for a different reason: the doctor reports what is
+ * outstanding, the batch decides what to ask consent for. Asking it
+ * twice would be two registries, and the one that only runs on Windows
+ * is the copy that would quietly stop matching.
+ */
+export async function probePrivileged(
+  items: string[],
+  p: Platform,
+): Promise<PrivilegedStates> {
   const states: PrivilegedStates = {};
   for (const item of items) {
     const load = PRIVILEGED_PROBES[item];

--- a/src/privileged.test.ts
+++ b/src/privileged.test.ts
@@ -1,0 +1,362 @@
+/**
+ * The privileged batch, without a Windows host.
+ *
+ * Every claim this slice makes is about *which* items are asked for,
+ * *when*, and how many times a person is interrupted — none of which
+ * needs a capability to be installed to be checked. The two halves that
+ * genuinely need Windows are behind BatchHost, so what is left is the
+ * part that is worth pinning and the part a Linux machine can run.
+ *
+ * The idempotence tests read the composed script rather than run it, for
+ * the same reason machineWideFontScript is a function: a batch that is
+ * unsafe to re-run parses perfectly and reports success.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { convergeExit, outcomeForError } from "./converge.ts";
+import {
+  batchScript,
+  privilegedItems,
+  reportedError,
+  runPrivilegedBatch,
+  sectionNames,
+  type BatchHost,
+  type Elevation,
+} from "./privileged.ts";
+import { applicableScopes, itemsNeedingAdmin, TOOLS } from "./manifest.ts";
+import { missingRights } from "./rights.ts";
+import type { Capabilities, Platform } from "./platform.ts";
+
+function platform(over: Partial<Platform> = {}): Platform {
+  const caps: Capabilities = {
+    apt: true,
+    gui: false,
+    systemd: true,
+    winget: false,
+    flatpak: false,
+    ...(over.caps ?? {}),
+  };
+  return { os: "linux", distro: "ubuntu", version: "24.04", codename: "noble", env: "wsl", arch: "x64", ...over, caps };
+}
+
+const WSL = platform();
+const WINDOWS = platform({
+  os: "windows",
+  env: "windows",
+  distro: null,
+  version: null,
+  caps: { apt: false, gui: true, systemd: false, winget: true, flatpak: false },
+});
+
+const ITEMS = itemsNeedingAdmin(WINDOWS);
+
+/** Everything the host was asked to do, in the order it was asked. */
+interface Asked {
+  calls: string[];
+}
+
+function host(over: Partial<BatchHost> = {}): BatchHost & Asked {
+  const calls: string[] = [];
+  return {
+    calls,
+    states: async (items) => {
+      calls.push(`states:${items.map((t) => t.name).join(",")}`);
+      return {};
+    },
+    elevated: async () => {
+      calls.push("elevated?");
+      return false;
+    },
+    consentPossible: () => {
+      calls.push("consent?");
+      return true;
+    },
+    applyHere: async (tool) => {
+      calls.push(`apply:${tool.name}`);
+    },
+    elevate: async (items) => {
+      calls.push(`elevate:${items.map((t) => t.name).join(",")}`);
+      return { consent: "given", report: items.map((t) => `ok ${t.name}`) };
+    },
+    ...over,
+  };
+}
+
+describe("the batch is the declared privileged set", () => {
+  test("it contains every declared privileged item exactly once", () => {
+    // Every row of the manifest whose column for this target needs
+    // administrator, and no row twice.
+    const declared = TOOLS.filter(
+      (t) => t.win.needsAdmin === true && applicableScopes(WINDOWS).includes(t.scope),
+    ).map((t) => t.name);
+    expect(privilegedItems(WINDOWS, applicableScopes(WINDOWS)).map((t) => t.name)).toEqual(declared);
+  });
+
+  test("and a scope named twice does not put an item in it twice", () => {
+    // `install` composes its scopes from the flag, the platform and the
+    // first-run answers, which is three places a duplicate can come
+    // from. Two prompts for one item is the exact failure this slice
+    // exists to remove.
+    const names = privilegedItems(WINDOWS, ["core", "core", "desktop", "core"]).map((t) => t.name);
+    expect(names).toEqual([...new Set(names)]);
+    expect(names).toEqual(itemsNeedingAdmin(WINDOWS, ["core", "desktop"]).map((t) => t.name));
+  });
+
+  test("a scope the run never reaches contributes nothing", () => {
+    // `install core` must not be asked for administrator on behalf of a
+    // desktop item it is not going to touch.
+    for (const tool of privilegedItems(WINDOWS, ["core"])) expect(tool.scope).toBe("core");
+  });
+
+  test("every item in the batch has a section to run", () => {
+    // The other direction of the registry, so an item that starts
+    // needing administrator cannot be composed into a batch that has
+    // nothing to run for it.
+    expect(ITEMS.map((t) => t.name).sort()).toEqual(sectionNames().sort());
+  });
+});
+
+describe("a plan with no privileged items", () => {
+  test("produces no batch on any Linux target", () => {
+    // sudo is its own path and it already works. A Ubuntu machine must
+    // never be asked to elevate for a Windows requirement.
+    for (const p of [WSL, platform({ env: "desktop", caps: { gui: true } as Capabilities })]) {
+      expect(privilegedItems(p, applicableScopes(p))).toEqual([]);
+    }
+  });
+
+  test("and requests no consent, nor anything else", async () => {
+    // Not "consent is declined for an empty batch" — nothing is asked at
+    // all. The common case is a machine that never sees this feature.
+    const machine = host();
+    expect(await runPrivilegedBatch([], machine)).toEqual([]);
+    expect(machine.calls).toEqual([]);
+  });
+});
+
+describe("an already-elevated session", () => {
+  test("runs the batch without requesting consent", async () => {
+    // Consent already given is not requested twice.
+    const machine = host({
+      elevated: async () => true,
+      consentPossible: () => {
+        throw new Error("an elevated session was asked to consent again");
+      },
+      elevate: async () => {
+        throw new Error("an elevated session tried to elevate again");
+      },
+    });
+
+    const steps = await runPrivilegedBatch(ITEMS, machine);
+    expect(steps.map((s) => s.error ?? null)).toEqual(ITEMS.map(() => null));
+    // Asked what is outstanding, then did it. The two overrides above
+    // are the assertion that nothing in between happened; this is the
+    // assertion that the work still did.
+    expect(machine.calls).toEqual([
+      `states:${ITEMS.map((t) => t.name).join(",")}`,
+      ...ITEMS.map((t) => `apply:${t.name}`),
+    ]);
+  });
+
+  test("and one item failing does not abandon the rest", async () => {
+    const [first] = ITEMS;
+    const machine = host({
+      elevated: async () => true,
+      applyHere: async (tool) => {
+        if (tool.name === first?.name) throw new Error("dism fell over");
+      },
+    });
+    const steps = await runPrivilegedBatch(ITEMS, machine);
+    expect(steps[0]?.error).toBe("dism fell over");
+    for (const step of steps.slice(1)) expect(step.error).toBeUndefined();
+  });
+});
+
+describe("consent declined", () => {
+  const declined = missingRights("administrator");
+
+  test("names every item it left behind", async () => {
+    // The run itself is finished — everything unprivileged converged in
+    // the loop before this. What is owed the operator is which items are
+    // still waiting, and the one thing to do about them.
+    const machine = host({ elevate: async (): Promise<Elevation> => ({ consent: "refused" }) });
+    const steps = await runPrivilegedBatch(ITEMS, machine);
+
+    expect(steps.map((s) => s.tool.name)).toEqual(ITEMS.map((t) => t.name));
+    for (const step of steps) expect(step.error).toBe(declined.message);
+  });
+
+  test("carries the wording the converge already reports for this", () => {
+    // Deliberately asked of rights.ts rather than written here: an item
+    // that ran out of rights mid-converge and one whose batch was
+    // declined are the same outcome, and two wordings would read as two
+    // different problems.
+    expect(declined.message).toContain(declined.cause);
+    expect(declined.message).toContain(declined.remedy);
+  });
+
+  test("and the converge reports it as deferred, not as a failure", async () => {
+    // The other half of the promise: declining is a real choice, so a
+    // run whose operator declined is a converged machine with work
+    // outstanding — exit 2 — rather than a broken one.
+    const machine = host({ elevate: async (): Promise<Elevation> => ({ consent: "refused" }) });
+    const steps = await runPrivilegedBatch(ITEMS, machine);
+
+    const outcomes = steps.map((s) => outcomeForError(s.error ?? ""));
+    for (const outcome of outcomes) {
+      expect(outcome.outcome).toBe("deferred");
+      expect(outcome.remedy).toBe(declined.remedy);
+    }
+    expect(convergeExit({ failed: 0, deferred: outcomes.length })).toBe(2);
+  });
+
+  test("a machine with nobody at it defers without raising a prompt", async () => {
+    // CI, a pipe, a non-interactive SSH session. A consent dialog raised
+    // where no one can answer it waits forever, and a converge that
+    // hangs is worse than one that says what is left.
+    const machine = host({
+      consentPossible: () => false,
+      elevate: async () => {
+        throw new Error("a prompt was raised with nobody to answer it");
+      },
+    });
+    const steps = await runPrivilegedBatch(ITEMS, machine);
+    for (const step of steps) expect(step.error).toBe(declined.message);
+  });
+});
+
+describe("work already done", () => {
+  test("is reported without asking for consent again", async () => {
+    // An operator who consented on the last run is not asked on this
+    // one, which is the difference between a prompt that means something
+    // and one people learn to dismiss.
+    const machine = host({
+      states: async (items) => Object.fromEntries(items.map((t) => [t.name, "finished" as const])),
+      elevated: async () => {
+        throw new Error("a finished batch went looking for rights");
+      },
+    });
+    const steps = await runPrivilegedBatch(ITEMS, machine);
+    expect(steps.map((s) => s.present)).toEqual(ITEMS.map(() => true));
+  });
+
+  test("while an unanswered probe still runs, because guessing done is the worse mistake", async () => {
+    const machine = host({
+      states: async (items) => Object.fromEntries(items.map((t) => [t.name, "unknown" as const])),
+    });
+    const steps = await runPrivilegedBatch(ITEMS, machine);
+    expect(steps.some((s) => s.present)).toBe(false);
+    expect(machine.calls).toContain(`elevate:${ITEMS.map((t) => t.name).join(",")}`);
+  });
+});
+
+describe("what the elevated child reported", () => {
+  test("ok is the item finishing", () => {
+    expect(reportedError(["ok ssh-server"], "ssh-server")).toBeNull();
+  });
+
+  test("failed carries the message and nothing else", () => {
+    expect(reportedError(["failed ssh-server dism fell over"], "ssh-server")).toBe("dism fell over");
+  });
+
+  test("silence about an item is not success", () => {
+    // The child stopped before it got there. Claiming it worked is how a
+    // half-configured machine reports as done.
+    expect(reportedError(["ok other"], "ssh-server")).toContain("ssh-server");
+  });
+
+  test("one item's line is not read as another's", () => {
+    expect(reportedError(["ok ssh-server-extra"], "ssh-server")).toContain("stopped before");
+  });
+});
+
+/**
+ * Every mutating cmdlet the batch may contain, and what makes running it
+ * a second time safe.
+ *
+ * A guard string must appear in the composed text; `desired-state` is
+ * for a cmdlet that sets what it is asked for rather than adding to it,
+ * where running it again changes nothing by construction.
+ *
+ * Both directions are checked below, so a new privileged item cannot
+ * quietly add an unguarded mutation: the batch is the one thing here an
+ * operator re-runs after a partial failure, and it is the one thing they
+ * have to consent to twice if it is not safe.
+ */
+const IDEMPOTENCE: Record<string, string> = {
+  "Add-WindowsCapability": "if ($cap.State -ne 'Installed')",
+  "Start-Service": "if ((Get-Service sshd).Status -ne 'Running')",
+  "New-NetFirewallRule":
+    "if (-not (Get-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -ErrorAction SilentlyContinue))",
+  "Set-Service": "desired-state",
+  "Enable-WindowsOptionalFeature": "desired-state",
+  "Stop-Service": "desired-state",
+};
+
+const RESULT = "C:\\Temp\\red-dev-privileged.txt";
+
+describe("the batch text is safe to run again", () => {
+  test("every mutation in it is guarded or sets a desired state", async () => {
+    const script = await batchScript(ITEMS, RESULT);
+    const mutations = Object.keys(IDEMPOTENCE).filter((op) => script.includes(op));
+    // Not an empty check dressed up as a passing one: the batch has to
+    // contain something to be worth asserting about.
+    expect(mutations.length).toBeGreaterThan(0);
+
+    for (const op of mutations) {
+      const guard = IDEMPOTENCE[op]!;
+      if (guard === "desired-state") continue;
+      expect([op, script.includes(guard)]).toEqual([op, true]);
+    }
+  });
+
+  test("and nothing mutates that has not said why that is safe", async () => {
+    // The other direction. A section reaching for a cmdlet nobody has
+    // reasoned about fails here rather than on somebody's machine, on
+    // the second run, after the first one half-finished.
+    const script = await batchScript(ITEMS, RESULT);
+    const unaccounted = [...script.matchAll(/\b(?:Add|New|Set|Start|Stop|Remove|Enable|Disable)-[A-Za-z]+\b/g)]
+      .map((m) => m[0])
+      .filter((op) => !(op in IDEMPOTENCE))
+      // Set-Content writes the report the parent reads back; it is the
+      // batch's own bookkeeping rather than a change to the machine.
+      .filter((op) => op !== "Set-Content");
+    expect([...new Set(unaccounted)]).toEqual([]);
+  });
+
+  test("one item failing leaves the rest of the batch to run", async () => {
+    // What makes a partial failure partial. An exception escaping a
+    // section stops the whole child, so the items after it never run and
+    // the report the parent reads is never written — turning one broken
+    // item into a whole batch to consent to again.
+    const script = await batchScript(ITEMS, RESULT);
+    for (const tool of ITEMS) {
+      expect([tool.name, script.includes(`# ---- ${tool.name}`)]).toEqual([tool.name, true]);
+      expect([tool.name, script.includes(`$report += 'ok ${tool.name}'`)]).toEqual([tool.name, true]);
+      expect([tool.name, script.includes(`$report += "failed ${tool.name}`)]).toEqual([tool.name, true]);
+    }
+    expect(script.split("try {").length - 1).toBe(ITEMS.length);
+    expect(script.split("} catch {").length - 1).toBe(ITEMS.length);
+  });
+
+  test("no section can exit out from under the ones after it", async () => {
+    // A composed script is not a script that runs alone. `exit` in any
+    // section abandons every section after it and the report at the end,
+    // and it does it silently — the parent sees a child that succeeded
+    // and a file that was never written.
+    const script = await batchScript(ITEMS, RESULT);
+    expect(/(^|\n)\s*exit\b/.test(script)).toBe(false);
+  });
+
+  test("it reports back to a path the unelevated parent can read", async () => {
+    // An elevated child is a separate process tree; its stdout does not
+    // come home. Without this line the batch runs perfectly and the
+    // converge learns nothing about what it did.
+    const script = await batchScript(ITEMS, RESULT);
+    expect(script).toContain(`Set-Content -LiteralPath '${RESULT}'`);
+  });
+
+  test("the same batch composes to the same text", async () => {
+    expect(await batchScript(ITEMS, RESULT)).toBe(await batchScript(ITEMS, RESULT));
+  });
+});

--- a/src/privileged.ts
+++ b/src/privileged.ts
@@ -1,0 +1,381 @@
+/**
+ * Every privileged item of a converge, run together, once, at the end,
+ * behind a single consent prompt.
+ *
+ * The alternative is what a converge does by default: each item asks for
+ * itself, when it happens to be reached. Thirty-six items in, the third
+ * prompt of the run lands on someone who is no longer reading them —
+ * and a run that interrupts repeatedly teaches exactly that. Worse, a
+ * prompt raised mid-converge arrives while the fullscreen view owns the
+ * screen, which is not a place a question can be answered at all.
+ *
+ * So the privileged half is lifted out of the loop and run after it. The
+ * items are known before anything executes — the manifest declares them
+ * per platform — so this is a partition of the plan, not a discovery
+ * made along the way.
+ *
+ * ## The prompt is Windows' own
+ *
+ * There is no second question in front of it. Elevation on Windows is a
+ * UAC consent dialog and it cannot be suppressed, so asking "may I ask
+ * you?" first would be two prompts for one decision, and the first of
+ * them answerable in a terminal the renderer has already taken over.
+ * One `Start-Process -Verb RunAs` for the whole batch is the single
+ * prompt this slice promises; declining it defers every item in the
+ * batch, named, with the one remedy they share.
+ *
+ * A session that is already elevated holds the rights, so it does the
+ * work in place and no prompt is raised anywhere — consent already given
+ * is not requested twice.
+ *
+ * ## Idempotence is the contract, not a nicety
+ *
+ * A batch can fail halfway: one item's capability lands, the next one's
+ * service does not, and the operator re-runs. Every section is guarded
+ * so re-running repeats nothing, and each is wrapped in its own
+ * try/catch so the failure of one does not abandon the rest. Both halves
+ * are asserted against the composed text, which is why the text is built
+ * by a function rather than assembled inside the runner.
+ *
+ * On every Linux target the batch is empty: sudo is its own path, which
+ * already works, and nothing here must disturb it.
+ */
+
+import { existsSync, rmSync } from "node:fs";
+import type { PrivilegedState } from "./drift.ts";
+import { itemsNeedingAdmin, type Scope, type Tool } from "./manifest.ts";
+import type { Platform } from "./platform.ts";
+import { missingRights } from "./rights.ts";
+import { interactive } from "./ui.ts";
+
+/**
+ * The declared privileged items of this run, in manifest order.
+ *
+ * Exactly once each, and that is a property of where the answer comes
+ * from rather than of a filter applied afterwards: the set is built by
+ * selecting rows of the manifest, so an item cannot appear twice however
+ * the caller assembled its scopes.
+ */
+export function privilegedItems(p: Platform, scopes: Scope[]): Tool[] {
+  return itemsNeedingAdmin(p, scopes);
+}
+
+/** What the batch did with one item. */
+export interface BatchStep {
+  tool: Tool;
+  /** Its privileged half was already in place; nothing was asked for it. */
+  present?: boolean;
+  /**
+   * The message it ended with, when it did not finish.
+   *
+   * A message rather than an outcome, because the converge already owns
+   * the one place that decides what a message means — an item that ran
+   * out of rights and an item that broke arrive there as strings either
+   * way, and classifying them twice is how the two answers drift apart.
+   */
+  error?: string;
+}
+
+/** What came back from the one elevation attempt. */
+export type Elevation =
+  | { consent: "refused" }
+  /** Granted, and this is what the elevated child reported per item. */
+  | { consent: "given"; report: string[] };
+
+/**
+ * Everything the batch needs from the machine, in one injectable piece.
+ *
+ * A host rather than direct calls because none of the four can run in a
+ * test: two spawn PowerShell, one asks whether a terminal is attached
+ * and one installs software. What is left once they are behind an
+ * interface is the part worth pinning — which items are asked for, in
+ * what order, and what each outcome means.
+ */
+export interface BatchHost {
+  /** How much of the privileged work is already in place, by item name. */
+  states: (items: Tool[]) => Promise<Record<string, PrivilegedState>>;
+  /** Does this session already hold administrator? */
+  elevated: () => Promise<boolean>;
+  /** Is there anyone here to answer a consent prompt? */
+  consentPossible: () => boolean;
+  /** Do one item's work with the rights already held. */
+  applyHere: (tool: Tool) => Promise<void>;
+  /** Raise consent once, and run the whole batch behind it. */
+  elevate: (items: Tool[]) => Promise<Elevation>;
+}
+
+/**
+ * Run the batch and say what happened to each item.
+ *
+ * An empty batch returns before it touches the host: no probe, no
+ * elevation check and no prompt, which is what keeps the majority of
+ * machines exactly as they were.
+ */
+export async function runPrivilegedBatch(
+  items: Tool[],
+  host: BatchHost,
+): Promise<BatchStep[]> {
+  if (items.length === 0) return [];
+
+  // Items whose privileged half is already done are not asked for again.
+  // The batch is idempotent, so running them would be harmless — but the
+  // prompt in front of it is not, and a converged machine raising a
+  // consent dialog every run is how an operator learns to dismiss one
+  // without reading it.
+  let states: Record<string, PrivilegedState> = {};
+  try {
+    states = await host.states(items);
+  } catch {
+    // A probe that threw answered nothing, and nothing is a state we
+    // have: the item goes into the batch, which is safe to run over work
+    // already done and is not safe to skip over work that is not.
+  }
+  const finished = new Set(items.filter((t) => states[t.name] === "finished").map((t) => t.name));
+  const outstanding = items.filter((t) => !finished.has(t.name));
+
+  let errors = new Map<string, string | null>();
+  if (outstanding.length > 0) {
+    try {
+      errors = await attempt(outstanding, host);
+    } catch (err) {
+      // The batch is the last thing a converge does, so anything that
+      // escapes here would take the summary of a run that has already
+      // finished down with it. Reported as what it is, against the items
+      // it happened to.
+      errors = new Map(outstanding.map((tool) => [tool.name, (err as Error).message]));
+    }
+  }
+
+  return items.map((tool) => {
+    if (finished.has(tool.name)) return { tool, present: true };
+    const error = errors.get(tool.name);
+    return error ? { tool, error } : { tool };
+  });
+}
+
+/**
+ * The three ways the outstanding items can be reached, in order of
+ * how little they have to ask for.
+ */
+async function attempt(items: Tool[], host: BatchHost): Promise<Map<string, string | null>> {
+  const verdicts = new Map<string, string | null>();
+
+  if (await host.elevated()) {
+    // Nothing to ask: the rights are already held, so the work happens
+    // here, in order, and each item answers for itself.
+    for (const tool of items) {
+      try {
+        await host.applyHere(tool);
+        verdicts.set(tool.name, null);
+      } catch (err) {
+        verdicts.set(tool.name, (err as Error).message);
+      }
+    }
+    return verdicts;
+  }
+
+  // No terminal means no one to consent, and a UAC dialog raised at a
+  // machine nobody is sitting at waits for an answer that never comes.
+  // Deferring is the outcome that already exists for this: the run
+  // finishes everything else and names what is still waiting.
+  if (!host.consentPossible()) return deferAll(items);
+
+  const elevation = await host.elevate(items);
+  if (elevation.consent === "refused") return deferAll(items);
+  for (const tool of items) verdicts.set(tool.name, reportedError(elevation.report, tool.name));
+  return verdicts;
+}
+
+/** Every item, waiting on rights this run does not have. */
+function deferAll(items: Tool[]): Map<string, string | null> {
+  // Asked for rather than written. One gate, one wording, one remedy —
+  // the same sentence an item that ran out of rights mid-converge has
+  // always printed.
+  const denied = missingRights("administrator").message;
+  return new Map(items.map((tool) => [tool.name, denied]));
+}
+
+/**
+ * What the elevated child said about one item. PURE.
+ *
+ * An elevated child is a separate process tree whose stdout does not
+ * come home, so the batch writes a line per item to a file and this
+ * reads it back. An item with no line at all is the case worth naming:
+ * the child stopped before reaching it, which is neither a success to
+ * claim nor a refusal to blame on the operator.
+ */
+export function reportedError(report: string[], name: string): string | null {
+  const line = report.map((l) => l.trim()).find((l) => l === `ok ${name}` || l.startsWith(`failed ${name} `));
+  if (!line) return `the batch stopped before it reached ${name}`;
+  return line === `ok ${name}` ? null : line.slice(`failed ${name} `.length);
+}
+
+/**
+ * The PowerShell each privileged item contributes to the batch.
+ *
+ * Loaded per item rather than imported up front, for the reason
+ * drift.ts loads its probes the same way: the module behind an entry is
+ * a platform adapter, and a machine with nothing to do here must not
+ * import one to find that out.
+ *
+ * Borrowed from the provider rather than written again. Two copies of
+ * the same three cmdlets is two things to keep true, and the one that
+ * only runs elevated is the copy nobody would notice going stale.
+ */
+const SECTIONS: Record<string, () => Promise<string>> = {
+  "ssh-server": async () => (await import("./ssh-server.ts")).windowsSshServerScript,
+};
+
+/** Which items this build can compose a batch for. */
+export function sectionNames(): string[] {
+  return Object.keys(SECTIONS);
+}
+
+/**
+ * The batch, as text.
+ *
+ * Separated from running it because running it needs a consent dialog
+ * and a Windows host, while the text is the half that can be wrong in a
+ * way nobody notices — a section that swallows its own failure, or one
+ * that is not safe to run twice, produces a batch that parses, reports
+ * success and leaves the machine where it was.
+ *
+ * `$report` is the whole protocol: one line per item, written at the end
+ * to a path the unelevated parent can read.
+ */
+export async function batchScript(items: Tool[], resultPath: string): Promise<string> {
+  const sections: string[] = [];
+  for (const tool of items) {
+    const load = SECTIONS[tool.name];
+    sections.push(
+      load
+        ? section(tool.name, await load())
+        : // Declared privileged, with nothing here to run for it. Said
+          // out loud in the report rather than skipped silently, so the
+          // item is reported as unfinished instead of as done.
+          `$report += 'failed ${tool.name} this build has no privileged section for it'`,
+    );
+  }
+
+  return [
+    "$ErrorActionPreference = 'Stop'",
+    "$report = @()",
+    ...sections,
+    `Set-Content -LiteralPath '${resultPath.replace(/'/g, "''")}' -Value ($report -join "\`n") -Encoding UTF8`,
+  ].join("\n\n");
+}
+
+/**
+ * One item's section: its own script, its own verdict, its own failure.
+ *
+ * The try/catch is what makes a partial failure a partial failure. Let
+ * one section's exception escape and the batch stops there, never writes
+ * the report, and every item after it — including the ones that would
+ * have worked — comes back as unreached. Re-running then costs a second
+ * consent for work that had no reason to wait.
+ */
+function section(name: string, body: string): string {
+  return [
+    `# ---- ${name}`,
+    "try {",
+    "  & {",
+    body
+      .split("\n")
+      .map((line) => (line.trim() ? `    ${line}` : line))
+      .join("\n"),
+    "  } | Out-Null",
+    `  $report += 'ok ${name}'`,
+    "} catch {",
+    // Flattened, because a report line is a line: a multi-line .NET
+    // exception would arrive back as several items' worth of report and
+    // match none of them.
+    `  $report += "failed ${name} $($_.Exception.Message -replace '\\s+', ' ')"`,
+    "}",
+  ].join("\n");
+}
+
+/** The real machine, for everything the batch cannot decide by itself. */
+export function batchHost(p: Platform, apply: (tool: Tool) => Promise<void>): BatchHost {
+  return {
+    states: async (items) => {
+      const { probePrivileged } = await import("./drift.ts");
+      return await probePrivileged(items.map((t) => t.name), p);
+    },
+    elevated: async () => {
+      try {
+        const { isElevated } = await import("./wsl-provision.ts");
+        return await isElevated();
+      } catch {
+        // A question that could not be put is not a yes. Treated as
+        // unelevated, the batch goes on to ask for consent, and whatever
+        // stopped the probe stops that too — one outcome instead of a
+        // converge that dies on its last step.
+        return false;
+      }
+    },
+    consentPossible: interactive,
+    applyHere: apply,
+    elevate: elevateAndRun,
+  };
+}
+
+/**
+ * Raise consent once, run the batch behind it, and read the report.
+ *
+ * Windows-only by construction: the batch is non-empty only where the
+ * manifest declares an administrator column, which is the Windows one,
+ * so there is no WSL path translation to do here — the paths this
+ * handles are the ones the process itself is already using.
+ */
+async function elevateAndRun(items: Tool[]): Promise<Elevation> {
+  const dir = process.env["TEMP"] ?? process.env["TMP"] ?? ".";
+  const scriptPath = `${dir}\\red-dev-privileged.ps1`;
+  const resultPath = `${dir}\\red-dev-privileged.txt`;
+  discard(resultPath);
+
+  await Bun.write(scriptPath, await batchScript(items, resultPath));
+
+  try {
+    // -Wait so the report below is read after the child, not beside it.
+    // A refused dialog fails here and leaves no report, which is the
+    // same answer arrived at from either direction.
+    await powershell(
+      "Start-Process powershell.exe -Verb RunAs -Wait -WindowStyle Hidden " +
+        `-ArgumentList '-NoProfile','-ExecutionPolicy','Bypass','-File','${scriptPath}'`,
+    );
+  } catch {
+    return { consent: "refused" };
+  } finally {
+    discard(scriptPath);
+  }
+
+  if (!existsSync(resultPath)) return { consent: "given", report: [] };
+  const report = (await Bun.file(resultPath).text())
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  discard(resultPath);
+  return { consent: "given", report };
+}
+
+/** Run one PowerShell command, raising whatever it printed when it fails. */
+async function powershell(command: string): Promise<void> {
+  const proc = Bun.spawn(["powershell.exe", "-NoProfile", "-Command", command], {
+    stdout: "pipe",
+    stderr: "pipe",
+    stdin: "ignore",
+  });
+  const err = (await new Response(proc.stderr).text()).trim();
+  if ((await proc.exited) !== 0) throw new Error(err.split("\n")[0] ?? "powershell failed");
+}
+
+/** A temp file that may not be there. Its absence is never an error. */
+function discard(path: string): void {
+  try {
+    rmSync(path, { force: true });
+  } catch {
+    // A leftover we could not remove changes nothing: the script is
+    // rewritten before each run and the report is read only after the
+    // one that just wrote it.
+  }
+}

--- a/src/ssh-server.ts
+++ b/src/ssh-server.ts
@@ -129,38 +129,51 @@ export async function installSshServerLinux(p: Platform): Promise<void> {
  * matched by port: Windows ships `OpenSSH-Server-In-TCP` with some
  * builds and not others, and adding a second rule for 22 each converge
  * is how a rule list becomes unreadable.
+ *
+ * Every step here is guarded, which is what lets the same text run
+ * again after a converge that got halfway: a capability already
+ * installed, a service already running and a rule already present are
+ * three no-ops, not three errors.
+ *
+ * Exported because the privileged batch composes it with every other
+ * item that needs administrator, so one consent covers all of them. That
+ * is also why the missing-capability branch nests the rest instead of
+ * calling `exit 0`: composed, an exit would abandon the sections after
+ * this one and the report they all write at the end.
  */
-const WINDOWS_SCRIPT = `
+export const windowsSshServerScript = `
 $ErrorActionPreference = 'Stop'
 
 $cap = Get-WindowsCapability -Online -Name 'OpenSSH.Server*' |
   Select-Object -First 1
-if (-not $cap) { 'openssh-capability-missing'; exit 0 }
-
-if ($cap.State -ne 'Installed') {
-  Add-WindowsCapability -Online -Name $cap.Name | Out-Null
-  "installed $($cap.Name)"
+if (-not $cap) {
+  'openssh-capability-missing'
 } else {
-  'capability already installed'
-}
+  if ($cap.State -ne 'Installed') {
+    Add-WindowsCapability -Online -Name $cap.Name | Out-Null
+    "installed $($cap.Name)"
+  } else {
+    'capability already installed'
+  }
 
-# Automatic, not Manual: the capability leaves it Manual, which survives
-# exactly until the next reboot.
-Set-Service -Name sshd -StartupType Automatic
-if ((Get-Service sshd).Status -ne 'Running') {
-  Start-Service sshd
-  'sshd started'
-} else {
-  'sshd already running'
-}
+  # Automatic, not Manual: the capability leaves it Manual, which
+  # survives exactly until the next reboot.
+  Set-Service -Name sshd -StartupType Automatic
+  if ((Get-Service sshd).Status -ne 'Running') {
+    Start-Service sshd
+    'sshd started'
+  } else {
+    'sshd already running'
+  }
 
-if (-not (Get-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -ErrorAction SilentlyContinue)) {
-  New-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' \`
-    -DisplayName 'OpenSSH Server (sshd)' \`
-    -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22 | Out-Null
-  'firewall rule added for TCP 22'
-} else {
-  'firewall rule already present'
+  if (-not (Get-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -ErrorAction SilentlyContinue)) {
+    New-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' \`
+      -DisplayName 'OpenSSH Server (sshd)' \`
+      -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22 | Out-Null
+    'firewall rule added for TCP 22'
+  } else {
+    'firewall rule already present'
+  }
 }
 `.trim();
 
@@ -178,7 +191,7 @@ export async function installSshServerWindows(p: Platform): Promise<void> {
     return;
   }
 
-  const proc = Bun.spawn(["powershell.exe", "-NoProfile", "-Command", WINDOWS_SCRIPT], {
+  const proc = Bun.spawn(["powershell.exe", "-NoProfile", "-Command", windowsSshServerScript], {
     stdout: "pipe",
     stderr: "pipe",
     stdin: "ignore",

--- a/src/tui-install.ts
+++ b/src/tui-install.ts
@@ -261,6 +261,18 @@ export function useInstallModel(
           releaseBatch = null;
           if (error) push(`    ${error}`);
         },
+        // The same redirect as apt, for the same reason and never at the
+        // same time: apt runs at the head of a scope, this runs after
+        // the last step of the run has closed.
+        privilegedStart: (items) => {
+          setCurrent("administrator");
+          releaseBatch = captureTo((line) => push(`    ${plain(line)}`));
+          push(`   administrator: ${items.length} item(s) behind one consent`);
+        },
+        privilegedEnd: () => {
+          releaseBatch?.();
+          releaseBatch = null;
+        },
         stepStart: (e) => {
           setCurrent(e.tool);
           // Hold provider chatter so it lands under its own step rather


### PR DESCRIPTION
Automated AFK landing for #70. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #70

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788811537&installation_model_id=20659&pr_number=90&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F90&signature=90bac55e92ad7363cc3346214c86fd8e538fb45dc08179c39d52ce46dd991d6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->