### PR TITLE
chore: #71 A command to run only the privileged remainder

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,7 +499,7 @@ needed no rights converged as usual.
   deferred
     ssh-server        this needs administrator and nothing here can raise it.
 
-    Start an elevated PowerShell first, then re-run red-dev — re-running is safe.
+    Run `red-dev privileged` to finish just this, or re-run red-dev from an elevated PowerShell — either is safe.
 
   Nothing here broke — this work is waiting, not lost.
 ```
@@ -516,6 +516,27 @@ out which one it was, and the exit status says the same thing to a script:
 So a wrapper can tell "done" from "done except the privileged part" without
 reading the summary, and without treating a healthy machine as a broken one.
 `red-dev doctor` reports the same outstanding work afterwards.
+
+### Finishing just the privileged part
+
+`red-dev privileged` runs the batch above and nothing else — one consent prompt,
+the same per-item rows and the same three exit codes as a converge, with none of
+the work that already converged repeated. It is what the deferral names, so
+finishing a run that was declined costs one command rather than the whole
+provision again.
+
+```console
+── administrator · 1 item ────────────────────────────────────────────
+  [ 1/1] ssh-server      builtin:ssh-server              ok
+```
+
+Run from an already-elevated session it asks nothing at all, and on a machine
+with nothing outstanding — every Ubuntu target, and every Windows one that has
+already consented once — it exits 0 having done nothing:
+
+```console
+ ok  nothing on this machine needs administrator
+```
 
 ### Reading the log while it is being written
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { buildCli, parseArgs } from "./cli.ts";
+import { missingRights } from "./rights.ts";
 import { DEFAULT_THEME, themeNames } from "./themes.ts";
 
 const cli = buildCli();
@@ -22,6 +23,16 @@ describe("command parsing", () => {
     expect(inv.command).toBe("install");
     expect(inv.scope).toBe("core");
     expect(inv.errors).toEqual([]);
+  });
+
+  test("the command a deferred converge names is typeable exactly as printed", () => {
+    // `red-dev privileged` is printed to an operator as the way to
+    // finish work a converge deferred, so a rename here turns a remedy
+    // into an unknown-command error at the worst possible moment.
+    const inv = parse(["privileged"]);
+    expect(inv.command).toBe("privileged");
+    expect(inv.errors).toEqual([]);
+    expect(missingRights("administrator").remedy).toContain("red-dev privileged");
   });
 
   test("no arguments means no command, not an error", () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -90,6 +90,15 @@ export function buildCli(): CLI {
       update: {
         description: "upgrade what the package managers own, then converge",
       },
+      privileged: {
+        // No positional and no flags, for the same reason `redwall` has
+        // none: what it does is settled by the manifest and by what this
+        // machine is still missing, so there is nothing here for the
+        // caller to decide. It is the command a deferred converge points
+        // at, and a command named in a remedy has to be typeable exactly
+        // as it was printed.
+        description: "finish only the work that needs administrator",
+      },
       doctor: {
         description: "report drift against the manifest",
       },

--- a/src/converge.test.ts
+++ b/src/converge.test.ts
@@ -7,9 +7,9 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import { converge, countSteps, type StepResult } from "./converge.ts";
+import { converge, convergeExit, countSteps, type StepResult } from "./converge.ts";
 import { applicableScopes, toolsInScope } from "./manifest.ts";
-import { privilegedItems } from "./privileged.ts";
+import { privilegedItems, type BatchHost } from "./privileged.ts";
 import type { Platform } from "./platform.ts";
 
 const wsl: Platform = {
@@ -172,5 +172,142 @@ describe("the privileged batch", () => {
     const { events } = await run(["core"]);
     const order = events.filter((e) => e.startsWith("end:")).map((e) => e.split(":")[1]);
     expect(order).toEqual(toolsInScope("core").map((t) => t.name));
+  });
+});
+
+/**
+ * The remainder on its own — the same batch, reached without the run in
+ * front of it.
+ *
+ * A converge that deferred its privileged half leaves a machine where
+ * everything else has converged, and re-running all of it to reach the
+ * one thing outstanding is half an hour of work already done. So this
+ * asks the same questions the batch answers inside a converge, of the
+ * path an operator takes when that is all that is left: which items are
+ * touched, how many times a person is interrupted, and what a machine
+ * with nothing outstanding does.
+ */
+describe("only the privileged remainder", () => {
+  const names = privilegedItems(windows, applicableScopes(windows)).map((t) => t.name);
+
+  /** Everything the batch asked the machine for, in the order it asked. */
+  function host(over: Partial<BatchHost> = {}, finished = false): BatchHost & { calls: string[] } {
+    const calls: string[] = [];
+    return {
+      calls,
+      states: async (items) => {
+        calls.push(`states:${items.map((t) => t.name).join(",")}`);
+        return finished
+          ? Object.fromEntries(items.map((t) => [t.name, "finished" as const]))
+          : {};
+      },
+      elevated: async () => false,
+      consentPossible: () => true,
+      applyHere: async (tool) => {
+        calls.push(`apply:${tool.name}`);
+      },
+      elevate: async (items) => {
+        calls.push(`elevate:${items.map((t) => t.name).join(",")}`);
+        return { consent: "given", report: items.map((t) => `ok ${t.name}`) };
+      },
+      ...over,
+    };
+  }
+
+  async function remainder(
+    p: Platform,
+    machine: BatchHost,
+  ): Promise<{ steps: StepResult[]; summary: Awaited<ReturnType<typeof converge>> }> {
+    const steps: StepResult[] = [];
+    const summary = await converge(
+      {
+        platform: p,
+        ctx: { ...ctx, platform: p },
+        scopes: applicableScopes(p),
+        dryRun: false,
+        only: "privileged",
+        host: machine,
+      },
+      { stepEnd: (r) => steps.push(r) },
+    );
+    return { steps, summary };
+  }
+
+  test("runs the privileged batch and nothing else", async () => {
+    // Not a converge with a filter in front of it: the unprivileged
+    // items are never opened, never reported and never installed, which
+    // is the whole reason to have this command rather than re-running
+    // the converge that deferred.
+    const machine = host();
+    const { steps, summary } = await remainder(windows, machine);
+
+    expect(names.length).toBeGreaterThan(0);
+    expect(steps.map((s) => s.tool)).toEqual(names);
+    expect(steps.length).toBeLessThan(countSteps(applicableScopes(windows)));
+    expect(convergeExit(summary)).toBe(0);
+  });
+
+  test("requests consent once, for the whole batch", async () => {
+    // One prompt, carrying every outstanding item. Two prompts for one
+    // decision is the failure the batch exists to remove, and reaching
+    // the batch by a different door must not reintroduce it.
+    const machine = host();
+    await remainder(windows, machine);
+    expect(machine.calls.filter((c) => c.startsWith("elevate:"))).toEqual([
+      `elevate:${names.join(",")}`,
+    ]);
+  });
+
+  test("and not at all from an already-elevated session", async () => {
+    // Consent already given is not requested twice. The two overrides
+    // are the assertion that nothing asked; the calls are the assertion
+    // that the work still happened.
+    const machine = host({
+      elevated: async () => true,
+      consentPossible: () => {
+        throw new Error("an elevated session was asked to consent");
+      },
+      elevate: async () => {
+        throw new Error("an elevated session tried to elevate again");
+      },
+    });
+    const { steps } = await remainder(windows, machine);
+
+    expect(machine.calls).toEqual([
+      `states:${names.join(",")}`,
+      ...names.map((n) => `apply:${n}`),
+    ]);
+    expect(steps.map((s) => s.outcome)).toEqual(names.map(() => "applied"));
+  });
+
+  test("a machine with nothing outstanding succeeds having done nothing", async () => {
+    // The answer to "did this finish" is the same whether it took a
+    // consent prompt to get there or nothing at all. Running this on a
+    // converged machine must not raise a dialog, and must not report a
+    // problem it does not have.
+    const machine = host(
+      {
+        elevated: async () => {
+          throw new Error("a finished remainder went looking for rights");
+        },
+      },
+      true,
+    );
+    const { steps, summary } = await remainder(windows, machine);
+
+    expect(steps.map((s) => s.outcome)).toEqual(names.map(() => "present"));
+    expect(machine.calls).toEqual([`states:${names.join(",")}`]);
+    expect(convergeExit(summary)).toBe(0);
+  });
+
+  test("and a target with no privileged items touches nothing at all", async () => {
+    // Every Ubuntu target. No probe, no elevation check and no prompt —
+    // sudo is its own path and nothing here may disturb it.
+    const machine = host();
+    const { steps, summary } = await remainder(wsl, machine);
+
+    expect(steps).toEqual([]);
+    expect(machine.calls).toEqual([]);
+    expect(convergeExit(summary)).toBe(0);
   });
 });

--- a/src/converge.ts
+++ b/src/converge.ts
@@ -118,6 +118,22 @@ export interface ConvergeOptions {
   scopes: Scope[];
   dryRun: boolean;
   /**
+   * Run the privileged batch and skip everything else.
+   *
+   * The companion to deferring it. A converge that was declined, or that
+   * ran where nobody could answer a prompt, leaves a machine on which
+   * everything unprivileged has already converged — and re-running all
+   * of it to reach the one thing outstanding is half an hour spent
+   * repeating work that is done.
+   *
+   * An option on the loop rather than a second runner beside it, because
+   * the batch is only half of what this has to get right: the outcomes,
+   * the per-item reporting, the transcript and the exit status are the
+   * other half, and a copy of those is a second place for them to
+   * disagree with the converge they are meant to finish.
+   */
+  only?: "privileged";
+  /**
    * Where the privileged batch gets its rights. Injected in tests only;
    * nothing in the product passes it.
    */
@@ -198,7 +214,22 @@ export async function converge(
 ): Promise<ConvergeSummary> {
   const { platform: p, ctx, scopes, dryRun } = opts;
   const results: StepResult[] = [];
-  const total = countSteps(scopes);
+
+  // The privileged half of the plan, lifted out of the loop below and
+  // run after all of it.
+  //
+  // Declared per platform in the manifest, so this is a partition
+  // settled before anything executes rather than a discovery made at the
+  // item that needs the rights. Empty on every Linux target, where it
+  // costs a filter over a list and nothing else.
+  const batch = privilegedItems(p, scopes);
+  const batched = new Set(batch.map((t) => t.name));
+
+  // Resolved here because it decides the denominator as well as the
+  // work: a remainder that counts every step of a converge it is not
+  // going to run reports `[ 1/38]` for the only item it touches.
+  const onlyPrivileged = opts.only === "privileged";
+  const total = onlyPrivileged ? batch.length : countSteps(scopes);
   let index = 0;
 
   /**
@@ -259,17 +290,12 @@ export async function converge(
     return { finish, finishError };
   };
 
-  // The privileged half of the plan, lifted out of the loop below and
-  // run after all of it.
-  //
-  // Declared per platform in the manifest, so this is a partition
-  // settled before anything executes rather than a discovery made at the
-  // item that needs the rights. Empty on every Linux target, where it
-  // costs a filter over a list and nothing else.
-  const batch = privilegedItems(p, scopes);
-  const batched = new Set(batch.map((t) => t.name));
-
-  for (const scope of scopes) {
+  // Skipped entirely for a remainder, which leaves the batch below to
+  // run alone. Not filtered down to nothing item by item: an item that
+  // is skipped is still opened, reported and counted, and a remainder
+  // that prints thirty-seven rows of work it did not do buries the one
+  // row it did.
+  for (const scope of onlyPrivileged ? [] : scopes) {
     const tools = toolsInScope(scope).filter((t) => !batched.has(t.name));
     observer.scopeStart?.(scope, tools.length);
 
@@ -361,11 +387,16 @@ export async function converge(
         else finish("skipped", "dry run");
       }
     } else {
-      observer.note?.(
-        batch.length === 1
-          ? "1 item needs administrator — asked for once, here at the end"
-          : `${batch.length} items need administrator — asked for once, here at the end`,
-      );
+      // Where it sits in the run is the news, and a remainder has no run
+      // for it to sit at the end of — the caller has already announced
+      // that administrator is the whole subject.
+      if (!onlyPrivileged) {
+        observer.note?.(
+          batch.length === 1
+            ? "1 item needs administrator — asked for once, here at the end"
+            : `${batch.length} items need administrator — asked for once, here at the end`,
+        );
+      }
 
       observer.privilegedStart?.(batch.map((t) => t.name));
       let steps;

--- a/src/main.ts
+++ b/src/main.ts
@@ -267,6 +267,83 @@ function endInstall(code: 0 | 1 | 2, deferred = 0): number {
   return code;
 }
 
+/**
+ * The privileged remainder, and nothing else.
+ *
+ * The command a deferred converge points at. Declining the consent
+ * prompt, or converging where nobody was there to answer one, leaves a
+ * machine whose unprivileged half is entirely done — and re-running the
+ * whole converge to reach the one item still outstanding is half an hour
+ * spent repeating work that finished the first time.
+ *
+ * The loop does the work, under `only: "privileged"`, so this shares the
+ * outcomes, the per-item rows, the transcript and the three exit codes
+ * with the converge it is finishing. A second runner beside it would be
+ * a second place for those to disagree, and they disagree about exactly
+ * the thing an operator came here to settle.
+ *
+ * Nothing outstanding is a success. The question a script asks is
+ * whether this machine is finished, and the answer does not depend on
+ * whether it took a consent prompt to get there.
+ */
+async function cmdPrivileged(p: Platform, inv: Invocation): Promise<number> {
+  const { privilegedItems } = await import("./privileged.ts");
+  const scopes = resolveScopes(p, inv.scope);
+  const items = privilegedItems(p, scopes);
+
+  // Answered before a context is built or the machine is probed. Every
+  // Ubuntu target lands here — privileged work there goes through sudo,
+  // which is its own path — and so does a Windows machine that already
+  // consented once. A summary of nothing reads as a failure to do
+  // something, so there is no summary.
+  if (items.length === 0) {
+    log.ok("nothing on this machine needs administrator");
+    return 0;
+  }
+
+  const ctx = await contextFor(p, inv, "install");
+  const { Reporter } = await import("./report.ts");
+  const { converge, convergeExit } = await import("./converge.ts");
+  const report = new Reporter();
+  // Announced as its own scope rather than left to the converge's note:
+  // this run has one subject, and the row counter needs a denominator
+  // before the first item opens.
+  report.scope("administrator", items.length);
+
+  let close:
+    | ((outcome: StepOutcome, detail?: string, remedy?: string) => void)
+    | null = null;
+  const summaryOf = await converge(
+    { platform: p, ctx, scopes, dryRun: false, only: "privileged" },
+    {
+      note: (message) => report.note(message),
+      stepStart: (e) => {
+        close = report.begin(e.tool, e.provider || "—");
+      },
+      stepEnd: (r) => {
+        close?.(r.outcome, r.detail, r.remedy);
+        close = null;
+      },
+    },
+  );
+  report.finish();
+
+  // The same three answers as a converge, and deliberately not the same
+  // three sentences: "converged" would claim a whole machine on the
+  // strength of one batch. A failure says nothing extra — the summary
+  // has just named it, item by item.
+  const code = convergeExit(summaryOf);
+  if (code === 0) log.ok("the privileged work is done");
+  else if (code === 2) {
+    log.warn(
+      summaryOf.deferred === 1
+        ? "one item is still waiting on rights this run did not have"
+        : `${summaryOf.deferred} items are still waiting on rights this run did not have`,
+    );
+  }
+  return code;
+}
+
 async function cmdUpdate(p: Platform, inv: Invocation): Promise<number> {
   try {
     await systemUpdate(p);
@@ -1080,6 +1157,8 @@ async function main(): Promise<number> {
       return await cmdInstall(p, inv);
     case "update":
       return await cmdUpdate(p, inv);
+    case "privileged":
+      return await cmdPrivileged(p, inv);
     case "theme":
       return await cmdTheme(p, inv, inv.scope);
     case "redwall":

--- a/src/privileged.test.ts
+++ b/src/privileged.test.ts
@@ -210,6 +210,18 @@ describe("consent declined", () => {
     expect(convergeExit({ failed: 0, deferred: outcomes.length })).toBe(2);
   });
 
+  test("and what the converge prints names the command that finishes it", async () => {
+    // The other end of the answer. Deferring tells the operator what was
+    // left; this is the line that tells them what to run, and asking it
+    // of the deferral itself is what stops the two from drifting apart.
+    const machine = host({ elevate: async (): Promise<Elevation> => ({ consent: "refused" }) });
+    const steps = await runPrivilegedBatch(ITEMS, machine);
+
+    for (const step of steps) {
+      expect(outcomeForError(step.error ?? "").remedy).toContain("red-dev privileged");
+    }
+  });
+
   test("a machine with nobody at it defers without raising a prompt", async () => {
     // CI, a pipe, a non-interactive SSH session. A consent dialog raised
     // where no one can answer it waits forever, and a converge that

--- a/src/rights.test.ts
+++ b/src/rights.test.ts
@@ -126,6 +126,17 @@ describe("both messages", () => {
     expect(missingRights("administrator").remedy).toContain("elevated PowerShell");
   });
 
+  test("and the administrator one names the command that finishes just that", () => {
+    // The deferral and the way out of it are the same sentence. An
+    // operator who reads "this needs administrator" on a machine where
+    // everything else converged should not have to guess that finishing
+    // it costs one command rather than the whole run again — and `sudo`
+    // deliberately does not say it, because the privileged batch is
+    // empty on every Linux target and would do nothing there.
+    expect(missingRights("administrator").remedy).toContain("red-dev privileged");
+    expect(missingRights("sudo").remedy).not.toContain("red-dev privileged");
+  });
+
   test("are the same shape, so the rule is learned once", () => {
     for (const gate of ["sudo", "administrator"] as const) {
       const outcome = missingRights(gate);

--- a/src/rights.ts
+++ b/src/rights.ts
@@ -73,7 +73,12 @@ const WORDING: Record<Gate, { cause: string; remedy: string }> = {
   },
   administrator: {
     cause: "this needs administrator and nothing here can raise it.",
-    remedy: "Start an elevated PowerShell first, then re-run red-dev — re-running is safe.",
+    // Names the command that finishes exactly this, because that is the
+    // cheaper of the two ways out and the one nobody would guess. The
+    // other stays: an operator already in an elevated PowerShell should
+    // not be sent to a different command to use the rights they hold.
+    remedy:
+      "Run `red-dev privileged` to finish just this, or re-run red-dev from an elevated PowerShell — either is safe.",
   },
 };
 


### PR DESCRIPTION
Automated AFK landing for #71. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #71

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788812182&installation_model_id=20659&pr_number=93&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F93&signature=0c5742dc18e307d7e27257d0c19fe669982b60b02b59ba4d92f67a5131c8a0b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->