### PR TITLE
Fix Redwall GNOME top safe area

### DIFF
--- a/src/redwall-render.test.ts
+++ b/src/redwall-render.test.ts
@@ -218,6 +218,19 @@ describe("the brand art underneath", () => {
     expect(box.height).toBeLessThan(before.height / 8);
   });
 
+  test("clears the GNOME top bar after a 4K sheet is fitted to the desktop", async () => {
+    const real = await Bun.file(`${root}/assets/wallpapers/flare.png`).bytes();
+    const before = decodePng(real);
+    const box = redwallBox(before, font, redwallLines(running), YEAR)!;
+
+    // Captured failure: a 3840px sheet displayed on a 1600px-wide GNOME
+    // desktop. Its 22px top bar covered the beginning of the instrument.
+    // Keep a little breathing room below system chrome as well as clearing it.
+    const displayScale = 1600 / before.width;
+    const displayedTop = box.y * displayScale;
+    expect(displayedTop).toBeGreaterThanOrEqual(22 + 8);
+  });
+
   test("is a rounded instrument with the brand signal at its edge", () => {
     const before = sheet();
     const after = decodePng(render(running));

--- a/src/redwall-render.ts
+++ b/src/redwall-render.ts
@@ -37,10 +37,11 @@
  *
  * Top right. The left edge is where GNOME and Windows put desktop icons,
  * while the bottom belongs to the taskbar, activation notices and transient
- * system UI. Keeping a small instrument against the top-right edge leaves
- * the brand mark and the working edges of the desktop alone. Its lower
- * half is a year-at-a-glance: week columns, weekday rows, and a continuous
- * progress bar, all derived from the local civil day.
+ * system UI. The top inset also clears desktop chrome after a high-resolution
+ * sheet is scaled down to the display. Keeping a small instrument near the
+ * top-right edge leaves the brand mark and the working edges of the desktop
+ * alone. Its lower half is a year-at-a-glance: week columns, weekday rows,
+ * and a continuous progress bar, all derived from the local civil day.
  */
 
 import { rgb } from "./brand.ts";
@@ -275,6 +276,7 @@ interface RedwallScale {
   padY: number;
   gap: number;
   margin: number;
+  topInset: number;
   radius: number;
   rail: number;
   calendarCell: number;
@@ -306,6 +308,10 @@ function scaleFor(height: number): RedwallScale {
     padY: Math.round(title * 0.52),
     gap: Math.max(4, Math.round(detail * 0.38)),
     margin: Math.round(title * 1.35),
+    // A 4K sheet is commonly reduced to less than half size on the desktop.
+    // Keep enough vertical room for GNOME's top bar after that projection;
+    // the right edge does not need the same system-chrome reserve.
+    topInset: Math.round(title * 2.5),
     radius: Math.round(title * 0.5),
     rail: Math.max(2, Math.round(title * 0.1)),
     calendarCell: Math.max(2, Math.round(title * 0.15)),
@@ -347,7 +353,7 @@ function layoutFor(
   return {
     box: {
       x: Math.max(0, art.width - scale.margin - width),
-      y: Math.max(0, scale.margin),
+      y: Math.max(0, scale.topInset),
       width,
       height,
     },


### PR DESCRIPTION
## What changed

- separate Redwall's vertical safe-area inset from its horizontal margin
- move the status instrument below GNOME's top bar after a 4K wallpaper is scaled to a 1600px desktop
- add a regression test based on the reported 1600px GNOME capture

## Why

The shared 45px source margin became only 18.75px when the 3840px wallpaper was displayed at 1600px wide. GNOME's 22px top bar therefore covered the beginning of the instrument.

The new proportional top inset projects to about 35px in that setup, while the right-edge position remains unchanged.

## Validation

- `bun run typecheck`
- `bun test` — 1133 passing, 0 failing
- `bun run build` — Linux and Windows binaries

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/113"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789161397&installation_model_id=20659&pr_number=113&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F113&signature=25857321007a8c13e037dc384ebae5f292c44b6af614f340b4c9e4d70290df03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->