### PR TITLE
fix: probe by file for packages that ship no binary

### DIFF
--- a/src/manifest.test.ts
+++ b/src/manifest.test.ts
@@ -4,6 +4,7 @@ import {
   TOOLS,
   applicableScopes,
   describeProvider,
+  installState,
   isInstalled,
   itemsNeedingAdmin,
   needsAdmin,
@@ -124,6 +125,27 @@ describe("the manifest itself", () => {
     const tool = TOOLS.find((t) => t.name === "wl-clipboard");
     expect(tool?.scope).toBe("desktop");
     expect(providerFor(tool!, DESKTOP)).toEqual({ kind: "apt", pkg: "wl-clipboard" });
+  });
+
+  test("a package that ships no binary is still findable", () => {
+    // The regression this pins: bash-completion installs a shell library
+    // and nothing executable, so the default probe looked for a command
+    // called `bash-completion` on PATH, never found one, and reported
+    // the package absent on a machine where dpkg said `install ok
+    // installed`. Every converge then tried to install it again and
+    // named it as a problem — the same failure, once per run, forever.
+    //
+    // Asserted through installState rather than by reading the field, so
+    // deleting the declaration fails here even if the field survives.
+    const tool = TOOLS.find((t) => t.name === "bash-completion");
+    expect(tool?.file).toBe("/usr/share/bash-completion/bash_completion");
+    expect(tool?.cmd).toBeUndefined();
+
+    const seen = { ...tool!, file: import.meta.path } as typeof tool;
+    expect(installState(seen!)).toBe("ok");
+
+    const missing = { ...tool!, file: "/nonexistent/bash_completion" } as typeof tool;
+    expect(installState(missing!)).toBe("absent");
   });
 
   test("what init.sh sources, the manifest installs", () => {

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -171,6 +171,23 @@ export interface Tool {
    */
   cmd?: string[];
   /**
+   * A file whose existence is the proof, for packages that ship no
+   * binary at all.
+   *
+   * Every probe above answers "is there a command on PATH", which is the
+   * right question for all but one shape of package. bash-completion
+   * installs a shell library and nothing executable, so probing by name
+   * asked for `bash-completion` on PATH, never found it, and reported
+   * the package absent on a machine where dpkg said `install ok
+   * installed`. The converge then tried to install it on every run,
+   * forever, and each run named it as a problem.
+   *
+   * The path is the same one the code that consumes the package already
+   * reads, which is what keeps this honest: a declaration pointing
+   * somewhere nothing uses would pass its own test and prove nothing.
+   */
+  file?: string;
+  /**
    * Proof that the command on PATH is the tool we mean.
    *
    * A name is not an identity. Ubuntu ships /usr/bin/red — GNU ed's
@@ -350,6 +367,11 @@ export const TOOLS: Tool[] = [
     // package that would put one where MSYS bash reads from.
     name: "bash-completion",
     scope: "core",
+    // The file config/bash/init.sh sources, which is the only observable
+    // this package leaves behind — it installs no binary, so the default
+    // name-on-PATH probe reported it absent forever and every converge
+    // tried to install it again.
+    file: "/usr/share/bash-completion/bash_completion",
     u24: apt("bash-completion"),
     win: skip("Git Bash ships its own bash-completion"),
   },
@@ -1010,6 +1032,12 @@ export type InstallState = "ok" | "absent" | "outdated";
 
 export function installState(tool: Tool): InstallState {
   if (tool.managed) return "absent"; // the provider decides; see Tool.managed
+
+  // Checked before the PATH probe rather than beside it: a tool that
+  // declares a file has no command to find, so falling through would ask
+  // the wrong question and answer "absent" on a machine that has it.
+  if (tool.file) return existsSync(tool.file) ? "ok" : "absent";
+
   const candidates = tool.cmd ?? [tool.name];
   if (!candidates.some(present)) return "absent";
   // A name on PATH is not proof it is the right program — see Tool.signature.


### PR DESCRIPTION
A regression I introduced in #48, reported twice by the maintainer as "it keeps saying there is a problem with bash-completion".

`installState` probes with `tool.cmd ?? [tool.name]` — a command on PATH. bash-completion installs a shell library and nothing executable, so the probe looked for a binary called `bash-completion`, never found one, and reported the package absent on a machine where `dpkg -s` says `install ok installed` and the file is on disk.

The consequence was not a one-off. Every converge saw it missing, tried to install it, and named it as a problem — the same failure once per run, forever. On a machine without cached sudo it also failed loudly each time.

`Tool.file` says the observable is a path rather than a command, and `installState` checks it before the PATH probe: a tool that declares a file has no command to find, so falling through would ask the wrong question.

bash-completion declares the same path `config/bash/init.sh` already sources. That is what keeps the declaration honest — pointing somewhere nothing reads would pass its own test and prove nothing.

## Checks

- `installState` for bash-completion: `absent` before, `ok` after.
- `red-dev plan` now reports `bash-completion apt:bash-completion (present)`; it reported it as missing on every run before.
- New test asserts through `installState`, not by reading the field, so deleting the declaration fails it even if the field survives. Verified non-vacuous: removing the line turns it red.
- `bun test` — 880 pass, 0 fail. `tsc --noEmit` clean.

## What this does not fix

The item still needs `sudo` the first time on a machine that genuinely lacks the package. This only stops red-dev asking for it on machines that already have it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhSZ5GCX26PgTZLNRpWmtv

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788983677&installation_model_id=20659&pr_number=95&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F95&signature=d2005338194b1b4576c1424f384f0365e7a2a4d44ab3305345469e1dcb774bb1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->