### PR TITLE
fix Windows fullscreen selection freeze

### DIFF
--- a/src/tui-install.ts
+++ b/src/tui-install.ts
@@ -39,6 +39,7 @@ import type { Scope } from "./manifest.ts";
 import type { Platform } from "./platform.ts";
 import type { ApplyContext } from "./providers.ts";
 import type { SetupPlanStep, SetupStepResult } from "./firstrun.ts";
+import { withConsoleSelectionSuspended } from "./windows-console-mode.ts";
 
 function human(ms: number): string {
   const s = Math.floor(ms / 1000);
@@ -586,7 +587,9 @@ export async function runInstallTui(
   // fullHeight: the panels are drawn to the terminal's height rather
   // than to their content, so the log fills the window instead of ending
   // partway down with the previous screen showing underneath.
-  const { waitUntilExit } = render(App, { fullHeight: true });
-  await waitUntilExit();
+  await withConsoleSelectionSuspended(async () => {
+    const { waitUntilExit } = render(App, { fullHeight: true });
+    await waitUntilExit();
+  });
   return outcome;
 }

--- a/src/tui-setup.ts
+++ b/src/tui-setup.ts
@@ -33,6 +33,7 @@ import { summary } from "./platform.ts";
 import { Screen, Surface } from "./tui-chrome.ts";
 import { muted, ui } from "./tui-theme.ts";
 import { swatches } from "./themes.ts";
+import { withConsoleSelectionSuspended } from "./windows-console-mode.ts";
 // The questions live in tui-setup-model.ts and only there. They were
 // declared in both files, identically, for two interfaces that ask the
 // same interview — which is a copy that drifts the first time one of
@@ -261,7 +262,9 @@ export async function runSetupTui(
   // fullHeight defaults to false, which is why the first version left a
   // dead band below the panels: the layout was drawn at its content
   // height and the rest of the terminal kept whatever was there before.
-  const { waitUntilExit } = render(App, { fullHeight: true });
-  await waitUntilExit();
+  await withConsoleSelectionSuspended(async () => {
+    const { waitUntilExit } = render(App, { fullHeight: true });
+    await waitUntilExit();
+  });
   return result;
 }

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -44,6 +44,7 @@ import {
   type SetupModel,
 } from "./tui-setup-model.ts";
 import { muted, text, wordmarkGradient } from "./tui-theme.ts";
+import { withConsoleSelectionSuspended } from "./windows-console-mode.ts";
 
 /**
  * A row of blocks in the palette's own colours.
@@ -481,7 +482,9 @@ export async function runTui(
     );
   }
 
-  const { waitUntilExit } = render(App, { fullHeight: true });
-  await waitUntilExit();
+  await withConsoleSelectionSuspended(async () => {
+    const { waitUntilExit } = render(App, { fullHeight: true });
+    await waitUntilExit();
+  });
   return result;
 }

--- a/src/windows-console-mode.test.ts
+++ b/src/windows-console-mode.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  ENABLE_EXTENDED_FLAGS,
+  ENABLE_QUICK_EDIT_MODE,
+  withConsoleSelectionSuspended,
+  type ConsoleModePort,
+} from "./windows-console-mode.ts";
+
+function port(initial: number): ConsoleModePort & { writes: number[] } {
+  let mode = initial;
+  const writes: number[] = [];
+  return {
+    writes,
+    read: () => mode,
+    write: (next) => {
+      writes.push(next);
+      mode = next;
+      return true;
+    },
+    close: () => {},
+  };
+}
+
+describe("a fullscreen view in Windows Console Host", () => {
+  test("guards every entry point that owns a render loop", () => {
+    for (const file of ["tui.ts", "tui-setup.ts", "tui-install.ts"]) {
+      const source = readFileSync(join(import.meta.dir, file), "utf8");
+      expect(source).toContain("withConsoleSelectionSuspended(async () =>");
+    }
+  });
+
+  test("cannot be frozen by entering QuickEdit selection", async () => {
+    const original = ENABLE_QUICK_EDIT_MODE | 0x001f;
+    const consoleMode = port(original);
+
+    await withConsoleSelectionSuspended(
+      async () => {
+        expect(consoleMode.read() & ENABLE_QUICK_EDIT_MODE).toBe(0);
+        expect(consoleMode.read() & ENABLE_EXTENDED_FLAGS).toBe(ENABLE_EXTENDED_FLAGS);
+      },
+      "win32",
+      async () => consoleMode,
+    );
+
+    expect(consoleMode.writes).toEqual([
+      (original | ENABLE_EXTENDED_FLAGS) & ~ENABLE_QUICK_EDIT_MODE,
+      original,
+    ]);
+  });
+
+  test("restores the operator's console mode even when the view throws", async () => {
+    const original = ENABLE_QUICK_EDIT_MODE | ENABLE_EXTENDED_FLAGS | 0x001f;
+    const consoleMode = port(original);
+
+    await expect(
+      withConsoleSelectionSuspended(
+        async () => {
+          throw new Error("render failed");
+        },
+        "win32",
+        async () => consoleMode,
+      ),
+    ).rejects.toThrow("render failed");
+
+    expect(consoleMode.read()).toBe(original);
+    expect(consoleMode.writes.at(-1)).toBe(original);
+  });
+
+  test("does not probe a Unix terminal", async () => {
+    let opened = false;
+    const answer = await withConsoleSelectionSuspended(
+      async () => 42,
+      "linux",
+      async () => {
+        opened = true;
+        return null;
+      },
+    );
+
+    expect(answer).toBe(42);
+    expect(opened).toBe(false);
+  });
+
+  test("does not sacrifice the view when the Console API is unavailable", async () => {
+    let closed = false;
+    const answer = await withConsoleSelectionSuspended(
+      async () => "still rendered",
+      "win32",
+      async () => ({
+        read: () => {
+          throw new Error("not a console handle");
+        },
+        write: () => false,
+        close: () => {
+          closed = true;
+        },
+      }),
+    );
+
+    expect(answer).toBe("still rendered");
+    expect(closed).toBe(true);
+  });
+});

--- a/src/windows-console-mode.ts
+++ b/src/windows-console-mode.ts
@@ -1,0 +1,96 @@
+/**
+ * Keep a fullscreen view alive in the classic Windows Console Host.
+ *
+ * QuickEdit is useful at a prompt, but in a live interface a mouse drag
+ * enters selection mode and Console Host pauses the attached process.
+ * Nothing in the application gets a signal or a key while it is paused;
+ * Enter merely ends the selection, which makes a long-running install
+ * look as though Enter was the missing answer.
+ */
+
+export const ENABLE_QUICK_EDIT_MODE = 0x0040;
+export const ENABLE_EXTENDED_FLAGS = 0x0080;
+
+export interface ConsoleModePort {
+  read: () => number;
+  write: (mode: number) => boolean;
+  close: () => void;
+}
+
+type OpenConsoleMode = () => Promise<ConsoleModePort | null>;
+
+/**
+ * Disable selection-driven process suspension for exactly one view.
+ *
+ * The original mode is restored byte-for-byte, including on exceptions.
+ * Failure to reach the Windows API is deliberately non-fatal: a console
+ * guard must never become the reason the interface cannot start.
+ */
+export async function withConsoleSelectionSuspended<T>(
+  view: () => Promise<T>,
+  platform: NodeJS.Platform = process.platform,
+  open: OpenConsoleMode = openWindowsConsoleMode,
+): Promise<T> {
+  if (platform !== "win32") return await view();
+
+  let port: ConsoleModePort | null = null;
+  try {
+    port = await open();
+  } catch {
+    return await view();
+  }
+  if (!port) return await view();
+
+  let original: number;
+  let changed = false;
+  try {
+    original = port.read();
+    const guarded = (original | ENABLE_EXTENDED_FLAGS) & ~ENABLE_QUICK_EDIT_MODE;
+    changed = guarded !== original && port.write(guarded);
+  } catch {
+    port.close();
+    return await view();
+  }
+
+  try {
+    return await view();
+  } finally {
+    if (changed) port.write(original);
+    port.close();
+  }
+}
+
+/** The real Console Host input mode, loaded only by a native Windows build. */
+async function openWindowsConsoleMode(): Promise<ConsoleModePort | null> {
+  const { dlopen } = await import("bun:ffi");
+  const kernel = dlopen("kernel32.dll", {
+    GetStdHandle: { args: ["i32"], returns: "ptr" },
+    GetConsoleMode: { args: ["ptr", "ptr"], returns: "i32" },
+    SetConsoleMode: { args: ["ptr", "u32"], returns: "i32" },
+  });
+  const input = kernel.symbols.GetStdHandle(-10); // STD_INPUT_HANDLE
+  if (!input) {
+    kernel.close();
+    return null;
+  }
+
+  const mode = new Uint32Array(1);
+  const read = (): number => {
+    if (kernel.symbols.GetConsoleMode(input, mode) === 0) throw new Error("GetConsoleMode failed");
+    return mode[0] ?? 0;
+  };
+
+  // Prove this really is a console handle before handing it to the view.
+  try {
+    read();
+  } catch {
+    kernel.close();
+    return null;
+  }
+
+  return {
+    read,
+    write: (next) => kernel.symbols.SetConsoleMode(input, next >>> 0) !== 0,
+    close: () => kernel.close(),
+  };
+}


### PR DESCRIPTION
## What changed

- disable Console Host QuickEdit only while a red-dev fullscreen view owns the terminal
- restore the exact original console mode on normal exit and exceptions
- apply the guard to the menu, setup wizard, and standalone install TUI
- add regression coverage for mode clearing, restoration, non-Windows behavior, API failure, and all render-loop entry points

## Root cause

The affected Windows PowerShell profile has QuickEdit enabled. In classic Console Host, entering mouse selection pauses the attached process. The final administrator step inherited no stdin, and unfinished TUI input ignores Enter, so Enter could not have released the OpenSSH operation in application code; it ended Console Host selection and resumed the process.

The run transcript and Windows Service Control Manager event place OpenSSH configuration immediately after the resume.

## Impact

Clicks or drags over the fullscreen installer can no longer suspend the converge. QuickEdit is not changed persistently and is restored after red-dev exits.

## Validation

- regression test failed before implementation and now passes
- `bun test` — 956 passing
- `bun run typecheck`
- `bun run build` — Linux and Windows binaries

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/104"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789061380&installation_model_id=20659&pr_number=104&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F104&signature=e873f91b331b7dde94404cb440d172b60c53a025ba177d73978542f11fa0bc52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->