### PR TITLE
Draw year progress on Redwall

### DIFF
--- a/.red/contexts/visual/CONTEXT.md
+++ b/.red/contexts/visual/CONTEXT.md
@@ -4,7 +4,7 @@ Visual system — themes, fonts, wallpapers, and the ownership of the configs th
 
 ## Redwall
 
-The theme's wallpaper with live machine state drawn over it. The brand art underneath is unchanged — Redwall composes on top of it, never in place of it, which is what keeps it compatible with the decision that the desktop carries the mark. It reaches two surfaces from one image: the desktop background and the lock screen. What it carries is state a person reads at a glance without unlocking — the count of active Workers, and the address this machine answers on.
+The theme's wallpaper with live machine state drawn over it. The brand art underneath is unchanged — Redwall composes on top of it, never in place of it, which is what keeps it compatible with the decision that the desktop carries the mark. It reaches two surfaces from one image: the desktop background and the lock screen. What it carries is state a person reads at a glance without unlocking — active Workers, queue and capacity, GitHub budget, the address this machine answers on, and the current year's progress. Year progress is a week-column grid of day squares plus a continuous bar; elapsed days use the theme signal, today uses strong ink, and future days stay muted.
 
 A Redwall is derived, never authored: the wallpaper is the source and the Redwall is regenerated whenever the state it displays changes. It therefore lives apart from the wallpapers, which are immutable per theme and content-addressed; a Redwall that shared that directory would make "retired" and "chosen by hand" indistinguishable to the sweep.
 

--- a/src/redwall-generate.test.ts
+++ b/src/redwall-generate.test.ts
@@ -46,6 +46,7 @@ const desktop: Platform = {
 const server: Platform = { ...desktop, env: "server", caps: { ...desktop.caps, gui: false } };
 
 const running: RedwallState = { workers: 3, address: "192.168.1.42" };
+const today = (): Date => new Date(2026, 7, 12, 12);
 
 /** A machine with nothing on it, torn down with the process. */
 async function onFreshMachine<T>(run: (home: string) => Promise<T>): Promise<T> {
@@ -66,7 +67,7 @@ async function onFreshMachine<T>(run: (home: string) => Promise<T>): Promise<T> 
  * keeps `gsettings` out of the run.
  */
 function generate(p: Platform, state: RedwallState = running) {
-  return generateRedwall(p, { state: async () => state, inUse: async () => null });
+  return generateRedwall(p, { state: async () => state, inUse: async () => null, now: today });
 }
 
 const listing = (dir: string): string[] => (existsSync(dir) ? readdirSync(dir).sort() : []);
@@ -228,6 +229,27 @@ describe("running it again", () => {
     });
   });
 
+  test("a new civil day advances the year and replaces yesterday's image", async () => {
+    await onFreshMachine(async () => {
+      await writePreferences(desktop, { redwall: true, theme: "dark" });
+
+      const first = await generateRedwall(desktop, {
+        state: async () => running,
+        inUse: async () => null,
+        now: today,
+      });
+      const second = await generateRedwall(desktop, {
+        state: async () => running,
+        inUse: async () => null,
+        now: () => new Date(2026, 7, 13, 12),
+      });
+
+      expect(second.path).not.toBe(first.path);
+      expect(second.written).toBe(true);
+      expect(second.removed).toEqual([first.path!.split("/").pop()!]);
+    });
+  });
+
   test("but never removes the image the desktop is currently showing", async () => {
     await onFreshMachine(async () => {
       await writePreferences(desktop, { redwall: true, theme: "dark" });
@@ -236,6 +258,7 @@ describe("running it again", () => {
       const first = await generateRedwall(desktop, {
         state: async () => running,
         inUse: async () => null,
+        now: today,
       });
       const second = await generateRedwall(desktop, {
         state: async () => ({ ...running, workers: 4 }),
@@ -243,6 +266,7 @@ describe("running it again", () => {
         // is how the background goes black in the gap before something
         // repoints it.
         inUse: async () => first.path,
+        now: today,
       });
 
       expect(second.removed).toEqual([]);

--- a/src/redwall-render.test.ts
+++ b/src/redwall-render.test.ts
@@ -26,7 +26,11 @@ import {
   redwallInk,
   redwallLines,
   renderRedwall,
+  yearCells,
+  yearProgress,
+  yearProgressLabel,
   type RedwallState,
+  type RedwallYear,
 } from "./redwall-render.ts";
 import { THEMES, THEME_SLUGS, type ThemeSlug } from "./themes.ts";
 import { readFont } from "./ttf.ts";
@@ -55,10 +59,49 @@ function sheet(width = 1280, height = 720): Raster {
 
 const art = encodePng(sheet());
 const running: RedwallState = { workers: 3, address: "192.168.1.42" };
+const YEAR = yearProgress(new Date(2026, 7, 12, 12));
 
-function render(state: RedwallState, slug: ThemeSlug = "dark"): Uint8Array {
-  return renderRedwall({ art, font: fontBytes, theme: THEMES[slug], state });
+function render(
+  state: RedwallState,
+  slug: ThemeSlug = "dark",
+  year: RedwallYear = YEAR,
+): Uint8Array {
+  return renderRedwall({ art, font: fontBytes, theme: THEMES[slug], state, year });
 }
+
+describe("the current year", () => {
+  test("becomes stable civil-calendar progress", () => {
+    expect(YEAR).toEqual({ year: 2026, elapsed: 224, days: 365, firstWeekday: 4 });
+    expect(yearProgressLabel(YEAR)).toBe("2026 · 61%");
+    expect(yearProgress(new Date(2024, 11, 31, 23))).toEqual({
+      year: 2024,
+      elapsed: 366,
+      days: 366,
+      firstWeekday: 1,
+    });
+  });
+
+  test("maps every day to weekday rows and week columns", () => {
+    const cells = yearCells(YEAR);
+    expect(cells).toHaveLength(365);
+    expect(cells[0]).toEqual({ day: 1, column: 0, row: 4, state: "past" });
+    expect(cells[222]?.state).toBe("past");
+    expect(cells[223]?.state).toBe("today");
+    expect(cells[224]?.state).toBe("future");
+    expect(Math.max(...cells.map((cell) => cell.column))).toBe(52);
+    expect(new Set(cells.map((cell) => `${cell.column}:${cell.row}`)).size).toBe(365);
+  });
+
+  test("changes the image on the next day, not later on the same day", () => {
+    const morning = yearProgress(new Date(2026, 7, 12, 8));
+    const evening = yearProgress(new Date(2026, 7, 12, 22));
+    const tomorrow = yearProgress(new Date(2026, 7, 13, 8));
+    expect([...render(running, "dark", morning)]).toEqual([...render(running, "dark", evening)]);
+    expect([...render(running, "dark", morning)]).not.toEqual([
+      ...render(running, "dark", tomorrow),
+    ]);
+  });
+});
 
 describe("the same inputs", () => {
   test("produce byte-identical output", () => {
@@ -102,7 +145,7 @@ describe("the brand art underneath", () => {
   test("is present unmodified outside the region the overlay occupies", () => {
     const before = sheet();
     const after = decodePng(render(running));
-    const box = redwallBox(before, font, redwallLines(running))!;
+    const box = redwallBox(before, font, redwallLines(running), YEAR)!;
 
     let moved = 0;
     let insideBox = 0;
@@ -135,9 +178,9 @@ describe("the brand art underneath", () => {
     const real = await Bun.file(`${root}/assets/wallpapers/dark.png`).bytes();
     const before = decodePng(real);
     const after = decodePng(
-      renderRedwall({ art: real, font: fontBytes, theme: THEMES.dark, state: running }),
+      renderRedwall({ art: real, font: fontBytes, theme: THEMES.dark, state: running, year: YEAR }),
     );
-    const box = redwallBox(before, font, redwallLines(running))!;
+    const box = redwallBox(before, font, redwallLines(running), YEAR)!;
 
     expect(after.width).toBe(before.width);
     expect(after.height).toBe(before.height);
@@ -158,7 +201,7 @@ describe("the brand art underneath", () => {
   test("keeps the machine state quiet and out of the way at the top right", async () => {
     const real = await Bun.file(`${root}/assets/wallpapers/flare.png`).bytes();
     const before = decodePng(real);
-    const box = redwallBox(before, font, redwallLines(running))!;
+    const box = redwallBox(before, font, redwallLines(running), YEAR)!;
 
     // Desktop icons own the left edge. The top-right keeps the state visible
     // without competing with the taskbar and Windows activation watermark.
@@ -170,13 +213,15 @@ describe("the brand art underneath", () => {
     // deliberately relative so the same apparent weight survives on 1080p
     // and 4K sheets.
     expect(box.width).toBeLessThan(before.width / 8);
-    expect(box.height).toBeLessThan(before.height / 14);
+    // The year grid adds useful vertical density, but the whole instrument
+    // still occupies less than one eighth of the desktop height.
+    expect(box.height).toBeLessThan(before.height / 8);
   });
 
   test("is a rounded instrument with the brand signal at its edge", () => {
     const before = sheet();
     const after = decodePng(render(running));
-    const box = redwallBox(before, font, redwallLines(running))!;
+    const box = redwallBox(before, font, redwallLines(running), YEAR)!;
     const corner = (box.y * before.width + box.x) * 4;
     const middle = ((box.y + Math.floor(box.height / 2)) * before.width + box.x) * 4;
 
@@ -195,7 +240,7 @@ describe("what actually landed inside the region", () => {
   test.each([...THEME_SLUGS])("%s writes its declared ink on its declared plate", (slug) => {
     const ink = redwallInk(THEMES[slug]);
     const after = decodePng(render(running, slug));
-    const box = redwallBox(after, font, redwallLines(running))!;
+    const box = redwallBox(after, font, redwallLines(running), YEAR)!;
 
     const tally = new Map<string, number>();
     for (let y = box.y; y < box.y + box.height; y++) {
@@ -302,6 +347,6 @@ describe("the lines", () => {
   });
 
   test("and there is no box to draw when there are no lines", () => {
-    expect(redwallBox({ width: 100, height: 100 }, font, [])).toBeNull();
+    expect(redwallBox({ width: 100, height: 100 }, font, [], YEAR)).toBeNull();
   });
 });

--- a/src/redwall-render.ts
+++ b/src/redwall-render.ts
@@ -38,7 +38,9 @@
  * Top right. The left edge is where GNOME and Windows put desktop icons,
  * while the bottom belongs to the taskbar, activation notices and transient
  * system UI. Keeping a small instrument against the top-right edge leaves
- * the brand mark and the working edges of the desktop alone.
+ * the brand mark and the working edges of the desktop alone. Its lower
+ * half is a year-at-a-glance: week columns, weekday rows, and a continuous
+ * progress bar, all derived from the local civil day.
  */
 
 import { rgb } from "./brand.ts";
@@ -78,6 +80,60 @@ export interface RedwallInput {
   readonly font: Uint8Array;
   readonly theme: Theme;
   readonly state: RedwallState;
+  /** Local calendar day to visualise. Explicit keeps the renderer pure. */
+  readonly year: RedwallYear;
+}
+
+/** The part of a civil year needed to draw its progress. */
+export interface RedwallYear {
+  readonly year: number;
+  /** Days elapsed including today. */
+  readonly elapsed: number;
+  readonly days: 365 | 366;
+  /** Sunday = 0, matching Date#getDay(). */
+  readonly firstWeekday: number;
+}
+
+/** Turn a local instant into stable calendar coordinates. */
+export function yearProgress(at: Date): RedwallYear {
+  const year = at.getFullYear();
+  const month = at.getMonth();
+  const date = at.getDate();
+  const elapsed = Math.floor(
+    (Date.UTC(year, month, date) - Date.UTC(year, 0, 1)) / 86_400_000,
+  ) + 1;
+  const days = (new Date(year, 1, 29).getMonth() === 1 ? 366 : 365) as 365 | 366;
+  return {
+    year,
+    elapsed: Math.max(1, Math.min(days, elapsed)),
+    days,
+    firstWeekday: new Date(year, 0, 1).getDay(),
+  };
+}
+
+export function yearProgressLabel(value: RedwallYear): string {
+  return `${value.year} · ${Math.floor((value.elapsed / value.days) * 100)}%`;
+}
+
+export interface RedwallYearCell {
+  readonly day: number;
+  readonly column: number;
+  readonly row: number;
+  readonly state: "past" | "today" | "future";
+}
+
+/** One square per day, arranged as week columns and weekday rows. */
+export function yearCells(value: RedwallYear): RedwallYearCell[] {
+  return Array.from({ length: value.days }, (_, index) => {
+    const day = index + 1;
+    const slot = value.firstWeekday + index;
+    return {
+      day,
+      column: Math.floor(slot / 7),
+      row: slot % 7,
+      state: day < value.elapsed ? "past" : day === value.elapsed ? "today" : "future",
+    };
+  });
 }
 
 /** The card's bounding box. Everything outside its rounded shape is art. */
@@ -221,6 +277,10 @@ interface RedwallScale {
   margin: number;
   radius: number;
   rail: number;
+  calendarCell: number;
+  calendarGap: number;
+  calendarBar: number;
+  sectionGap: number;
 }
 
 interface RedwallLayout {
@@ -228,6 +288,11 @@ interface RedwallLayout {
   scale: RedwallScale;
   title: Mask;
   details: Mask[];
+  year: RedwallYear;
+  yearLabel: Mask;
+  calendarTop: number;
+  calendarWidth: number;
+  calendarHeight: number;
 }
 
 /** Two levels of type and the quiet space around them, scaled with the art. */
@@ -243,6 +308,10 @@ function scaleFor(height: number): RedwallScale {
     margin: Math.round(title * 1.35),
     radius: Math.round(title * 0.5),
     rail: Math.max(2, Math.round(title * 0.1)),
+    calendarCell: Math.max(2, Math.round(title * 0.15)),
+    calendarGap: Math.max(1, Math.round(title * 0.06)),
+    calendarBar: Math.max(2, Math.round(title * 0.14)),
+    sectionGap: Math.max(6, Math.round(detail * 0.7)),
   };
 }
 
@@ -250,18 +319,29 @@ function layoutFor(
   art: { readonly width: number; readonly height: number },
   font: Font,
   lines: readonly string[],
+  year: RedwallYear,
 ): RedwallLayout | null {
   if (lines.length === 0) return null;
   const scale = scaleFor(art.height);
   const title = typeset(font, [lines[0]!], scale.title);
   const details = lines.slice(1).map((line) => typeset(font, [line], scale.detail));
+  const yearLabel = typeset(font, [yearProgressLabel(year)], scale.detail);
+  const calendarColumns = Math.ceil((year.firstWeekday + year.days) / 7);
+  const calendarWidth = calendarColumns * scale.calendarCell +
+    (calendarColumns - 1) * scale.calendarGap;
+  const calendarHeight = 7 * scale.calendarCell + 6 * scale.calendarGap;
   const signalReserve = Math.round(scale.title * 1.5);
   const contentWidth = Math.max(
     title.width + signalReserve,
     ...details.map((mask) => mask.width),
+    yearLabel.width,
+    calendarWidth,
   );
-  const contentHeight = title.height +
+  const stateHeight = title.height +
     details.reduce((sum, mask) => sum + scale.gap + mask.height, 0);
+  const calendarTop = scale.padY + stateHeight + scale.sectionGap;
+  const contentHeight = stateHeight + scale.sectionGap + yearLabel.height + scale.gap +
+    calendarHeight + scale.gap + scale.calendarBar;
   const width = contentWidth + scale.padX * 2;
   const height = contentHeight + scale.padY * 2;
   return {
@@ -274,6 +354,11 @@ function layoutFor(
     scale,
     title,
     details,
+    year,
+    yearLabel,
+    calendarTop,
+    calendarWidth,
+    calendarHeight,
   };
 }
 
@@ -289,8 +374,9 @@ export function redwallBox(
   art: { readonly width: number; readonly height: number },
   font: Font,
   lines: readonly string[],
+  year: RedwallYear,
 ): RedwallBox | null {
-  return layoutFor(art, font, lines)?.box ?? null;
+  return layoutFor(art, font, lines, year)?.box ?? null;
 }
 
 /**
@@ -306,7 +392,7 @@ export function renderRedwall(input: RedwallInput): Uint8Array {
 
   const raster = decodePng(input.art);
   const font = readFont(input.font);
-  const layout = layoutFor(raster, font, lines)!;
+  const layout = layoutFor(raster, font, lines, input.year)!;
 
   paint(raster, layout, lines[0]!, redwallInk(input.theme));
   return encodePng(raster);
@@ -359,6 +445,76 @@ function paint(
     top += detail.height;
   }
   paintSignal(raster, layout, headline, ink);
+  paintYear(raster, layout, ink);
+}
+
+/** Draw a week-column calendar and its continuous progress rail. */
+function paintYear(raster: Raster, layout: RedwallLayout, ink: RedwallInk): void {
+  const { box, scale, year, yearLabel, calendarTop, calendarWidth, calendarHeight } = layout;
+  const left = box.x + scale.padX;
+  const labelTop = box.y + calendarTop;
+  pour(raster, yearLabel, left, labelTop, ink.plate, ink.secondary);
+
+  const gridTop = labelTop + yearLabel.height + scale.gap;
+  for (const cell of yearCells(year)) {
+    const { column, row } = cell;
+    const x = left + column * (scale.calendarCell + scale.calendarGap);
+    const y = gridTop + row * (scale.calendarCell + scale.calendarGap);
+    const colour = cell.state === "today"
+      ? ink.text
+      : cell.state === "past"
+      ? ink.signal
+      : ink.secondary;
+    const coverage = cell.state === "future" ? 72 : 255;
+    fillRect(raster, x, y, scale.calendarCell, scale.calendarCell, ink.plate, colour, coverage);
+  }
+
+  const barTop = gridTop + calendarHeight + scale.gap;
+  fillRect(
+    raster,
+    left,
+    barTop,
+    calendarWidth,
+    scale.calendarBar,
+    ink.plate,
+    ink.secondary,
+    72,
+  );
+  fillRect(
+    raster,
+    left,
+    barTop,
+    Math.max(1, Math.round(calendarWidth * year.elapsed / year.days)),
+    scale.calendarBar,
+    ink.plate,
+    ink.signal,
+    255,
+  );
+}
+
+function fillRect(
+  raster: Raster,
+  left: number,
+  top: number,
+  width: number,
+  height: number,
+  under: Hex,
+  over: Hex,
+  coverage: number,
+): void {
+  const [ur, ug, ub] = rgb(under);
+  const [or, og, ob] = rgb(over);
+  for (let y = top; y < top + height; y++) {
+    if (y < 0 || y >= raster.height) continue;
+    for (let x = left; x < left + width; x++) {
+      if (x < 0 || x >= raster.width) continue;
+      const at = (y * raster.width + x) * 4;
+      raster.data[at] = mix(ur, or, coverage);
+      raster.data[at + 1] = mix(ug, og, coverage);
+      raster.data[at + 2] = mix(ub, ob, coverage);
+      raster.data[at + 3] = 255;
+    }
+  }
 }
 
 function insideRounded(

--- a/src/redwall.ts
+++ b/src/redwall.ts
@@ -67,7 +67,7 @@ import { resolveRedwallAddress, spawnCapture } from "./lan-address.ts";
 import type { Platform } from "./platform.ts";
 import { readPreferences, resolveRedwall } from "./preferences.ts";
 import { REDWALL_SUBSET } from "./redwall-font.ts";
-import { renderRedwall, type RedwallState } from "./redwall-render.ts";
+import { renderRedwall, yearProgress, type RedwallState } from "./redwall-render.ts";
 import { resolveThemeSlug, THEMES } from "./themes.ts";
 import { hiddenCapture, hiddenPowershell } from "./windows-hidden.ts";
 import {
@@ -168,6 +168,8 @@ export interface RedwallSeams {
    * every screen this machine has rather than only the desktop.
    */
   readonly show?: (path: string) => Promise<boolean>;
+  /** The local civil day drawn in the year-progress calendar. */
+  readonly now?: () => Date;
 }
 
 /**
@@ -242,8 +244,8 @@ export async function generateRedwall(
    * A theme switch is exactly that caller, and it needs this: `red-dev
    * theme` does not record the new slug before it applies it, so a
    * Redwall that only ever read the preference would draw the machine's
-   * state over the art the user just switched away from. Omitted, the
-   * recorded preference is the answer — which is what the hook, firing
+ * state over the art the user just switched away from. Omitted, the
+ * recorded preference is the answer — which is what the hook, firing
    * on a state change rather than a theme change, has to fall back on.
    */
   theme?: string,
@@ -265,6 +267,7 @@ export async function generateRedwall(
     font: await Bun.file(REDWALL_SUBSET).bytes(),
     theme: THEMES[slug],
     state,
+    year: yearProgress((seams.now ?? (() => new Date()))()),
   });
 
   const dir = await redwallDir(p);


### PR DESCRIPTION
## What changed

- add a 365/366-day calendar grid arranged as weekday rows and week columns
- colour elapsed days with the theme signal, highlight today, and mute future days
- add the current year, elapsed percentage, and a continuous progress bar
- regenerate the content-addressed Redwall when the local civil day changes
- document the new visual contract

## Why

Redwall already summarizes live machine state at a glance. Year progress adds a quiet time horizon to the same instrument without modifying the underlying brand wallpaper.

## Impact

Every enabled Redwall now advances once per local day, including leap years. The renderer remains deterministic because the civil date is supplied explicitly.

## Validation

- 1132 tests pass
- TypeScript typecheck
- Linux and Windows standalone builds
- visual inspection on the real 4K dark wallpaper
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/112"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789160479&installation_model_id=20659&pr_number=112&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F112&signature=35581d4a3bd822608780038dfd76c5993e5e4abbfc3c844dea51fb07c7224b5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->