### PR TITLE
fix curl install sudo handoff

### DIFF
--- a/boot.sh
+++ b/boot.sh
@@ -196,6 +196,11 @@ fi
 
 say "starting red-dev"
 
+# Tell the binary this launch is the installation handoff, not an ordinary
+# visit to its menu. On Ubuntu that lets it authenticate sudo once before the
+# fullscreen renderer owns stdin; providers themselves remain unattended.
+export RED_DEV_BOOTSTRAP=1
+
 # Reconnect stdin to the terminal before handing over.
 #
 # The documented way to run this is `curl ... | sh`, which makes the

--- a/src/completion.test.ts
+++ b/src/completion.test.ts
@@ -77,6 +77,25 @@ describe("the verdict", () => {
     expect(v.nextSteps.some((s) => s.includes("rights"))).toBe(true);
   });
 
+  test("deferred items show their shared cause without opening the log", () => {
+    const detail = "sudo needs a password and nothing here can supply one.";
+    const v = convergeVerdict(
+      [
+        item("btop", { outcome: "deferred", detail }),
+        item("red-ui", { outcome: "deferred", detail }),
+      ],
+      1_000,
+    );
+
+    expect(v.deferrals).toEqual([
+      { tool: "btop", detail },
+      { tool: "red-ui", detail },
+    ]);
+    const banner = plain(completionBanner(v, 72, { color: false })).join("\n");
+    expect(banner).toContain("Waiting");
+    expect(banner).toContain("sudo needs a password");
+  });
+
   test("a failure says the machine is not converged, and names the item", () => {
     const v = convergeVerdict([item("docker", { outcome: "failed" })], 90_000);
     expect(v.status).toBe("failed");
@@ -84,6 +103,24 @@ describe("the verdict", () => {
     expect(v.headline).toContain("docker");
     expect(v.nextSteps[0]).toContain("Re-run");
     expect(v.elapsed).toBe("1m 30s");
+  });
+
+  test("a failure carries its cause into the closing verdict", () => {
+    const failed = item("nerd-font", {
+      outcome: "failed",
+      detail: "GitHub API 403 for ryanoasis/nerd-fonts — rate limited",
+    });
+    const v = convergeVerdict([failed], 1_000);
+
+    expect(v.failures).toEqual([
+      {
+        tool: "nerd-font",
+        detail: "GitHub API 403 for ryanoasis/nerd-fonts — rate limited",
+      },
+    ]);
+    expect(plain(completionBanner(v, 72, { color: false })).join("\n")).toContain(
+      "GitHub API 403 for ryanoasis/nerd-fonts",
+    );
   });
 
   test("failures outrank deferrals when a run has both", () => {

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -38,7 +38,15 @@ export type CompletionOutcome =
 export interface VerdictItem {
   tool: string;
   outcome: CompletionOutcome;
+  /** The provider's actual failure, carried all the way to the closing screen. */
+  detail?: string;
   remedy?: string;
+}
+
+export interface CompletionFailure {
+  tool: string;
+  /** Absent only when the provider itself supplied no diagnostic. */
+  detail?: string;
 }
 
 export interface VerdictOptions {
@@ -64,6 +72,10 @@ export interface CompletionVerdict {
   };
   elapsed: string;
   logPath: string | null;
+  /** Failed items and their immediate causes, in execution order. */
+  failures: CompletionFailure[];
+  /** Work that could not cross its rights gate, with the reason it stopped. */
+  deferrals: CompletionFailure[];
   /**
    * What to do next, in the order it has to be done.
    *
@@ -103,6 +115,14 @@ export function convergeVerdict(
   };
   const elapsed = formatDuration(elapsedMs);
   const logPath = options.logPath ?? null;
+  const failures = failed.map((item) => ({
+    tool: item.tool,
+    ...(item.detail?.trim() ? { detail: item.detail.replace(/\s+/g, " ").trim() } : {}),
+  }));
+  const deferrals = deferred.map((item) => ({
+    tool: item.tool,
+    ...(item.detail?.trim() ? { detail: item.detail.replace(/\s+/g, " ").trim() } : {}),
+  }));
 
   if (options.dryRun === true) {
     return {
@@ -111,6 +131,8 @@ export function convergeVerdict(
       counts,
       elapsed,
       logPath,
+      failures,
+      deferrals,
       nextSteps: ["Run `red-dev install` to carry this out."],
     };
   }
@@ -153,6 +175,8 @@ export function convergeVerdict(
       counts,
       elapsed,
       logPath,
+      failures,
+      deferrals,
       nextSteps,
     };
   }
@@ -167,6 +191,8 @@ export function convergeVerdict(
       counts,
       elapsed,
       logPath,
+      failures,
+      deferrals,
       nextSteps,
     };
   }
@@ -177,6 +203,8 @@ export function convergeVerdict(
     counts,
     elapsed,
     logPath,
+    failures,
+    deferrals,
     nextSteps,
   };
 }
@@ -204,6 +232,23 @@ export function verdictFacts(verdict: CompletionVerdict): string[] {
   const rows = [parts.join(" · "), `took ${verdict.elapsed}`];
   if (verdict.logPath) rows.push(`log  ${verdict.logPath}`);
   return rows;
+}
+
+/** Human-readable provider failures shared by both closing presentations. */
+export function failureFacts(verdict: CompletionVerdict): string[] {
+  return verdict.failures.map(
+    (failure) => `${failure.tool}: ${failure.detail ?? "no error detail was reported"}`,
+  );
+}
+
+/** Group a shared rights failure once, followed by every item it held back. */
+export function deferralFacts(verdict: CompletionVerdict): string[] {
+  const groups = new Map<string, string[]>();
+  for (const deferral of verdict.deferrals) {
+    const detail = deferral.detail ?? "no deferral detail was reported";
+    groups.set(detail, [...(groups.get(detail) ?? []), deferral.tool]);
+  }
+  return [...groups].map(([detail, tools]) => `${detail} — ${tools.join(", ")}`);
 }
 
 /**
@@ -299,6 +344,16 @@ export function completionBanner(
     const split = fact.indexOf("  ");
     const lead = split > 0 ? fact.slice(0, split + 2) : "";
     out.push(...item(lead, fact.slice(lead.length), "1;90"));
+  }
+  if (verdict.failures.length > 0) {
+    out.push(blank());
+    out.push(row("Errors", "1;31"));
+    for (const failure of failureFacts(verdict)) out.push(...item("✗ ", failure, "1;31"));
+  }
+  if (verdict.deferrals.length > 0) {
+    out.push(blank());
+    out.push(row("Waiting", "1;33"));
+    for (const deferral of deferralFacts(verdict)) out.push(...item("! ", deferral, "1;33"));
   }
   if (verdict.nextSteps.length > 0) {
     out.push(blank());

--- a/src/console-ownership.test.ts
+++ b/src/console-ownership.test.ts
@@ -45,6 +45,10 @@ const ALLOWED = new Map<string, string>([
     "`red-dev uninstall` is a plain command with no fullscreen view; it prints a plan and asks at the terminal.",
   ],
   [
+    "sudo-preflight.ts",
+    "`sudo -v` is the explicit boundary before a human install starts fullscreen rendering; bootstrap and direct install call it before render, while unattended paths never call it.",
+  ],
+  [
     "wsl-provision.ts",
     "`wsl --install` and `--set-version` prompt for a UNIX username and take minutes. They need real stdin, which spawnLogged's captured branch sets to ignore — so routing them through it would hang rather than tear. Known gap: reachable from the TUI menu, where it WOULD tear. Not fixed here because the fix is to refuse the capture, not to pipe it.",
   ],

--- a/src/main.ts
+++ b/src/main.ts
@@ -30,6 +30,14 @@ function resolveScopes(p: Platform, arg?: string): Scope[] {
   return arg ? [arg as Scope] : applicableScopes(p);
 }
 
+/** Warm sudo while the ordinary terminal still owns stdin. */
+async function prepareSudo(p: Platform, scopes: Scope[]): Promise<boolean> {
+  const { primeSudoInteractive, sudoItemsFor } = await import("./sudo-preflight.ts");
+  if (sudoItemsFor(p, scopes).length === 0) return false;
+  await primeSudoInteractive();
+  return true;
+}
+
 async function contextFor(
   p: Platform,
   inv: Invocation,
@@ -447,6 +455,7 @@ async function cmdInstall(
 ): Promise<number> {
   let ctx = await contextFor(p, inv, entry);
   let extraScopes: Scope[] = [];
+  let sudoPrepared = false;
 
   // Ask once, on a real terminal, when this machine is new. Every ui.ts
   // primitive returns its fallback without a TTY, so this is inert in
@@ -467,6 +476,16 @@ async function cmdInstall(
         if (choices.apps.length > 0) extraScopes = ["optional"];
         await writeShellEnv(p, choices.blesh);
 
+        // Before agents, runtimes or optional apps can reach a package
+        // provider. This is a visible top-level authentication, never a
+        // prompt hidden inside one of their unattended children.
+        if (!inv.yes && interactive()) {
+          sudoPrepared = await prepareSudo(p, [
+            ...resolveScopes(p, inv.scope),
+            ...extraScopes,
+          ]);
+        }
+
         // One implementation, reachable from both paths. It used to live
         // only here, so the fullscreen menu asked which agents you wanted
         // and installed none of them.
@@ -483,6 +502,13 @@ async function cmdInstall(
   }
 
   const scopes = [...resolveScopes(p, inv.scope), ...extraScopes];
+
+  // Direct `red-dev install` reaches here without the first-run interview.
+  // Prime once before either fullscreen or line reporting begins. `--yes`
+  // remains strictly unattended and non-TTY runs never ask anything.
+  if (!inv.dryRun && !inv.yes && interactive() && !sudoPrepared) {
+    await prepareSudo(p, scopes);
+  }
 
   // Fullscreen when there is a terminal wide enough for it: the live
   // view is the default experience, and the line report is what runs in
@@ -1085,6 +1111,13 @@ async function cmdUi(p: Platform, inv: Invocation): Promise<number> {
     log.err("the fullscreen interface needs a terminal");
     log.plain("     Use `red-dev` for the menu, or a command directly.");
     return 1;
+  }
+
+  // The bootstrap one-liner is an explicit installation entry. Warm sudo
+  // before its first fullscreen frame; later bare `red-dev` launches are a
+  // menu and must not demand a password merely to inspect a theme or doctor.
+  if (process.env["RED_DEV_BOOTSTRAP"] === "1" && !inv.yes) {
+    await prepareSudo(p, resolveScopes(p, inv.scope));
   }
 
   const { runTui } = await import("./tui.ts");

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -148,6 +148,15 @@ type ProviderSpec =
 /** One column of the manifest: how this platform gets this tool. */
 export type Provider = ProviderSpec & {
   /**
+   * This Linux provider eventually invokes sudo.
+   *
+   * The common package shapes (apt, PPA, apt repository and .deb release)
+   * imply this themselves. This flag exists for installers and builtins whose
+   * script body is the only other place the requirement could be discovered —
+   * too late to authenticate before the fullscreen renderer owns stdin.
+   */
+  needsSudo?: true;
+  /**
    * This column cannot complete without administrator rights.
    *
    * Declared per column, never per tool, because the need is not
@@ -334,6 +343,8 @@ const builtin = (
     | "ssh-server",
 ): Provider => ({ kind: "builtin", name });
 const skip = (reason: string): Provider => ({ kind: "skip", reason });
+/** A Linux provider whose implementation performs system work through sudo. */
+const sudoProvider = (pr: ProviderSpec): Provider => ({ ...pr, needsSudo: true });
 /**
  * Wraps a column that cannot complete without administrator rights.
  *
@@ -400,7 +411,7 @@ export const TOOLS: Tool[] = [
     name: "ssh-server",
     scope: "core",
     managed: true,
-    u24: builtin("ssh-server"),
+    u24: sudoProvider(builtin("ssh-server")),
     win: admin(builtin("ssh-server")),
   },
   {
@@ -739,10 +750,12 @@ export const TOOLS: Tool[] = [
     about: "open-source API client, powered by recker",
     cmd: ["red-request", "rr"],
     scope: "desktop",
-    u24: installer(
-      "https://raw.githubusercontent.com/reddb-io/red-request/main/install.sh",
-      "reddb-io/red-request — installs the .deb and verifies its checksum",
-      "--no-color",
+    u24: sudoProvider(
+      installer(
+        "https://raw.githubusercontent.com/reddb-io/red-request/main/install.sh",
+        "reddb-io/red-request — installs the .deb and verifies its checksum",
+        "--no-color",
+      ),
     ),
     // /S is NSIS's silent flag, and this asset really is NSIS: its PE
     // manifest asks for asInvoker, so it installs per-user with no UAC
@@ -785,11 +798,13 @@ export const TOOLS: Tool[] = [
     name: "dit",
     about: "push-to-toggle voice dictation, typed into the focused app",
     scope: "desktop",
-    u24: installer(
-      "https://raw.githubusercontent.com/reddb-io/dit/main/install.sh",
-      "reddb-io/dit — installs the binary and the /dev/uinput permissions it needs",
-      "--yes",
-      "--no-service",
+    u24: sudoProvider(
+      installer(
+        "https://raw.githubusercontent.com/reddb-io/dit/main/install.sh",
+        "reddb-io/dit — installs the binary and the /dev/uinput permissions it needs",
+        "--yes",
+        "--no-service",
+      ),
     ),
     win: gh("reddb-io/dit", "dit-windows-x86_64.exe", "dit"),
   },

--- a/src/ssh-server.test.ts
+++ b/src/ssh-server.test.ts
@@ -46,7 +46,11 @@ describe("the manifest entry", () => {
   test("is core on both columns, so a converge always reaches it", () => {
     const tool = TOOLS.find((t) => t.name === "ssh-server");
     expect(tool?.scope).toBe("core");
-    expect(providerFor(tool!, platform())).toEqual({ kind: "builtin", name: "ssh-server" });
+    expect(providerFor(tool!, platform())).toEqual({
+      kind: "builtin",
+      name: "ssh-server",
+      needsSudo: true,
+    });
     // Same builtin on both, and one extra word on the Windows column:
     // the capability, the service and the firewall rule all need
     // administrator, while Ubuntu's apt-get takes the usual sudo path.

--- a/src/sudo-preflight.test.ts
+++ b/src/sudo-preflight.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Sudo authentication belongs before the fullscreen renderer owns stdin.
+ *
+ * Inside the TUI every provider deliberately uses `sudo -n`: an unexpected
+ * password prompt must fail rather than become an invisible hang. The human
+ * install path therefore warms the credential once, visibly, before render.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import type { Platform } from "./platform.ts";
+import { primeSudoInteractive, sudoItemsFor } from "./sudo-preflight.ts";
+
+const ubuntu: Platform = {
+  os: "linux",
+  env: "desktop",
+  distro: "ubuntu",
+  version: "24.04",
+  codename: "noble",
+  arch: "x64",
+  caps: { apt: true, gui: true, systemd: true, winget: false, flatpak: true },
+};
+
+describe("the sudo preflight plan", () => {
+  test("a fresh Ubuntu install names archive and deb-installer work", () => {
+    const names = sudoItemsFor(ubuntu, ["core", "desktop"], () => "absent");
+
+    expect(names).toContain("btop");
+    expect(names).toContain("carapace");
+    expect(names).toContain("red-request");
+    expect(names).toContain("dit");
+  });
+
+  test("a converged machine and native Windows ask for nothing", () => {
+    expect(sudoItemsFor(ubuntu, ["core", "desktop"], () => "ok")).toEqual([]);
+    expect(
+      sudoItemsFor(
+        { ...ubuntu, os: "windows", env: "windows", caps: { ...ubuntu.caps, apt: false } },
+        ["core", "desktop"],
+        () => "absent",
+      ),
+    ).toEqual([]);
+  });
+});
+
+describe("visible sudo authentication", () => {
+  test("uses sudo -v with the terminal attached exactly once", async () => {
+    const calls: string[][] = [];
+    const ok = await primeSudoInteractive({
+      uid: () => 1000,
+      run: async (argv) => {
+        calls.push(argv);
+        return 0;
+      },
+    });
+
+    expect(ok).toBe(true);
+    expect(calls).toEqual([["sudo", "-v"]]);
+  });
+
+  test("root needs no sudo process", async () => {
+    let ran = false;
+    expect(
+      await primeSudoInteractive({ uid: () => 0, run: async () => ((ran = true), 0) }),
+    ).toBe(true);
+    expect(ran).toBe(false);
+  });
+});
+
+describe("the human install entry points", () => {
+  test("the bootstrap marks its launch and direct install primes before rendering", () => {
+    const boot = readFileSync(`${import.meta.dir}/../boot.sh`, "utf8");
+    const main = readFileSync(`${import.meta.dir}/main.ts`, "utf8");
+
+    expect(boot).toContain("export RED_DEV_BOOTSTRAP=1");
+    // `curl | sh` leaves stdin pointing at the exhausted script pipe. The
+    // downloaded binary must inherit the controlling terminal or neither
+    // its sudo prompt nor its fullscreen interface can read a key.
+    expect(boot).toContain('exec "$BIN" < /dev/tty');
+    expect(boot.indexOf("export RED_DEV_BOOTSTRAP=1")).toBeLessThan(
+      boot.indexOf('exec "$BIN" < /dev/tty'),
+    );
+
+    // The bootstrap enters the menu rather than `cmdInstall`, so it needs
+    // the same visible preflight before the first fullscreen frame.
+    expect(main).toContain('process.env["RED_DEV_BOOTSTRAP"] === "1"');
+    expect(main.indexOf('process.env["RED_DEV_BOOTSTRAP"] === "1"')).toBeLessThan(
+      main.indexOf("const { runTui }"),
+    );
+    expect(main.indexOf("await prepareSudo(p, scopes)")).toBeLessThan(
+      main.indexOf("await runInstallTui("),
+    );
+  });
+});

--- a/src/sudo-preflight.ts
+++ b/src/sudo-preflight.ts
@@ -1,0 +1,75 @@
+/**
+ * Authenticate sudo before a human install enters fullscreen mode.
+ *
+ * Providers deliberately use `sudo -n`: once the renderer owns stdin, a
+ * password prompt is hidden work and can hang forever. A visible `sudo -v`
+ * before render preserves that non-interactive provider contract while still
+ * letting an ordinary Ubuntu install finish in one run.
+ */
+
+import {
+  installState,
+  providerFor,
+  toolsInScope,
+  type InstallState,
+  type Provider,
+  type Scope,
+  type Tool,
+} from "./manifest.ts";
+import { log } from "./log.ts";
+import type { Platform } from "./platform.ts";
+
+/** Whether a Linux provider will need a warm sudo credential. PURE. */
+export function providerUsesSudo(provider: Provider): boolean {
+  if (provider.needsSudo === true) return true;
+  if (provider.kind === "apt" || provider.kind === "ppa" || provider.kind === "aptrepo") {
+    return true;
+  }
+  return provider.kind === "gh" && /\.deb$/i.test(provider.asset);
+}
+
+/** Pending items that would otherwise all become deferred inside the TUI. PURE with injected state. */
+export function sudoItemsFor(
+  platform: Platform,
+  scopes: readonly Scope[],
+  state: (tool: Tool) => InstallState = installState,
+): string[] {
+  if (platform.os !== "linux") return [];
+  return scopes
+    .flatMap((scope) => toolsInScope(scope))
+    // Managed providers deliberately probe inside their implementation, so
+    // installState reports them pending forever. Including one here would ask
+    // for a password on every already-converged run. Ordinary package and
+    // installer rows have an honest pre-render presence state and are enough
+    // to cover a fresh Ubuntu machine.
+    .filter((tool) => !tool.managed)
+    .filter((tool) => state(tool) !== "ok" && providerUsesSudo(providerFor(tool, platform)))
+    .map((tool) => tool.name);
+}
+
+export interface SudoPrimeOptions {
+  uid?: () => number;
+  run?: (argv: string[]) => Promise<number>;
+}
+
+const runAttached = async (argv: string[]): Promise<number> => {
+  try {
+    const child = Bun.spawn(argv, { stdin: "inherit", stdout: "inherit", stderr: "inherit" });
+    return await child.exited;
+  } catch {
+    return 127;
+  }
+};
+
+/** Ask once, in the ordinary terminal, before any fullscreen frame exists. */
+export async function primeSudoInteractive(options: SudoPrimeOptions = {}): Promise<boolean> {
+  const uid = options.uid ?? (() => process.getuid?.() ?? -1);
+  if (uid() === 0) return true;
+
+  log.step("sudo: authenticate once for system packages before the installer opens");
+  const code = await (options.run ?? runAttached)(["sudo", "-v"]);
+  if (code === 0) return true;
+
+  log.warn("sudo was not authenticated — system packages will be deferred, not hidden");
+  return false;
+}

--- a/src/tui-install-lifecycle.test.ts
+++ b/src/tui-install-lifecycle.test.ts
@@ -9,12 +9,13 @@
 
 import { describe, expect, test } from "bun:test";
 import { PassThrough } from "node:stream";
-import { createScrollArea, render, useEffect } from "tuiuiu.js";
+import { createScrollArea, render, renderToString, useEffect } from "tuiuiu.js";
 import { converge } from "./converge.ts";
 import { log } from "./log.ts";
 import type { Platform } from "./platform.ts";
 import {
   InstallLayout,
+  CompletionLayout,
   type InstallModel,
   type InstallOutcome,
   type InstallTuiOptions,
@@ -46,6 +47,69 @@ const base: Omit<InstallTuiOptions, "converge"> = {
 };
 
 describe("the final converge boundary", () => {
+  test("the fullscreen completion explains a sudo deferral without opening the log", () => {
+    const frame = renderToString(
+      CompletionLayout(
+        {
+          failed: 0,
+          deferred: 2,
+          elapsedMs: 1_000,
+          results: [
+            {
+              tool: "btop",
+              outcome: "deferred",
+              detail: "sudo needs a password and nothing here can supply one.",
+              remedy: "Run `sudo -v` first, then re-run red-dev.",
+            },
+            {
+              tool: "red-ui",
+              outcome: "deferred",
+              detail: "sudo needs a password and nothing here can supply one.",
+              remedy: "Run `sudo -v` first, then re-run red-dev.",
+            },
+          ],
+        },
+        96,
+        30,
+        "/tmp/install.log",
+      ),
+      96,
+      30,
+    );
+
+    expect(frame).toContain("Waiting");
+    expect(frame).toContain("sudo needs a password");
+    expect(frame).toContain("btop, red-ui");
+    expect(frame).toContain("sudo -v");
+  });
+
+  test("the fullscreen completion shows the provider's error without opening the log", () => {
+    const frame = renderToString(
+      CompletionLayout(
+        {
+          failed: 1,
+          deferred: 0,
+          elapsedMs: 1_000,
+          results: [
+            {
+              tool: "nerd-font",
+              outcome: "failed",
+              detail: "GitHub API 403 for ryanoasis/nerd-fonts — rate limited",
+            },
+          ],
+        },
+        96,
+        30,
+        "/tmp/install.log",
+      ),
+      96,
+      30,
+    );
+
+    expect(frame).toContain("Errors");
+    expect(frame).toContain("GitHub API 403 for ryanoasis/nerd-fonts");
+  });
+
   test("names and narrates the step after a present dit while it is still running", async () => {
     let releaseFont!: () => void;
     const fontMayFinish = new Promise<void>((resolve) => (releaseFont = resolve));
@@ -135,6 +199,11 @@ describe("the final converge boundary", () => {
       await Bun.sleep(60);
       expect(model.finished()).toBe(true);
       expect((finished as InstallOutcome | null)?.failed).toBe(1);
+      expect((finished as InstallOutcome | null)?.results.at(-1)).toMatchObject({
+        tool: "dit",
+        outcome: "failed",
+        detail: "probe exploded after dit",
+      });
       expect(model.lines().join("\n")).toContain("probe exploded after dit");
     } finally {
       app.unmount();

--- a/src/tui-install.ts
+++ b/src/tui-install.ts
@@ -32,6 +32,8 @@ import { createScrollArea, type ScrollAreaState } from "tuiuiu.js";
 import { VERSION } from "./cli.ts";
 import {
   convergeVerdict,
+  deferralFacts,
+  failureFacts,
   shortenHome,
   verdictFacts,
   wrapTo,
@@ -228,7 +230,11 @@ export function useInstallModel(
     let releaseStep: (() => void) | null = null;
 
     const setupVerdicts = (): VerdictItem[] =>
-      setupResults().map((r) => ({ tool: r.tool, outcome: r.outcome }));
+      setupResults().map((r) => ({
+        tool: r.tool,
+        outcome: r.outcome,
+        ...(r.detail ? { detail: r.detail } : {}),
+      }));
 
     const finishRun = (
       summary: { failed: number; deferred: number; results: StepResult[] },
@@ -245,6 +251,7 @@ export function useInstallModel(
           ...summary.results.map((r) => ({
             tool: r.tool,
             outcome: r.outcome,
+            ...(r.detail ? { detail: r.detail } : {}),
             ...(r.remedy ? { remedy: r.remedy } : {}),
           })),
         ],
@@ -662,6 +669,28 @@ export function CompletionLayout(
         ),
       ),
       Text({}, ""),
+      ...(verdict.failures.length > 0
+        ? [
+            Text({ color: ui.danger, bold: true }, "Errors"),
+            ...failureFacts(verdict).flatMap((failure) =>
+              wrapTo(failure, room - 2).map((line, i) =>
+                Text({ color: ui.danger }, `${i === 0 ? "✗ " : "  "}${line}`),
+              ),
+            ),
+            Text({}, ""),
+          ]
+        : []),
+      ...(verdict.deferrals.length > 0
+        ? [
+            Text({ color: ui.warn, bold: true }, "Waiting"),
+            ...deferralFacts(verdict).flatMap((deferral) =>
+              wrapTo(deferral, room - 2).map((line, i) =>
+                Text({ color: ui.warn }, `${i === 0 ? "! " : "  "}${line}`),
+              ),
+            ),
+            Text({}, ""),
+          ]
+        : []),
       ...(verdict.nextSteps.length > 0
         ? [
             Text({ color: muted, bold: true }, "Next"),


### PR DESCRIPTION
## What changed

- prime `sudo` on the controlling terminal before the bootstrap enters fullscreen mode
- keep package providers non-interactive so no hidden password prompt can hang the run
- carry provider failures and deferrals into both completion screens
- declare installer providers whose Linux path requires sudo

## Root cause

`curl | sh` correctly reattached stdin to `/dev/tty`, but the downloaded binary entered fullscreen mode before authenticating sudo. Providers then used the intentional non-interactive rights probe and deferred every system package. The completion screen hid those causes behind the transcript path.

## Impact

The documented one-liner can visibly ask for sudo once before rendering. If authentication is refused, the run remains non-blocking and the closing screen names the exact cause and affected tools.

## Validation

- `bun test` — 1173 passed
- `bun run typecheck`
- `bun run build`
- `shellcheck -s sh boot.sh`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/120"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789222289&installation_model_id=20659&pr_number=120&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F120&signature=5dca486639501af1b1887b046768a461008227fc46162b7899c2ad49cb08301a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->