### PR TITLE
Add recommended and latest runtime versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,8 @@ choice: compatible CLI agents and runtimes are installed on Windows **and** in
 the selected WSL 2 distro. Desktop applications remain on Windows. Choosing Git
 Bash keeps the selection native-Windows only. The unattended forms are
 `red-dev agents claude-code,codex` and `red-dev lang node@lts,bun@latest`.
+Add `--latest` to the latter to choose the newest release of every selected
+runtime; an exact mise version such as `python@3.14.1` is accepted too.
 Convergence makes the input gestures a workstation contract rather than an
 agent-specific surprise. Shift+Enter is emitted as CSI-u by Alacritty and
 Windows Terminal, mapped to a newline in Claude Code, and stated explicitly in
@@ -325,7 +327,8 @@ red-dev wallpaper [source]   # theme | Red artwork | absolute PNG path | HTTPS U
 red-dev redwall              # redraw the wallpaper carrying this machine's state
 red-dev apps                 # choose optional tools
 red-dev lang                 # choose runtimes for mise to manage
-red-dev lang node@lts,bun@latest # unattended runtime selection
+red-dev lang node@lts,bun@latest # unattended, recommended channels
+red-dev lang --latest node,python # newest release of each
 red-dev shell                # Windows + WSL: where a terminal lands
 red-dev agents               # choose coding agents, wire in red-skills
 red-dev agents claude-code,codex # unattended agent selection
@@ -408,7 +411,7 @@ deliberately:
 | `red-dev theme` | which theme, when given no name |
 | `red-dev wallpaper` | which bundled Red artwork, a custom PNG path/HTTPS URL, or whether to follow the theme |
 | `red-dev apps` | which optional tools — all ticked; untick to opt out |
-| `red-dev lang` | which runtimes mise should manage — Java, Ruby and Go start off; the rest are opt-out |
+| `red-dev lang` | which runtimes mise should manage, then recommended or latest versions — Java, Ruby and Go start off; the rest are opt-out |
 | `red-dev shell` | whether a terminal lands in WSL or Git Bash |
 | `red-dev agents` | which coding agents — all ticked; untick to opt out, then offers red-skills |
 | `red-dev uninstall` | what to remove — and confirms before removing it |

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -17,6 +17,10 @@ describe("command parsing", () => {
       "node@lts",
       "bun@latest",
     ]);
+    expect(parse(["lang", "--latest", "node,python"])).toMatchObject({
+      runtimeIds: ["node", "python"],
+      latest: true,
+    });
   });
 
   test("reads a wallpaper independently from the theme", () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -194,6 +194,13 @@ export function buildCli(): CLI {
       },
       lang: {
         description: "choose language runtimes for mise to manage",
+        options: {
+          latest: {
+            type: "boolean",
+            description: "install the newest release of every selected runtime",
+            default: false,
+          },
+        },
         positional: [
           {
             name: "runtime_selection",
@@ -266,6 +273,8 @@ export interface Invocation {
   /** Explicit selections make agents/lang safe to invoke across WSL unattended. */
   agentKeys: string[] | undefined;
   runtimeIds: string[] | undefined;
+  /** `lang --latest`: rewrite every selected runtime selector to `latest`. */
+  latest: boolean;
   /** `wallpaper [theme|slug|absolute-path|https-url]` — absent opens the picker. */
   wallpaperName: string | undefined;
   /**
@@ -333,6 +342,7 @@ export function parseArgs(cli: CLI, argv: string[]): Invocation {
       typeof pos["runtime_selection"] === "string"
         ? pos["runtime_selection"].split(",").map((value) => value.trim()).filter(Boolean)
         : undefined,
+    latest: opts["latest"] === true,
     wallpaperName: typeof rawWallpaper === "string" ? rawWallpaper : undefined,
     themeName: typeof opts["theme"] === "string" ? opts["theme"] : DEFAULT_THEME,
     font: typeof opts["font"] === "string" ? opts["font"] : "firacode",

--- a/src/dual-install.test.ts
+++ b/src/dual-install.test.ts
@@ -43,8 +43,11 @@ describe("selected tooling sent into WSL", () => {
       distroSetupCommands(
         "wsl",
         ["claude-code", "$(touch nope)", "not-an-agent"],
-        ["node@lts", "bad; command"],
+        ["node@lts", "bad; command", "python@latest", "ruby@3.4.7"],
       ),
-    ).toEqual(["red-dev lang node@lts", "red-dev agents claude-code"]);
+    ).toEqual([
+      "red-dev lang node@lts,python@latest,ruby@3.4.7",
+      "red-dev agents claude-code",
+    ]);
   });
 });

--- a/src/firstrun.ts
+++ b/src/firstrun.ts
@@ -408,12 +408,25 @@ export async function askFirstRun(p: Platform): Promise<FirstRunChoices | null> 
   }
 
   // 3. What you build with.
-  const { OFFERED_RUNTIMES, runtimeSelectedByDefault } = await import("./runtimes.ts");
+  const { OFFERED_RUNTIMES, runtimeIdsForPolicy, runtimeSelectedByDefault } =
+    await import("./runtimes.ts");
   const runtimeLabels = OFFERED_RUNTIMES.map((r) => `${r.id} — ${r.about}`);
   const pickedRuntimes = await checkbox(
     "Language runtimes for mise to manage?",
     runtimeLabels as [string, ...string[]],
     runtimeLabels.filter((label) => runtimeSelectedByDefault(label.split(" ")[0]!)),
+  );
+  const runtimePolicy = await select(
+    "Which runtime versions?",
+    [
+      "recommended — LTS, stable or the tested release",
+      "latest — newest release of every selected runtime",
+    ] as const,
+    "recommended — LTS, stable or the tested release",
+  );
+  const selectedRuntimes = runtimeIdsForPolicy(
+    pickedRuntimes.map((label) => label.split(" ")[0]!),
+    runtimePolicy.startsWith("latest") ? "latest" : "recommended",
   );
 
   // 4. Extra tools, all of them ticked.
@@ -475,7 +488,7 @@ export async function askFirstRun(p: Platform): Promise<FirstRunChoices | null> 
     wallpaper,
     font,
     apps: pickedApps.map((l) => l.split(" ")[0]!),
-    runtimes: pickedRuntimes.map((l) => l.split(" ")[0]!),
+    runtimes: selectedRuntimes,
     blesh,
   };
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1367,24 +1367,38 @@ async function cmdAgents(p: Platform, inv: Invocation): Promise<number> {
 
 /** Choose which language runtimes mise manages. */
 async function cmdLang(p: Platform, inv: Invocation): Promise<number> {
-  const { checkbox } = await import("./ui.ts");
-  const { OFFERED_RUNTIMES, useRuntimes, currentRuntimes, runtimeSelectedByDefault } =
+  const { checkbox, select } = await import("./ui.ts");
+  const {
+    OFFERED_RUNTIMES,
+    useRuntimes,
+    currentRuntimes,
+    resolveRuntimeIds,
+    runtimeIdsForPolicy,
+    runtimeSelectedByDefault,
+  } =
     await import("./runtimes.ts");
 
   let ids = inv.runtimeIds;
   if (ids !== undefined) {
-    const known = new Set(OFFERED_RUNTIMES.map((runtime) => runtime.id));
-    const unknown = ids.filter((id) => !known.has(id));
+    // `--latest` makes the channel explicit, so the terse and natural
+    // `red-dev lang --latest node,python` is enough. Selectors supplied
+    // alongside it are intentionally replaced by the same policy.
+    const resolved = resolveRuntimeIds(ids, inv.latest ? "latest" : "recommended");
+    ids = resolved.ids;
+    const { unknown } = resolved;
     if (unknown.length > 0) {
       log.err(`unknown runtime(s): ${unknown.join(", ")}`);
-      log.plain(`     known runtimes: ${OFFERED_RUNTIMES.map((runtime) => runtime.id).join(", ")}`);
+      log.plain(
+        `     known runtime names: ${OFFERED_RUNTIMES.map((runtime) => runtime.id.split("@")[0]).join(", ")}`,
+      );
+      log.plain("     use @latest, the recommended selector shown by `red-dev lang`, or an exact version");
       return 1;
     }
   } else {
     if (!interactive()) {
       log.err("choosing runtimes needs a terminal");
       log.plain("     For unattended installs, name them explicitly:");
-      log.plain("       red-dev lang node@lts,bun@latest");
+      log.plain("       red-dev lang --latest node,bun");
       return 1;
     }
 
@@ -1400,6 +1414,16 @@ async function cmdLang(p: Platform, inv: Invocation): Promise<number> {
       labels.filter((label) => runtimeSelectedByDefault(label.split(" ")[0]!)),
     );
     ids = picked.map((label) => label.split(" ")[0]!.trim());
+
+    const policy = await select(
+      "Which versions?",
+      [
+        "recommended — LTS, stable or the tested release",
+        "latest — newest release of every selected runtime",
+      ] as const,
+      "recommended — LTS, stable or the tested release",
+    );
+    ids = runtimeIdsForPolicy(ids, policy.startsWith("latest") ? "latest" : "recommended");
   }
 
   if (ids.length === 0) {

--- a/src/runtime-policy.test.ts
+++ b/src/runtime-policy.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import {
+  isKnownRuntimeId,
+  resolveRuntimeIds,
+  runtimeIdsForPolicy,
+  runtimeInstallRequest,
+} from "./runtimes.ts";
+
+describe("runtime version policy", () => {
+  test("can move every offered runtime to its newest release", () => {
+    expect(
+      runtimeIdsForPolicy(
+        ["node@lts", "python@3.13", "rust@stable", "bun@latest"],
+        "latest",
+      ),
+    ).toEqual(["node@latest", "python@latest", "rust@latest", "bun@latest"]);
+  });
+
+  test("leaves the compatibility-tested selectors intact by default", () => {
+    expect(runtimeIdsForPolicy(["node@lts", "python@3.13"], "recommended")).toEqual([
+      "node@lts",
+      "python@3.13",
+    ]);
+  });
+
+  test("accepts latest and exact versions for known names only", () => {
+    expect(isKnownRuntimeId("node@latest")).toBe(true);
+    expect(isKnownRuntimeId("python@3.14.1")).toBe(true);
+    expect(isKnownRuntimeId("unknown@latest")).toBe(false);
+    expect(isKnownRuntimeId("node@latest;touch-nope")).toBe(false);
+  });
+
+  test("makes bare CLI runtime names valid when --latest supplies the selector", () => {
+    expect(resolveRuntimeIds(["node", "python@3.13"], "latest")).toEqual({
+      ids: ["node@latest", "python@latest"],
+      unknown: [],
+    });
+    expect(resolveRuntimeIds(["unknown", "node;touch-nope"], "latest").unknown).toEqual([
+      "unknown@latest",
+      "node;touch-nope@latest",
+    ]);
+  });
+
+  test("never silently compiles a latest Python without its expected libraries", () => {
+    expect(runtimeInstallRequest("python@latest")).toEqual({
+      id: "python@latest",
+      env: { MISE_PYTHON_COMPILE: "0" },
+    });
+  });
+});

--- a/src/runtimes.ts
+++ b/src/runtimes.ts
@@ -48,6 +48,46 @@ export const OFFERED_RUNTIMES: { id: string; about: string }[] = [
   { id: "java@lts", about: "Java LTS" },
 ];
 
+export type RuntimeVersionPolicy = "recommended" | "latest";
+
+const RUNTIME_NAMES = new Set(
+  OFFERED_RUNTIMES.map((runtime) => runtime.id.split("@")[0]!),
+);
+
+/** Apply the setup's version policy without changing which runtimes were chosen. */
+export function runtimeIdsForPolicy(
+  ids: string[],
+  policy: RuntimeVersionPolicy,
+): string[] {
+  if (policy === "recommended") return [...ids];
+  return ids.map((id) => `${id.split("@")[0]}@latest`);
+}
+
+/**
+ * Runtime ids accepted at the CLI and safe to mirror through a WSL shell.
+ *
+ * The runtime name stays inside our catalog, while the mise selector may be
+ * a channel (`latest`, `lts`, `stable`) or an exact version. Keeping the
+ * selector deliberately boring also means a preference can be interpolated
+ * into `red-dev lang ...` without becoming shell syntax.
+ */
+export function isKnownRuntimeId(id: string): boolean {
+  const match = /^([a-z0-9-]+)@([A-Za-z0-9][A-Za-z0-9._+-]*)$/.exec(id);
+  return match !== null && RUNTIME_NAMES.has(match[1]!);
+}
+
+/** Normalize an explicit CLI selection, returning bad values without running mise. */
+export function resolveRuntimeIds(
+  ids: string[],
+  policy: RuntimeVersionPolicy,
+): { ids: string[]; unknown: string[] } {
+  const resolved = runtimeIdsForPolicy(ids, policy);
+  return {
+    ids: resolved,
+    unknown: resolved.filter((id) => !isKnownRuntimeId(id)),
+  };
+}
+
 /** Common runtimes start checked; the heavier project-specific three are opt-in. */
 export function runtimeSelectedByDefault(id: string): boolean {
   const name = id.split("@")[0];
@@ -74,6 +114,9 @@ export function runtimeInstallRequest(id: string): RuntimeInstallRequest {
       id: "python@3.13.14",
       env: { MISE_PYTHON_COMPILE: "0" },
     };
+  }
+  if (id.startsWith("python@")) {
+    return { id, env: { MISE_PYTHON_COMPILE: "0" } };
   }
   return { id, env: {} };
 }

--- a/src/setup-defaults.test.ts
+++ b/src/setup-defaults.test.ts
@@ -75,6 +75,13 @@ describe("multi-choice defaults", () => {
     expect(q?.preset).toEqual(["node@lts", "bun@latest", "python@3.13"]);
   });
 
+  test("runtime versions default to the recommended compatibility channels", () => {
+    const q = step("runtime-versions");
+    expect(q.multi).toBe(false);
+    expect(q.preset).toEqual(["recommended"]);
+    expect(q.choices.map((choice) => choice.key)).toEqual(["recommended", "latest"]);
+  });
+
   test("all agents arrive marked", () => {
     const q = step("agents");
     expect(q.preset).toEqual(q.choices.map((choice) => choice.key));

--- a/src/tui-setup-model.ts
+++ b/src/tui-setup-model.ts
@@ -30,7 +30,7 @@ import { Screen, Surface } from "./tui-chrome.ts";
 import { muted, ui } from "./tui-theme.ts";
 import { DEFAULT_THEME, swatches, THEMES, themeNames } from "./themes.ts";
 import type { ThemeSlug } from "./themes.ts";
-import { runtimeSelectedByDefault } from "./runtimes.ts";
+import { runtimeIdsForPolicy, runtimeSelectedByDefault } from "./runtimes.ts";
 
 export interface SetupAnswers {
   theme: string;
@@ -150,6 +150,29 @@ export function questions(
       multi: true,
       choices: runtimes,
       preset: runtimes.filter((runtime) => runtimeSelectedByDefault(runtime.key)).map((runtime) => runtime.key),
+      applies: () => true,
+    },
+    {
+      id: "runtime-versions",
+      title: "Versions",
+      description:
+        "Recommended follows the compatibility channel chosen by red-dev — for " +
+        "example Node LTS and Python 3.13. Latest asks mise for the newest release " +
+        "of every runtime you selected.",
+      multi: false,
+      choices: [
+        {
+          key: "recommended",
+          label: "Recommended versions",
+          note: "the default — LTS, stable or a tested release where appropriate",
+        },
+        {
+          key: "latest",
+          label: "Latest versions",
+          note: "rewrite every selected runtime to @latest",
+        },
+      ],
+      preset: ["recommended"],
       applies: () => true,
     },
     {
@@ -319,7 +342,10 @@ export function useSetupModel(steps: Question[], wizard: ReturnType<typeof creat
         : {}),
       font: get("font")[0] ?? "firacode",
       apps: get("apps"),
-      runtimes: get("runtimes"),
+      runtimes: runtimeIdsForPolicy(
+        get("runtimes"),
+        get("runtime-versions")[0] === "latest" ? "latest" : "recommended",
+      ),
       agents: get("agents"),
       blesh: get("plugins").includes("blesh"),
       redwall: get("redwall")[0] === "yes",

--- a/src/tui-setup.ts
+++ b/src/tui-setup.ts
@@ -34,6 +34,7 @@ import { Screen, Surface } from "./tui-chrome.ts";
 import { muted, ui } from "./tui-theme.ts";
 import { swatches } from "./themes.ts";
 import type { ThemeSlug } from "./themes.ts";
+import { runtimeIdsForPolicy } from "./runtimes.ts";
 import { withConsoleSelectionSuspended } from "./windows-console-mode.ts";
 // The questions live in tui-setup-model.ts and only there. They were
 // declared in both files, identically, for two interfaces that ask the
@@ -93,7 +94,10 @@ export async function runSetupTui(
             : {}),
           font: get("font")[0] ?? "firacode",
           apps: get("apps"),
-          runtimes: get("runtimes"),
+          runtimes: runtimeIdsForPolicy(
+            get("runtimes"),
+            get("runtime-versions")[0] === "latest" ? "latest" : "recommended",
+          ),
           agents: get("agents"),
           blesh: get("plugins").includes("blesh"),
           redwall: get("redwall")[0] === "yes",

--- a/src/wsl-sync.ts
+++ b/src/wsl-sync.ts
@@ -30,7 +30,7 @@ import { log, RedError } from "./log.ts";
 import type { Platform } from "./platform.ts";
 import { readPreferences, type TerminalShell } from "./preferences.ts";
 import { spawnLogged } from "./providers.ts";
-import { OFFERED_RUNTIMES } from "./runtimes.ts";
+import { isKnownRuntimeId } from "./runtimes.ts";
 import { detectWsl, setWsl2Default, type WslDistribution } from "./wsl-provision.ts";
 import { readWindowsOutput } from "./windows-output.ts";
 import { unattendedShellCommand } from "./unattended.ts";
@@ -48,8 +48,7 @@ export function distroSetupCommands(
   // Preferences are user-editable JSON and eventually cross a shell
   // boundary. Resolve them against closed catalogs before constructing
   // argv text: unknown data is ignored, never interpolated.
-  const knownRuntimes = new Set(OFFERED_RUNTIMES.map((runtime) => runtime.id));
-  const runtimes = runtimeIds.filter((id) => knownRuntimes.has(id));
+  const runtimes = runtimeIds.filter(isKnownRuntimeId);
   const cliAgents = agentKeys.filter((key) => {
     const agent = AGENTS.find((candidate) => candidate.key === key);
     return agent !== undefined && !agent.desktopOnly;


### PR DESCRIPTION
## Summary

- add a Recommended/Latest version policy step to both setup interfaces
- support `red-dev lang --latest node,python` for unattended use
- accept exact mise selectors such as `python@3.14.1`
- persist the resolved runtime ids and safely reproduce them inside WSL

## Impact

Recommended remains the default, preserving Node LTS, Rust stable and the tested Python release. Choosing Latest rewrites every selected runtime to `@latest`. Known runtime names remain a closed catalog, and selectors are validated before they can cross the WSL shell boundary.

Optional non-runtime tools already follow the newest version exposed by their package/release provider; this change covers the language and runtime choices owned by mise.

## Validation

- full `bun test` suite
- `bun run typecheck`
- Linux and Windows compiled builds
- compiled CLI help and invalid-selection smoke checks

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/123"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789242528&installation_model_id=20659&pr_number=123&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F123&signature=290cf9732a302392bd3d78ba564b71c7a441fa1af581b83a204d3b1bcd8340cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->