### PR TITLE
fix growing log scrollbar layout

### DIFF
--- a/src/tui-install.ts
+++ b/src/tui-install.ts
@@ -391,10 +391,11 @@ export function InstallLayout(m: InstallModel, width: number, height: number) {
   const logRows = Math.max(5, height - (twoColumn ? 8 : 16));
 
   // What a log line actually gets: Accented spends one column on its
-  // bar and one on the margin, and LogViewer spends one more on the
-  // scrollbar as soon as there is anything to scroll — which, during a
-  // converge, is immediately.
-  const logTextWidth = Math.max(8, leftWidth - 3);
+  // bar and one on the margin. Once there is anything to scroll,
+  // LogViewer spends two more: its scrollbar glyph and its left margin.
+  // Reserve all four up front so the scrollbar appearing cannot make
+  // already-visible lines wrap and change the viewport height.
+  const logTextWidth = Math.max(8, leftWidth - 4);
 
   const by = (o: string): number => results.filter((r) => r.outcome === o).length;
   const failures = results.filter((r) => r.outcome === "failed");

--- a/src/tui-overflow.test.ts
+++ b/src/tui-overflow.test.ts
@@ -112,6 +112,24 @@ describe("a log line wider than its column", () => {
   });
 });
 
+describe("the transition from a full viewport to a scrollbar", () => {
+  test("does not turn one logical line into two physical rows", () => {
+    // At WIDTH=96 the log text receives 50 columns before overflow. The
+    // scrollbar adds both a margin and a glyph when line 23 arrives; if
+    // only one of those columns is reserved, every 50-column line wraps.
+    const edge = Array.from(
+      { length: 23 },
+      (_, index) => `L${String(index).padStart(2, "0")} ${"x".repeat(46)}`,
+    );
+    const visibleLabels = frame(edge).flatMap((row) => row.match(/L\d\d/g) ?? []);
+
+    // logRows is 22, so following the tail must show L01 through L22.
+    expect(visibleLabels).toEqual(
+      Array.from({ length: 22 }, (_, index) => `L${String(index + 1).padStart(2, "0")}`),
+    );
+  });
+});
+
 describe("fitToWidth", () => {
   test("leaves a line that fits", () => {
     expect(fitToWidth("short", 20)).toBe("short");


### PR DESCRIPTION
## What changed

- reserve the scrollbar glyph and its margin before the log starts scrolling
- add a regression test at the exact viewport-width boundary where the scrollbar appears

## Root cause

The log width calculation reserved one column for `LogViewer`, but its scrollbar consumes two: one for the glyph and one for `marginLeft`. When the 23rd line made the scrollbar appear, lines that previously fit wrapped, changed the physical viewport height, and made entries disappear from the visible tail.

## Impact

The live install log keeps one physical row per fitted logical line when it grows enough to become scrollable. The scrollbar no longer breaks the left column mid-run.

## Validation

- `bun test` (full suite)
- `bun run typecheck`
- `bun run build` (Linux and Windows binaries)
- regression test demonstrated red before the fix and green after it

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/103"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789059827&installation_model_id=20659&pr_number=103&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F103&signature=1f66447fa2916663d4746f6abf2d1be20a070ab73375fc1458003bed7722070b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->