### PR TITLE
fix Redwall worker state across Windows and WSL

### DIFF
--- a/src/host-state.test.ts
+++ b/src/host-state.test.ts
@@ -30,7 +30,9 @@ import {
   parseHostState,
   readHostInventoryNoStart,
   readHostState,
+  readWindowsWslHostState,
 } from "./host-state.ts";
+import type { BoundedCommandResult } from "./bounded-command.ts";
 
 // Read as text rather than imported as a module, so what the parser is given
 // is the bytes the daemon printed — an import would hand it a document
@@ -160,5 +162,58 @@ describe("a daemon that is not running", () => {
 
     expect(state).toBeNull();
     expect(performance.now() - started).toBeLessThan(500);
+  });
+});
+
+function result(over: Partial<BoundedCommandResult> = {}): BoundedCommandResult {
+  return {
+    stdout: "",
+    stderr: "",
+    exitCode: 0,
+    timedOut: false,
+    groupGone: true,
+    ...over,
+  };
+}
+
+describe("native Windows looking into running WSL hosts", () => {
+  test("sums Workers from participating distros without entering a stopped one", async () => {
+    const commands: string[][] = [];
+    const three = JSON.stringify(payload({ workers: [{ pid: 101 }, { pid: 102 }, { pid: 103 }] }));
+    const two = JSON.stringify(payload({ workers: [{ pid: 201 }, { pid: 202 }] }));
+
+    const state = await readWindowsWslHostState(async (argv) => {
+      commands.push(argv);
+      if (argv.includes("--list")) {
+        // wsl.exe commonly writes redirected inventory as UTF-16LE. The NULs
+        // are intentional: the production parser has to survive those bytes.
+        return result({ stdout: "Ubuntu-24.04\0\r\nDebian\0\r\n" });
+      }
+      if (argv.includes("Ubuntu-24.04")) return result({ stdout: three });
+      if (argv.includes("Debian")) return result({ stdout: two });
+      throw new Error(`unexpected distro command: ${argv.join(" ")}`);
+    });
+
+    expect(state).toEqual({ workers: 5 });
+    expect(commands[0]?.slice(-3)).toEqual(["--list", "--running", "--quiet"]);
+    expect(commands.filter((argv) => argv.includes("-d"))).toHaveLength(2);
+    // A non-interactive WSL shell does not source mise activation. The probe
+    // must therefore find the runtime red-dev installed even when `node` is
+    // absent from that shell's sparse PATH.
+    const wrapper = commands[1]?.at(-1) ?? "";
+    const encoded = /^printf %s ([A-Za-z0-9+/=]+) \| base64 -d \| sh$/.exec(wrapper)?.[1];
+    expect(encoded).toBeDefined();
+    expect(Buffer.from(encoded!, "base64").toString("utf8"))
+      .toContain(".local/share/mise/installs/node/*/bin/node");
+  });
+
+  test("returns unknown when no running distro exposes a live daemon", async () => {
+    const state = await readWindowsWslHostState(async (argv) =>
+      argv.includes("--list")
+        ? result({ stdout: "docker-desktop\0\r\n" })
+        : result({ exitCode: 3, stderr: "no resident daemon" })
+    );
+
+    expect(state).toBeNull();
   });
 });

--- a/src/host-state.ts
+++ b/src/host-state.ts
@@ -40,6 +40,11 @@ import { existsSync, readdirSync } from "node:fs";
 import { createConnection } from "node:net";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
+import {
+  runBounded,
+  type BoundedCommandOptions,
+  type BoundedCommandResult,
+} from "./bounded-command.ts";
 
 /** The document shape this build reads. Not a floor: an exact match. */
 export const HOST_STATE_VERSION = 1;
@@ -126,6 +131,11 @@ export function parseHostState(text: string | null | undefined): HostState | nul
 
 /** Produces the host-state document as text, or null when there is none. */
 export type HostStateSource = () => Promise<string | null>;
+
+export type HostStateCommand = (
+  argv: string[],
+  options?: BoundedCommandOptions,
+) => Promise<BoundedCommandResult>;
 
 function latestResidentBundle(dir: string): string | null {
   try {
@@ -236,6 +246,64 @@ export async function readHostState(
   } finally {
     if (timer) clearTimeout(timer);
   }
+}
+
+const WSL_HOST_STATE_PROGRAM = [
+  'b=$(ls -1 "$HOME"/.red/redskilled/bundles/redskilled-*.bundle.min.mjs "$HOME"/.cache/red-skills/bundles/redskilled-*.bundle.min.mjs 2>/dev/null | sort -V | tail -1)',
+  '[ -n "$b" ] || b="$HOME/.red-skills/current/packaging/npm/bin/red-skills-redskilled.mjs"',
+  '[ -f "$b" ] || exit 3',
+  'n=$(command -v node 2>/dev/null || ls -1 /usr/local/bin/node /usr/bin/node "$HOME"/.local/share/mise/installs/node/*/bin/node "$HOME"/.volta/bin/node "$HOME"/.asdf/shims/node "$HOME"/.nodenv/shims/node "$HOME"/.nvm/versions/node/*/bin/node "$HOME"/.local/share/fnm/node-versions/*/installation/bin/node 2>/dev/null | sort -V | tail -1)',
+  '[ -n "$n" ] || exit 3',
+  'exec "$n" "$b" host-state',
+].join("; ");
+
+// wsl.exe reconstructs a command line while crossing the Windows/Linux
+// boundary. A literal shell program containing `$()` and globs can therefore
+// be expanded once too early when red-dev itself runs under WSL. Base64 keeps
+// the program inert until the shell inside the selected distro decodes it.
+const WSL_HOST_STATE_SCRIPT =
+  `printf %s ${Buffer.from(WSL_HOST_STATE_PROGRAM).toString("base64")} | base64 -d | sh`;
+
+/**
+ * Read every already-running WSL RedSkills host from native Windows.
+ *
+ * The inventory call comes first so a cosmetic refresh never knowingly
+ * starts a stopped distro. Inside each running distro the resident
+ * `redskilled host-state` client contacts the existing socket only; it has no
+ * daemon birth path. Non-RedSkills distros (Docker's internal distro is the
+ * common one) contribute nothing rather than withholding a real count from a
+ * participating Ubuntu or Debian host.
+ */
+export async function readWindowsWslHostState(
+  run: HostStateCommand = runBounded,
+): Promise<HostState | null> {
+  const wsl = Bun.which("wsl.exe");
+  if (!wsl && run === runBounded) return null;
+
+  const running = await run([wsl ?? "wsl.exe", "--list", "--running", "--quiet"], {
+    timeoutMs: 2_000,
+  });
+  if (running.timedOut || running.exitCode !== 0) return null;
+  const distros = running.stdout
+    .replace(/\0/g, "")
+    .split(/\r?\n/)
+    .map((name) => name.trim().replace(/^\*\s*/, ""))
+    .filter(Boolean);
+  if (distros.length === 0) return null;
+
+  const states = await Promise.all(
+    distros.map(async (distro): Promise<HostState | null> => {
+      const result = await run(
+        [wsl ?? "wsl.exe", "-d", distro, "--", "sh", "-lc", WSL_HOST_STATE_SCRIPT],
+        { timeoutMs: 2_000 },
+      );
+      return result.timedOut || result.exitCode !== 0 ? null : parseHostState(result.stdout);
+    }),
+  );
+  const known = states.filter((state): state is HostState => state !== null);
+  return known.length === 0
+    ? null
+    : { workers: known.reduce((total, state) => total + state.workers, 0) };
 }
 
 /**

--- a/src/redwall-render.test.ts
+++ b/src/redwall-render.test.ts
@@ -155,6 +155,24 @@ describe("the brand art underneath", () => {
     }
     expect(moved).toBe(0);
   });
+
+  test("keeps the machine state quiet and out of the way at the top right", async () => {
+    const real = await Bun.file(`${root}/assets/wallpapers/flare.png`).bytes();
+    const before = decodePng(real);
+    const box = redwallBox(before, font, redwallLines(running))!;
+
+    // Desktop icons own the left edge. The top-right keeps the state visible
+    // without competing with the taskbar and Windows activation watermark.
+    expect(box.x).toBeGreaterThan(before.width * 0.75);
+    expect(box.y).toBeGreaterThan(0);
+    expect(box.y + box.height).toBeLessThan(before.height * 0.15);
+
+    // It is a small instrument, not a second brand mark. These bounds are
+    // deliberately relative so the same apparent weight survives on 1080p
+    // and 4K sheets.
+    expect(box.width).toBeLessThan(before.width / 8);
+    expect(box.height).toBeLessThan(before.height / 14);
+  });
 });
 
 describe("what actually landed inside the region", () => {

--- a/src/redwall-render.ts
+++ b/src/redwall-render.ts
@@ -35,10 +35,10 @@
  *
  * ## Where it sits
  *
- * Bottom right. The top left is where both GNOME and Windows put desktop
- * icons, the left edge is where GNOME's dock lives, and both lock
- * screens set their clock along the top. What is left is the corner
- * nothing else claims.
+ * Top right. The left edge is where GNOME and Windows put desktop icons,
+ * while the bottom belongs to the taskbar, activation notices and transient
+ * system UI. Keeping a small instrument against the top-right edge leaves
+ * the brand mark and the working edges of the desktop alone.
  */
 
 import { brand, rgb } from "./brand.ts";
@@ -132,12 +132,12 @@ export function redwallLines(state: RedwallState): string[] {
 
 /** Text height in pixels, and the space around it, for art this tall. */
 function scaleFor(height: number): { size: number; pad: number; margin: number } {
-  // A fortieth of the height puts about forty lines of text on any
+  // A sixtieth of the height puts about sixty lines of text on any
   // screen, so a 4K sheet and a 1080p one carry the same overlay at
   // different resolutions rather than the same overlay at different
   // apparent sizes. The floor is what keeps a thumbnail legible.
-  const size = Math.max(12, Math.round(height / 40));
-  return { size, pad: Math.round(size * 0.75), margin: Math.round(size * 2) };
+  const size = Math.max(12, Math.round(height / 60));
+  return { size, pad: Math.round(size * 0.5), margin: Math.round(size * 1.25) };
 }
 
 /**
@@ -163,7 +163,7 @@ export function redwallBox(
   // the overlay is a thumbnail, and a thumbnail should show what it can.
   return {
     x: Math.max(0, art.width - margin - width),
-    y: Math.max(0, art.height - margin - height),
+    y: Math.max(0, margin),
     width,
     height,
   };

--- a/src/redwall.ts
+++ b/src/redwall.ts
@@ -61,7 +61,7 @@
  */
 
 import { existsSync, mkdirSync, readdirSync, rmSync } from "node:fs";
-import { readHostState } from "./host-state.ts";
+import { readHostState, readWindowsWslHostState } from "./host-state.ts";
 import { resolveRedwallAddress } from "./lan-address.ts";
 import type { Platform } from "./platform.ts";
 import { readPreferences, resolveRedwall } from "./preferences.ts";
@@ -133,7 +133,10 @@ export interface RedwallSeams {
  * survives.
  */
 export async function redwallState(p: Platform): Promise<RedwallState> {
-  const [host, address] = await Promise.all([readHostState(), resolveRedwallAddress(p)]);
+  const [host, address] = await Promise.all([
+    p.os === "windows" ? readWindowsWslHostState() : readHostState(),
+    resolveRedwallAddress(p),
+  ]);
   return { workers: host?.workers ?? null, address };
 }
 


### PR DESCRIPTION
## What changed

- move the Redwall state plate to the top-right and reduce its visual weight
- read Worker state from every already-running WSL RedSkills host when Redwall runs natively on Windows
- preserve the existing local socket path for Linux and WSL
- resolve Node from managed runtime locations in non-interactive WSL shells

## Why

The native Windows process has no Unix socket, so it always rendered only the LAN address even while WSL had active Workers. The previous bottom-right plate also competed with the taskbar and Windows activation notice.

## Impact

Windows and Linux now render the same live Worker count. The overlay is compact and stays away from desktop icons, taskbar UI, and the central brand mark.

## Validation

- full `bun test`
- `bun run typecheck`
- Linux and Windows production builds
- live comparison returned identical Worker state through the Linux socket and the Windows-to-WSL path
- inspected a generated 4K flare preview

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/105"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789062672&installation_model_id=20659&pr_number=105&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F105&signature=085d76378a32fa26148f9fd07fcf7004147c015ff0c8e576f7c59195babac913"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->