### PR TITLE
Fix unattended installer execution

### DIFF
--- a/src/agents.ts
+++ b/src/agents.ts
@@ -357,9 +357,10 @@ async function agentRuntimeEnvironment(
  * turns the steady state of an idempotent converge into a red line.
  */
 async function runWinget(argv: string[], label: string): Promise<void> {
-  const proc = Bun.spawn(argv, { stdout: "pipe", stderr: "pipe", stdin: "ignore" });
-  const out = (await new Response(proc.stdout).text()) + (await new Response(proc.stderr).text());
-  const code = await proc.exited;
+  const { spawnLoggedCapture } = await import("./providers.ts");
+  const result = await spawnLoggedCapture(argv);
+  const out = result.out + result.err;
+  const { code } = result;
   if (code === 0) return;
 
   if (/No available upgrade found|already installed|No newer package versions/i.test(out)) {

--- a/src/blesh.ts
+++ b/src/blesh.ts
@@ -36,8 +36,8 @@ export function isInstalled(): boolean {
 }
 
 async function run(cmd: string[]): Promise<void> {
-  const proc = Bun.spawn(cmd, { stdout: "ignore", stderr: "ignore", stdin: "ignore" });
-  if ((await proc.exited) !== 0) throw new RedError(`${cmd[0]} failed`);
+  const { spawnLogged } = await import("./providers.ts");
+  if ((await spawnLogged(cmd)) !== 0) throw new RedError(`${cmd[0]} failed`);
 }
 
 /**

--- a/src/installer-noninteractive.test.ts
+++ b/src/installer-noninteractive.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Every provisioning child is unattended, and captured installers remain
+ * observable while retaining enough output to explain a non-zero exit.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { captureTo } from "./log.ts";
+import { providerStdinMode, spawnLoggedCapture } from "./providers.ts";
+
+const providers = readFileSync(`${import.meta.dir}/providers.ts`, "utf8");
+const agents = readFileSync(`${import.meta.dir}/agents.ts`, "utf8");
+const blesh = readFileSync(`${import.meta.dir}/blesh.ts`, "utf8");
+
+describe("unattended provider commands", () => {
+  test("a real terminal never grants an installer access to the keyboard", () => {
+    expect(providerStdinMode(true)).toBe("ignore");
+    expect(providerStdinMode(false)).toBe("ignore");
+  });
+
+  test("captured stdout and stderr are both live and retained", async () => {
+    const seen: string[] = [];
+    const release = captureTo((line) => seen.push(line));
+    try {
+      const result = await spawnLoggedCapture([
+        process.execPath,
+        "-e",
+        'console.log("LIVE OUT"); console.error("LIVE ERROR"); process.exit(7)',
+      ]);
+      expect(result.code).toBe(7);
+      expect(result.out).toContain("LIVE OUT");
+      expect(result.err).toContain("LIVE ERROR");
+      expect(seen).toContain("LIVE OUT");
+      expect(seen).toContain("LIVE ERROR");
+    } finally {
+      release();
+    }
+  });
+
+  test("every winget path uses the observable capture helper", () => {
+    expect(providers).toContain("await spawnLoggedCapture(");
+    expect(agents).toContain("await spawnLoggedCapture(argv)");
+  });
+
+  test("winget upgrades explicitly disable interaction", () => {
+    const start = providers.indexOf("export async function systemUpdate");
+    const end = providers.indexOf("// -------------------------------------------------------- dispatch", start);
+    expect(providers.slice(start, end)).toContain('"--disable-interactivity"');
+  });
+
+  test("ble.sh routes command output through the shared logger", () => {
+    expect(blesh).toContain('import("./providers.ts")');
+    expect(blesh).toContain("spawnLogged(cmd)");
+    expect(blesh).not.toContain('stdout: "ignore", stderr: "ignore"');
+  });
+});

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -17,15 +17,16 @@ import type { Platform } from "./platform.ts";
 import { missingRights } from "./rights.ts";
 
 /**
- * Inheriting stdin is only safe when there is a real terminal behind it.
- * Under CI, a pipe, or a background job, apt and dpkg can stop at a
- * prompt that nothing will ever answer — the process then sits at full
- * CPU forever rather than failing. Observed exactly once, for eight
- * minutes, which is how this guard came to exist. Detaching stdin turns
- * that deadlock into a normal non-zero exit.
+ * Provisioning never delegates a question to a child process.
+ *
+ * The public command may itself be interactive, but once the user has chosen
+ * what to install every provider is unattended. A child that unexpectedly
+ * prompts must receive EOF and fail instead of stealing keys from the TUI or
+ * waiting forever in CI, over SSH, or at an ordinary terminal.
  */
-const stdinMode = (): "inherit" | "ignore" =>
-  process.stdin.isTTY === true ? "inherit" : "ignore";
+export const providerStdinMode = (
+  _stdinIsTTY: boolean | undefined = process.stdin.isTTY,
+): "ignore" => "ignore";
 
 /**
  * Forward a child's stream into the log, one line at a time.
@@ -34,21 +35,47 @@ const stdinMode = (): "inherit" | "ignore" =>
  * line that rewrites itself becomes the last thing it said, rather than
  * every state it passed through concatenated into one unreadable row.
  */
-async function pumpToLog(stream: ReadableStream<Uint8Array> | null): Promise<void> {
-  if (!stream) return;
+async function pumpToLog(stream: ReadableStream<Uint8Array> | null): Promise<string> {
+  if (!stream) return "";
   const decoder = new TextDecoder();
+  let raw = "";
   let rest = "";
   const say = (raw: string): void => {
     const line = (raw.includes("\r") ? raw.slice(raw.lastIndexOf("\r") + 1) : raw).trimEnd();
     if (line) log.plain(line);
   };
   for await (const chunk of stream) {
-    rest += decoder.decode(chunk as Uint8Array, { stream: true });
+    const text = decoder.decode(chunk as Uint8Array, { stream: true });
+    raw += text;
+    rest += text;
     const parts = rest.split("\n");
     rest = parts.pop() ?? "";
     for (const part of parts) say(part);
   }
+  const final = decoder.decode();
+  raw += final;
+  rest += final;
   say(rest);
+  return raw;
+}
+
+/** Stream both child outputs through the logger and retain them for classification. */
+export async function spawnLoggedCapture(
+  cmd: string[],
+  extra: { env?: Record<string, string | undefined>; cwd?: string } = {},
+): Promise<{ code: number; out: string; err: string }> {
+  const proc = Bun.spawn(cmd, {
+    stdout: "pipe",
+    stderr: "pipe",
+    stdin: providerStdinMode(),
+    ...extra,
+  });
+  const [out, err, code] = await Promise.all([
+    pumpToLog(proc.stdout),
+    pumpToLog(proc.stderr),
+    proc.exited,
+  ]);
+  return { code, out, err };
 }
 
 /**
@@ -61,10 +88,9 @@ async function pumpToLog(stream: ReadableStream<Uint8Array> | null): Promise<voi
  * of installer output ended up painted through the middle of the
  * right-hand column on a 96-column window.
  *
- * stdin goes with it. A child inheriting stdin while the interface is
- * reading keys steals them, so captured means detached — which turns a
- * prompt nobody could have answered into a non-zero exit, exactly as
- * the apt guard above already does.
+ * stdin is always detached, independently of output routing. The caller has
+ * already made every product choice; a provider opening its own prompt is a
+ * failure, not a second interactive interface hidden inside the first.
  */
 export async function spawnLogged(
   cmd: string[],
@@ -74,20 +100,13 @@ export async function spawnLogged(
     const proc = Bun.spawn(cmd, {
       stdout: "inherit",
       stderr: "inherit",
-      stdin: stdinMode(),
+      stdin: providerStdinMode(),
       ...extra,
     });
     return await proc.exited;
   }
 
-  const proc = Bun.spawn(cmd, {
-    stdout: "pipe",
-    stderr: "pipe",
-    stdin: "ignore",
-    ...extra,
-  });
-  await Promise.all([pumpToLog(proc.stdout), pumpToLog(proc.stderr)]);
-  return await proc.exited;
+  return (await spawnLoggedCapture(cmd, extra)).code;
 }
 
 /** Keep Git's POSIX utilities visible when a caller supplies Windows PATH. */
@@ -228,7 +247,7 @@ export async function wingetInstall(id: string): Promise<void> {
   // treating every non-zero as a warning turns the steady state of an
   // idempotent converge into something that reads like a problem —
   // right underneath winget's own line saying it is fine.
-  const proc = Bun.spawn(
+  const result = await spawnLoggedCapture(
     wingetArgv([
       "install",
       "--id",
@@ -249,10 +268,9 @@ export async function wingetInstall(id: string): Promise<void> {
       // lines, which the pipe does capture.
       "--disable-interactivity",
     ]),
-    { stdout: "pipe", stderr: "pipe" },
   );
-  const out = await new Response(proc.stdout).text();
-  const code = await proc.exited;
+  const out = result.out + result.err;
+  const { code } = result;
 
   if (code === 0) return;
 
@@ -950,6 +968,7 @@ export async function systemUpdate(p: Platform): Promise<void> {
         "--silent",
         "--accept-package-agreements",
         "--accept-source-agreements",
+        "--disable-interactivity",
       ]),
       { allowFailure: true },
     );

--- a/src/runtime-install.test.ts
+++ b/src/runtime-install.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Runtime installs must report both child streams.
+ *
+ * Real installers commonly put progress and failures on stderr. If that stream
+ * is hidden, the terminal stays on the `:: mise: ...` line throughout the
+ * download and the useful error is absent when the child finally exits.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runBounded } from "./bounded-command.ts";
+
+const created: string[] = [];
+
+afterEach(() => {
+  for (const dir of created.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe("mise runtime install output", () => {
+  test("a stderr-heavy failure terminates and exposes the actual error", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "red-dev-runtime-"));
+    created.push(dir);
+    const fakeMise = join(dir, "mise");
+    writeFileSync(
+      fakeMise,
+      `#!/usr/bin/env bun
+if (Bun.argv[2] === "use") {
+  console.log("ARGS: " + Bun.argv.slice(2).join(" "));
+  console.log("resolving bun");
+  for (let i = 0; i < 8_000; i++) console.error("download diagnostic " + i);
+  console.error("REAL INSTALL ERROR: artifact unavailable");
+  process.exit(19);
+}
+process.exit(0);
+`,
+    );
+    chmodSync(fakeMise, 0o755);
+
+    const harness = join(dir, "harness.ts");
+    const runtimes = join(import.meta.dir, "runtimes.ts");
+    writeFileSync(
+      harness,
+      `import { useRuntimes } from ${JSON.stringify(runtimes)};
+let detail = "";
+await useRuntimes(["bun@latest"], {
+  stepEnd: (_id, error) => { detail = error ?? ""; },
+});
+console.log("OBSERVED: " + detail);
+`,
+    );
+
+    const result = await runBounded([process.execPath, harness], {
+      timeoutMs: 2_000,
+      env: { ...process.env, PATH: `${dir}:${process.env.PATH ?? ""}` },
+    });
+
+    expect(result.timedOut).toBe(false);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("--yes");
+    expect(result.stdout).toContain("--verbose");
+    expect(result.stdout + result.stderr).toContain(
+      "REAL INSTALL ERROR: artifact unavailable",
+    );
+    expect(result.stdout).toContain("OBSERVED: REAL INSTALL ERROR: artifact unavailable");
+  });
+
+  test("one runtime failure does not prevent the next selection from running", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "red-dev-runtime-"));
+    created.push(dir);
+    const fakeMise = join(dir, "mise");
+    writeFileSync(
+      fakeMise,
+      `#!/usr/bin/env bun
+const request = Bun.argv.at(-1) ?? "";
+if (request === "node@lts") {
+  console.log("NODE INSTALL COMPLETED");
+  process.exit(0);
+}
+if (request.startsWith("python@")) {
+  console.error("PYTHON INSTALL FAILED");
+  process.exit(12);
+}
+if (request === "bun@latest") {
+  console.log("BUN INSTALL COMPLETED");
+  process.exit(0);
+}
+process.exit(2);
+`,
+    );
+    chmodSync(fakeMise, 0o755);
+
+    const harness = join(dir, "harness.ts");
+    const runtimes = join(import.meta.dir, "runtimes.ts");
+    writeFileSync(
+      harness,
+      `import { useRuntimes } from ${JSON.stringify(runtimes)};
+const outcomes: Array<[string, string | null]> = [];
+await useRuntimes(["node@lts", "python@3.13", "bun@latest"], {
+  stepEnd: (id, error) => outcomes.push([id, error]),
+});
+console.log("OUTCOMES: " + JSON.stringify(outcomes));
+`,
+    );
+
+    const result = await runBounded([process.execPath, harness], {
+      timeoutMs: 2_000,
+      env: { ...process.env, PATH: `${dir}:${process.env.PATH ?? ""}` },
+    });
+
+    expect(result.timedOut).toBe(false);
+    expect(result.stdout).toContain("NODE INSTALL COMPLETED");
+    expect(result.stdout).toContain("PYTHON INSTALL FAILED");
+    expect(result.stdout).toContain("BUN INSTALL COMPLETED");
+    expect(result.stdout).toContain(
+      'OUTCOMES: [["node@lts",null],["python@3.13","PYTHON INSTALL FAILED"],["bun@latest",null]]',
+    );
+  });
+});

--- a/src/runtimes.ts
+++ b/src/runtimes.ts
@@ -87,11 +87,16 @@ export async function useRuntimes(ids: string[], observer: RuntimeObserver = {})
     observer.stepStart?.(id);
     log.step(`mise: ${id}`);
     const request = runtimeInstallRequest(id);
-    const { code, out } = await run([mise, "use", "-g", request.id], request.env);
+    const result = await run(
+      [mise, "use", "-g", "--yes", "--verbose", request.id],
+      request.env,
+      true,
+    );
+    const { code } = result;
     if (code !== 0) {
-      const detail = out.trim().split("\n").slice(-2).join(" ");
+      const detail = failureDetail(result, code);
       log.err(`${id}: ${detail}`);
-      observer.stepEnd?.(id, detail || `mise exited ${code}`);
+      observer.stepEnd?.(id, detail);
       continue;
     }
 
@@ -131,15 +136,58 @@ async function miseBin(): Promise<string | null> {
 async function run(
   cmd: string[],
   extraEnv: Record<string, string> = {},
-): Promise<{ code: number; out: string }> {
+  live = false,
+): Promise<{ code: number; out: string; err: string }> {
   const proc = Bun.spawn(cmd, {
     stdout: "pipe",
     stderr: "pipe",
+    stdin: "ignore",
     env: { ...process.env, ...extraEnv },
   });
-  const out = await new Response(proc.stdout).text();
-  const code = await proc.exited;
-  return { code, out };
+  const [out, err, code] = await Promise.all([
+    readRuntimeOutput(proc.stdout, live),
+    readRuntimeOutput(proc.stderr, live),
+    proc.exited,
+  ]);
+  return { code, out, err };
+}
+
+/** Forward mise progress without surrendering the error text needed by callers. */
+async function readRuntimeOutput(
+  stream: ReadableStream<Uint8Array>,
+  live: boolean,
+): Promise<string> {
+  const decoder = new TextDecoder();
+  let raw = "";
+  let rest = "";
+  const emit = (line: string): void => {
+    if (!live) return;
+    const current = line.includes("\r") ? line.slice(line.lastIndexOf("\r") + 1) : line;
+    if (current.trim()) log.plain(current.trimEnd());
+  };
+
+  for await (const chunk of stream) {
+    const text = decoder.decode(chunk as Uint8Array, { stream: true });
+    raw += text;
+    rest += text;
+    const lines = rest.split("\n");
+    rest = lines.pop() ?? "";
+    for (const line of lines) emit(line);
+  }
+  const final = decoder.decode();
+  raw += final;
+  rest += final;
+  emit(rest);
+  return raw;
+}
+
+function failureDetail(
+  result: { out: string; err: string },
+  code: number,
+): string {
+  const output = result.err.trim() || result.out.trim();
+  const last = output.split(/\r?\n/).map((line) => line.trim()).filter(Boolean).at(-1);
+  return last || `mise exited ${code}`;
 }
 
 export async function installRuntimes(p: Platform): Promise<void> {
@@ -160,9 +208,14 @@ export async function installRuntimes(p: Platform): Promise<void> {
       continue;
     }
     log.step(`mise: ${runtime}`);
-    const { code, out } = await run([mise, "use", "-g", runtime]);
+    const result = await run(
+      [mise, "use", "-g", "--yes", "--verbose", runtime],
+      {},
+      true,
+    );
+    const { code } = result;
     if (code !== 0) {
-      throw new RedError(`mise use -g ${runtime} failed:\n${out.trim()}`);
+      throw new RedError(`mise use -g ${runtime} failed: ${failureDetail(result, code)}`);
     }
   }
 


### PR DESCRIPTION
## What changed

- run mise runtime installs with `--yes --verbose` and detached stdin
- stream and retain stdout and stderr so long installs remain observable and failures keep their real error
- enforce detached stdin across shared provisioning commands
- make winget install/update paths non-interactive and observable
- route ble.sh command output through the shared logger
- add regressions for stderr-heavy failures and the Node → Python failure → Bun continuation path

## Why

Runtime installers wrote progress and failures to stderr while red-dev only consumed stdout. The UI therefore appeared frozen at the current mise item, and the actual Python error disappeared. Other provider paths had the same observability gap or could still inherit a terminal and wait on a nested prompt.

## Impact

Provisioning commands now fail instead of waiting for hidden input, show install progress as it happens, preserve useful error details, and continue to later runtime selections after an isolated failure.

## Validation

- `bun run typecheck`
- `bun test`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/109"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789157318&installation_model_id=20659&pr_number=109&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F109&signature=47c3f20b04ce2295918cbf61a3091f4eaa7c6e38ac10d195a281e8cd2383bece"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->