### PR TITLE
show GitHub identities and Codex session status

### DIFF
--- a/src/codex-statusline.test.ts
+++ b/src/codex-statusline.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  CODEX_STATUS_LINE,
+  codexConfigPath,
+  convergeCodexStatusline,
+  withCodexStatusline,
+} from "./codex-statusline.ts";
+
+const roots: string[] = [];
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("Codex statusline", () => {
+  test("contains project, directory, branch, model with effort, context and both quota windows", () => {
+    expect(CODEX_STATUS_LINE).toEqual([
+      "project-name",
+      "current-dir",
+      "git-branch",
+      "model-with-reasoning",
+      "context-remaining",
+      "five-hour-limit",
+      "weekly-limit",
+    ]);
+  });
+
+  test("adds a tui table without changing existing config", () => {
+    const before = 'model = "gpt-5.6-sol"\n\n[plugins.dev]\nenabled = true\n';
+    const after = withCodexStatusline(before);
+    expect(after).toStartWith(before);
+    expect(after).toContain("[tui]\nstatus_line = [");
+  });
+
+  test("replaces only an existing status line inside tui", () => {
+    const before = '[tui]\nanimations = false\nstatus_line = ["thread-id"]\n\n[history]\npersistence = "save-all"\n';
+    const after = withCodexStatusline(before);
+    expect(after).toContain("animations = false");
+    expect(after).toContain('[history]\npersistence = "save-all"');
+    expect(after).not.toContain("thread-id");
+    expect(after.match(/status_line/g)).toHaveLength(1);
+  });
+
+  test("understands the dotted-key spelling and preserves CRLF", () => {
+    const after = withCodexStatusline('model = "x"\r\ntui.status_line = ["thread-id"]\r\n');
+    expect(after).toContain("\r\ntui.status_line = [");
+    expect(after.split("\r\n")).toHaveLength(3);
+  });
+
+  test("replaces a multi-line array without leaving orphaned values", () => {
+    const after = withCodexStatusline('[tui]\nstatus_line = [\n  "thread-id",\n  "model-name",\n]\nanimations = true\n');
+    expect(after.match(/status_line/g)).toHaveLength(1);
+    expect(after).not.toContain('  "thread-id",');
+    expect(after).toEndWith("animations = true\n");
+  });
+
+  test("writes atomically and is idempotent", async () => {
+    const root = mkdtempSync(join(tmpdir(), "red-dev-codex-statusline-"));
+    roots.push(root);
+    const path = join(root, ".codex", "config.toml");
+    expect(await convergeCodexStatusline(path)).toBe("written");
+    const first = readFileSync(path, "utf8");
+    expect(await convergeCodexStatusline(path)).toBe("unchanged");
+    expect(readFileSync(path, "utf8")).toBe(first);
+  });
+
+  test("uses USERPROFILE when HOME is absent", () => {
+    const home = process.env["HOME"];
+    const profile = process.env["USERPROFILE"];
+    delete process.env["HOME"];
+    process.env["USERPROFILE"] = "C:\\Users\\filipe";
+    try {
+      expect(codexConfigPath()).toBe("C:/Users/filipe/.codex/config.toml");
+    } finally {
+      if (home === undefined) delete process.env["HOME"];
+      else process.env["HOME"] = home;
+      if (profile === undefined) delete process.env["USERPROFILE"];
+      else process.env["USERPROFILE"] = profile;
+    }
+  });
+});

--- a/src/codex-statusline.ts
+++ b/src/codex-statusline.ts
@@ -1,0 +1,110 @@
+/** Codex TUI status-line convergence, preserving the rest of config.toml. */
+
+import { existsSync, mkdirSync, renameSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+import { log } from "./log.ts";
+
+export const CODEX_STATUS_LINE = [
+  "project-name",
+  "current-dir",
+  "git-branch",
+  "model-with-reasoning",
+  "context-remaining",
+  "five-hour-limit",
+  "weekly-limit",
+] as const;
+
+const STATUS_LINE = `status_line = [${CODEX_STATUS_LINE.map((item) => `"${item}"`).join(", ")}]`;
+
+export type CodexStatuslineResult = "written" | "unchanged";
+
+/** The user-level config Codex reads on every supported host. */
+export function codexConfigPath(): string | null {
+  const home = process.env["HOME"] ?? process.env["USERPROFILE"];
+  return home ? `${home.replace(/\\/g, "/")}/.codex/config.toml` : null;
+}
+
+/**
+ * Set only tui.status_line in an arbitrary TOML document. PURE.
+ *
+ * Both Codex-supported spellings are understood: a root dotted key and a
+ * `[tui]` table. Everything else, including comments and unknown future keys,
+ * is retained byte-for-byte apart from the one managed assignment.
+ */
+export function withCodexStatusline(source: string): string {
+  const newline = source.includes("\r\n") ? "\r\n" : "\n";
+  const terminalNewline = source.endsWith("\n");
+  const lines = source === "" ? [] : source.replace(/\r?\n$/, "").split(/\r?\n/);
+
+  const dotted = lines.findIndex((line) => /^\s*tui\.status_line\s*=/.test(line));
+  if (dotted >= 0) {
+    replaceAssignment(lines, dotted, `tui.${STATUS_LINE}`);
+    return lines.join(newline) + (terminalNewline ? newline : "");
+  }
+
+  const tui = lines.findIndex((line) => /^\s*\[tui\]\s*(?:#.*)?$/.test(line));
+  if (tui >= 0) {
+    let end = lines.length;
+    for (let index = tui + 1; index < lines.length; index += 1) {
+      if (/^\s*\[/.test(lines[index]!)) {
+        end = index;
+        break;
+      }
+    }
+    const assignment = lines.findIndex(
+      (line, index) => index > tui && index < end && /^\s*status_line\s*=/.test(line),
+    );
+    if (assignment >= 0) replaceAssignment(lines, assignment, STATUS_LINE);
+    else lines.splice(end, 0, STATUS_LINE);
+    return lines.join(newline) + (terminalNewline ? newline : "");
+  }
+
+  if (lines.length > 0 && lines.at(-1)?.trim() !== "") lines.push("");
+  lines.push("[tui]", STATUS_LINE);
+  return lines.join(newline) + newline;
+}
+
+/** Replace a scalar or a possibly multi-line array assignment as one unit. */
+function replaceAssignment(lines: string[], at: number, replacement: string): void {
+  const value = lines[at]!.slice(lines[at]!.indexOf("=") + 1);
+  let balance = brackets(value);
+  let end = at;
+  while (balance > 0 && end + 1 < lines.length) {
+    end += 1;
+    balance += brackets(lines[end]!);
+  }
+  lines.splice(at, end - at + 1, replacement);
+}
+
+function brackets(value: string): number {
+  return [...value].reduce((total, char) => total + (char === "[" ? 1 : char === "]" ? -1 : 0), 0);
+}
+
+/** Merge the managed line into one Codex config, atomically and idempotently. */
+export async function convergeCodexStatusline(path: string): Promise<CodexStatuslineResult> {
+  const before = existsSync(path) ? await Bun.file(path).text() : "";
+  const after = withCodexStatusline(before);
+  if (after === before) return "unchanged";
+
+  mkdirSync(dirname(path), { recursive: true });
+  const temporary = `${path}.red-dev-${process.pid}`;
+  writeFileSync(temporary, after, { encoding: "utf8", mode: 0o600 });
+  renameSync(temporary, path);
+  return "written";
+}
+
+/** Converge when Codex is installed; otherwise this managed item has no target. */
+export async function configureCodexStatusline(): Promise<void> {
+  if (!Bun.which("codex")) {
+    log.skip("Codex statusline: Codex CLI not installed");
+    return;
+  }
+  const path = codexConfigPath();
+  if (path === null) {
+    log.skip("Codex statusline: no user home available");
+    return;
+  }
+  const result = await convergeCodexStatusline(path);
+  if (result === "unchanged") log.skip("Codex statusline already configured");
+  else log.ok("Codex statusline configured");
+}

--- a/src/github-rate.test.ts
+++ b/src/github-rate.test.ts
@@ -3,7 +3,10 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import {
   githubRatePercent,
+  githubRatesFromHistoryJson,
+  mergeGithubCredentialRates,
   readGithubRateLimit,
+  readRedskilledGithubRates,
   type GithubRateSnapshot,
 } from "./github-rate.ts";
 
@@ -27,6 +30,79 @@ const response = JSON.stringify({
 });
 
 describe("GitHub rate-limit snapshot", () => {
+  test("reduces the PAT and optional App snapshots into four numbers", () => {
+    const askedAt = "2026-08-12T20:30:00Z";
+    expect(githubRatesFromHistoryJson(JSON.stringify([
+      { pool: "rest", remaining: 4500, limit: 5000, asked_at: askedAt },
+      { pool: "graphql", remaining: 3500, limit: 5000, asked_at: askedAt },
+      { identity: "app:153309957", pool: "rest", remaining: 4900, limit: 5000, asked_at: askedAt },
+      { identity: "app:153309957", pool: "graphql", remaining: 4250, limit: 5000, asked_at: askedAt },
+    ]), Date.parse("2026-08-12T20:45:00Z"))).toEqual({
+      pat: { api: 90, graphql: 70 },
+      app: { api: 98, graphql: 85 },
+    });
+  });
+
+  test("keeps github_app optional and refuses a fossil PAT snapshot", () => {
+    const fossil = JSON.stringify([
+      { pool: "rest", remaining: 5000, limit: 5000, asked_at: "2026-08-12T19:00:00Z" },
+      { pool: "graphql", remaining: 5000, limit: 5000, asked_at: "2026-08-12T19:00:00Z" },
+    ]);
+    expect(githubRatesFromHistoryJson(
+      fossil,
+      Date.parse("2026-08-12T20:00:00Z"),
+    )).toBeNull();
+  });
+
+  test("reads PAT and App from the identity-aware balance history", async () => {
+    const path = cachePath();
+    writeFileSync(path, "placeholder\n");
+    const directory = path.slice(0, path.lastIndexOf("/"));
+    writeFileSync(`${directory}/balance-history.toonl`, "toonl is converted by the injected tq\n");
+    const history = JSON.stringify([
+      { pool: "rest", remaining: 4500, limit: 5000, asked_at: "2026-08-12T20:30:00Z" },
+      { pool: "graphql", remaining: 3500, limit: 5000, asked_at: "2026-08-12T20:30:00Z" },
+      {
+        identity: "app:153309957",
+        pool: "rest",
+        remaining: 4900,
+        limit: 5000,
+        asked_at: "2026-08-12T20:31:00Z",
+      },
+      {
+        identity: "app:153309957",
+        pool: "graphql",
+        remaining: 4250,
+        limit: 5000,
+        asked_at: "2026-08-12T20:31:00Z",
+      },
+    ]);
+    expect(await readRedskilledGithubRates({
+      path: directory,
+      nowMs: Date.parse("2026-08-12T20:45:00Z"),
+      command: async () => ({
+        exitCode: 0,
+        stdout: history,
+        stderr: "",
+        timedOut: false,
+        groupGone: true,
+      }),
+    })).toEqual({
+      pat: { api: 90, graphql: 70 },
+      app: { api: 98, graphql: 85 },
+    });
+  });
+
+  test("merges domains by the tightest credential bucket instead of summing", () => {
+    expect(mergeGithubCredentialRates([
+      { pat: { api: 90, graphql: 80 }, app: { api: 70, graphql: 60 } },
+      { pat: { api: 50, graphql: 85 }, app: null },
+    ])).toEqual({
+      pat: { api: 50, graphql: 80 },
+      app: { api: 70, graphql: 60 },
+    });
+  });
+
   test("keeps REST and GraphQL separate and reports percent remaining", async () => {
     const snapshot = await readGithubRateLimit({
       path: cachePath(),

--- a/src/github-rate.ts
+++ b/src/github-rate.ts
@@ -21,7 +21,11 @@ import {
 } from "node:fs";
 import { dirname } from "node:path";
 import { randomUUID } from "node:crypto";
-import { runBounded } from "./bounded-command.ts";
+import {
+  runBounded,
+  type BoundedCommandOptions,
+  type BoundedCommandResult,
+} from "./bounded-command.ts";
 import { transcriptDir } from "./transcript.ts";
 
 const TTL_MS = 15 * 60 * 1_000;
@@ -57,13 +61,184 @@ export interface GithubRateOptions {
   readonly probe?: () => Promise<string | null>;
 }
 
+export interface GithubRatePercentPair {
+  readonly api: number;
+  readonly graphql: number;
+}
+
+/** Independent credential ceilings. They are deliberately never summed. */
+export interface GithubCredentialRates {
+  readonly pat: GithubRatePercentPair | null;
+  readonly app: GithubRatePercentPair | null;
+}
+
+export interface RedskilledGithubRateOptions {
+  readonly path?: string;
+  readonly nowMs?: number;
+  readonly command?: GithubRateCommand;
+}
+
+export type GithubRateCommand = (
+  argv: string[],
+  options?: BoundedCommandOptions,
+) => Promise<BoundedCommandResult>;
+
 export function githubRatePath(): string {
   return `${transcriptDir()}/github-rate-limit.json`;
+}
+
+export function redskilledGithubHistoryPath(home = process.env["HOME"] ?? process.env["USERPROFILE"] ?? ""): string {
+  return `${home.replace(/\\/g, "/")}/.red/redskilled/state/github/balance-history.toonl`;
 }
 
 export function githubRatePercent(bucket: GithubRateBucket): number {
   if (!Number.isFinite(bucket.limit) || bucket.limit <= 0) return 0;
   return Math.max(0, Math.min(100, Math.floor((bucket.remaining / bucket.limit) * 100)));
+}
+
+interface GithubHistoryRow {
+  readonly identity: string;
+  readonly pool: "rest" | "graphql";
+  readonly remaining: number;
+  readonly limit: number;
+  readonly askedAtMs: number;
+}
+
+function historyRow(value: unknown): GithubHistoryRow | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  const found = value as Record<string, unknown>;
+  const identity = found["identity"] === undefined ? "pat" : found["identity"];
+  const pool = found["pool"];
+  const remaining = found["remaining"];
+  const limit = found["limit"];
+  const askedAtMs = Date.parse(String(found["asked_at"] ?? ""));
+  if (
+    typeof identity !== "string" || (identity !== "pat" && !identity.startsWith("app:")) ||
+    (pool !== "rest" && pool !== "graphql") ||
+    !validNonNegative(remaining) || !validNonNegative(limit) || limit === 0 || remaining > limit ||
+    !Number.isFinite(askedAtMs)
+  ) return null;
+  return { identity, pool, remaining, limit, askedAtMs };
+}
+
+/** Reduce redskilled's identity-aware history into independent credential ceilings. PURE. */
+export function githubRatesFromHistoryJson(
+  raw: string,
+  nowMs = Date.now(),
+): GithubCredentialRates | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!Array.isArray(parsed)) return null;
+
+  const latest = new Map<string, GithubHistoryRow>();
+  for (const value of parsed) {
+    const row = historyRow(value);
+    if (
+      row === null || nowMs - row.askedAtMs >= MAX_STALE_MS ||
+      row.askedAtMs > nowMs + 60_000
+    ) continue;
+    const key = `${row.identity}:${row.pool}`;
+    if ((latest.get(key)?.askedAtMs ?? -1) <= row.askedAtMs) latest.set(key, row);
+  }
+
+  const pair = (identity: string): GithubRatePercentPair | null => {
+    const rest = latest.get(`${identity}:rest`);
+    const graphql = latest.get(`${identity}:graphql`);
+    return rest === undefined || graphql === undefined ? null : {
+      api: Math.floor((rest.remaining / rest.limit) * 100),
+      graphql: Math.floor((graphql.remaining / graphql.limit) * 100),
+    };
+  };
+  const appIdentities = [...new Set(
+    [...latest.values()].map((row) => row.identity).filter((identity) => identity.startsWith("app:")),
+  )].sort((left, right) => {
+    const newest = (identity: string): number => Math.max(
+      latest.get(`${identity}:rest`)?.askedAtMs ?? -1,
+      latest.get(`${identity}:graphql`)?.askedAtMs ?? -1,
+    );
+    return newest(right) - newest(left);
+  });
+  const rates = {
+    pat: pair("pat"),
+    app: appIdentities.map(pair).find((value) => value !== null) ?? null,
+  };
+  return rates.pat === null && rates.app === null ? null : rates;
+}
+
+/** Read the two redskilled credential buckets without asking GitHub again. */
+export async function readRedskilledGithubRates(
+  options: RedskilledGithubRateOptions = {},
+): Promise<GithubCredentialRates | null> {
+  const configuredPath = options.path ?? redskilledGithubHistoryPath();
+  const path = configuredPath.endsWith(".toonl")
+    ? configuredPath
+    : `${configuredPath}/balance-history.toonl`;
+  if (!existsSync(path)) return null;
+  const tq = Bun.which("tq");
+  if (!tq && options.command === undefined) return null;
+  try {
+    const result = await (options.command ?? runBounded)(
+      [tq ?? "tq", "-p", "toonl", "-s", "-c", "-o", "json", ".", path],
+      { timeoutMs: 2_000, killGraceMs: 250 },
+    );
+    return result.timedOut || result.exitCode !== 0
+      ? null
+      : githubRatesFromHistoryJson(result.stdout, options.nowMs);
+  } catch {
+    return null;
+  }
+}
+
+/** Merge execution domains conservatively: the tightest visible bucket wins. */
+export function mergeGithubCredentialRates(
+  values: readonly (GithubCredentialRates | null)[],
+): GithubCredentialRates | null {
+  const merge = (identity: "pat" | "app"): GithubRatePercentPair | null => {
+    const known = values.flatMap((value) => value?.[identity] ? [value[identity]] : []);
+    return known.length === 0 ? null : {
+      api: Math.min(...known.map((value) => value.api)),
+      graphql: Math.min(...known.map((value) => value.graphql)),
+    };
+  };
+  const rates = { pat: merge("pat"), app: merge("app") };
+  return rates.pat === null && rates.app === null ? null : rates;
+}
+
+const WSL_GITHUB_BALANCES_PROGRAM = [
+  'f="$HOME/.red/redskilled/state/github/balance-history.toonl"',
+  '[ -f "$f" ] || exit 3',
+  'q=$(command -v tq 2>/dev/null || true)',
+  '[ -n "$q" ] || exit 3',
+  '"$q" -p toonl -s -c -o json . "$f"',
+].join("; ");
+const WSL_GITHUB_BALANCES_SCRIPT =
+  `printf %s ${Buffer.from(WSL_GITHUB_BALANCES_PROGRAM).toString("base64")} | base64 -d | sh`;
+
+/** Read every already-running WSL domain without waking a stopped distro. */
+export async function readWindowsWslGithubRates(
+  run: GithubRateCommand = runBounded,
+  nowMs = Date.now(),
+): Promise<GithubCredentialRates | null> {
+  const wsl = Bun.which("wsl.exe");
+  if (!wsl && run === runBounded) return null;
+  const listed = await run([wsl ?? "wsl.exe", "--list", "--running", "--quiet"], { timeoutMs: 2_000 });
+  if (listed.timedOut || listed.exitCode !== 0) return null;
+  const distros = listed.stdout.replace(/\0/g, "").split(/\r?\n/)
+    .map((name) => name.trim().replace(/^\*\s*/, "")).filter(Boolean);
+  const rates = await Promise.all(distros.map(async (distro) => {
+    const result = await run(
+      [wsl ?? "wsl.exe", "-d", distro, "--", "sh", "-lc", WSL_GITHUB_BALANCES_SCRIPT],
+      { timeoutMs: 5_000, killGraceMs: 250 },
+    );
+    return result.timedOut || result.exitCode !== 0
+      ? null
+      : githubRatesFromHistoryJson(result.stdout, nowMs);
+  }));
+  return mergeGithubCredentialRates(rates);
 }
 
 function validNonNegative(value: unknown): value is number {

--- a/src/manifest.test.ts
+++ b/src/manifest.test.ts
@@ -121,6 +121,13 @@ describe("isInstalled", () => {
 });
 
 describe("the manifest itself", () => {
+  test("the Codex statusline is a managed core surface on every supported host", () => {
+    const tool = TOOLS.find((candidate) => candidate.name === "codex-statusline");
+    expect(tool).toMatchObject({ scope: "core", managed: true });
+    expect(providerFor(tool!, WSL24)).toEqual({ kind: "builtin", name: "codex-statusline" });
+    expect(providerFor(tool!, WINDOWS)).toEqual({ kind: "builtin", name: "codex-statusline" });
+  });
+
   test("Linux desktop declares wl-clipboard for Zellij copy", () => {
     const tool = TOOLS.find((t) => t.name === "wl-clipboard");
     expect(tool?.scope).toBe("desktop");

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -137,6 +137,7 @@ type ProviderSpec =
         | "red-skills-herdr"
         | "blender"
         | "wsl-sync"
+        | "codex-statusline"
         | "claude-keybindings"
         | "redwall-schedule"
         | "ssh-server";
@@ -327,6 +328,7 @@ const builtin = (
     | "red-skills-vscode"
     | "red-skills-herdr"
     | "blender"
+    | "codex-statusline"
     | "claude-keybindings"
     | "redwall-schedule"
     | "ssh-server",
@@ -936,6 +938,14 @@ export const TOOLS: Tool[] = [
     managed: true,
     u24: builtin("red-skills"),
     win: builtin("red-skills"),
+  },
+  {
+    name: "codex-statusline",
+    about: "project, branch, model, effort, context and quota windows in the Codex TUI",
+    scope: "core",
+    managed: true,
+    u24: builtin("codex-statusline"),
+    win: builtin("codex-statusline"),
   },
   {
     // Skipped silently when claude is not installed. Idempotent and

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -1019,6 +1019,7 @@ const BUILTIN_INTENT: Partial<Record<BuiltinName, string>> = {
   "red-skills-herdr": "installing the herdr plugin for red-skills",
   blender: "installing Blender — this one is over a gigabyte",
   "wsl-sync": "syncing the WSL distro settings with the host",
+  "codex-statusline": "writing project, branch, model, effort, context and quotas into the Codex statusline",
   "claude-keybindings": "writing the Claude Code keybindings",
   "redwall-schedule": "scheduling the wallpaper rotation",
   "ssh-server": "installing and enabling the SSH server",
@@ -1136,6 +1137,11 @@ export async function applyProvider(pr: Provider, ctx: ApplyContext): Promise<vo
       if (pr.name === "claude-keybindings") {
         const { convergeClaudeKeybindings } = await import("./claude-keybindings.ts");
         await convergeClaudeKeybindings();
+        return;
+      }
+      if (pr.name === "codex-statusline") {
+        const { configureCodexStatusline } = await import("./codex-statusline.ts");
+        await configureCodexStatusline();
         return;
       }
       if (pr.name === "redwall-schedule") {

--- a/src/redwall-render.test.ts
+++ b/src/redwall-render.test.ts
@@ -301,11 +301,15 @@ describe("the lines", () => {
       capacity: 6,
       queued: 18,
       attention: null,
-      github: { api: 95, graphql: 0 },
+      github: {
+        pat: { api: 95, graphql: 0 },
+        app: { api: 88, graphql: 72 },
+      },
     })).toEqual([
       "redskilled at work",
       "3/6 workers · 18 queued",
-      "github api 95% · gql 0%",
+      "github pat api 95% · gql 0%",
+      "github app api 88% · gql 72%",
       "192.168.1.42",
     ]);
   });
@@ -313,8 +317,20 @@ describe("the lines", () => {
   test("drops invalid GitHub percentages without dropping machine state", () => {
     expect(redwallLines({
       ...running,
-      github: { api: 101, graphql: -1 },
+      github: { pat: { api: 101, graphql: -1 }, app: null },
     })).toEqual(["redskilled at work", "3 workers", "192.168.1.42"]);
+  });
+
+  test("draws only PAT when the optional GitHub App is not configured", () => {
+    expect(redwallLines({
+      ...running,
+      github: { pat: { api: 98, graphql: 85 }, app: null },
+    })).toEqual([
+      "redskilled at work",
+      "3 workers",
+      "github pat api 98% · gql 85%",
+      "192.168.1.42",
+    ]);
   });
 
   test("distinguishes standing by, capacity, attention and unavailable", () => {

--- a/src/redwall-render.ts
+++ b/src/redwall-render.ts
@@ -68,8 +68,11 @@ export interface RedwallState {
   readonly queued?: number | null;
   /** The highest-severity condition the daemon can state compactly. */
   readonly attention?: HostStateAttention | null;
-  /** Remaining GitHub budgets, kept separate because API and GraphQL reset independently. */
-  readonly github?: { readonly api: number; readonly graphql: number } | null;
+  /** PAT and App budgets; neither identity can spend the other's ceiling. */
+  readonly github?: {
+    readonly pat: { readonly api: number; readonly graphql: number } | null;
+    readonly app: { readonly api: number; readonly graphql: number } | null;
+  } | null;
   /** The address this machine answers on, as a dotted quad. */
   readonly address: string | null;
 }
@@ -191,9 +194,9 @@ export function redwallLines(state: RedwallState): string[] {
   const address = state.address !== null && validAddress(state.address) && drawable(state.address)
     ? state.address
     : null;
-  const github = githubLine(state.github);
+  const github = githubLines(state.github);
   if (state.workers === null) {
-    return ["redskilled unavailable", github, address].filter((line): line is string => line !== null);
+    return ["redskilled unavailable", ...github, address].filter((line): line is string => line !== null);
   }
   if (!Number.isSafeInteger(state.workers) || state.workers < 0) return [];
 
@@ -220,14 +223,19 @@ export function redwallLines(state: RedwallState): string[] {
   }
 
   const lines = [headline, detail];
-  if (github !== null) lines.push(github);
+  lines.push(...github);
   if (address !== null) lines.push(address);
   return lines.every(drawable) ? lines : [];
 }
 
-function githubLine(value: RedwallState["github"]): string | null {
-  if (!value || !validPercent(value.api) || !validPercent(value.graphql)) return null;
-  return `github api ${value.api}% · gql ${value.graphql}%`;
+function githubLines(value: RedwallState["github"]): string[] {
+  if (!value) return [];
+  const line = (identity: "pat" | "app"): string | null => {
+    const rate = value[identity];
+    if (!rate || !validPercent(rate.api) || !validPercent(rate.graphql)) return null;
+    return `github ${identity} api ${rate.api}% · gql ${rate.graphql}%`;
+  };
+  return [line("pat"), line("app")].filter((value): value is string => value !== null);
 }
 
 function validPercent(value: number): boolean {

--- a/src/redwall.ts
+++ b/src/redwall.ts
@@ -61,7 +61,13 @@
  */
 
 import { existsSync, mkdirSync, readdirSync, rmSync } from "node:fs";
-import { githubRatePercent, readGithubRateLimit } from "./github-rate.ts";
+import {
+  githubRatePercent,
+  mergeGithubCredentialRates,
+  readGithubRateLimit,
+  readRedskilledGithubRates,
+  readWindowsWslGithubRates,
+} from "./github-rate.ts";
 import { mergeHostStates, readHostState, readWindowsWslHostState } from "./host-state.ts";
 import { resolveRedwallAddress, spawnCapture } from "./lan-address.ts";
 import type { Platform } from "./platform.ts";
@@ -181,23 +187,31 @@ export interface RedwallSeams {
  * throw. The address is resolved without the daemon's help so it survives.
  */
 export async function redwallState(p: Platform): Promise<RedwallState> {
-  const [host, address, githubRate] = await Promise.all([
+  const [host, address, redskilledGithub] = await Promise.all([
     p.os === "windows"
       ? Promise.all([readHostState(), readWindowsWslHostState()]).then(mergeHostStates)
       : readHostState(),
     redwallAddress(p),
-    readGithubRateLimit(),
+    p.os === "windows"
+      ? Promise.all([readRedskilledGithubRates(), readWindowsWslGithubRates()]).then(mergeGithubCredentialRates)
+      : readRedskilledGithubRates(),
   ]);
+  // The daemon already paid to learn this answer. Only installations from
+  // before its identity-labelled history ask `gh` themselves as a fallback.
+  const githubRate = redskilledGithub?.pat ? null : await readGithubRateLimit();
+  const fallbackPat = githubRate === null
+    ? null
+    : { api: githubRatePercent(githubRate.core), graphql: githubRatePercent(githubRate.graphql) };
   return {
     workers: host?.workers ?? null,
     capacity: host?.capacity ?? null,
     queued: host?.queued ?? null,
     attention: host?.attention ?? null,
-    github: githubRate === null
+    github: redskilledGithub === null && fallbackPat === null
       ? null
       : {
-        api: githubRatePercent(githubRate.core),
-        graphql: githubRatePercent(githubRate.graphql),
+        pat: redskilledGithub?.pat ?? fallbackPat,
+        app: redskilledGithub?.app ?? null,
       },
     address,
   };


### PR DESCRIPTION
## What changed

- read redskilled `balance-history.toonl` and render PAT/App REST + GraphQL ceilings independently on Redwall
- preserve the legacy PAT probe only as a fallback when redskilled has no PAT history
- merge already-running WSL domains conservatively without waking stopped distros
- configure the Codex statusline with project, directory, branch, model, effort, context, five-hour quota and weekly quota

## Root cause

Redwall was looking for identity-named balance snapshot files that the daemon does not produce. The supported bridge is the identity-aware history: absent identity means PAT and `app:<installation>` means the optional GitHub App.

## Impact

Existing PAT-only installations continue to work. Once redskilled writes the App series, Redwall automatically adds the second line and shows all four values without summing independent credentials.

## Validation

- full suite: 1,162 passed, 0 failed
- TypeScript typecheck passed
- Linux and Windows production builds passed
- live history probe returned PAT api 95% / graphql 99%; App correctly remains absent until the upstream producer lands

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/118"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789194837&installation_model_id=20659&pr_number=118&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F118&signature=d7e5dfd261d012f7e4749743c899c4d670a8cdaea483953f136ec749124cb3ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->