### PR TITLE
docs: define Reclaim and record that it is asked for, never scheduled

### DIFF
--- a/.red/adr/0004-reclaim-is-asked-for-never-scheduled.md
+++ b/.red/adr/0004-reclaim-is-asked-for-never-scheduled.md
@@ -1,0 +1,72 @@
+# 0004 — Reclaim is asked for, never scheduled
+
+- Status: accepted
+- Date: 2026-08-10
+
+## Context
+
+A machine that runs red-dev accumulates cost it never gives back. The WSL virtual
+disk grows and does not shrink: measured on the maintainer's host, `ext4.vhdx`
+occupied 184.9 GB while the filesystem inside it used 37 GB — roughly 148 GB held
+by nothing. Build caches keep artefacts no build will read again. Journals keep
+lines past their usefulness. None of this is drift against the manifest, so a
+converge sees a healthy machine and moves on.
+
+The obvious answer is a scheduled task. Every operating system red-dev targets
+offers one, the work is periodic by nature, and an operator who has to remember
+to reclaim disk will not remember until the disk is full — which is exactly the
+state this decision was taken in, with 18 GB free of 894 GB.
+
+That answer was rejected. What follows is why, because the next reader will
+propose it again.
+
+## Decision
+
+**Reclaim runs when an operator asks for it, and at no other time.** It is not a
+converge step, not a scheduled task, and not a systemd timer. red-dev schedules
+nothing today — no `schtasks`, no timer, no cron — and this decision keeps that
+true.
+
+Three consequences follow, and each is part of the decision rather than an
+implementation detail:
+
+**A Reclaim refuses while Workers are alive.** Compacting the virtual disk means
+shutting the virtual machine down, and AFK Workers are systemd units inside it.
+An interrupted Worker loses its attempt. Waiting costs minutes; interrupting
+costs the work.
+
+**The compaction is a wizard, not a command.** `wsl --shutdown` invoked from
+inside WSL kills the process that invoked it, so the command cannot survive to
+report what it did. Rather than invent an orchestration that outlives its own
+death, red-dev generates a script the operator runs from the Windows side.
+
+**Reclaim never removes anything a person authored.** Not code, not branches, not
+uncommitted work, and not a value an operator wrote into their own configuration.
+The test is what losing it costs: if only time, it is Reclaim's to take; if work,
+it is not.
+
+## Consequences
+
+An operator with a full disk and no memory of this feature stays stuck. That is
+the real cost, and it is accepted: `doctor` reporting reclaimable space is the
+mitigation, and it does not automate anything.
+
+The decision also constrains what may be added later. A future item that wants to
+reclaim on a timer is not a small extension — it reopens this ADR, because the
+argument here is not "scheduling is hard" but "these acts cost more when they
+surprise someone than when they wait".
+
+## Alternatives considered
+
+**A scheduled task** — the conventional answer, rejected above. It would also make
+red-dev a project that installs background jobs, which nothing in it does today.
+
+**A converge step** — rejected because a converge is something people run to make
+a machine correct, and they do not expect it to shut the machine down or delete
+caches. It would also make the converge's runtime depend on how long a virtual
+disk takes to compact.
+
+**Report only, act never** — `doctor` names the reclaimable space and stops. This
+is retained as the discovery half, but on its own it leaves the operator to
+assemble the commands, which is where a half-remembered `diskpart` invocation
+against the wrong file becomes possible.

--- a/.red/contexts/provisioning/CONTEXT.md
+++ b/.red/contexts/provisioning/CONTEXT.md
@@ -2,6 +2,14 @@
 
 Convergence engine — manifest, providers, plan/apply, and the proof discipline.
 
+## Reclaim
+
+Giving back host resource that has already been spent — disk a virtual disk grew into and never released, build caches nothing reads any more, logs kept past their usefulness. Reclaim is the counterpart to convergence: convergence makes a machine match the manifest, Reclaim makes it give back what matching it cost.
+
+It is never a side effect of a converge and never scheduled. An operator asks for it, because the acts it performs — shutting down the virtual machine, deleting caches — cost more when they surprise someone than when they wait. For the same reason a Reclaim refuses while Workers are alive rather than interrupting them.
+
+Reclaim never removes anything a person authored: not code, not branches, not uncommitted work, and not a value an operator wrote into their own configuration. What it touches is derived, and derived is the whole test — if losing it costs only time, it is Reclaim's to take; if losing it costs work, it is not.
+
 ## E2E lane
 
 A clean machine (VM) for one target platform that walks the full journey — install → second convergence with zero drift → theme/font switch → N-1 update → rollback → uninstall. Incremental definition of done: each phase only closes with lanes covering what it shipped; no item is ever declared ready by mere file existence.


### PR DESCRIPTION
From a `/start` grilling session on host resource that a converge never gives back.

**Glossary — `Reclaim`** in the `provisioning` context. The counterpart to convergence: convergence makes a machine match the manifest, Reclaim makes it give back what matching it cost — disk a virtual disk grew into, build caches nothing reads, logs kept past their usefulness.

**ADR 0004 — Reclaim is asked for, never scheduled.** The obvious answer here is a scheduled task, and the next reader will propose it again, so the reasons it was rejected are written down rather than left as an absence.

The measurement that prompted it: `ext4.vhdx` occupying 184.9 GB while the filesystem inside used 37 GB, on a host with 18 GB free of 894 GB.

Three consequences are part of the decision rather than implementation detail: a Reclaim refuses while Workers are alive, because they are systemd units inside the VM it would shut down; the compaction is a wizard rather than a command, because `wsl --shutdown` from inside WSL kills its own caller; and Reclaim never removes anything a person authored — the test is whether losing it costs time or work.

Landed through the docs worktree lane: the primary checkout was never committed in, never switched, never stashed, never reset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhSZ5GCX26PgTZLNRpWmtv

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788982461&installation_model_id=20659&pr_number=94&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F94&signature=0ed35b5d584a313649a702e884af85ac278a9f2d4e93ea7ab636a40a5362ee58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->