### PR TITLE
Fix unattended installs and Redwall ownership

### DIFF
--- a/src/agents.ts
+++ b/src/agents.ts
@@ -23,6 +23,7 @@ import {
   unlinkSync,
 } from "node:fs";
 import { log, RedError } from "./log.ts";
+import { unattendedEnvironment } from "./unattended.ts";
 import type { Platform } from "./platform.ts";
 
 export interface AgentSpec {
@@ -305,7 +306,7 @@ export function executablesEnvironment(
       ) === index;
     });
   const path = [...dirs, inherited].filter(Boolean).join(sep);
-  return { ...current, PATH: path, Path: path };
+  return unattendedEnvironment(current, { PATH: path, Path: path });
 }
 
 export function executableEnvironment(

--- a/src/main.ts
+++ b/src/main.ts
@@ -714,6 +714,19 @@ async function cmdTheme(p: Platform, inv: Invocation, name?: string): Promise<nu
     return 1;
   }
 
+  // Record the decision before touching a surface. Redwall is repainted
+  // by another process every two minutes, and that process reconstructs
+  // its canvas from preferences; applying cobalt while leaving flare on
+  // disk makes the switch last only until the next tick. Writing first
+  // also closes the race where a tick fires halfway through this command.
+  try {
+    const { writePreferences } = await import("./preferences.ts");
+    await writePreferences(p, { theme: chosen });
+  } catch (err) {
+    log.err(`theme preference: ${(err as Error).message}`);
+    return 1;
+  }
+
   let failures = 0;
 
   // Alacritty is the terminal on every target, so this is the branch

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -9,12 +9,13 @@
  */
 
 import { removeTemp, tempDir, tempFile } from "./temp.ts";
-import { copyFileSync, existsSync, mkdirSync, rmSync } from "node:fs";
+import { chmodSync, copyFileSync, existsSync, mkdirSync, rmSync } from "node:fs";
 import { formatBytes, formatDuration, log, logIsCaptured, RedError } from "./log.ts";
 import { parseChecksums, pickChecksumAsset, sha256Hex, verifyChecksum } from "./checksum.ts";
 import type { Provider } from "./manifest.ts";
 import type { Platform } from "./platform.ts";
 import { missingRights } from "./rights.ts";
+import { unattendedEnvironment } from "./unattended.ts";
 
 /**
  * Provisioning never delegates a question to a child process.
@@ -74,11 +75,13 @@ export async function spawnLoggedCapture(
   cmd: string[],
   extra: { env?: Record<string, string | undefined>; cwd?: string } = {},
 ): Promise<{ code: number; out: string; err: string }> {
+  const { env, ...spawnOptions } = extra;
   const proc = Bun.spawn(cmd, {
     stdout: "pipe",
     stderr: "pipe",
     stdin: providerStdinMode(),
-    ...extra,
+    ...spawnOptions,
+    env: unattendedEnvironment(process.env, env),
   });
   const [out, err, code] = await Promise.all([
     pumpToLog(proc.stdout),
@@ -107,11 +110,13 @@ export async function spawnLogged(
   extra: { env?: Record<string, string | undefined>; cwd?: string } = {},
 ): Promise<number> {
   if (!logIsCaptured()) {
+    const { env, ...spawnOptions } = extra;
     const proc = Bun.spawn(cmd, {
       stdout: "inherit",
       stderr: "inherit",
       stdin: providerStdinMode(),
-      ...extra,
+      ...spawnOptions,
+      env: unattendedEnvironment(process.env, env),
     });
     return await proc.exited;
   }
@@ -558,7 +563,9 @@ export async function ghInstall(
     // and there is no user-level equivalent.
     log.info(`installing the .deb with apt-get (needs sudo)`);
     await requireSudo();
-    await run(["sudo", "apt-get", "install", "-y", `${tmp}/${file}`]);
+    // -E is not cosmetic: without it sudo discards the unattended envelope
+    // before apt launches dpkg and its maintainer scripts.
+    await run(["sudo", "-E", "apt-get", "install", "-y", `${tmp}/${file}`]);
   } else if (file.endsWith(".tar.gz") || file.endsWith(".tgz")) {
     log.info(`extracting the archive into ${tmp}`);
     await run(["tar", "-xzf", `${tmp}/${file}`, "-C", tmp]);
@@ -833,11 +840,36 @@ export async function installerInstall(
   // A script that genuinely needs root cannot run here regardless; that
   // is a reason to not reach this function, which installAgent now
   // handles by preferring npm on Windows.
-  if (process.platform !== "win32" && body.includes("sudo ")) await requireSudo();
+  const usesSudo = process.platform !== "win32" && body.includes("sudo ");
+  if (usesSudo) await requireSudo();
 
   log.info(`running it with ${shell}${args.length > 0 ? ` ${args.join(" ")}` : ""}`);
-  const childEnv = env ? windowsInstallerEnvironment(shell, env) : undefined;
-  const code = await spawnLogged([shell, tmp, ...args], childEnv ? { env: childEnv } : {});
+  let installerEnv = unattendedEnvironment(process.env, env);
+  let sudoShim: string | null = null;
+
+  // An installer child inherits our variables, but an internal `sudo apt`
+  // normally erases them before dpkg and maintainer scripts start. Put a
+  // private shim first on PATH for the audited vendor script: it delegates to
+  // the real sudo with -E, preserving exactly the envelope we supplied. The
+  // password itself was already handled visibly by the top-level preflight.
+  if (usesSudo) {
+    const realSudo = Bun.which("sudo");
+    if (realSudo) {
+      sudoShim = tempDir(`sudo-env-${Date.now()}`);
+      const wrapper = `${sudoShim}/sudo`;
+      const quoted = `'${realSudo.replace(/'/g, `'"'"'`)}'`;
+      await Bun.write(wrapper, `#!/bin/sh\nexec ${quoted} -E "$@"\n`);
+      chmodSync(wrapper, 0o700);
+      installerEnv = {
+        ...installerEnv,
+        PATH: `${sudoShim}:${installerEnv["PATH"] ?? ""}`,
+      };
+    }
+  }
+
+  const childEnv = windowsInstallerEnvironment(shell, installerEnv);
+  const code = await spawnLogged([shell, tmp, ...args], { env: childEnv });
+  if (sudoShim) removeTemp(sudoShim);
   // node:fs, not `rm`. There is no rm on native Windows, so cleaning up
   // failed with `Executable not found in $PATH: "rm"` — reported as the
   // installer's own failure, which sent the reader looking at the vendor

--- a/src/redwall-schedule.test.ts
+++ b/src/redwall-schedule.test.ts
@@ -364,15 +364,42 @@ describe("on a machine that cannot hold a schedule", () => {
   test("WSL with systemd is an ordinary Linux target", async () => {
     await onFreshMachine(async (unitDir) => {
       // The images live on the Windows disk, but the binary that writes
-      // them runs in here — so the distro is where the timer belongs.
+      // them can run in here when the Windows host has no native owner.
       const outcome = await applyRedwallSchedule(wsl, {
         unitDir,
         run: supervisor({ "is-enabled": failed() }).run,
         enabled: on,
+        windowsOwns: async () => false,
       });
 
       expect(outcome.skipped).toBeNull();
       expect(outcome.action).toBe("installed");
+    });
+  });
+
+  test("WSL removes its timer when the Windows task already owns this desktop", async () => {
+    await onFreshMachine(async (unitDir) => {
+      await applyRedwallSchedule(wsl, {
+        unitDir,
+        run: supervisor({ "is-enabled": failed() }).run,
+        enabled: on,
+        windowsOwns: async () => false,
+      });
+
+      const host = supervisor();
+      const outcome = await applyRedwallSchedule(wsl, {
+        unitDir,
+        run: host.run,
+        enabled: on,
+        windowsOwns: async () => true,
+      });
+
+      expect(outcome.action).toBe("removed");
+      expect(outcome.removed.sort()).toEqual(
+        [`${unitDir}/${REDWALL_SERVICE}`, `${unitDir}/${REDWALL_TIMER}`].sort(),
+      );
+      expect(host.ran(`disable --now ${REDWALL_TIMER}`)).toBe(true);
+      expect(existsSync(`${unitDir}/${REDWALL_TIMER}`)).toBe(false);
     });
   });
 });

--- a/src/redwall-schedule.ts
+++ b/src/redwall-schedule.ts
@@ -151,6 +151,8 @@ export interface RedwallScheduleSeams {
   readonly wrapper?: string;
   /** Whether the preference is on. Defaults to the recorded preference. */
   readonly enabled?: () => Promise<boolean>;
+  /** Whether a native Windows task already owns this WSL desktop. */
+  readonly windowsOwns?: () => Promise<boolean>;
 }
 
 function home(): string {
@@ -330,7 +332,49 @@ export async function applyRedwallSchedule(
 
   const wanted = await (seams.enabled ?? (() => resolveRedwall(p)))();
   if (!wanted) return await unschedule(p, seams);
+  if (p.env === "wsl" && await windowsOwnsRedwall(seams)) {
+    // Windows and WSL point at the same preference and paint the same
+    // Windows desktop. Keeping both supervisors made two binaries race
+    // every two minutes (and let an older distro binary repaint after a
+    // newer native one). Native Windows survives the distro shutting
+    // down, so it is the canonical owner when its task is healthy.
+    return await unscheduleSystemd(seams, "windows");
+  }
   return p.os === "windows" ? await scheduleWindows(p, seams) : await scheduleSystemd(p, seams);
+}
+
+/**
+ * Whether Windows has a complete native Redwall producer.
+ *
+ * A task name alone is not enough: an old task can outlive the binary or
+ * wrapper it names. All three pieces must exist before WSL gives up its
+ * fallback timer. The injectable answer keeps tests away from the real
+ * host scheduler.
+ */
+async function windowsOwnsRedwall(seams: RedwallScheduleSeams): Promise<boolean> {
+  if (seams.windowsOwns) return await seams.windowsOwns();
+
+  try {
+    const { windowsLocalAppData } = await import("./wsl.ts");
+    const root = `${await windowsLocalAppData()}/red-dev/bin`;
+    if (!existsSync(`${root}/red-dev.exe`) || !existsSync(`${root}/${REDWALL_TASK_WRAPPER}`)) {
+      return false;
+    }
+
+    // A systemd user manager does not inherit WSL's augmented PATH.
+    // Resolve the host executable absolutely when needed, just as the
+    // rest of the WSL boundary does for PowerShell and cmd.exe.
+    const absolute = "/mnt/c/Windows/System32/schtasks.exe";
+    const schtasks = Bun.which("schtasks.exe") ?? (existsSync(absolute) ? absolute : "schtasks.exe");
+    const task = await runner(seams)([schtasks, "/Query", "/TN", REDWALL_TASK], {
+      timeoutMs: 5_000,
+    });
+    return task.exitCode === 0;
+  } catch {
+    // Host interop being unavailable is not evidence that Windows owns
+    // the refresh. Keep the local fallback alive.
+    return false;
+  }
 }
 
 /**
@@ -451,6 +495,7 @@ async function scheduleSystemd(
 
 async function unscheduleSystemd(
   seams: RedwallScheduleSeams,
+  owner: "off" | "windows" = "off",
 ): Promise<RedwallScheduleOutcome> {
   const dir = seams.unitDir ?? redwallUnitDir();
   const paths = [`${dir}/${REDWALL_TIMER}`, `${dir}/${REDWALL_SERVICE}`];
@@ -471,7 +516,11 @@ async function unscheduleSystemd(
   for (const path of present) rmSync(path, { force: true });
   await run(["systemctl", "--user", "daemon-reload"], { timeoutMs: 10_000 });
 
-  log.ok("redwall schedule: removed — the preference is off");
+  log.ok(
+    owner === "windows"
+      ? "redwall schedule: removed from WSL — Windows owns this desktop"
+      : "redwall schedule: removed — the preference is off",
+  );
   return { action: "removed", skipped: null, written: [], removed: present };
 }
 

--- a/src/redwall.test.ts
+++ b/src/redwall.test.ts
@@ -205,6 +205,35 @@ describe("the menu", () => {
   });
 });
 
+describe("a theme chosen after setup", () => {
+  test("the command records the choice before a scheduled Redwall can repaint", () => {
+    // This is deliberately pinned at the command boundary. Applying the
+    // surfaces is not enough: `red-dev redwall` is another process and
+    // reconstructs its canvas from this preference on every timer tick.
+    // Without the write, a visible cobalt switch over a recorded flare
+    // lasts only until that next tick.
+    const main = readFileSync(`${import.meta.dir}/main.ts`, "utf8");
+    const start = main.indexOf("async function cmdTheme");
+    const end = main.indexOf("async function cmdWallpaper", start);
+    const command = main.slice(start, end);
+    const write = command.indexOf("writePreferences(p, { theme: chosen })");
+    const apply = command.indexOf("applyThemeEverywhere(chosen, p)");
+
+    expect(write).toBeGreaterThan(-1);
+    expect(write).toBeLessThan(apply);
+  });
+
+  test("the recorded choice is the canvas a later Redwall tick resolves", async () => {
+    await onFreshMachine(async () => {
+      await writePreferences(linux, { redwall: true, theme: "flare" });
+      await writePreferences(linux, { theme: "cobalt" });
+
+      const { resolveWallpaperSlug } = await import("./preferences.ts");
+      expect(await resolveWallpaperSlug(linux)).toBe("cobalt");
+    });
+  });
+});
+
 /**
  * The pin, which is an override and nothing more: absent is the normal
  * state of this setting, and the default route is what absent means.

--- a/src/runtimes.ts
+++ b/src/runtimes.ts
@@ -20,6 +20,7 @@
 
 import { log, RedError } from "./log.ts";
 import type { Platform } from "./platform.ts";
+import { unattendedEnvironment } from "./unattended.ts";
 
 /**
  * Runtimes installed on every machine.
@@ -148,7 +149,7 @@ async function run(
     stdout: "pipe",
     stderr: "pipe",
     stdin: "ignore",
-    env: { ...process.env, ...extraEnv },
+    env: unattendedEnvironment(process.env, extraEnv),
   });
   const [out, err, code] = await Promise.all([
     readRuntimeOutput(proc.stdout, live),

--- a/src/ssh-server.ts
+++ b/src/ssh-server.ts
@@ -34,6 +34,7 @@ import type { PrivilegedState } from "./drift.ts";
 import { log, RedError } from "./log.ts";
 import type { Platform } from "./platform.ts";
 import { classifyRights } from "./rights.ts";
+import { unattendedEnvironment } from "./unattended.ts";
 
 /** Ran, and what it printed. */
 interface Ran {
@@ -42,7 +43,12 @@ interface Ran {
 }
 
 async function run(cmd: string[]): Promise<Ran> {
-  const proc = Bun.spawn(cmd, { stdout: "pipe", stderr: "pipe", stdin: "ignore" });
+  const proc = Bun.spawn(cmd, {
+    stdout: "pipe",
+    stderr: "pipe",
+    stdin: "ignore",
+    env: unattendedEnvironment(),
+  });
   const out = (
     (await new Response(proc.stdout).text()) + (await new Response(proc.stderr).text())
   ).trim();
@@ -75,7 +81,17 @@ async function linuxUnit(): Promise<string | null> {
  * both a failure and a success.
  */
 export async function installSshServerLinux(p: Platform): Promise<void> {
-  const install = await run(["sudo", "-n", "apt-get", "install", "-y", "openssh-server"]);
+  // -n refuses a missing credential; -E carries the unattended envelope
+  // through sudo into apt, dpkg and package maintainer scripts.
+  const install = await run([
+    "sudo",
+    "-n",
+    "-E",
+    "apt-get",
+    "install",
+    "-y",
+    "openssh-server",
+  ]);
   if (!install.ok) {
     // Raised rather than warned past, and this is the item that made
     // the distinction necessary. Warning and returning left the converge

--- a/src/unattended.test.ts
+++ b/src/unattended.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Provisioning is unattended all the way down, not only at red-dev's first
+ * child. Package managers routinely spawn lifecycle scripts and installers;
+ * those grandchildren must inherit the same refusal to ask questions.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { spawnLoggedCapture } from "./providers.ts";
+import { unattendedShellCommand } from "./unattended.ts";
+
+const expected = {
+  RED_DEV_UNATTENDED: "1",
+  CI: "1",
+  NONINTERACTIVE: "1",
+  DEBIAN_FRONTEND: "noninteractive",
+  APT_LISTCHANGES_FRONTEND: "none",
+  NEEDRESTART_MODE: "a",
+  GIT_TERMINAL_PROMPT: "0",
+  GCM_INTERACTIVE: "Never",
+  npm_config_yes: "true",
+  npm_config_audit: "false",
+  npm_config_fund: "false",
+  npm_config_update_notifier: "false",
+  npm_config_progress: "false",
+  COREPACK_ENABLE_DOWNLOAD_PROMPT: "0",
+  PIP_NO_INPUT: "1",
+  PIP_DISABLE_PIP_VERSION_CHECK: "1",
+  POETRY_NO_INTERACTION: "1",
+  MISE_YES: "1",
+  MISE_SYSTEM_DEPS: "auto",
+  YARN_PREFER_INTERACTIVE: "false",
+} as const;
+
+describe("the unattended provisioning envelope", () => {
+  test("survives a package manager and reaches its lifecycle child", async () => {
+    const names = Object.keys(expected);
+    const grandchild =
+      `console.log(JSON.stringify(Object.fromEntries(${JSON.stringify(names)}.map(k => [k, process.env[k] ?? null]))))`;
+    const manager =
+      `const p = Bun.spawnSync([process.execPath, "-e", ${JSON.stringify(grandchild)}], { stdout: "pipe" });` +
+      `process.stdout.write(p.stdout); process.exit(p.exitCode);`;
+
+    const result = await spawnLoggedCapture([process.execPath, "-e", manager], {
+      // A caller and its ambient shell cannot weaken the contract.
+      env: { ...process.env, CI: "0", npm_config_yes: "false", CUSTOM_ENV: "kept" },
+    });
+
+    expect(result.code).toBe(0);
+    expect(JSON.parse(result.out.trim())).toEqual(expected);
+  });
+
+  test("is explicitly carried across the Windows to WSL boundary", () => {
+    const source = readFileSync(`${import.meta.dir}/wsl-sync.ts`, "utf8");
+
+    expect(source).toContain("unattendedShellCommand(");
+    expect(source).not.toContain('"red-dev install core",');
+
+    const command = unattendedShellCommand("red-dev install core");
+    for (const [name, value] of Object.entries(expected)) {
+      expect(command).toContain(`${name}='${value}'`);
+    }
+  });
+
+  test("survives our Linux privilege boundary before apt and dpkg", () => {
+    const providers = readFileSync(`${import.meta.dir}/providers.ts`, "utf8");
+    const ssh = readFileSync(`${import.meta.dir}/ssh-server.ts`, "utf8");
+
+    expect(providers).not.toContain('["sudo", "apt-get", "install"');
+    expect(providers).toContain('["sudo", "-E", "apt-get", "install"');
+    expect(providers).toContain('exec ${quoted} -E "$@"');
+    expect(ssh).toContain('"-n",\n    "-E",\n    "apt-get"');
+  });
+});

--- a/src/unattended.ts
+++ b/src/unattended.ts
@@ -1,0 +1,73 @@
+/**
+ * The environment contract for provisioning children.
+ *
+ * stdin=ignore prevents a prompt from stealing the TUI's keyboard, but EOF is
+ * only a last line of defence. Package managers and their lifecycle children
+ * should be told explicitly that nobody will answer. Environment inheritance
+ * then carries this contract through second- and third-level installers.
+ */
+
+export const UNATTENDED_ENV = {
+  RED_DEV_UNATTENDED: "1",
+  // Widely understood by JS package managers and lifecycle scripts.
+  CI: "1",
+  NONINTERACTIVE: "1",
+
+  // Debian packages, apt-listchanges and needrestart.
+  DEBIAN_FRONTEND: "noninteractive",
+  APT_LISTCHANGES_FRONTEND: "none",
+  NEEDRESTART_MODE: "a",
+
+  // Git and Git Credential Manager must fail instead of opening a prompt/UI.
+  GIT_TERMINAL_PROMPT: "0",
+  GCM_INTERACTIVE: "Never",
+
+  // npm settings are inherited by lifecycle scripts and are also understood
+  // by pnpm where it follows npm's configuration surface.
+  // Lowercase is intentional. npm accepts either spelling at its own CLI,
+  // but documents that lifecycle scripts prefer the lowercase variables it
+  // creates internally. Starting lowercase prevents an inherited user value
+  // from winning at that second hop.
+  npm_config_yes: "true",
+  npm_config_audit: "false",
+  npm_config_fund: "false",
+  npm_config_update_notifier: "false",
+  npm_config_progress: "false",
+  COREPACK_ENABLE_DOWNLOAD_PROMPT: "0",
+
+  // Python and mise runtime/plugin installers.
+  PIP_NO_INPUT: "1",
+  PIP_DISABLE_PIP_VERSION_CHECK: "1",
+  POETRY_NO_INTERACTION: "1",
+  MISE_YES: "1",
+  MISE_SYSTEM_DEPS: "auto",
+
+  // Yarn Berry's documented prompt preference. Classic Yarn also observes CI.
+  YARN_PREFER_INTERACTIVE: "false",
+} as const satisfies Record<string, string>;
+
+/** Merge caller-specific values, then enforce the unattended contract. */
+export function unattendedEnvironment(
+  current: Record<string, string | undefined> = process.env,
+  extra: Record<string, string | undefined> = {},
+): Record<string, string | undefined> {
+  return { ...current, ...extra, ...UNATTENDED_ENV };
+}
+
+function shellWord(value: string): string {
+  return `'${value.replace(/'/g, `'"'"'`)}'`;
+}
+
+/**
+ * Carry the same environment across `wsl.exe`, which does not promise to
+ * forward arbitrary Windows variables into the distro.
+ */
+export function unattendedShellCommand(
+  command: string,
+  extra: Record<string, string> = {},
+): string {
+  const assignments = Object.entries({ ...extra, ...UNATTENDED_ENV })
+    .map(([name, value]) => `${name}=${shellWord(value)}`)
+    .join(" ");
+  return `env ${assignments} ${command}`;
+}

--- a/src/wsl-sync.ts
+++ b/src/wsl-sync.ts
@@ -33,6 +33,7 @@ import { spawnLogged } from "./providers.ts";
 import { OFFERED_RUNTIMES } from "./runtimes.ts";
 import { detectWsl, setWsl2Default, type WslDistribution } from "./wsl-provision.ts";
 import { readWindowsOutput } from "./windows-output.ts";
+import { unattendedShellCommand } from "./unattended.ts";
 
 const BOOT_URL = "https://raw.githubusercontent.com/reddb-io/red-dev/main/boot.sh";
 
@@ -114,7 +115,7 @@ export async function syncSelectedTooling(
       "--",
       "bash",
       "-lc",
-      command,
+      unattendedShellCommand(command),
     ]);
     if (code !== 0) {
       log.warn(`${selected.name}: \`${command}\` failed (${code})`);
@@ -207,7 +208,7 @@ async function ensureDistroRedDev(distro: string): Promise<number> {
     "--",
     "bash",
     "-lc",
-    `curl -fsSL ${BOOT_URL} | RED_DEV_NO_LAUNCH=1 sh`,
+    `curl -fsSL ${BOOT_URL} | ${unattendedShellCommand("sh", { RED_DEV_NO_LAUNCH: "1" })}`,
   ]);
 }
 
@@ -276,7 +277,7 @@ export async function syncWslDistro(p: Platform): Promise<void> {
     "--",
     "bash",
     "-lc",
-    "red-dev install core",
+    unattendedShellCommand("red-dev install core"),
   ]);
   log.plain(`       ── end of ${distro}; counts above are the distro's, not this run's`);
   if (converged !== 0) {


### PR DESCRIPTION
## What changed

- enforce one unattended environment contract across provider children, runtime installers, npm lifecycle processes, sudo, and Windows-to-WSL handoffs
- persist an explicit theme choice before repainting desktop surfaces
- make native Windows the canonical Redwall scheduler when both Windows and WSL can repaint the same desktop, while preserving WSL as a fallback

## Why

Nested installers could still prompt after the top-level process detached stdin. Separately, the theme command applied a new theme without recording it, so the next scheduled Redwall tick restored the old preference. Machines with both a Windows task and WSL systemd timer also ran two Redwall binaries against the same desktop every two minutes.

## Impact

Installs now fail or continue unattended instead of hanging in a child installer. Theme changes survive scheduled repaints. Existing WSL Redwall units are removed automatically when a healthy native Windows task owns the desktop.

## Validation

- full bun test suite
- bun run typecheck
- Linux compiled binary
- Windows compiled binary
- live Windows and WSL reconciliation followed by a real scheduled repaint; cobalt remained selected after the tick

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/121"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789229263&installation_model_id=20659&pr_number=121&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F121&signature=59db691d30574bb51efba2c8352b3b29f5c44cab989937a657011e2b63646dd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->