### PR TITLE
Fix Ubuntu install progress and runtime defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,7 +408,7 @@ deliberately:
 | `red-dev theme` | which theme, when given no name |
 | `red-dev wallpaper` | which bundled Red artwork, a custom PNG path/HTTPS URL, or whether to follow the theme |
 | `red-dev apps` | which optional tools — all ticked; untick to opt out |
-| `red-dev lang` | which runtimes mise should manage — all ticked; untick to opt out |
+| `red-dev lang` | which runtimes mise should manage — Java, Ruby and Go start off; the rest are opt-out |
 | `red-dev shell` | whether a terminal lands in WSL or Git Bash |
 | `red-dev agents` | which coding agents — all ticked; untick to opt out, then offers red-skills |
 | `red-dev uninstall` | what to remove — and confirms before removing it |
@@ -752,8 +752,9 @@ where to share configuration, which shell the terminal opens, which agents,
 which runtimes, which optional tools, ble.sh, the font, the theme, the wallpaper,
 and Redwall — with
 the palette previewed while the cursor moves. Previous answers come back
-pre-ticked. Every install group starts fully selected and is opt-out, so agreeing
-is enter, enter, enter; `q` returns to the menu rather than starting anything.
+pre-ticked. Tools and agents are opt-out; Java, Ruby and Go start off because
+they are project-specific toolchains. Agreeing is enter, enter, enter; `q`
+returns to the menu rather than starting anything.
 
 #### The distro, converged from the Windows side
 

--- a/src/firstrun.ts
+++ b/src/firstrun.ts
@@ -408,12 +408,12 @@ export async function askFirstRun(p: Platform): Promise<FirstRunChoices | null> 
   }
 
   // 3. What you build with.
-  const { OFFERED_RUNTIMES } = await import("./runtimes.ts");
+  const { OFFERED_RUNTIMES, runtimeSelectedByDefault } = await import("./runtimes.ts");
   const runtimeLabels = OFFERED_RUNTIMES.map((r) => `${r.id} — ${r.about}`);
   const pickedRuntimes = await checkbox(
     "Language runtimes for mise to manage?",
     runtimeLabels as [string, ...string[]],
-    runtimeLabels,
+    runtimeLabels.filter((label) => runtimeSelectedByDefault(label.split(" ")[0]!)),
   );
 
   // 4. Extra tools, all of them ticked.

--- a/src/installer-noninteractive.test.ts
+++ b/src/installer-noninteractive.test.ts
@@ -37,6 +37,24 @@ describe("unattended provider commands", () => {
     }
   });
 
+  test("carriage-return progress reaches the TUI before the child exits", async () => {
+    const seen: string[] = [];
+    const release = captureTo((line) => seen.push(line));
+    try {
+      const child = spawnLoggedCapture([
+        process.execPath,
+        "-e",
+        'process.stderr.write("download 25%\\r"); setTimeout(() => process.stderr.write("download 100%\\n"), 250)',
+      ]);
+
+      await Bun.sleep(100);
+      expect(seen).toContain("download 25%");
+      await child;
+    } finally {
+      release();
+    }
+  });
+
   test("every winget path uses the observable capture helper", () => {
     expect(providers).toContain("await spawnLoggedCapture(");
     expect(agents).toContain("await spawnLoggedCapture(argv)");

--- a/src/main.ts
+++ b/src/main.ts
@@ -1322,7 +1322,8 @@ async function cmdAgents(p: Platform, inv: Invocation): Promise<number> {
 /** Choose which language runtimes mise manages. */
 async function cmdLang(p: Platform, inv: Invocation): Promise<number> {
   const { checkbox } = await import("./ui.ts");
-  const { OFFERED_RUNTIMES, useRuntimes, currentRuntimes } = await import("./runtimes.ts");
+  const { OFFERED_RUNTIMES, useRuntimes, currentRuntimes, runtimeSelectedByDefault } =
+    await import("./runtimes.ts");
 
   let ids = inv.runtimeIds;
   if (ids !== undefined) {
@@ -1347,7 +1348,11 @@ async function cmdLang(p: Platform, inv: Invocation): Promise<number> {
       return `${r.id} — ${r.about}${current.includes(name) ? "  (installed)" : ""}`;
     });
 
-    const picked = await checkbox("Which runtimes?", labels as [string, ...string[]], labels);
+    const picked = await checkbox(
+      "Which runtimes?",
+      labels as [string, ...string[]],
+      labels.filter((label) => runtimeSelectedByDefault(label.split(" ")[0]!)),
+    );
     ids = picked.map((label) => label.split(" ")[0]!.trim());
   }
 

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -48,9 +48,19 @@ async function pumpToLog(stream: ReadableStream<Uint8Array> | null): Promise<str
     const text = decoder.decode(chunk as Uint8Array, { stream: true });
     raw += text;
     rest += text;
-    const parts = rest.split("\n");
-    rest = parts.pop() ?? "";
-    for (const part of parts) say(part);
+    // curl, mise and several archive tools redraw download progress with a
+    // carriage return and do not send a newline until they finish. Waiting for
+    // `\n` made an active Ubuntu install look frozen for the whole download.
+    // A chunk may contain several redraws, so publish only its newest state:
+    // this stays live between chunks without filling the log with 10/11/12%.
+    const lines = rest.split("\n");
+    rest = lines.pop() ?? "";
+    for (const line of lines) say(line);
+    if (rest.includes("\r")) {
+      const redraws = rest.split("\r");
+      rest = redraws.pop() ?? "";
+      say(redraws.at(-1) ?? "");
+    }
   }
   const final = decoder.decode();
   raw += final;

--- a/src/runtimes.ts
+++ b/src/runtimes.ts
@@ -47,6 +47,12 @@ export const OFFERED_RUNTIMES: { id: string; about: string }[] = [
   { id: "java@lts", about: "Java LTS" },
 ];
 
+/** Common runtimes start checked; the heavier project-specific three are opt-in. */
+export function runtimeSelectedByDefault(id: string): boolean {
+  const name = id.split("@")[0];
+  return name !== "go" && name !== "ruby" && name !== "java";
+}
+
 export interface RuntimeObserver {
   stepStart?: (id: string) => void;
   stepEnd?: (id: string, error: string | null) => void;
@@ -173,6 +179,11 @@ async function readRuntimeOutput(
     const lines = rest.split("\n");
     rest = lines.pop() ?? "";
     for (const line of lines) emit(line);
+    if (rest.includes("\r")) {
+      const redraws = rest.split("\r");
+      rest = redraws.pop() ?? "";
+      emit(redraws.at(-1) ?? "");
+    }
   }
   const final = decoder.decode();
   raw += final;

--- a/src/setup-defaults.test.ts
+++ b/src/setup-defaults.test.ts
@@ -3,10 +3,9 @@
  *
  * A preset is not a detail: it is the answer most people will give. The
  * optional tools shipped with none of them ticked and a description
- * arguing that empty was a good answer, which is true for a list you
- * have to evaluate one by one and wrong for a curated one — the whole
- * premise of an omakase setup is that somebody already chose. Every
- * multi-choice step is therefore opt-out: enter accepts the whole set.
+ * arguing that empty was a good answer. Curated tools and agents are
+ * opt-out; project-specific language toolchains may deliberately start
+ * off while remaining one keypress away.
  */
 
 import { describe, expect, test } from "bun:test";
@@ -60,25 +59,20 @@ describe("the optional tools", () => {
   });
 });
 
-describe("every multi-choice step", () => {
-  test("uses one opt-out contract", () => {
-    for (const q of questions(WSL, choices(4), choices(5), choices(3)).filter(
-      (candidate) => candidate.multi,
-    )) {
-      expect(q.preset, q.id).toEqual(q.choices.map((choice) => choice.key));
-    }
-  });
-
-  test("all language runtimes arrive marked", () => {
+describe("multi-choice defaults", () => {
+  test("language runtimes leave Java, Ruby and Go unmarked", () => {
     const runtimes = [
       { key: "node@lts", label: "Node", note: "" },
       { key: "bun@latest", label: "Bun", note: "" },
       { key: "python@3.13", label: "Python", note: "" },
+      { key: "go@latest", label: "Go", note: "" },
+      { key: "ruby@3.4", label: "Ruby", note: "" },
+      { key: "java@lts", label: "Java", note: "" },
     ];
     const q = questions(WSL, choices(2), choices(3), runtimes).find(
       (candidate) => candidate.id === "runtimes",
     );
-    expect(q?.preset).toEqual(runtimes.map((runtime) => runtime.key));
+    expect(q?.preset).toEqual(["node@lts", "bun@latest", "python@3.13"]);
   });
 
   test("all agents arrive marked", () => {

--- a/src/tui-install-lifecycle.test.ts
+++ b/src/tui-install-lifecycle.test.ts
@@ -1,0 +1,143 @@
+/**
+ * The boundary immediately after a completed row.
+ *
+ * This is where the Ubuntu report appeared to stop: `dit — present` was
+ * visible, while the next managed item was already fetching a Nerd Font.
+ * Cross the real hook/render boundary so a regression cannot hide behind a
+ * structural assertion about source text.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { PassThrough } from "node:stream";
+import { createScrollArea, render, useEffect } from "tuiuiu.js";
+import { converge } from "./converge.ts";
+import { log } from "./log.ts";
+import type { Platform } from "./platform.ts";
+import {
+  InstallLayout,
+  type InstallModel,
+  type InstallOutcome,
+  type InstallTuiOptions,
+  useInstallModel,
+} from "./tui-install.ts";
+
+const desktop: Platform = {
+  os: "linux",
+  env: "desktop",
+  distro: "ubuntu",
+  version: "24.04",
+  codename: "noble",
+  arch: "x64",
+  caps: { apt: true, gui: true, systemd: true, winget: false, flatpak: true },
+};
+
+function terminal() {
+  const stdin = new PassThrough() as PassThrough & NodeJS.ReadStream;
+  const stdout = new PassThrough() as PassThrough & NodeJS.WriteStream;
+  Object.assign(stdin, { isTTY: true, isRaw: false, setRawMode: () => stdin });
+  Object.assign(stdout, { isTTY: true, columns: 96, rows: 30 });
+  return { stdin, stdout };
+}
+
+const base: Omit<InstallTuiOptions, "converge"> = {
+  platform: desktop,
+  ctx: { platform: desktop, theme: "reddb", font: "firacode", opacity: 100 },
+  scopes: ["desktop"],
+};
+
+describe("the final converge boundary", () => {
+  test("names and narrates the step after a present dit while it is still running", async () => {
+    let releaseFont!: () => void;
+    const fontMayFinish = new Promise<void>((resolve) => (releaseFont = resolve));
+    const runner: typeof converge = async (_opts, observer = {}) => {
+      const dit = {
+        scope: "desktop" as const,
+        tool: "dit",
+        provider: "installer:dit",
+        index: 1,
+        total: 2,
+      };
+      observer.stepStart?.(dit);
+      observer.stepEnd?.({ ...dit, outcome: "present", ms: 0 });
+
+      const font = {
+        scope: "desktop" as const,
+        tool: "nerd-font",
+        provider: "builtin:nerd-font",
+        index: 2,
+        total: 2,
+      };
+      observer.stepStart?.(font);
+      log.info("downloading https://example.invalid/FiraCode.zip");
+      await fontMayFinish;
+      const result = { ...font, outcome: "applied" as const, ms: 250 };
+      observer.stepEnd?.(result);
+      return { results: [{ ...dit, outcome: "present", ms: 0 }, result], failed: 0, deferred: 0 };
+    };
+
+    let model!: InstallModel;
+    let finished: InstallOutcome | null = null;
+    const logScroll = createScrollArea({ height: 10, content: [], autoScroll: true });
+    function App() {
+      model = useInstallModel({ ...base, converge: runner }, logScroll, (outcome) => {
+        finished = outcome;
+      });
+      useEffect(() => model.begin());
+      return InstallLayout(model, 96, 30);
+    }
+
+    const io = terminal();
+    const app = render(App, { ...io, fullHeight: true });
+    try {
+      await Bun.sleep(60);
+      expect(model.current()).toBe("nerd-font");
+      expect(model.lines()).toContain(":: nerd-font — builtin:nerd-font");
+      expect(model.lines()).toContain("    info downloading https://example.invalid/FiraCode.zip");
+      expect(finished).toBeNull();
+
+      releaseFont();
+      await Bun.sleep(60);
+      expect(finished).not.toBeNull();
+    } finally {
+      releaseFont();
+      app.unmount();
+    }
+  });
+
+  test("an unexpected rejection becomes a failed completion instead of working forever", async () => {
+    const runner: typeof converge = async (_opts, observer = {}) => {
+      const dit = {
+        scope: "desktop" as const,
+        tool: "dit",
+        provider: "installer:dit",
+        index: 1,
+        total: 1,
+      };
+      observer.stepStart?.(dit);
+      observer.stepEnd?.({ ...dit, outcome: "present", ms: 0 });
+      throw new Error("probe exploded after dit");
+    };
+
+    let model!: InstallModel;
+    let finished: InstallOutcome | null = null;
+    const logScroll = createScrollArea({ height: 10, content: [], autoScroll: true });
+    function App() {
+      model = useInstallModel({ ...base, converge: runner }, logScroll, (outcome) => {
+        finished = outcome;
+      });
+      useEffect(() => model.begin());
+      return InstallLayout(model, 96, 30);
+    }
+
+    const io = terminal();
+    const app = render(App, { ...io, fullHeight: true });
+    try {
+      await Bun.sleep(60);
+      expect(model.finished()).toBe(true);
+      expect((finished as InstallOutcome | null)?.failed).toBe(1);
+      expect(model.lines().join("\n")).toContain("probe exploded after dit");
+    } finally {
+      app.unmount();
+    }
+  });
+});

--- a/src/tui-install.ts
+++ b/src/tui-install.ts
@@ -15,7 +15,6 @@
 
 import {
   Box,
-  ListItem,
   MultiProgressBar,
   ProgressBar,
   ScrollArea,
@@ -40,7 +39,7 @@ import {
   type VerdictItem,
 } from "./completion.ts";
 import { converge, countSteps, type StepResult } from "./converge.ts";
-import { captureStart, captureStop, captureTo } from "./log.ts";
+import { captureTo } from "./log.ts";
 import { Accented, Header, Screen, Section, StatusLine, Surface } from "./tui-chrome.ts";
 import { muted, subtle, text, ui } from "./tui-theme.ts";
 import { transcriptPath } from "./transcript.ts";
@@ -88,6 +87,8 @@ export interface InstallTuiOptions {
   platform: Platform;
   ctx: ApplyContext;
   scopes: Scope[];
+  /** Test seam for exercising the renderer across live converge events. */
+  converge?: typeof converge;
 }
 
 /**
@@ -218,7 +219,40 @@ export function useInstallModel(
   useEffect(() => {
     if (!started()) return;
 
-    void converge(
+    // A step owns a live redirect for exactly as long as it runs. Holding
+    // these lines until stepEnd made the current provider completely silent:
+    // on Ubuntu, `dit — present` remained the last row while the following
+    // Nerd Font download was already under way. There is no concurrency here,
+    // so streaming cannot interleave two tools; releasing before the outcome
+    // row keeps the same grouping while making the active work observable.
+    let releaseStep: (() => void) | null = null;
+
+    const setupVerdicts = (): VerdictItem[] =>
+      setupResults().map((r) => ({ tool: r.tool, outcome: r.outcome }));
+
+    const finishRun = (
+      summary: { failed: number; deferred: number; results: StepResult[] },
+      endedAt: number,
+    ): void => {
+      setFinishedAt(endedAt);
+      setFinished(true);
+      const setupFailed = setupResults().filter((result) => result.outcome === "failed").length;
+      onFinish({
+        failed: summary.failed + setupFailed,
+        deferred: summary.deferred,
+        results: [
+          ...setupVerdicts(),
+          ...summary.results.map((r) => ({
+            tool: r.tool,
+            outcome: r.outcome,
+            ...(r.remedy ? { remedy: r.remedy } : {}),
+          })),
+        ],
+        elapsedMs: startedAt() === 0 ? 0 : endedAt - startedAt(),
+      });
+    };
+
+    void (opts.converge ?? converge)(
       { platform: opts.platform, ctx: opts.ctx, scopes: opts.scopes, dryRun: false },
       {
         scopeStart: (s, n) => {
@@ -254,12 +288,12 @@ export function useInstallModel(
         },
         stepStart: (e) => {
           setCurrent(e.tool);
-          // Hold provider chatter so it lands under its own step rather
-          // than interleaving with the next one.
-          captureStart();
+          push(`:: ${e.tool} — ${e.provider}`);
+          releaseStep = captureTo((line) => push(`    ${plain(line)}`));
         },
         stepEnd: (r) => {
-          const held = captureStop();
+          releaseStep?.();
+          releaseStep = null;
           // LogViewer takes plain strings, so the glyph is chosen here
           // rather than by a component.
           // A deferral gets its own glyph rather than the failure's: it
@@ -274,7 +308,6 @@ export function useInstallModel(
                   ? "·"
                   : "✓";
           push(`${glyph} ${r.tool.padEnd(16)} ${r.outcome}${r.ms >= 1000 ? `  ${human(r.ms)}` : ""}`);
-          for (const h of held) push(`    ${plain(h)}`);
           if (r.detail && (r.outcome === "failed" || r.outcome === "deferred")) {
             push(`    ${r.detail}`);
           }
@@ -285,31 +318,42 @@ export function useInstallModel(
           setResults((prev) => [...prev, r]);
         },
       },
-    ).then((summary) => {
-      const endedAt = Date.now();
-      setFinishedAt(endedAt);
-      setFinished(true);
-      const setupFailed = setupResults().filter((result) => result.outcome === "failed").length;
-      // Setup first, converge second: the same order they ran in, and
-      // the order the completion screen counts them in.
-      // Mapped apart because they are different records: a setup result
-      // has no remedy at all, and a converge result has one only when
-      // something is waiting on a gate.
-      const all: VerdictItem[] = [
-        ...setupResults().map((r) => ({ tool: r.tool, outcome: r.outcome })),
-        ...summary.results.map((r) => ({
-          tool: r.tool,
-          outcome: r.outcome,
-          ...(r.remedy ? { remedy: r.remedy } : {}),
-        })),
-      ];
-      onFinish({
-        failed: summary.failed + setupFailed,
-        deferred: summary.deferred,
-        results: all,
-        elapsedMs: startedAt() === 0 ? 0 : endedAt - startedAt(),
-      });
-    });
+    ).then(
+      (summary) => finishRun(summary, Date.now()),
+      (err: unknown) => {
+        // No rejected converge may leave the fullscreen UI saying
+        // "working…" forever. Most provider failures are ordinary step
+        // outcomes; this is the guard for failures outside that bracket
+        // (a probe, observer, transcript or future orchestration bug).
+        releaseStep?.();
+        releaseStep = null;
+        releaseBatch?.();
+        releaseBatch = null;
+        const message = (err as Error).message || String(err);
+        const completed = results();
+        const fatal: StepResult = {
+          scope: opts.scopes.at(-1) ?? "core",
+          tool: current() || "red-dev",
+          provider: "internal",
+          index: completed.length + 1,
+          total,
+          outcome: "failed",
+          ms: 0,
+          detail: message,
+        };
+        push(`✗ ${fatal.tool.padEnd(16)} failed`);
+        push(`    ${message}`);
+        setResults((previous) => [...previous, fatal]);
+        finishRun(
+          {
+            failed: completed.filter((result) => result.outcome === "failed").length + 1,
+            deferred: completed.filter((result) => result.outcome === "deferred").length,
+            results: [...completed, fatal],
+          },
+          Date.now(),
+        );
+      },
+    );
   });
 
   return {
@@ -507,14 +551,14 @@ export function InstallLayout(
                 Text({ color: ui.warn, bold: true }, "Deferred"),
                 ...deferrals
                   .slice(0, 6)
-                  .map((d) => ListItem({ primary: d.tool, status: "warning" })),
+                  .map((d) => Text({ color: ui.warn }, `! ${d.tool}`)),
               ]
             : []),
 
           ...(failures.length > 0
             ? [
                 Text({ color: ui.danger, bold: true }, "Failed"),
-                ...failures.slice(0, 6).map((f) => ListItem({ primary: f.tool, status: "error" })),
+                ...failures.slice(0, 6).map((f) => Text({ color: ui.danger }, `✗ ${f.tool}`)),
               ]
             : []),
 

--- a/src/tui-setup-model.ts
+++ b/src/tui-setup-model.ts
@@ -30,6 +30,7 @@ import { Screen, Surface } from "./tui-chrome.ts";
 import { muted, ui } from "./tui-theme.ts";
 import { DEFAULT_THEME, swatches, THEMES, themeNames } from "./themes.ts";
 import type { ThemeSlug } from "./themes.ts";
+import { runtimeSelectedByDefault } from "./runtimes.ts";
 
 export interface SetupAnswers {
   theme: string;
@@ -144,10 +145,11 @@ export function questions(
       description:
         "Owned by mise, so node resolves the same way in WSL, on the desktop " +
         "and in Git Bash. A version manager that manages nothing is how pnpm " +
-        "ends up working in one shell and not another.",
+        "ends up working in one shell and not another. Java, Ruby and Go are " +
+        "available but start off; select them when a project needs them.",
       multi: true,
       choices: runtimes,
-      preset: runtimes.map((runtime) => runtime.key),
+      preset: runtimes.filter((runtime) => runtimeSelectedByDefault(runtime.key)).map((runtime) => runtime.key),
       applies: () => true,
     },
     {

--- a/src/wsl.ts
+++ b/src/wsl.ts
@@ -334,24 +334,18 @@ export const NERD_FONTS: Record<string, NerdFontSpec> = {
 };
 
 async function ghAsset(repo: string, name: string): Promise<string> {
-  const headers: Record<string, string> = { Accept: "application/vnd.github+json" };
-  const token = process.env["GITHUB_TOKEN"];
-  if (token) headers["Authorization"] = `Bearer ${token}`;
+  // One GitHub resolver for every provider: authenticated when a token is
+  // available, bounded to 90 seconds, and explicit about rate limits. The
+  // old font-only request had no deadline, so `nerd-font` could wait forever
+  // immediately after the visible `dit — present` row.
+  const { resolveGhAsset } = await import("./providers.ts");
+  return await resolveGhAsset(repo, name);
+}
 
-  const res = await fetch(`https://api.github.com/repos/${repo}/releases/latest`, {
-    headers,
-  });
-  if (!res.ok) throw new RedError(`GitHub API ${res.status} for ${repo}`);
-
-  const body = (await res.json()) as { assets?: { name: string; browser_download_url: string }[] };
-  const hit = (body.assets ?? []).find((a) => a.name === name);
-  if (!hit) {
-    throw new RedError(
-      `no asset named '${name}' in latest ${repo} release. Available:\n` +
-        (body.assets ?? []).map((a) => `  ${a.name}`).join("\n"),
-    );
-  }
-  return hit.browser_download_url;
+/** Download a font archive through the same bounded, narrated path as tools. */
+async function downloadFont(url: string, dest: string): Promise<void> {
+  const { downloadVerified } = await import("./providers.ts");
+  await downloadVerified(url, dest);
 }
 
 /**
@@ -406,9 +400,7 @@ async function installWindowsNerdFont(key: string): Promise<void> {
   // failure rather than as red-dev's plumbing.
   const tmp = tempDir(`font-${spec.asset}`);
 
-  const res = await fetch(url);
-  if (!res.ok) throw new RedError(`font download failed ${res.status}`);
-  await Bun.write(`${tmp}/font.zip`, res);
+  await downloadFont(url, `${tmp}/font.zip`);
   await run(["unzip", "-qo", `${tmp}/font.zip`, "-d", tmp]);
 
   await run(["mkdir", "-p", fontDir]);
@@ -468,9 +460,7 @@ async function installLinuxNerdFont(key: string): Promise<void> {
   // failure rather than as red-dev's plumbing.
   const tmp = tempDir(`font-${spec.asset}`);
 
-  const res = await fetch(url);
-  if (!res.ok) throw new RedError(`font download failed ${res.status}`);
-  await Bun.write(`${tmp}/font.zip`, res);
+  await downloadFont(url, `${tmp}/font.zip`);
   await run(["unzip", "-qo", `${tmp}/font.zip`, "-d", tmp]);
 
   const fontDir = `${process.env["HOME"] ?? ""}/.local/share/fonts/red-dev/${spec.asset}`;


### PR DESCRIPTION
## What changed

- stream each install step and carriage-return progress into the fullscreen log while it runs
- show the next provider immediately after a present item such as dit
- make Nerd Font GitHub resolution and downloads use the shared bounded path
- finish the TUI with an explicit failure when converge rejects unexpectedly
- keep failure and deferral rendering hook-stable
- leave Java, Ruby and Go unchecked by default

## Why

On Ubuntu, dit could report present while the following Nerd Font download ran with all narration buffered until completion. A stalled network request or unexpected rejection therefore left dit as the last visible row and the UI saying working forever. The font-specific GitHub requests also had no deadline.

WSL synchronization remains Windows-only: Ubuntu reaches that manifest row only as a documented skip.

## Validation

- full bun test suite
- bun run typecheck
- Linux and Windows production builds
- lifecycle regression across the real tuiuiu render boundary
- explicit Ubuntu/WSL provider tests

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/119"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789216541&installation_model_id=20659&pr_number=119&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F119&signature=cffd0a4e0933f712ee2ce9211af24513c376963c7ea81d24a3cd087dd2fc302e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->