### PR TITLE
docs: land AFK boot docs sweep

### DIFF
--- a/.red/contexts/visual/CONTEXT.md
+++ b/.red/contexts/visual/CONTEXT.md
@@ -4,9 +4,11 @@ Visual system — themes, fonts, wallpapers, and the ownership of the configs th
 
 ## Redwall
 
-The theme's wallpaper with live machine state drawn over it. The brand art underneath is unchanged — Redwall composes on top of it, never in place of it, which is what keeps it compatible with the decision that the desktop carries the mark. It reaches two surfaces from one image: the desktop background and the lock screen. What it carries is state a person reads at a glance without unlocking — active Workers, queue and capacity, GitHub budget, the address this machine answers on, and the current year's progress. Year progress is a week-column grid of day squares plus a continuous bar; elapsed days use the theme signal, today uses strong ink, and future days stay muted.
+The selected Red wallpaper with live machine state drawn over it. The brand art underneath is unchanged — Redwall composes on top of it, never in place of it, which is what keeps it compatible with the decision that the desktop carries the mark. It reaches two surfaces from one image: the desktop background and the lock screen. What it carries is state a person reads at a glance without unlocking — active Workers, queue and capacity, GitHub budget, the address this machine answers on, and the current year's progress. Year progress is a week-column grid of day squares plus a continuous bar; elapsed days use the theme signal, today uses strong ink, and future days stay muted.
 
 A Redwall is derived, never authored: the wallpaper is the source and the Redwall is regenerated whenever the state it displays changes. It therefore lives apart from the wallpapers, which are immutable per theme and content-addressed; a Redwall that shared that directory would make "retired" and "chosen by hand" indistinguishable to the sweep.
+
+Wallpaper follows the colour theme by default but may be pinned independently to any of the six embedded Red artworks. The pin survives theme changes; both the plain wallpaper surface and Redwall resolve through the same choice. Clearing the pin returns to following the theme. Arbitrary external files remain externally owned and are never swept or adopted by this preference.
 
 Redwall is part of the default desktop experience. A missing preference means on; boolean `false` is the durable opt-out and later converges preserve it.
 


### PR DESCRIPTION
Automated Docs Sweep landing for stranded .red documentation.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/115"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789168257&installation_model_id=20659&pr_number=115&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F115&signature=2f2993473c883b208292e1b90692122eed2d9f6fc05e931d1d8cb277a669616a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->