### PR TITLE
chore: #72 Move the SSH server onto the shared elevation mechanism

### DIFF
--- a/src/ssh-server.test.ts
+++ b/src/ssh-server.test.ts
@@ -16,10 +16,14 @@
 
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
+import { outcomeForError } from "./converge.ts";
 import { TOOLS, providerFor } from "./manifest.ts";
 import type { Capabilities, Platform } from "./platform.ts";
+import { batchScript, runPrivilegedBatch, type BatchHost } from "./privileged.ts";
 
 const source = readFileSync("src/ssh-server.ts", "utf8");
+
+const sshServer = TOOLS.find((t) => t.name === "ssh-server")!;
 
 function platform(over: Partial<Platform> = {}): Platform {
   return {
@@ -93,6 +97,66 @@ describe("the Windows half", () => {
     // which is not the same string on every Windows build.
     expect(source).toContain("'OpenSSH.Server*'");
     expect(source).not.toContain("OpenSSH.Server~~~~0.0.1.0");
+  });
+});
+
+describe("the administrator half is declared, not discovered", () => {
+  /** Nobody at the machine, no rights held: the unelevated case. */
+  const unelevated: BatchHost = {
+    states: async () => ({}),
+    elevated: async () => false,
+    consentPossible: () => false,
+    applyHere: async () => {
+      throw new Error("an unelevated run did the privileged work anyway");
+    },
+    elevate: async () => {
+      throw new Error("a consent prompt was raised with nobody to answer it");
+    },
+  };
+
+  test("the module classifies no administrator refusal of its own", () => {
+    // What this item used to do, and what named the gap: run PowerShell
+    // unelevated, read the refusal back out of stderr, and hand the
+    // operator its own instruction to open an elevated shell. A
+    // requirement discovered by failing, once per item.
+    //
+    // The manifest declares it now, so anything reaching the Windows
+    // half already holds the rights — a second classifier here would be
+    // answering a question that was settled before the run started.
+    expect(source).not.toMatch(/classifyRights\([^)]*"administrator"\)/);
+    // The sudo half is untouched: apt is not the gate that moved, and
+    // Ubuntu has no batch to join.
+    expect(source).toContain('classifyRights(install.out, "sudo")');
+  });
+
+  test("and the Windows column says so before anything runs", () => {
+    // Declared as data, which is what lets `plan` print the requirement
+    // and the batch collect the item without either of them running it.
+    expect(providerFor(sshServer, platform({ os: "windows", env: "windows" })).needsAdmin).toBe(
+      true,
+    );
+  });
+
+  test("its three steps are the ones the batch runs", async () => {
+    // The capability, the service and the firewall rule, composed into
+    // the shared script rather than spawned by this module. Borrowed
+    // from the provider, so there is no second copy to keep true.
+    const script = await batchScript([sshServer], "C:\\Temp\\red-dev-privileged.txt");
+    expect(script).toContain("Add-WindowsCapability");
+    expect(script).toContain("Set-Service -Name sshd -StartupType Automatic");
+    expect(script).toContain("New-NetFirewallRule");
+    expect(script).toContain("$report += 'ok ssh-server'");
+  });
+
+  test("an unelevated run defers it rather than failing it", async () => {
+    // The outcome the item is owed: a machine that could not elevate is
+    // one with work outstanding, not a broken one, and the operator gets
+    // the shared remedy instead of a DISM stack trace.
+    const [step] = await runPrivilegedBatch([sshServer], unelevated);
+    expect(step?.tool.name).toBe("ssh-server");
+    const outcome = outcomeForError(step?.error ?? "");
+    expect(outcome.outcome).toBe("deferred");
+    expect(outcome.remedy).toContain("elevated PowerShell");
   });
 });
 

--- a/src/ssh-server.ts
+++ b/src/ssh-server.ts
@@ -184,6 +184,24 @@ if (-not $cap) {
  * an inbound connection can land: WSL2 sits behind a NAT and a sshd
  * inside the distro is unreachable from the network without a port
  * proxy nobody asked for.
+ *
+ * ## The rights are settled before this runs
+ *
+ * This item is the one that exposed the gap: it used to find out it
+ * needed administrator by running the script unelevated, reading the
+ * refusal back out of stderr, and telling the operator to open an
+ * elevated PowerShell — a requirement discovered by failing, once per
+ * item, at whatever point in a converge it happened to be reached.
+ *
+ * The manifest declares it now (`win: admin(builtin("ssh-server"))`),
+ * which is what lets `plan` print the requirement up front and the
+ * batch collect the item without running it. So there are exactly two
+ * ways to arrive here, and neither is unelevated: a session that
+ * already holds administrator, or the elevated child, which runs the
+ * script text above rather than this function. Classifying a refusal
+ * here would be answering a question that was settled before the run
+ * started — and an unelevated run never gets this far, because the
+ * batch defers the item instead.
  */
 export async function installSshServerWindows(p: Platform): Promise<void> {
   if (p.os !== "windows" && p.env !== "wsl") {
@@ -199,20 +217,12 @@ export async function installSshServerWindows(p: Platform): Promise<void> {
   const out = (await new Response(proc.stdout).text()).trim();
 
   if ((await proc.exited) !== 0) {
+    // A failure with the rights in hand is a failure: a capability the
+    // build does not carry, a service that would not start, a firewall
+    // that refused the rule. Raised as one, and left to the converge to
+    // report — which is also where a message that does turn out to name
+    // a gate is classified, in the one place that does that.
     const err = (await new Response(proc.stderr).text()).trim();
-
-    // Adding a capability is an administrator operation, and a converge
-    // started from an unelevated shell is the common case rather than a
-    // mistake. Asked of the one classifier so this reads exactly like
-    // every other item that runs out of rights, instead of handing the
-    // operator the first line of a DISM stack trace to decode.
-    // Raised so the converge can report it as deferred rather than as
-    // done: an unelevated run has not configured this, and a warning
-    // under an `applied` row is a claim the machine cannot back up.
-    const denied = classifyRights(err, "administrator");
-    if (denied) throw new RedError(denied.message);
-
-    // Anything else really is a failure, and is raised as one.
     const first = err.split("\n")[0] ?? "unknown";
     throw new RedError(`could not configure the OpenSSH server: ${first}`);
   }


### PR DESCRIPTION
Automated AFK landing for #72. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #72

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788811943&installation_model_id=20659&pr_number=91&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F91&signature=6f1afb97a90d4b50d60b1db20fc977d0cacd758dabd7fd16a534c4311416b84a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->