### PR TITLE
Fix fresh-machine bootstrap GitHub rate-limit failure

### DIFF
--- a/boot.ps1
+++ b/boot.ps1
@@ -35,75 +35,60 @@ if ([Environment]::Is64BitOperatingSystem -eq $false) {
     Fail 'red-dev publishes 64-bit builds only'
 }
 
-# Channel, matching boot.sh and toon's installer. 'stable' asks for
-# /releases/latest, which by GitHub's definition never returns a
-# prerelease -- so a repository publishing only prereleases 404s there
-# and looks empty. 'next' lists all releases and takes the newest.
+# Channel, matching boot.sh and toon's installer. Stable uses GitHub's
+# public latest-release asset redirect, not the anonymously rate-limited
+# API. Next still needs the API because /latest excludes prereleases.
 $Channel = if ($env:RED_DEV_CHANNEL) { $env:RED_DEV_CHANNEL } else { 'stable' }
 if ($Channel -notin @('stable', 'next')) {
     Fail "RED_DEV_CHANNEL must be 'stable' or 'next' (got '$Channel')"
 }
 
-$api = if ($Channel -eq 'stable') {
-    "https://api.github.com/repos/$Repo/releases/latest"
-} else {
+$DownloadUrl = "https://github.com/$Repo/releases/latest/download/$Asset"
+$ExpectedBytes = $null
+
+if ($Channel -eq 'next') {
     # Not per_page=1: /releases is not ordered so the newest prerelease
     # comes first, and taking [0] handed the stable release to everyone
     # who asked for next. Fetch a page and filter below.
-    "https://api.github.com/repos/$Repo/releases?per_page=20"
+    $api = "https://api.github.com/repos/$Repo/releases?per_page=20"
 }
 
 Say "resolving $Channel release of $Repo"
 
-# Ask the API which assets exist rather than assembling a URL from an
-# assumed version -- the failure mode that motivated this project.
-$headers = @{ 'User-Agent' = 'red-dev-boot'; 'Accept' = 'application/vnd.github+json' }
-if ($env:GITHUB_TOKEN) { $headers['Authorization'] = "Bearer $env:GITHUB_TOKEN" }
+if ($Channel -eq 'next') {
+    $headers = @{ 'User-Agent' = 'red-dev-boot'; 'Accept' = 'application/vnd.github+json' }
+    if ($env:GITHUB_TOKEN) { $headers['Authorization'] = "Bearer $env:GITHUB_TOKEN" }
 
-try {
-    $release = Invoke-RestMethod $api -Headers $headers
-    if ($release -is [array]) {
+    try {
+        $release = Invoke-RestMethod $api -Headers $headers
         # Filter, do not index: the array mixes stable and prerelease
         # entries and is not ordered newest-prerelease-first.
         $release = $release | Where-Object { $_.prerelease } | Select-Object -First 1
         if (-not $release) { Fail "$Repo has no prerelease to install" }
-    }
-} catch {
-    $code = $_.Exception.Response.StatusCode.value__
-    # 404 is ambiguous: GitHub returns it both for "no releases" and for
-    # "you cannot see this repository". Reporting only the first sends
-    # someone with a private repo hunting a release that already exists.
-    if ($code -eq 404 -and $Channel -eq 'stable') {
-        # Distinguish "no stable yet" from "nothing at all" instead of
-        # guessing, the same way boot.sh does.
-        $any = $null
-        try {
-            $any = Invoke-RestMethod "https://api.github.com/repos/$Repo/releases?per_page=1" -Headers $headers
-        } catch { }
-        if ($any -and $any.Count -gt 0) {
-            Fail "$Repo has no stable release yet, only prereleases. Install the newest with: `$env:RED_DEV_CHANNEL='next'; irm .../boot.ps1 | iex"
+    } catch {
+        $code = $_.Exception.Response.StatusCode.value__
+        if ($code -eq 404) {
+            Fail "$Repo has no published prerelease"
+        } elseif ($code -eq 403) {
+            Fail "GitHub API refused the prerelease lookup (HTTP 403) -- set GITHUB_TOKEN and retry"
+        } elseif ($code -eq 401) {
+            Fail "GITHUB_TOKEN was rejected -- check that it can read $Repo"
+        } else {
+            Fail "cannot reach the GitHub API: $($_.Exception.Message)"
         }
-        Fail "no release found for $Repo. Either none has been published, or the repository is private -- in which case set GITHUB_TOKEN and retry."
-    } elseif ($code -eq 404) {
-        Fail "$Repo has no published releases yet"
-    } elseif ($code -eq 403) {
-        Fail "GitHub API rate limit reached -- set GITHUB_TOKEN and retry"
-    } elseif ($code -eq 401) {
-        Fail "GITHUB_TOKEN was rejected -- check that it can read $Repo"
-    } else {
-        Fail "cannot reach the GitHub API: $($_.Exception.Message)"
     }
+
+    $match = $release.assets | Where-Object { $_.name -eq $Asset } | Select-Object -First 1
+    if (-not $match) {
+        Write-Host "fail no asset named $Asset in the newest prerelease. Available:" -ForegroundColor Red
+        $release.assets | ForEach-Object { Write-Host "  $($_.name)" }
+        exit 1
+    }
+    $DownloadUrl = $match.browser_download_url
+    $ExpectedBytes = $match.size
 }
 
-$match = $release.assets | Where-Object { $_.name -eq $Asset } | Select-Object -First 1
-if (-not $match) {
-    Write-Host "fail no asset named $Asset in the latest release. Available:" -ForegroundColor Red
-    $release.assets | ForEach-Object { Write-Host "  $($_.name)" }
-    exit 1
-}
-
-$SizeMb = [math]::Round($match.size / 1MB, 1)
-Say "downloading $Asset ($SizeMb MB)"
+Say "downloading $Asset"
 New-Item -ItemType Directory -Force -Path $BinDir | Out-Null
 
 # Downloaded to a temporary file and moved into place: an interrupted
@@ -112,7 +97,7 @@ New-Item -ItemType Directory -Force -Path $BinDir | Out-Null
 # being there at all.
 $Tmp = "$Bin.download"
 try {
-    Invoke-WebRequest -Uri $match.browser_download_url -OutFile $Tmp -UseBasicParsing
+    Invoke-WebRequest -Uri $DownloadUrl -OutFile $Tmp -UseBasicParsing
 } catch {
     if (Test-Path $Tmp) { Remove-Item $Tmp -Force }
     Fail "download failed: $($_.Exception.Message)"
@@ -122,7 +107,8 @@ try {
 # confirm the size afterwards instead. A wrong one here is a truncated
 # or redirected download, not a working install.
 $Got = [math]::Round((Get-Item $Tmp).Length / 1MB, 1)
-if ((Get-Item $Tmp).Length -ne $match.size) {
+if ($ExpectedBytes -and (Get-Item $Tmp).Length -ne $ExpectedBytes) {
+    $SizeMb = [math]::Round($ExpectedBytes / 1MB, 1)
     Remove-Item $Tmp -Force
     Fail "downloaded $Got MB, expected $SizeMb MB -- transfer was incomplete"
 }

--- a/boot.sh
+++ b/boot.sh
@@ -30,14 +30,15 @@ esac
 
 command -v curl >/dev/null 2>&1 || fail "curl is required"
 
-# Channel, the way toon's installer does it. `stable` asks for
-# /releases/latest, which by GitHub's definition never returns a
-# prerelease — so a repository publishing only prereleases 404s there
-# and looks empty. `next` lists all releases and takes the newest.
+# Channel, the way toon's installer does it. Stable needs no API lookup:
+# GitHub's public /releases/latest/download/<asset> redirect resolves the
+# newest non-prerelease by contract. That matters on a fresh machine,
+# where an anonymous API request spends a shared per-IP quota unrelated
+# to any PAT or GitHub App the user has configured elsewhere.
 CHANNEL="${RED_DEV_CHANNEL:-stable}"
 
 case "$CHANNEL" in
-  stable) API="https://api.github.com/repos/$REPO/releases/latest" ;;
+  stable) URL="https://github.com/$REPO/releases/latest/download/$ASSET" ;;
   # /releases is not ordered the way you would hope: the newest
   # prerelease is not reliably first, and taking [0] served the stable
   # release to everyone who asked for `next`. Fetch a page and pick the
@@ -48,60 +49,32 @@ esac
 
 say "resolving $CHANNEL release of $REPO"
 
-# Ask the API which assets the release actually has, rather than
-# constructing a URL from a version we assume. Guessing that is exactly
-# the bug that motivated this project.
-
-# Capture the status rather than relying on curl -f, so each failure
-# gets the hint that actually applies. A 404 here means no release has
-# been published, and telling that person to check their rate limit
-# sends them hunting the wrong problem.
-BODY=$(mktemp)
-if [ -n "${GITHUB_TOKEN:-}" ]; then
-  STATUS=$(curl -sSL -o "$BODY" -w '%{http_code}' \
-    -H "Authorization: Bearer $GITHUB_TOKEN" "$API" || echo 000)
-else
-  STATUS=$(curl -sSL -o "$BODY" -w '%{http_code}' "$API" || echo 000)
-fi
-
-case "$STATUS" in
-  200) ;;
-  404)
-    rm -f "$BODY"
-    # /releases/latest 404s for three different reasons, and guessing
-    # wrong sends people hunting the wrong problem. Ask the plain
-    # /releases endpoint which of the three this is.
-    if [ "$CHANNEL" = "stable" ]; then
-      PRERELEASES="$(curl -sSL "https://api.github.com/repos/$REPO/releases?per_page=1" \
-        ${GITHUB_TOKEN:+-H "Authorization: Bearer $GITHUB_TOKEN"} 2>/dev/null \
-        | grep -c '"tag_name"' || true)"
-      if [ "${PRERELEASES:-0}" -gt 0 ]; then
-        printf 'fail %s has no stable release yet, only prereleases.\n' "$REPO" >&2
-        printf '     Install the newest prerelease with:\n' >&2
-        printf '       RED_DEV_CHANNEL=next curl -fsSL .../boot.sh | sh\n' >&2
-        exit 1
-      fi
-    fi
-    printf 'fail no release found for %s.\n' "$REPO" >&2
-    printf '     Either none has been published, or the repository is\n' >&2
-    printf '     private -- in which case export GITHUB_TOKEN and retry.\n' >&2
-    exit 1
-    ;;
-  403) rm -f "$BODY"; fail "GitHub API rate limit reached — set GITHUB_TOKEN and retry" ;;
-  401) rm -f "$BODY"; fail "GITHUB_TOKEN was rejected — check that it can read $REPO" ;;
-  000) rm -f "$BODY"; fail "could not reach github.com — check your network" ;;
-  *)   rm -f "$BODY"; fail "GitHub API returned HTTP $STATUS" ;;
-esac
-
-JSON=$(cat "$BODY")
-rm -f "$BODY"
-
-# On `next` the response is an array of releases and only some are
-# prereleases. Walk it in order, remember the most recent asset URL seen
-# for our platform, and commit to it the moment a "prerelease": true
-# closes that release's block. Picking by position instead served the
-# stable build to everyone who asked for next.
 if [ "$CHANNEL" = "next" ]; then
+  # `next` cannot use /latest because GitHub deliberately excludes
+  # prereleases there. This explicit opt-in is the only path that pays
+  # for an API request and may therefore need GITHUB_TOKEN.
+  BODY=$(mktemp)
+  if [ -n "${GITHUB_TOKEN:-}" ]; then
+    STATUS=$(curl -sSL -o "$BODY" -w '%{http_code}' \
+      -H "Authorization: Bearer $GITHUB_TOKEN" "$API" || echo 000)
+  else
+    STATUS=$(curl -sSL -o "$BODY" -w '%{http_code}' "$API" || echo 000)
+  fi
+
+  case "$STATUS" in
+    200) ;;
+    404) rm -f "$BODY"; fail "$REPO has no published prerelease" ;;
+    403) rm -f "$BODY"; fail "GitHub API refused the prerelease lookup (HTTP 403) — set GITHUB_TOKEN and retry" ;;
+    401) rm -f "$BODY"; fail "GITHUB_TOKEN was rejected — check that it can read $REPO" ;;
+    000) rm -f "$BODY"; fail "could not reach github.com — check your network" ;;
+    *)   rm -f "$BODY"; fail "GitHub API returned HTTP $STATUS" ;;
+  esac
+
+  JSON=$(cat "$BODY")
+  rm -f "$BODY"
+
+  # Walk all releases in order and take the first prerelease carrying
+  # the platform asset. Picking element zero served stable to `next`.
   # Field order inside each release object is: tag_name, then
   # prerelease, then assets. So the flag has to be set first and the
   # asset matched after — accumulating the asset and checking the flag
@@ -120,19 +93,11 @@ if [ "$CHANNEL" = "next" ]; then
       if (n >= 4 && q[4] ~ ("/" asset "$")) { print q[4]; exit }
     }
   ')
-else
-  URL=$(printf '%s' "$JSON" \
-    | tr ',' '\n' \
-    | grep '"browser_download_url"' \
-    | sed 's/.*"\(https[^"]*\)".*/\1/' \
-    | grep "/$ASSET\$" \
-    | head -1)
-fi
-
-if [ -z "$URL" ]; then
-  printf 'fail no asset named %s in the latest release. Available:\n' "$ASSET" >&2
-  printf '%s' "$JSON" | tr ',' '\n' | grep '"name"' | sed 's/.*"name": *"\([^"]*\)".*/  \1/' >&2
-  exit 1
+  if [ -z "$URL" ]; then
+    printf 'fail no asset named %s in the newest prerelease. Available:\n' "$ASSET" >&2
+    printf '%s' "$JSON" | tr ',' '\n' | grep '"name"' | sed 's/.*"name": *"\([^"]*\)".*/  \1/' >&2
+    exit 1
+  fi
 fi
 
 # Arguments turn this into a run, not an install.

--- a/src/bootstrap-release.test.ts
+++ b/src/bootstrap-release.test.ts
@@ -1,0 +1,79 @@
+/**
+ * The stable bootstrap must not spend a GitHub API request merely to find a
+ * public release asset whose name is part of our own release contract.
+ *
+ * Anonymous API limits are per public IP and unrelated to the PAT/App pools
+ * RedSkills reports. A fresh machine behind a shared/NATed address can
+ * therefore receive 403 before red-dev has even downloaded. GitHub's public
+ * `releases/latest/download/<asset>` redirect has no such API dependency.
+ */
+
+import { chmodSync, mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { describe, expect, test } from "bun:test";
+
+describe("the stable bootstrap release resolver", () => {
+  test("installs through the public latest redirect when the anonymous API is exhausted", async () => {
+    const root = mkdtempSync(`${tmpdir()}/red-dev-bootstrap-release-`);
+    const fakeBin = `${root}/bin`;
+    await Bun.$`mkdir -p ${fakeBin}`.quiet();
+    const calls = `${root}/curl.calls`;
+    const curl = `${fakeBin}/curl`;
+
+    await Bun.write(
+      curl,
+      `#!/bin/sh
+set -eu
+out=''
+url=''
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) out="$2"; shift 2 ;;
+    -w) shift 2 ;;
+    -*) shift ;;
+    *) url="$1"; shift ;;
+  esac
+done
+printf '%s\n' "$url" >> '${calls}'
+case "$url" in
+  https://api.github.com/*)
+    [ -z "$out" ] || printf '%s\n' '{"message":"API rate limit exceeded"}' > "$out"
+    printf '403'
+    ;;
+  https://github.com/reddb-io/red-dev/releases/latest/download/red-dev-linux-x64)
+    printf '%s\n' '#!/bin/sh' 'exit 0' > "$out"
+    ;;
+  *)
+    printf '%s\n' "unexpected URL: $url" >&2
+    exit 22
+    ;;
+esac
+`,
+    );
+    chmodSync(curl, 0o700);
+
+    const proc = Bun.spawn(["sh", `${import.meta.dir}/../boot.sh`], {
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {
+        ...process.env,
+        HOME: root,
+        PATH: `${fakeBin}:/usr/bin:/bin`,
+        RED_DEV_NO_LAUNCH: "1",
+      },
+    });
+    const [stdout, stderr, code] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+    const requested = readFileSync(calls, "utf8");
+
+    expect(code, `${stdout}\n${stderr}`).toBe(0);
+    expect(requested).toContain(
+      "https://github.com/reddb-io/red-dev/releases/latest/download/red-dev-linux-x64",
+    );
+    expect(requested).not.toContain("api.github.com");
+    expect(await Bun.file(`${root}/.local/bin/red-dev`).exists()).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- resolve stable release assets through GitHub’s public `releases/latest/download` redirect
- reserve API lookup for the opt-in prerelease (`next`) channel
- add a regression test that removes `gh`, makes the anonymous API return 403, and verifies installation still succeeds

## Root cause

The bootstrap queried `api.github.com` before red-dev or authenticated `gh` existed. That request used GitHub’s separate anonymous per-IP pool, so it could fail even while the user’s PAT and GitHub App pools were healthy. Installing `gh` first would still be unauthenticated and would add an apt/sudo dependency to the bootstrap.

## Validation

- `bun test src/bootstrap-release.test.ts src/regressions.test.ts`
- `shellcheck -s sh boot.sh`
- `bun run typecheck`
- real stable bootstrap download and execution on Linux
- PowerShell parser check for `boot.ps1`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/122"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789241694&installation_model_id=20659&pr_number=122&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F122&signature=2649ca2d2e9114ed025167208ce99694677d662bc331363eb7e4c9363e765850"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->