### PR TITLE
Quiet mise output and restore install-log scrolling

### DIFF
--- a/src/runtime-install.test.ts
+++ b/src/runtime-install.test.ts
@@ -59,7 +59,7 @@ console.log("OBSERVED: " + detail);
     expect(result.timedOut).toBe(false);
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toContain("--yes");
-    expect(result.stdout).toContain("--verbose");
+    expect(result.stdout).not.toContain("--verbose");
     expect(result.stdout + result.stderr).toContain(
       "REAL INSTALL ERROR: artifact unavailable",
     );

--- a/src/runtimes.ts
+++ b/src/runtimes.ts
@@ -88,7 +88,7 @@ export async function useRuntimes(ids: string[], observer: RuntimeObserver = {})
     log.step(`mise: ${id}`);
     const request = runtimeInstallRequest(id);
     const result = await run(
-      [mise, "use", "-g", "--yes", "--verbose", request.id],
+      [mise, "use", "-g", "--yes", request.id],
       request.env,
       true,
     );
@@ -209,7 +209,7 @@ export async function installRuntimes(p: Platform): Promise<void> {
     }
     log.step(`mise: ${runtime}`);
     const result = await run(
-      [mise, "use", "-g", "--yes", "--verbose", runtime],
+      [mise, "use", "-g", "--yes", runtime],
       {},
       true,
     );

--- a/src/setup-progress.test.ts
+++ b/src/setup-progress.test.ts
@@ -116,6 +116,7 @@ describe("the install progress panel", () => {
       scope: () => "setup",
       finished: () => false,
       following: () => true,
+      followScroll: () => {},
       elapsedMs: () => 18_000,
       total: 46,
       logScroll: createScrollArea({ height: 10, content: [], autoScroll: true }),
@@ -125,7 +126,6 @@ describe("the install progress panel", () => {
       setupStepEnd: () => {},
       begin: () => {},
       note: () => {},
-      handleKey: () => false,
     } as unknown as InstallModel;
 
     const frame = strip(renderToString(InstallLayout(model, 96, 30), 96, 30));

--- a/src/tui-install.ts
+++ b/src/tui-install.ts
@@ -16,9 +16,9 @@
 import {
   Box,
   ListItem,
-  LogViewer,
   MultiProgressBar,
   ProgressBar,
+  ScrollArea,
   Text,
   render,
   useApp,
@@ -120,6 +120,8 @@ export interface InstallModel {
   scope: () => string;
   finished: () => boolean;
   following: () => boolean;
+  /** Pause tail-following when the reader moves away; resume at the end. */
+  followScroll: (position: number) => void;
   elapsedMs: () => number;
   total: number;
   logScroll: ScrollAreaState;
@@ -139,55 +141,6 @@ export interface InstallModel {
    * renderer owns.
    */
   note: (line: string) => void;
-  /** True when the key was a scroll key and the caller should stop. */
-  handleKey: (input: string, key: KeyPress) => boolean;
-}
-
-export interface KeyPress {
-  upArrow?: boolean;
-  downArrow?: boolean;
-  pageUp?: boolean;
-  pageDown?: boolean;
-}
-
-/** Apply one install-log navigation key to the real scroll state. */
-export function handleInstallScroll(
-  logScroll: ScrollAreaState,
-  setFollowing: (following: boolean) => void,
-  input: string,
-  key: KeyPress,
-): boolean {
-  if (key.upArrow || input === "k") {
-    logScroll.scrollBy(-1);
-    setFollowing(false);
-    return true;
-  }
-  if (key.downArrow || input === "j") {
-    logScroll.scrollBy(1);
-    setFollowing(logScroll.scrollTop() >= logScroll.maxScroll());
-    return true;
-  }
-  if (key.pageUp) {
-    logScroll.pageUp();
-    setFollowing(false);
-    return true;
-  }
-  if (key.pageDown) {
-    logScroll.pageDown();
-    setFollowing(logScroll.scrollTop() >= logScroll.maxScroll());
-    return true;
-  }
-  if (input === "g") {
-    logScroll.scrollToTop();
-    setFollowing(false);
-    return true;
-  }
-  if (input === "G") {
-    logScroll.scrollToBottom();
-    setFollowing(true);
-    return true;
-  }
-  return false;
 }
 
 /**
@@ -368,6 +321,7 @@ export function useInstallModel(
     scope,
     finished,
     following,
+    followScroll: (position) => setFollowing(position >= logScroll.maxScroll()),
     // Frozen once the run ends.
     //
     // This read Date.now() on every render, and clearInterval only stops
@@ -399,24 +353,22 @@ export function useInstallModel(
       setStarted(true);
     },
     note: (line) => push(line.replace(/\x1b\[[0-9;]*m/g, "").trimEnd()),
-    handleKey: (input, key) => {
-      // Following the tail is right while a converge runs, but it makes
-      // the one thing you would want to do — read the error that
-      // scrolled past — impossible. Moving up stops the follow; reaching
-      // the bottom resumes it, so there is no mode to remember.
-      return handleInstallScroll(logScroll, setFollowing, input, key);
-    },
   };
 }
 
 /**
  * The converge view, as a function of the model and nothing else.
  *
- * No hooks in here on purpose: whoever owns the state decides when to
- * draw this, and a conditional hook call would shift the hook order
- * between frames.
+ * ScrollArea owns the input lifecycle for the viewport it draws. Callers
+ * build this layout on every frame and switch `isActive`; keeping the hook
+ * slot stable matters when the menu swaps between sections and the log.
  */
-export function InstallLayout(m: InstallModel, width: number, height: number) {
+export function InstallLayout(
+  m: InstallModel,
+  width: number,
+  height: number,
+  isActive: boolean = true,
+) {
   const results = [...m.setupResults(), ...m.results()];
   const total = m.total + m.setupTotal();
   const finished = m.finished();
@@ -437,7 +389,7 @@ export function InstallLayout(m: InstallModel, width: number, height: number) {
 
   // What a log line actually gets: Accented spends one column on its
   // bar and one on the margin. Once there is anything to scroll,
-  // LogViewer spends two more: its scrollbar glyph and its left margin.
+  // ScrollArea spends two more: its scrollbar glyph and its left margin.
   // Reserve all four up front so the scrollbar appearing cannot make
   // already-visible lines wrap and change the viewport height.
   const logTextWidth = Math.max(8, leftWidth - 4);
@@ -448,6 +400,31 @@ export function InstallLayout(m: InstallModel, width: number, height: number) {
   const elapsedMs = m.elapsedMs();
   const rightRows =
     14 + Math.min(failures.length, 6) + Math.min(deferrals.length, 6) + (finished ? 4 : 0);
+
+  const logContent = m.lines().map((line) => {
+    const fitted = fitToWidth(line, logTextWidth);
+    return Text(
+      { color: /(✗|failed)/.test(fitted) ? ui.danger : text },
+      fitted,
+    );
+  });
+  // Give the state the new bounds before deciding where "bottom" is.
+  // Waiting for ScrollArea.updateOptions would render one stale frame at
+  // the old offset, which is visible when the scrollbar first appears.
+  m.logScroll.setContent(logContent);
+  m.logScroll.setHeight(logRows);
+  if (m.following()) m.logScroll.scrollToBottom();
+
+  const logViewport = ScrollArea({
+    content: logContent,
+    height: logRows,
+    width: leftWidth - 2,
+    state: m.logScroll,
+    onScroll: m.followScroll,
+    isActive,
+  });
+  // ScrollArea intentionally has no auto-follow policy: it owns input,
+  // while the log decides whether new output should keep it at the tail.
 
   return Screen(
     width,
@@ -468,24 +445,7 @@ export function InstallLayout(m: InstallModel, width: number, height: number) {
           failures.length > 0 ? ui.warn : ui.accent,
           logRows,
           leftWidth,
-          LogViewer({
-            // Cut here rather than where the lines are made: this is
-            // where the width is known, and it is the width now rather
-            // than whatever it was when the line arrived. A fresh array
-            // each frame is safe — the scroll area keys off content
-            // length, which this does not change.
-            lines: m.lines().map((l) => fitToWidth(l, logTextWidth)),
-            height: logRows,
-            // Follow the tail only while nobody has scrolled away from
-            // it. Passing `true` unconditionally is what made the scroll
-            // position unreachable: LogViewer calls scrollToBottom() on
-            // every render when autoScroll is set, so a keypress moved
-            // the view and the next frame put it straight back.
-            autoScroll: m.following(),
-            state: m.logScroll,
-            highlightPattern: /(✗|failed)/,
-            highlightColor: ui.danger,
-          }),
+          logViewport,
         ),
       ),
 
@@ -705,7 +665,6 @@ export async function runInstallTui(opts: InstallTuiOptions): Promise<InstallOut
         else if (key.return || input === "q" || key.escape) exit();
         return;
       }
-      if (model.handleKey(input, key)) return;
       // Refused until it finishes: leaving halfway abandons the machine
       // mid-converge with no report of where it stopped. Once it has,
       // the same key goes back to the verdict rather than out — the
@@ -716,8 +675,12 @@ export async function runInstallTui(opts: InstallTuiOptions): Promise<InstallOut
     const width = size.columns ?? 100;
     const height = Math.max(size.rows ?? 24, 16);
     const finished = done();
+    // Built even while the completion screen is showing so ScrollArea's
+    // hook keeps the same slot; isActive prevents a hidden log from
+    // consuming navigation keys.
+    const installView = InstallLayout(model, width, height, !finished || reviewing());
     if (finished && !reviewing()) return CompletionLayout(finished, width, height, transcriptPath());
-    return InstallLayout(model, width, height);
+    return installView;
   }
 
   // fullHeight: the panels are drawn to the terminal's height rather

--- a/src/tui-overflow.test.ts
+++ b/src/tui-overflow.test.ts
@@ -41,6 +41,7 @@ function frame(lines: string[]): string[] {
     scope: () => "core",
     finished: () => false,
     following: () => true,
+    followScroll: () => {},
     elapsedMs: () => 8000,
     total: 39,
     logScroll: createScrollArea({
@@ -51,7 +52,6 @@ function frame(lines: string[]): string[] {
     }),
     begin: () => {},
     note: () => {},
-    handleKey: () => false,
   } as unknown as InstallModel;
 
   return strip(renderToString(InstallLayout(model, WIDTH, HEIGHT), WIDTH, HEIGHT)).split("\n");

--- a/src/tui-scroll.test.ts
+++ b/src/tui-scroll.test.ts
@@ -1,47 +1,63 @@
 /**
  * The log has to be readable while it is being written to.
  *
- * There was never a scroll bug to fix: LogViewer registers no key
- * handling of its own — ScrollArea does, LogViewer does not — so nothing
- * could move the view, and autoScroll pinned it to the tail on every one
- * of thirty frames a second regardless. These check the two halves that
- * make it work: that an external state can hold a position, and that
- * autoScroll is what overrides it.
+ * LogViewer can display an externally moved position, but it registers
+ * neither keyboard nor wheel handling. The live pane uses ScrollArea so
+ * the component that draws the viewport also owns its input. These tests
+ * cross the real renderer boundary: raw terminal sequences must move the
+ * same external state the frame reads.
  */
 
 import { describe, expect, test } from "bun:test";
-import { LogViewer, createScrollArea, renderToString } from "tuiuiu.js";
-import { handleInstallScroll } from "./tui-install.ts";
+import { PassThrough } from "node:stream";
+import { LogViewer, createScrollArea, render, renderToString } from "tuiuiu.js";
+import { InstallLayout, type InstallModel } from "./tui-install.ts";
 
 const LINES = Array.from({ length: 40 }, (_, i) => `linha ${i}`);
 const strip = (s: string): string => s.replace(/\x1b\[[0-9;]*m/g, "");
 
+function interactiveLog() {
+  const stdin = new PassThrough() as PassThrough & NodeJS.ReadStream;
+  const stdout = new PassThrough() as PassThrough & NodeJS.WriteStream;
+  Object.assign(stdin, {
+    isTTY: true,
+    isRaw: false,
+    setRawMode: () => stdin,
+  });
+  Object.assign(stdout, { isTTY: true, columns: 96, rows: 30 });
+
+  const state = createScrollArea({ height: 5, content: LINES, autoScroll: true });
+  state.scrollToBottom();
+  const model = {
+    lines: () => LINES,
+    results: () => [],
+    setupResults: () => [],
+    setupTotal: () => 0,
+    current: () => "git",
+    scope: () => "desktop",
+    finished: () => false,
+    following: () => false,
+    followScroll: () => {},
+    elapsedMs: () => 1000,
+    total: 40,
+    logScroll: state,
+    prelude: () => {},
+    setupBegin: () => {},
+    setupStepStart: () => {},
+    setupStepEnd: () => {},
+    begin: () => {},
+    note: () => {},
+  } as unknown as InstallModel;
+
+  const app = render(() => InstallLayout(model, 96, 30), {
+    stdin,
+    stdout,
+    fullHeight: true,
+  });
+  return { app, stdin, state };
+}
+
 describe("the converge log", () => {
-  test("the install key handler moves up and pauses tail-following", () => {
-    const state = createScrollArea({ height: 5, content: LINES, autoScroll: false });
-    state.scrollToBottom();
-    const before = state.scrollTop();
-    let following = true;
-
-    const handled = handleInstallScroll(state, (value) => (following = value), "", {
-      upArrow: true,
-    });
-
-    expect(handled).toBe(true);
-    expect(state.scrollTop()).toBeLessThan(before);
-    expect(following).toBe(false);
-  });
-
-  test("G returns to the tail and resumes following", () => {
-    const state = createScrollArea({ height: 5, content: LINES, autoScroll: false });
-    state.scrollToTop();
-    let following = false;
-
-    expect(handleInstallScroll(state, (value) => (following = value), "G", {})).toBe(true);
-    expect(state.scrollTop()).toBe(state.maxScroll());
-    expect(following).toBe(true);
-  });
-
   test("an external scroll state decides what is shown", () => {
     const state = createScrollArea({ height: 5, content: LINES, autoScroll: false });
     state.scrollToTop();
@@ -78,5 +94,35 @@ describe("the converge log", () => {
     state.pageDown();
     // Back at the bottom is what re-arms following in tui-install.
     expect(state.scrollTop()).toBe(state.maxScroll());
+  });
+
+  test("the rendered log receives arrow and page keys", async () => {
+    const { app, stdin, state } = interactiveLog();
+    try {
+      const bottom = state.scrollTop();
+      stdin.write("\x1b[A");
+      await Bun.sleep(40);
+      expect(state.scrollTop()).toBeLessThan(bottom);
+
+      const afterArrow = state.scrollTop();
+      stdin.write("\x1b[5~");
+      await Bun.sleep(40);
+      expect(state.scrollTop()).toBeLessThan(afterArrow);
+    } finally {
+      app.unmount();
+    }
+  });
+
+  test("the rendered log receives the mouse wheel inside its bounds", async () => {
+    const { app, stdin, state } = interactiveLog();
+    try {
+      const bottom = state.scrollTop();
+      // SGR mouse: wheel-up at column 5, row 6 (one-based).
+      stdin.write("\x1b[<64;5;6M");
+      await Bun.sleep(40);
+      expect(state.scrollTop()).toBeLessThan(bottom);
+    } finally {
+      app.unmount();
+    }
   });
 });

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -349,7 +349,6 @@ export async function runTui(
           else if (input === "q" || key.escape) exit();
           return;
         }
-        if (model.handleKey(input, key)) return;
         // Refused until it finishes: leaving halfway abandons the machine
         // mid-converge with no report of where it stopped. Afterwards the
         // same key goes back to the verdict, never straight out.
@@ -411,6 +410,11 @@ export async function runTui(
 
     const width = Math.max(size.columns ?? 80, 60);
     const height = Math.max(size.rows ?? 24, 16);
+    // Built on every frame so ScrollArea's input hook never changes
+    // position as the menu swaps views. A hidden viewport is inactive.
+    const installView = model
+      ? InstallLayout(model, width, height, mode() === "install" && (!done() || reviewing()))
+      : null;
 
     if (mode() === "setup" && setup) return SetupLayout(setup, p, width, height);
 
@@ -421,7 +425,7 @@ export async function runTui(
       if (finished && !reviewing()) {
         return CompletionLayout(finished, width, height, transcriptPath());
       }
-      return InstallLayout(model, width, height);
+      return installView!;
     }
 
     if (mode() === "task") {


### PR DESCRIPTION
## What changed

- stop passing --verbose to normal mise use calls while retaining unattended execution and live errors
- replace the display-only LogViewer with tuiuiu ScrollArea for the install log
- keep the viewport pinned only until the reader scrolls away, then resume following at the bottom
- cover arrow keys, Page Up, and the mouse wheel through the real renderer input stream

## Why

Normal installs mixed red-dev narration with mise DEBUG internals. Separately, the install log drew a scrollbar but its component owned neither keyboard nor wheel input; keyboard handling was split into an outer app handler and mouse handling did not exist.

## Impact

Runtime installs remain observable without debug noise. During a long install, the log now scrolls with Up/Down, Page Up/Page Down, g/G, and the mouse wheel; moving away pauses tail-following.

## Validation

- bun run typecheck
- bun test: 1128 pass, 0 fail
- Linux and Windows standalone builds
- git diff --check