### PR TITLE
chore: #99 /go: Give the manifest the ability to pin a GitHub release, and use it to hol

### DIFF
--- a/src/converge.ts
+++ b/src/converge.ts
@@ -23,6 +23,7 @@ import {
 import { aptInstall, applyProvider, type ApplyContext } from "./providers.ts";
 import {
   describeProvider,
+  installedVersion,
   installState,
   isInstalled,
   providerFor,
@@ -349,6 +350,12 @@ export async function converge(
           // newer. Saying "absent" here sends the reader hunting for a
           // missing binary that is sitting right there on PATH.
           finish("failed", `apt has nothing newer than ${tool.minVersion} for ${tool.name}`);
+        } else if (installState(tool) === "mismatched") {
+          // apt installs what the archive has and will not be argued
+          // down to an exact version, so a pinned tool on an apt column
+          // reports the gap rather than pretending to have closed it.
+          const found = installedVersion(tool) ?? "unknown";
+          finish("failed", `${tool.name} ${found}, pinned to ${tool.pinVersion}`);
         } else finish("failed", "apt reported success but the binary is absent");
         continue;
       }

--- a/src/main.ts
+++ b/src/main.ts
@@ -60,7 +60,12 @@ async function cmdPlan(p: Platform, inv: Invocation): Promise<number> {
               ? " (present)"
               : installState(tool) === "outdated"
                 ? ` (outdated, wants ${tool.minVersion})`
-                : "";
+                : installState(tool) === "mismatched"
+                  ? // Both numbers, because the found one may be the
+                    // higher: "wants 0.44.1" alone reads as an upgrade
+                    // on a machine that has to go the other way.
+                    ` (${installedVersion(tool) ?? "unknown"}, pinned to ${tool.pinVersion})`
+                  : "";
       log.plain(`  ${tool.name.padEnd(17)}${describeProvider(pr)}${state}`);
     }
   }
@@ -76,6 +81,7 @@ async function cmdPlan(p: Platform, inv: Invocation): Promise<number> {
 async function cmdDoctor(p: Platform, inv: Invocation): Promise<number> {
   let missing = 0;
   let outdated = 0;
+  let mismatched = 0;
 
   // Which of the two this machine currently is.
   //
@@ -115,6 +121,13 @@ async function cmdDoctor(p: Platform, inv: Invocation): Promise<number> {
         const found = installedVersion(tool) ?? "unknown";
         log.err(`${tool.name} ${found} — older than ${tool.minVersion} (${describeProvider(pr)})`);
         outdated++;
+      } else if (installState(tool) === "mismatched") {
+        // Deliberately not phrased as old or new: this is the one case
+        // where the machine may be ahead of where it must be, and the
+        // remedy is the pinned release either way.
+        const found = installedVersion(tool) ?? "unknown";
+        log.err(`${tool.name} ${found} — pinned to ${tool.pinVersion} (${describeProvider(pr)})`);
+        mismatched++;
       } else {
         log.err(`${tool.name} missing (${describeProvider(pr)})`);
         missing++;
@@ -142,9 +155,10 @@ async function cmdDoctor(p: Platform, inv: Invocation): Promise<number> {
   }
 
   log.plain("");
-  if (missing > 0 || outdated > 0 || drifted > 0) {
+  if (missing > 0 || outdated > 0 || mismatched > 0 || drifted > 0) {
     const parts = [`${missing} tool(s) missing`];
     if (outdated > 0) parts.push(`${outdated} outdated`);
+    if (mismatched > 0) parts.push(`${mismatched} off the pinned version`);
     parts.push(`${drifted} config drift(s)`);
     log.warn(parts.join(", "));
     return 1;

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -65,6 +65,26 @@ type ProviderSpec =
       repo: string;
       asset: string;
       /**
+       * Hold this repo at one release instead of following /latest.
+       *
+       * For the case a glob cannot express: not "which file in the
+       * newest release", but "not the newest release at all", because a
+       * later one is the defect. zellij 0.44.2 shipped the OSC-reply
+       * leak and there is no filename that says so.
+       *
+       * The *tag*, as the publisher writes it — `v0.44.1`, not `0.44.1`,
+       * for a repo that tags with a prefix. It is used verbatim, since
+       * decorating it is a guess and a guess here is a 404 on the next
+       * repo that tags the other way. Absent, resolution is exactly what
+       * it always was: /releases/latest, glob matched against the names
+       * that release publishes.
+       *
+       * Half a pin on its own. The tool it belongs to also needs
+       * `pinVersion`, or a machine that already carries a later build
+       * is never told — see Tool.pinVersion.
+       */
+      version?: string;
+      /**
        * Install name, when the release publishes a bare binary whose
        * asset name is not the command. tealdeer ships
        * `tealdeer-linux-x86_64-musl` and the command is `tldr`.
@@ -216,6 +236,27 @@ export interface Tool {
    * prerelease ordering, because no tool here needs it.
    */
   minVersion?: string;
+  /**
+   * This version, exactly. Newer is also wrong.
+   *
+   * The floor above answers "is this new enough", which is the wrong
+   * question whenever a *later* release is the defect — and a floor is
+   * then silent on precisely the machine that has the bad build. zellij
+   * 0.44.2 introduced the OSC-reply leak; a floor of 0.44.1 calls a host
+   * running 0.44.3 `ok` and the terminal keeps filling with replies.
+   *
+   * So a pin is a point, not a range: any other version is reported as
+   * `mismatched` and the report names both numbers. Downgrading is left
+   * to the provider — on a `gh` column that follows, because the tag is
+   * declared there too; on a column whose package manager only moves
+   * forward it does not, and saying so out loud beats a doctor that
+   * reports `ok` about the version we know is broken.
+   *
+   * Declared with the reason and the condition for lifting it written
+   * beside the tool. A pin whose justification is lost is a pin nobody
+   * dares remove, and it outlives the bug by years.
+   */
+  pinVersion?: string;
   scope: Scope;
   /**
    * True when presence cannot be answered by probing for a command —
@@ -237,6 +278,21 @@ const gh = (repo: string, asset: string, bin?: string): Provider => ({
   kind: "gh",
   repo,
   asset,
+  ...(bin ? { bin } : {}),
+});
+/**
+ * The same release asset, held at one tag.
+ *
+ * A separate helper rather than a fourth positional argument to `gh`,
+ * because the tag is the unusual thing on the line and burying it behind
+ * an optional `bin` would let it read as noise. The reason for the pin
+ * belongs in a comment above the tool; this only carries the tag.
+ */
+const ghPinned = (repo: string, version: string, asset: string, bin?: string): Provider => ({
+  kind: "gh",
+  repo,
+  asset,
+  version,
   ...(bin ? { bin } : {}),
 });
 /** A release asset that is an installer rather than a binary. */
@@ -516,9 +572,29 @@ export const TOOLS: Tool[] = [
     // Upstream ships an official windows-msvc build (0.44.3 has both a
     // .zip and an .msi), which an earlier revision of this manifest
     // wrongly claimed did not exist.
+    //
+    // Held at 0.44.1, which is the last release that does not leak OSC
+    // replies. 0.44.2 began answering the terminal's OSC queries without
+    // consuming the replies, so they land in the pane as literal text —
+    // `11;rgb:...` sprayed across whatever is running — and the newer
+    // the release, the more of it. That is zellij-org/zellij#5174.
+    //
+    // Lift the pin when #5174 closes, or when a later release is shown
+    // not to leak; either way move both numbers below, since the tag and
+    // the version the binary prints have to keep agreeing.
     name: "zellij",
     scope: "core",
-    u24: gh("zellij-org/zellij", "zellij-x86_64-unknown-linux-musl.tar.gz"),
+    pinVersion: "0.44.1",
+    u24: ghPinned(
+      "zellij-org/zellij",
+      "v0.44.1",
+      "zellij-x86_64-unknown-linux-musl.tar.gz",
+    ),
+    // winget installs what its manifest has, which is the newest — so on
+    // Windows the pin is a report rather than a repair: the doctor names
+    // the machine as off the pinned version and the downgrade is manual.
+    // Silence would be the alternative, and silence is how 0.44.3 got
+    // onto a machine in the first place.
     win: winget("Zellij.Zellij"),
   },
   {
@@ -1021,14 +1097,18 @@ export function itemsNeedingAdmin(p: Platform, scopes: Scope[] = applicableScope
 }
 
 /**
- * The three answers, kept apart so a report can tell them apart.
+ * The four answers, kept apart so a report can tell them apart.
  *
- * "absent" and "outdated" both mean there is work to do, but they fail
- * differently and a converge that says "the binary is absent" about a
- * binary sitting on PATH sends whoever reads it looking in the wrong
- * place.
+ * "absent", "outdated" and "mismatched" all mean there is work to do,
+ * but they fail differently and a converge that says "the binary is
+ * absent" about a binary sitting on PATH sends whoever reads it looking
+ * in the wrong place. "mismatched" is the one that can mean *too new* —
+ * see Tool.pinVersion — and it is separate from "outdated" for that
+ * reason alone: telling someone on 0.44.3 that they are behind 0.44.1
+ * would be a lie, and the fix it implies is the opposite of the one
+ * that works.
  */
-export type InstallState = "ok" | "absent" | "outdated";
+export type InstallState = "ok" | "absent" | "outdated" | "mismatched";
 
 export function installState(tool: Tool): InstallState {
   if (tool.managed) return "absent"; // the provider decides; see Tool.managed
@@ -1042,6 +1122,10 @@ export function installState(tool: Tool): InstallState {
   if (!candidates.some(present)) return "absent";
   // A name on PATH is not proof it is the right program — see Tool.signature.
   if (tool.signature && !identify(candidates, tool.signature)) return "absent";
+  // Before the floor, and above it in the file for the same reason: a
+  // pin is an exact answer, so a floor declared alongside one could only
+  // ever agree with it or contradict it.
+  if (tool.pinVersion && versionOtherThan(candidates, tool.pinVersion)) return "mismatched";
   if (tool.minVersion && versionBelow(candidates, tool.minVersion)) return "outdated";
   return "ok";
 }
@@ -1071,7 +1155,18 @@ export function isPresent(tool: Tool): boolean {
  * reader to run --version themselves.
  */
 export function installedVersion(tool: Tool): string | null {
-  for (const c of tool.cmd ?? [tool.name]) {
+  return probeVersion(tool.cmd ?? [tool.name]);
+}
+
+/**
+ * What the first candidate on PATH says its version is, or null.
+ *
+ * Null covers two different disappointments — nothing on PATH, and
+ * something on PATH whose output carries no version — and every caller
+ * treats them the same way, by not claiming anything.
+ */
+function probeVersion(candidates: string[]): string | null {
+  for (const c of candidates) {
     if (!commandExists(c)) continue;
     return parseVersion(versionOutput(c) ?? "");
   }
@@ -1096,15 +1191,17 @@ export function compareVersions(a: string, b: string): number {
 }
 
 function versionBelow(candidates: string[], min: string): boolean {
-  for (const c of candidates) {
-    if (!commandExists(c)) continue;
-    const found = parseVersion(versionOutput(c) ?? "");
-    // Unreadable output is not evidence of an old version, and treating
-    // it as one would reinstall the tool on every single converge with
-    // no run ever reaching a fixed point. Fail open and say nothing.
-    return found === null ? false : compareVersions(found, min) < 0;
-  }
-  return false;
+  const found = probeVersion(candidates);
+  // Unreadable output is not evidence of an old version, and treating
+  // it as one would reinstall the tool on every single converge with
+  // no run ever reaching a fixed point. Fail open and say nothing.
+  return found === null ? false : compareVersions(found, min) < 0;
+}
+
+/** Anything but the pinned version, newer included. Fails open, as above. */
+function versionOtherThan(candidates: string[], pin: string): boolean {
+  const found = probeVersion(candidates);
+  return found === null ? false : compareVersions(found, pin) !== 0;
 }
 
 /**
@@ -1181,7 +1278,10 @@ export function describeProvider(pr: Provider): string {
     case "installer":
       return `installer:${pr.url}`;
     case "gh":
-      return `gh:${pr.repo}:${pr.asset}`;
+      // The tag, when there is one, sits where the reader is already
+      // looking for "which release": a plan that says only the repo
+      // hides the whole point of a pinned column.
+      return `gh:${pr.repo}${pr.version ? `@${pr.version}` : ""}:${pr.asset}`;
     case "ppa":
       return `ppa:${pr.ppa}`;
     case "aptrepo":

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -289,11 +289,31 @@ interface GhAsset {
 }
 
 /**
+ * Which release to ask for: the newest, or one named tag.
+ *
+ * Exported and separate from the fetch so the choice can be asserted
+ * without a network — the pin is worth nothing if this silently keeps
+ * resolving /latest, and that is a failure no unit test would see if the
+ * URL were built inline.
+ */
+export function releaseApiUrl(repo: string, version?: string): string {
+  const which = version ? `tags/${version}` : "latest";
+  return `https://api.github.com/repos/${repo}/releases/${which}`;
+}
+
+/**
  * Resolve a release asset by matching a glob against the names the
  * release actually publishes. Never construct the filename from a
  * pinned version — see the note on the `gh` provider in manifest.ts.
+ *
+ * `version` names a tag to hold to; without it this is /releases/latest,
+ * which is what every unpinned tool still gets.
  */
-export async function resolveGhAsset(repo: string, glob: string): Promise<string> {
+export async function resolveGhAsset(
+  repo: string,
+  glob: string,
+  version?: string,
+): Promise<string> {
   const headers: Record<string, string> = { Accept: "application/vnd.github+json" };
   const token = process.env["GITHUB_TOKEN"];
   if (token) headers["Authorization"] = `Bearer ${token}`;
@@ -303,7 +323,7 @@ export async function resolveGhAsset(repo: string, glob: string): Promise<string
   // and nothing else — never even the "github: …" line, which is logged
   // after this call returns — so the API request was where it sat, with
   // no child process to notice and no error to report.
-  const res = await fetch(`https://api.github.com/repos/${repo}/releases/latest`, {
+  const res = await fetch(releaseApiUrl(repo, version), {
     headers,
     signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS),
   }).catch((err: unknown) => {
@@ -314,6 +334,11 @@ export async function resolveGhAsset(repo: string, glob: string): Promise<string
   if (!res.ok) {
     throw new RedError(
       `GitHub API ${res.status} for ${repo}` +
+        // A pinned tag has a failure of its own: 404 here means the tag
+        // does not exist, usually because it was written as a version
+        // when the publisher prefixes with `v`. Saying which tag was
+        // asked for is the difference between a one-line fix and a hunt.
+        (version && res.status === 404 ? ` — no release tagged '${version}'` : "") +
         (res.status === 403 ? " — rate limited, set GITHUB_TOKEN" : ""),
     );
   }
@@ -326,7 +351,7 @@ export async function resolveGhAsset(repo: string, glob: string): Promise<string
   if (!hit) {
     const available = assets.map((a) => `  ${a.name}`).join("\n");
     throw new RedError(
-      `no asset matching '${glob}' in latest ${repo} release.\nAvailable:\n${available}`,
+      `no asset matching '${glob}' in ${version ?? "latest"} ${repo} release.\nAvailable:\n${available}`,
     );
   }
   return hit.browser_download_url;
@@ -336,8 +361,9 @@ export async function ghInstall(
   repo: string,
   glob: string,
   bin?: string,
+  version?: string,
 ): Promise<void> {
-  const url = await resolveGhAsset(repo, glob);
+  const url = await resolveGhAsset(repo, glob, version);
   const file = url.split("/").pop() ?? "asset";
   log.step(`github: ${repo} -> ${file}`);
 
@@ -417,8 +443,9 @@ export async function ghInstallWindows(
   glob: string,
   bin?: string,
   silentArgs?: string[],
+  version?: string,
 ): Promise<void> {
-  const url = await resolveGhAsset(repo, glob);
+  const url = await resolveGhAsset(repo, glob, version);
   const file = url.split("/").pop() ?? "asset";
   log.step(`github: ${repo} -> ${file}`);
 
@@ -817,9 +844,9 @@ export async function applyProvider(pr: Provider, ctx: ApplyContext): Promise<vo
       // into two provider kinds would put the same repo in two places
       // and let them drift.
       if (ctx.platform.os === "windows") {
-        await ghInstallWindows(pr.repo, pr.asset, pr.bin, pr.silentArgs);
+        await ghInstallWindows(pr.repo, pr.asset, pr.bin, pr.silentArgs, pr.version);
       } else {
-        await ghInstall(pr.repo, pr.asset, pr.bin);
+        await ghInstall(pr.repo, pr.asset, pr.bin, pr.version);
       }
       return;
     case "ppa":

--- a/src/release-pin.test.ts
+++ b/src/release-pin.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Release pins: held at one version, in both directions.
+ *
+ * A floor (minVersion) answers "is this new enough", which is the wrong
+ * question when a *newer* release is the defect. zellij 0.44.2 introduced
+ * the OSC-reply leak, so the machine that most needs to hear about it is
+ * the one running 0.44.3 — and a floor is silent on exactly that machine.
+ *
+ * Two halves, and the pin is only real with both: the manifest asks
+ * GitHub for the pinned tag instead of /releases/latest, and installState
+ * stops calling a machine ok when it is on some other version.
+ */
+
+import { readFileSync } from "node:fs";
+import { describe, expect, test } from "bun:test";
+import {
+  describeProvider,
+  installedVersion,
+  installState,
+  isInstalled,
+  isPresent,
+  TOOLS,
+  type Tool,
+} from "./manifest.ts";
+import { releaseApiUrl } from "./providers.ts";
+
+describe("releaseApiUrl", () => {
+  test("without a pin it is the latest release, byte for byte what it was", () => {
+    expect(releaseApiUrl("jesseduffield/lazygit")).toBe(
+      "https://api.github.com/repos/jesseduffield/lazygit/releases/latest",
+    );
+  });
+
+  test("with a pin it is that tag, and nothing resolves to latest", () => {
+    expect(releaseApiUrl("zellij-org/zellij", "v0.44.1")).toBe(
+      "https://api.github.com/repos/zellij-org/zellij/releases/tags/v0.44.1",
+    );
+  });
+
+  test("the tag is used verbatim, prefix and all", () => {
+    // The field holds the tag as the publisher writes it, not a version
+    // we decorate: zellij tags are `v0.44.1` and plenty of projects tag
+    // `0.44.1`, and guessing which is a 404 waiting for the next repo.
+    expect(releaseApiUrl("owner/repo", "0.44.1")).toEndWith("/releases/tags/0.44.1");
+    expect(releaseApiUrl("owner/repo", "v0.44.1")).toEndWith("/releases/tags/v0.44.1");
+  });
+});
+
+/**
+ * `bun` rather than a manifest tool, for min-version.test.ts's reason:
+ * these need a binary that is certainly present and certainly prints a
+ * version, and the process running the test is exactly that.
+ */
+function bunPinnedAt(version: string): Tool {
+  return {
+    name: "bun",
+    cmd: ["bun"],
+    pinVersion: version,
+    scope: "core",
+    u24: { kind: "apt", pkg: "bun" },
+    win: { kind: "skip", reason: "not under test" },
+  };
+}
+
+const BUN_VERSION = installedVersion(bunPinnedAt("0.0.0")) ?? "";
+
+describe("installState under a pin", () => {
+  test("the pinned version is ok", () => {
+    expect(BUN_VERSION).not.toBe("");
+    expect(installState(bunPinnedAt(BUN_VERSION))).toBe("ok");
+    expect(isInstalled(bunPinnedAt(BUN_VERSION))).toBe(true);
+  });
+
+  test("a version ABOVE the pin is mismatched, not ok", () => {
+    // The whole point. This is the maintainer's own host on zellij
+    // 0.44.3 against a pin of 0.44.1: a floor reports it present and
+    // says nothing, and the bad version stays on the machine.
+    const ahead = bunPinnedAt("0.0.1");
+    expect(installState(ahead)).toBe("mismatched");
+    expect(isInstalled(ahead)).toBe(false);
+  });
+
+  test("a version below the pin is mismatched too", () => {
+    expect(installState(bunPinnedAt("999.0.0"))).toBe("mismatched");
+  });
+
+  test("a mismatched tool is still present, so it can be removed", () => {
+    // Same reasoning as the floor: the uninstall list is built from
+    // isPresent, and a tool that vanishes from it while sitting on disk
+    // leaves no way to remove the thing being complained about.
+    expect(isPresent(bunPinnedAt("0.0.1"))).toBe(true);
+  });
+
+  test("a command that is not there is absent, not mismatched", () => {
+    // "absent" and "mismatched" send the reader to different places.
+    const ghost = { ...bunPinnedAt("0.0.1"), cmd: ["red-dev-no-such-binary"] };
+    expect(installState(ghost)).toBe("absent");
+  });
+
+  test("no pin is the state of every other tool, unchanged", () => {
+    const unpinned: Tool = { ...bunPinnedAt("0.0.1"), pinVersion: undefined };
+    expect(installState(unpinned)).toBe("ok");
+  });
+});
+
+describe("the zellij pin", () => {
+  const zellij = TOOLS.find((t) => t.name === "zellij");
+
+  test("is declared at 0.44.1, the last release before the OSC leak", () => {
+    expect(zellij?.pinVersion).toBe("0.44.1");
+  });
+
+  test("carries the reason and the release condition beside it", () => {
+    // Asserted against the source because a pin without its justification
+    // is a pin nobody dares lift: the next reader needs to know which
+    // upstream issue closing lets this go.
+    const text = readFileSync("src/manifest.ts", "utf8");
+    const at = text.indexOf('name: "zellij"');
+    const comment = text.slice(Math.max(0, at - 2500), at);
+    expect(comment).toContain("5174");
+    expect(comment.toLowerCase()).toContain("osc");
+  });
+
+  test("fetches the pinned tag rather than whatever is newest", () => {
+    expect(zellij?.u24).toEqual({
+      kind: "gh",
+      repo: "zellij-org/zellij",
+      asset: "zellij-x86_64-unknown-linux-musl.tar.gz",
+      version: "v0.44.1",
+    });
+  });
+
+  test("the tag and the version the binary reports agree", () => {
+    // Two fields saying the same thing in two dialects — a git tag and
+    // what `zellij --version` prints. They drift silently otherwise.
+    expect(zellij?.u24).toMatchObject({ version: `v${zellij?.pinVersion}` });
+  });
+
+  test("plan names the tag it will fetch", () => {
+    expect(describeProvider(zellij!.u24)).toContain("v0.44.1");
+  });
+});
+
+describe("every other release provider", () => {
+  test("is unpinned, so it still resolves latest exactly as before", () => {
+    const pinned = TOOLS.flatMap((t) => [t.u24, t.u26, t.win])
+      .filter((pr) => pr?.kind === "gh" && pr.version !== undefined)
+      .length;
+    // One column, one tool. A second entry here means a pin arrived
+    // without the comment that has to justify it.
+    expect(pinned).toBe(1);
+  });
+
+  test("no tool declares a floor and a pin at once", () => {
+    // They answer different questions and the pin wins, so declaring
+    // both hides the floor rather than combining them.
+    const both = TOOLS.filter((t) => t.minVersion && t.pinVersion).map((t) => t.name);
+    expect(both).toEqual([]);
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #99. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #99

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/100"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788987670&installation_model_id=20659&pr_number=100&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F100&signature=cb616526487ded0025955175ed6a2498f7b2d8a80e02abb0075b476a1b90bdf2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->