### PR TITLE
Select runtime versions and trust machine CAs

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,8 +257,10 @@ marketplace in Claude Code and Codex and generates plugin modules for OpenCode.
 On native Windows, a WSL terminal choice makes the selection a workstation
 choice: compatible CLI agents and runtimes are installed on Windows **and** in
 the selected WSL 2 distro. Desktop applications remain on Windows. Choosing Git
-Bash keeps the selection native-Windows only. The unattended forms are
-`red-dev agents claude-code,codex` and `red-dev lang node@lts,bun@latest`.
+Bash keeps the selection native-Windows only. On the runtime screen, Space
+enables a language and Left/Right changes that language's version — Node can
+stay on 24 LTS while Python moves to 3.14, for example. The unattended forms
+are `red-dev agents claude-code,codex` and `red-dev lang node@26,bun@1.3`.
 Add `--latest` to the latter to choose the newest release of every selected
 runtime; an exact mise version such as `python@3.14.1` is accepted too.
 Convergence makes the input gestures a workstation contract rather than an
@@ -327,7 +329,7 @@ red-dev wallpaper [source]   # theme | Red artwork | absolute PNG path | HTTPS U
 red-dev redwall              # redraw the wallpaper carrying this machine's state
 red-dev apps                 # choose optional tools
 red-dev lang                 # choose runtimes for mise to manage
-red-dev lang node@lts,bun@latest # unattended, recommended channels
+red-dev lang node@24,bun@1.3 # unattended, independently selected versions
 red-dev lang --latest node,python # newest release of each
 red-dev shell                # Windows + WSL: where a terminal lands
 red-dev agents               # choose coding agents, wire in red-skills

--- a/README.md
+++ b/README.md
@@ -263,6 +263,14 @@ stay on 24 LTS while Python moves to 3.14, for example. The unattended forms
 are `red-dev agents claude-code,codex` and `red-dev lang node@26,bun@1.3`.
 Add `--latest` to the latter to choose the newest release of every selected
 runtime; an exact mise version such as `python@3.14.1` is accepted too.
+Every provider and vendor installer also inherits the machine certificate
+store. On Linux and WSL, red-dev points curl, Git, npm/Node/Bun, pip/Requests,
+uv and Deno at the `update-ca-certificates` bundle; on Windows, Node, Deno and
+uv use the Windows certificate store. TLS verification stays enabled. This
+lets a corporate interception proxy work after its CA has been registered by
+the administrator, including inside npm lifecycle scripts and other nested
+installers. If the CA is absent, the result names the untrusted certificate
+chain instead of reducing it to `npm exited non-zero`.
 Convergence makes the input gestures a workstation contract rather than an
 agent-specific surprise. Shift+Enter is emitted as CSI-u by Alacritty and
 Windows Terminal, mapped to a newline in Claude Code, and stated explicitly in

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -23,7 +23,7 @@ import {
   unlinkSync,
 } from "node:fs";
 import { log, RedError } from "./log.ts";
-import { unattendedEnvironment } from "./unattended.ts";
+import { tlsTrustFailure, unattendedEnvironment } from "./unattended.ts";
 import type { Platform } from "./platform.ts";
 
 export interface AgentSpec {
@@ -266,9 +266,11 @@ export async function isAgentReady(a: AgentSpec): Promise<boolean> {
  * file had its own two-line copy of the wrong half.
  */
 async function run(cmd: string[], env?: Record<string, string | undefined>): Promise<void> {
-  const { spawnLogged } = await import("./providers.ts");
-  const code = await spawnLogged(cmd, env ? { env } : {});
-  if (code !== 0) throw new RedError(`${cmd[0]} exited non-zero`);
+  const { spawnLoggedCapture } = await import("./providers.ts");
+  const result = await spawnLoggedCapture(cmd, env ? { env } : {});
+  if (result.code !== 0) {
+    throw new RedError(tlsTrustFailure(result.out + result.err) ?? `${cmd[0]} exited non-zero`);
+  }
 }
 
 /**

--- a/src/firstrun.ts
+++ b/src/firstrun.ts
@@ -94,7 +94,7 @@ export async function setupPlan(p: Platform, choices: SetupChoices): Promise<Set
   const runtimes = [...choices.runtimes];
   if (!runtimes.some((runtime) => runtime.startsWith("node"))) {
     const needsNpm = chosen.some((agent) => agentInstallMethod(agent, p) === "npm");
-    if (needsNpm) runtimes.unshift("node@lts");
+    if (needsNpm) runtimes.unshift("node@24");
   }
   for (const runtime of chosen.flatMap((agent) => agent.runtimeNeeds ?? [])) {
     const name = runtime.split("@")[0]!;
@@ -154,7 +154,7 @@ export async function buildSetupSteps(p: Platform) {
     toolsInScope("optional")
       .filter((t) => providerFor(t, p).kind !== "skip")
       .map((t) => ({ key: t.name, label: t.name, note: t.about ?? "" })),
-    OFFERED_RUNTIMES.map((r) => ({ key: r.id, label: r.id, note: r.about })),
+    OFFERED_RUNTIMES.map((r) => ({ key: r.id, label: r.label, note: r.about })),
   );
 }
 
@@ -232,8 +232,8 @@ export async function carryOutChoices(
   // with "npm not on PATH", which is the tool reporting its own missing
   // prerequisite as the user's mistake.
   const runtimes = plan.filter((step) => step.kind === "runtime");
-  if (runtimes.some((step) => step.key === "node@lts") && !choices.runtimes.includes("node@lts")) {
-    log.plain("       an npm-installed agent was chosen, so node@lts comes with it");
+  if (runtimes.some((step) => step.key === "node@24") && !choices.runtimes.includes("node@24")) {
+    log.plain("       an npm-installed agent was chosen, so node@24 comes with it");
   }
   if (
     runtimes.some((step) => step.key === "python@3.13") &&
@@ -334,7 +334,7 @@ export async function askFirstRun(p: Platform): Promise<FirstRunChoices | null> 
       toolsInScope("optional")
         .filter((t) => providerFor(t, p).kind !== "skip")
         .map((t) => ({ key: t.name, label: t.name, note: t.about ?? "" })),
-      OFFERED_RUNTIMES.map((r) => ({ key: r.id, label: r.id, note: r.about })),
+      OFFERED_RUNTIMES.map((r) => ({ key: r.id, label: r.label, note: r.about })),
     );
 
     if (!answers) {
@@ -408,7 +408,7 @@ export async function askFirstRun(p: Platform): Promise<FirstRunChoices | null> 
   }
 
   // 3. What you build with.
-  const { OFFERED_RUNTIMES, runtimeIdsForPolicy, runtimeSelectedByDefault } =
+  const { OFFERED_RUNTIMES, offeredRuntime, runtimeSelectedByDefault } =
     await import("./runtimes.ts");
   const runtimeLabels = OFFERED_RUNTIMES.map((r) => `${r.id} — ${r.about}`);
   const pickedRuntimes = await checkbox(
@@ -416,18 +416,22 @@ export async function askFirstRun(p: Platform): Promise<FirstRunChoices | null> 
     runtimeLabels as [string, ...string[]],
     runtimeLabels.filter((label) => runtimeSelectedByDefault(label.split(" ")[0]!)),
   );
-  const runtimePolicy = await select(
-    "Which runtime versions?",
-    [
-      "recommended — LTS, stable or the tested release",
-      "latest — newest release of every selected runtime",
-    ] as const,
-    "recommended — LTS, stable or the tested release",
-  );
-  const selectedRuntimes = runtimeIdsForPolicy(
-    pickedRuntimes.map((label) => label.split(" ")[0]!),
-    runtimePolicy.startsWith("latest") ? "latest" : "recommended",
-  );
+  const selectedRuntimes: string[] = [];
+  for (const id of pickedRuntimes.map((label) => label.split(" ")[0]!)) {
+    const runtime = offeredRuntime(id);
+    if (!runtime) {
+      selectedRuntimes.push(id);
+      continue;
+    }
+    const versions = runtime.versions.map((version) => `${version.id} — ${version.label}`);
+    const fallback = versions.find((version) => version.startsWith(`${id} `)) ?? versions[0]!;
+    const picked = await select(
+      `${runtime.label} version?`,
+      versions as [string, ...string[]],
+      fallback,
+    );
+    selectedRuntimes.push(picked.split(" ")[0]!);
+  }
 
   // 4. Extra tools, all of them ticked.
   //

--- a/src/main.ts
+++ b/src/main.ts
@@ -1370,10 +1370,10 @@ async function cmdLang(p: Platform, inv: Invocation): Promise<number> {
   const { checkbox, select } = await import("./ui.ts");
   const {
     OFFERED_RUNTIMES,
+    offeredRuntime,
     useRuntimes,
     currentRuntimes,
     resolveRuntimeIds,
-    runtimeIdsForPolicy,
     runtimeSelectedByDefault,
   } =
     await import("./runtimes.ts");
@@ -1415,15 +1415,23 @@ async function cmdLang(p: Platform, inv: Invocation): Promise<number> {
     );
     ids = picked.map((label) => label.split(" ")[0]!.trim());
 
-    const policy = await select(
-      "Which versions?",
-      [
-        "recommended — LTS, stable or the tested release",
-        "latest — newest release of every selected runtime",
-      ] as const,
-      "recommended — LTS, stable or the tested release",
-    );
-    ids = runtimeIdsForPolicy(ids, policy.startsWith("latest") ? "latest" : "recommended");
+    const versioned: string[] = [];
+    for (const id of ids) {
+      const runtime = offeredRuntime(id);
+      if (!runtime) {
+        versioned.push(id);
+        continue;
+      }
+      const versions = runtime.versions.map((version) => `${version.id} — ${version.label}`);
+      const fallback = versions.find((version) => version.startsWith(`${id} `)) ?? versions[0]!;
+      const picked = await select(
+        `${runtime.label} version?`,
+        versions as [string, ...string[]],
+        fallback,
+      );
+      versioned.push(picked.split(" ")[0]!);
+    }
+    ids = versioned;
   }
 
   if (ids.length === 0) {

--- a/src/npm-resolution.test.ts
+++ b/src/npm-resolution.test.ts
@@ -163,11 +163,11 @@ describe("ordering and implication", () => {
     expect(runtimesAt).toBeLessThan(agentsAt);
   });
 
-  test("choosing an npm agent implies node@lts", () => {
+  test("choosing an npm agent implies the default Node line", () => {
     // Picking Gemini without ticking node is not a contradiction the
     // user should have to notice; it names an end and leaves the means
     // to the tool whose job that is.
-    expect(firstrun).toContain('runtimes.unshift("node@lts")');
+    expect(firstrun).toContain('runtimes.unshift("node@24")');
   });
 });
 

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -15,7 +15,7 @@ import { parseChecksums, pickChecksumAsset, sha256Hex, verifyChecksum } from "./
 import type { Provider } from "./manifest.ts";
 import type { Platform } from "./platform.ts";
 import { missingRights } from "./rights.ts";
-import { unattendedEnvironment } from "./unattended.ts";
+import { tlsTrustFailure, unattendedEnvironment } from "./unattended.ts";
 
 /**
  * Provisioning never delegates a question to a child process.
@@ -868,7 +868,7 @@ export async function installerInstall(
   }
 
   const childEnv = windowsInstallerEnvironment(shell, installerEnv);
-  const code = await spawnLogged([shell, tmp, ...args], { env: childEnv });
+  const result = await spawnLoggedCapture([shell, tmp, ...args], { env: childEnv });
   if (sudoShim) removeTemp(sudoShim);
   // node:fs, not `rm`. There is no rm on native Windows, so cleaning up
   // failed with `Executable not found in $PATH: "rm"` — reported as the
@@ -876,7 +876,11 @@ export async function installerInstall(
   // script instead of at this line.
   removeTemp(tmp);
 
-  if (code !== 0) throw new RedError(`installer exited ${code}: ${url}`);
+  if (result.code !== 0) {
+    throw new RedError(
+      tlsTrustFailure(result.out + result.err) ?? `installer exited ${result.code}: ${url}`,
+    );
+  }
 }
 
 // ------------------------------------------------- ppa / apt repos

--- a/src/runtime-version-picker.test.ts
+++ b/src/runtime-version-picker.test.ts
@@ -1,0 +1,79 @@
+/** Per-runtime version selection belongs on the language row itself. */
+
+import { describe, expect, test } from "bun:test";
+import { renderToString } from "tuiuiu.js";
+import type { Platform } from "./platform.ts";
+import {
+  OFFERED_RUNTIMES,
+  shiftRuntimeVersion,
+} from "./runtimes.ts";
+import {
+  questions,
+  SetupLayout,
+  type Choice,
+  type SetupModel,
+} from "./tui-setup-model.ts";
+
+const UBUNTU_26: Platform = {
+  os: "linux",
+  distro: "ubuntu",
+  version: "26.04",
+  codename: "resolute",
+  env: "desktop",
+  arch: "x64",
+  caps: { apt: true, gui: true, systemd: true, winget: false, flatpak: true },
+};
+
+const strip = (text: string): string => text.replace(/\x1b\[[0-9;]*m/g, "");
+const runtimeChoices = (): Choice[] =>
+  OFFERED_RUNTIMES.map((runtime) => ({
+    key: runtime.id,
+    label: runtime.label,
+    note: runtime.about,
+  }));
+
+function runtimesFrame(selection: string[]): string {
+  const steps = questions(UBUNTU_26, [], [], runtimeChoices());
+  const index = steps.findIndex((step) => step.id === "runtimes");
+  const model = {
+    steps,
+    stepIndex: () => index,
+    cursor: () => 0,
+    selection: () => selection,
+    pickedFor: () => [],
+    wizard: { isCompleted: () => false },
+  } as unknown as SetupModel;
+  return strip(renderToString(SetupLayout(model, UBUNTU_26, 100, 30), 100, 30));
+}
+
+describe("per-runtime version picker", () => {
+  test("Node can move from the supported LTS line to the current line", () => {
+    expect(shiftRuntimeVersion(["node@24", "python@3.13"], "node@24", 1)).toEqual([
+      "node@26",
+      "python@3.13",
+    ]);
+  });
+
+  test("each selected language keeps its own version", () => {
+    expect(shiftRuntimeVersion(["node@26", "python@3.13"], "python@3.13", 1)).toEqual([
+      "node@26",
+      "python@3.14",
+    ]);
+  });
+
+  test("version arrows do not also opt an unchecked language in", () => {
+    expect(shiftRuntimeVersion(["node@24"], "java@25", 1)).toEqual(["node@24"]);
+  });
+
+  test("the language screen shows the active version and its controls", () => {
+    const frame = runtimesFrame(["node@26"]);
+    expect(frame).toContain("Node.js");
+    expect(frame).toContain("26 Current");
+    expect(frame).toContain("left/right");
+  });
+
+  test("there is no hidden global Versions step anymore", () => {
+    const ids = questions(UBUNTU_26, [], [], runtimeChoices()).map((step) => step.id);
+    expect(ids).not.toContain("runtime-versions");
+  });
+});

--- a/src/runtimes.ts
+++ b/src/runtimes.ts
@@ -30,22 +30,117 @@ import { unattendedEnvironment } from "./unattended.ts";
  * `mise use`. A prompt that installs four runtimes nobody asked for is
  * how a dev environment becomes 8 GB.
  */
-const DEFAULT_RUNTIMES = ["node@lts"] as const;
+const DEFAULT_RUNTIMES = ["node@24"] as const;
 
 /**
  * Offered by `red-dev lang`. omakub asks the same question at first
  * run; here it is a command you can re-run, because the answer changes
  * when a project does.
  */
-export const OFFERED_RUNTIMES: { id: string; about: string }[] = [
-  { id: "node@lts", about: "Node.js LTS — also brings npm and corepack" },
-  { id: "bun@latest", about: "Bun — runtime, bundler and package manager" },
-  { id: "deno@latest", about: "Deno" },
-  { id: "python@3.13", about: "Python 3.13" },
-  { id: "go@latest", about: "Go" },
-  { id: "rust@stable", about: "Rust, via rustup" },
-  { id: "ruby@3.4", about: "Ruby 3.4" },
-  { id: "java@lts", about: "Java LTS" },
+export interface RuntimeVersionChoice {
+  id: string;
+  label: string;
+}
+
+export interface OfferedRuntime {
+  /** Default selector used when the language is first checked. */
+  id: string;
+  label: string;
+  about: string;
+  versions: RuntimeVersionChoice[];
+}
+
+/**
+ * Supported lines shown directly on the language picker.
+ *
+ * Every list ends in a moving channel so the UI remains useful between
+ * red-dev releases, while the numbered entries let a project stay on a
+ * major/minor line. Mise resolves each selector to the newest patch on it.
+ */
+export const OFFERED_RUNTIMES: OfferedRuntime[] = [
+  {
+    id: "node@24",
+    label: "Node.js",
+    about: "also brings npm and corepack",
+    versions: [
+      { id: "node@22", label: "22 LTS" },
+      { id: "node@24", label: "24 LTS" },
+      { id: "node@26", label: "26 Current" },
+      { id: "node@latest", label: "Latest" },
+    ],
+  },
+  {
+    id: "bun@1.3",
+    label: "Bun",
+    about: "runtime, bundler and package manager",
+    versions: [
+      { id: "bun@1.2", label: "1.2" },
+      { id: "bun@1.3", label: "1.3" },
+      { id: "bun@latest", label: "Latest" },
+    ],
+  },
+  {
+    id: "deno@2.9",
+    label: "Deno",
+    about: "secure JavaScript and TypeScript runtime",
+    versions: [
+      { id: "deno@2.8", label: "2.8" },
+      { id: "deno@2.9", label: "2.9" },
+      { id: "deno@latest", label: "Latest" },
+    ],
+  },
+  {
+    id: "python@3.13",
+    label: "Python",
+    about: "CPython with SQLite support verified after install",
+    versions: [
+      { id: "python@3.13", label: "3.13" },
+      { id: "python@3.14", label: "3.14" },
+      { id: "python@latest", label: "Latest" },
+    ],
+  },
+  {
+    id: "go@1.26",
+    label: "Go",
+    about: "compiler and standard toolchain",
+    versions: [
+      { id: "go@1.25", label: "1.25" },
+      { id: "go@1.26", label: "1.26" },
+      { id: "go@latest", label: "Latest" },
+    ],
+  },
+  {
+    id: "rust@1.97",
+    label: "Rust",
+    about: "via rustup",
+    versions: [
+      { id: "rust@1.96", label: "1.96" },
+      { id: "rust@1.97", label: "1.97" },
+      { id: "rust@stable", label: "Stable" },
+    ],
+  },
+  {
+    id: "ruby@3.4",
+    label: "Ruby",
+    about: "MRI Ruby",
+    versions: [
+      { id: "ruby@3.3", label: "3.3" },
+      { id: "ruby@3.4", label: "3.4" },
+      { id: "ruby@4.0", label: "4.0" },
+      { id: "ruby@latest", label: "Latest" },
+    ],
+  },
+  {
+    id: "java@25",
+    label: "Java",
+    about: "OpenJDK",
+    versions: [
+      { id: "java@21", label: "21 LTS" },
+      { id: "java@25", label: "25 LTS" },
+      { id: "java@26", label: "26 Current" },
+      { id: "java@latest", label: "Latest" },
+    ],
+  },
 ];
 
 export type RuntimeVersionPolicy = "recommended" | "latest";
@@ -53,6 +148,52 @@ export type RuntimeVersionPolicy = "recommended" | "latest";
 const RUNTIME_NAMES = new Set(
   OFFERED_RUNTIMES.map((runtime) => runtime.id.split("@")[0]!),
 );
+
+function runtimeName(id: string): string {
+  return id.split("@")[0] ?? id;
+}
+
+/** The catalog entry for any selector belonging to a known runtime. */
+export function offeredRuntime(id: string): OfferedRuntime | undefined {
+  const name = runtimeName(id);
+  return OFFERED_RUNTIMES.find((runtime) => runtimeName(runtime.id) === name);
+}
+
+/** The currently selected id for this language, or its displayed default. */
+export function selectedRuntimeId(ids: string[], defaultId: string): string {
+  const name = runtimeName(defaultId);
+  return ids.find((id) => runtimeName(id) === name) ?? defaultId;
+}
+
+/** Human label for the selector currently shown on a language row. */
+export function runtimeVersionLabel(id: string): string {
+  const runtime = offeredRuntime(id);
+  return runtime?.versions.find((version) => version.id === id)?.label ?? id.split("@")[1] ?? id;
+}
+
+/** Check or uncheck one language without creating two versions of it. */
+export function toggleRuntimeSelection(ids: string[], defaultId: string): string[] {
+  const name = runtimeName(defaultId);
+  const found = ids.findIndex((id) => runtimeName(id) === name);
+  if (found >= 0) return ids.filter((_, index) => index !== found);
+  return [...ids, defaultId];
+}
+
+/** Cycle one language's selector in place, preserving every other choice. */
+export function shiftRuntimeVersion(ids: string[], defaultId: string, delta: -1 | 1): string[] {
+  const runtime = offeredRuntime(defaultId);
+  if (!runtime || runtime.versions.length === 0) return [...ids];
+  const name = runtimeName(defaultId);
+  const selectedIndex = ids.findIndex((id) => runtimeName(id) === name);
+  // Version arrows change a checked language; they do not also opt an
+  // unchecked language in. Space owns that decision.
+  if (selectedIndex < 0) return [...ids];
+  const current = ids[selectedIndex]!;
+  const currentIndex = Math.max(0, runtime.versions.findIndex((version) => version.id === current));
+  const nextIndex = (currentIndex + delta + runtime.versions.length) % runtime.versions.length;
+  const next = runtime.versions[nextIndex]!.id;
+  return ids.map((id, index) => (index === selectedIndex ? next : id));
+}
 
 /** Apply the setup's version policy without changing which runtimes were chosen. */
 export function runtimeIdsForPolicy(

--- a/src/setup-defaults.test.ts
+++ b/src/setup-defaults.test.ts
@@ -62,24 +62,17 @@ describe("the optional tools", () => {
 describe("multi-choice defaults", () => {
   test("language runtimes leave Java, Ruby and Go unmarked", () => {
     const runtimes = [
-      { key: "node@lts", label: "Node", note: "" },
-      { key: "bun@latest", label: "Bun", note: "" },
+      { key: "node@24", label: "Node", note: "" },
+      { key: "bun@1.3", label: "Bun", note: "" },
       { key: "python@3.13", label: "Python", note: "" },
-      { key: "go@latest", label: "Go", note: "" },
+      { key: "go@1.26", label: "Go", note: "" },
       { key: "ruby@3.4", label: "Ruby", note: "" },
-      { key: "java@lts", label: "Java", note: "" },
+      { key: "java@25", label: "Java", note: "" },
     ];
     const q = questions(WSL, choices(2), choices(3), runtimes).find(
       (candidate) => candidate.id === "runtimes",
     );
-    expect(q?.preset).toEqual(["node@lts", "bun@latest", "python@3.13"]);
-  });
-
-  test("runtime versions default to the recommended compatibility channels", () => {
-    const q = step("runtime-versions");
-    expect(q.multi).toBe(false);
-    expect(q.preset).toEqual(["recommended"]);
-    expect(q.choices.map((choice) => choice.key)).toEqual(["recommended", "latest"]);
+    expect(q?.preset).toEqual(["node@24", "bun@1.3", "python@3.13"]);
   });
 
   test("all agents arrive marked", () => {

--- a/src/setup-progress.test.ts
+++ b/src/setup-progress.test.ts
@@ -43,7 +43,7 @@ describe("the setup work plan", () => {
     });
 
     expect(plan.map((step) => step.tool)).toEqual([
-      "node@lts",
+      "node@24",
       "Gemini CLI",
       "T3 Code",
       "red-skills",
@@ -68,7 +68,7 @@ describe("the setup work plan", () => {
     });
 
     expect(plan.map((step) => step.tool)).toEqual([
-      "node@lts",
+      "node@24",
       "python@3.13",
       "Hermes Agent",
       "red-skills",
@@ -83,7 +83,7 @@ describe("the setup work plan", () => {
     });
 
     expect(plan.map((step) => step.tool)).toEqual([
-      "node@lts",
+      "node@24",
       "python@3.13",
       "OpenClaw",
       "Hermes Agent",

--- a/src/tui-centered.test.ts
+++ b/src/tui-centered.test.ts
@@ -3,6 +3,7 @@
 import { describe, expect, test } from "bun:test";
 import { renderToString } from "tuiuiu.js";
 import type { Platform } from "./platform.ts";
+import { OFFERED_RUNTIMES } from "./runtimes.ts";
 import {
   questions,
   SetupLayout,
@@ -28,15 +29,20 @@ function setupFrame(width: number, height: number): string[] {
     UBUNTU_26,
     [choice("codex")],
     [choice("btop")],
-    [choice("node@lts")],
+    OFFERED_RUNTIMES.map((runtime) => ({
+      key: runtime.id,
+      label: runtime.label,
+      note: runtime.about,
+    })),
   );
+  const runtimeStep = steps.findIndex((step) => step.id === "runtimes");
   const model = {
     steps,
-    stepIndex: () => 2,
+    stepIndex: () => runtimeStep,
     cursor: () => 0,
-    selection: () => ["node@lts"],
+    selection: () => ["node@24"],
     pickedFor: () => [],
-    wizard: { isCompleted: (index: number) => index < 2 },
+    wizard: { isCompleted: (index: number) => index < runtimeStep },
   } as unknown as SetupModel;
   return strip(renderToString(SetupLayout(model, UBUNTU_26, width, height), width, height))
     .split("\n");
@@ -64,7 +70,7 @@ describe("the Ubuntu installer composition", () => {
   test("still fits a normal 80x24 terminal", () => {
     const rows = setupFrame(80, 24);
     expect(rows).toHaveLength(24);
-    expect(rows.some((row) => row.includes("Versions"))).toBe(true);
+    expect(rows.some((row) => row.includes("24 LTS"))).toBe(true);
     expect(rows.some((row) => row.length > 80)).toBe(false);
   });
 });

--- a/src/tui-setup-model.ts
+++ b/src/tui-setup-model.ts
@@ -30,7 +30,13 @@ import { CenteredScreen, centeredFrame, Surface } from "./tui-chrome.ts";
 import { muted, ui } from "./tui-theme.ts";
 import { DEFAULT_THEME, swatches, THEMES, themeNames } from "./themes.ts";
 import type { ThemeSlug } from "./themes.ts";
-import { runtimeIdsForPolicy, runtimeSelectedByDefault } from "./runtimes.ts";
+import {
+  runtimeSelectedByDefault,
+  runtimeVersionLabel,
+  selectedRuntimeId,
+  shiftRuntimeVersion,
+  toggleRuntimeSelection,
+} from "./runtimes.ts";
 
 export interface SetupAnswers {
   theme: string;
@@ -145,34 +151,11 @@ export function questions(
       description:
         "Owned by mise, so node resolves the same way in WSL, on the desktop " +
         "and in Git Bash. A version manager that manages nothing is how pnpm " +
-        "ends up working in one shell and not another. Java, Ruby and Go are " +
-        "available but start off; select them when a project needs them.",
+        "ends up working in one shell and not another. Space enables a language; " +
+        "left/right chooses its version. Java, Ruby and Go start off.",
       multi: true,
       choices: runtimes,
       preset: runtimes.filter((runtime) => runtimeSelectedByDefault(runtime.key)).map((runtime) => runtime.key),
-      applies: () => true,
-    },
-    {
-      id: "runtime-versions",
-      title: "Versions",
-      description:
-        "Recommended follows the compatibility channel chosen by red-dev — for " +
-        "example Node LTS and Python 3.13. Latest asks mise for the newest release " +
-        "of every runtime you selected.",
-      multi: false,
-      choices: [
-        {
-          key: "recommended",
-          label: "Recommended versions",
-          note: "the default — LTS, stable or a tested release where appropriate",
-        },
-        {
-          key: "latest",
-          label: "Latest versions",
-          note: "rewrite every selected runtime to @latest",
-        },
-      ],
-      preset: ["recommended"],
       applies: () => true,
     },
     {
@@ -313,6 +296,7 @@ interface SetupKey {
   upArrow?: boolean;
   downArrow?: boolean;
   leftArrow?: boolean;
+  rightArrow?: boolean;
   escape?: boolean;
   return?: boolean;
 }
@@ -342,10 +326,7 @@ export function useSetupModel(steps: Question[], wizard: ReturnType<typeof creat
         : {}),
       font: get("font")[0] ?? "firacode",
       apps: get("apps"),
-      runtimes: runtimeIdsForPolicy(
-        get("runtimes"),
-        get("runtime-versions")[0] === "latest" ? "latest" : "recommended",
-      ),
+      runtimes: get("runtimes"),
       agents: get("agents"),
       blesh: get("plugins").includes("blesh"),
       redwall: get("redwall")[0] === "yes",
@@ -365,12 +346,28 @@ export function useSetupModel(steps: Question[], wizard: ReturnType<typeof creat
         setCursor(Math.min(max, cursor() + 1));
         return "handled";
       }
+      if (q.id === "runtimes" && (key.leftArrow || key.rightArrow || input === "h" || input === "l")) {
+        const choice = q.choices[cursor()];
+        if (choice) {
+          setPicked({
+            ...picked(),
+            [q.id]: shiftRuntimeVersion(
+              selection(),
+              choice.key,
+              key.leftArrow || input === "h" ? -1 : 1,
+            ),
+          });
+        }
+        return "handled";
+      }
       if (input === " " && q.multi) {
         const k = q.choices[cursor()]!.key;
         const cur = selection();
         setPicked({
           ...picked(),
-          [q.id]: cur.includes(k) ? cur.filter((x) => x !== k) : [...cur, k],
+          [q.id]: q.id === "runtimes"
+            ? toggleRuntimeSelection(cur, k)
+            : cur.includes(k) ? cur.filter((x) => x !== k) : [...cur, k],
         });
         return "handled";
       }
@@ -385,7 +382,7 @@ export function useSetupModel(steps: Question[], wizard: ReturnType<typeof creat
         wizard.next();
         return "handled";
       }
-      if (key.leftArrow || key.escape) {
+      if ((key.leftArrow && q.id !== "runtimes") || key.escape) {
         if (stepIndex() > 0) {
           setStepIndex(stepIndex() - 1);
           setCursor(0);
@@ -428,6 +425,7 @@ export function SetupLayout(m: SetupModel, p: Platform, width: number, height: n
   const leftWidth = 26;
   const rightWidth = twoColumn ? frame.width - leftWidth - 3 : frame.width;
   const isTheme = q.id === "theme";
+  const isRuntimes = q.id === "runtimes";
   const activeKey = q.choices[m.cursor()]?.key ?? "";
 
   return CenteredScreen(
@@ -485,13 +483,19 @@ export function SetupLayout(m: SetupModel, p: Platform, width: number, height: n
           Text({}, ""),
           Text({ color: muted }, q.description),
           Text({}, ""),
-          ...q.choices.map((c, i) =>
-            ListItem({
-              primary: `${q.multi ? (m.selection().includes(c.key) ? "[x] " : "[ ] ") : ""}${c.label}`,
-              secondary: c.note,
+          ...q.choices.map((c, i) => {
+            const runtimeId = selectedRuntimeId(m.selection(), c.key);
+            const checked = isRuntimes
+              ? m.selection().includes(runtimeId)
+              : m.selection().includes(c.key);
+            return ListItem({
+              primary: isRuntimes
+                ? `${checked ? "[x]" : "[ ]"} ${c.label}  ‹ ${runtimeVersionLabel(runtimeId)} ›`
+                : `${q.multi ? (checked ? "[x] " : "[ ] ") : ""}${c.label}`,
+              ...(!isRuntimes ? { secondary: c.note } : {}),
               selected: i === m.cursor(),
-            }),
-          ),
+            });
+          }),
           // The reason this screen exists: the palette is visible while
           // the cursor moves, not after the choice is made.
           ...(isTheme
@@ -513,11 +517,13 @@ export function SetupLayout(m: SetupModel, p: Platform, width: number, height: n
         hints: [
           { shortcut: "up/down", action: "move" },
           ...(q.multi ? [{ shortcut: "space", action: "toggle" }] : []),
+          ...(isRuntimes ? [{ shortcut: "left/right", action: "version" }] : []),
           {
             shortcut: "enter",
             action: m.stepIndex() === m.steps.length - 1 ? "install" : "next",
           },
-          ...(m.stepIndex() > 0 ? [{ shortcut: "left", action: "back" }] : []),
+          ...(m.stepIndex() > 0 && !isRuntimes ? [{ shortcut: "left", action: "back" }] : []),
+          ...(m.stepIndex() > 0 && isRuntimes ? [{ shortcut: "esc", action: "back" }] : []),
           { shortcut: "q", action: "skip" },
         ],
       }),

--- a/src/tui-setup.ts
+++ b/src/tui-setup.ts
@@ -34,7 +34,12 @@ import { CenteredScreen, centeredFrame, Surface } from "./tui-chrome.ts";
 import { muted, ui } from "./tui-theme.ts";
 import { swatches } from "./themes.ts";
 import type { ThemeSlug } from "./themes.ts";
-import { runtimeIdsForPolicy } from "./runtimes.ts";
+import {
+  runtimeVersionLabel,
+  selectedRuntimeId,
+  shiftRuntimeVersion,
+  toggleRuntimeSelection,
+} from "./runtimes.ts";
 import { withConsoleSelectionSuspended } from "./windows-console-mode.ts";
 // The questions live in tui-setup-model.ts and only there. They were
 // declared in both files, identically, for two interfaces that ask the
@@ -94,10 +99,7 @@ export async function runSetupTui(
             : {}),
           font: get("font")[0] ?? "firacode",
           apps: get("apps"),
-          runtimes: runtimeIdsForPolicy(
-            get("runtimes"),
-            get("runtime-versions")[0] === "latest" ? "latest" : "recommended",
-          ),
+          runtimes: get("runtimes"),
           agents: get("agents"),
           blesh: get("plugins").includes("blesh"),
           redwall: get("redwall")[0] === "yes",
@@ -126,12 +128,29 @@ export async function runSetupTui(
         return;
       }
 
+      if (q.id === "runtimes" && (key.leftArrow || key.rightArrow || input === "h" || input === "l")) {
+        const choice = q.choices[cursor()];
+        if (choice) {
+          setPicked({
+            ...picked(),
+            [q.id]: shiftRuntimeVersion(
+              selection(),
+              choice.key,
+              key.leftArrow || input === "h" ? -1 : 1,
+            ),
+          });
+        }
+        return;
+      }
+
       if (input === " " && q.multi) {
         const k = q.choices[cursor()]!.key;
         const cur = selection();
         setPicked({
           ...picked(),
-          [q.id]: cur.includes(k) ? cur.filter((x) => x !== k) : [...cur, k],
+          [q.id]: q.id === "runtimes"
+            ? toggleRuntimeSelection(cur, k)
+            : cur.includes(k) ? cur.filter((x) => x !== k) : [...cur, k],
         });
         return;
       }
@@ -146,7 +165,7 @@ export async function runSetupTui(
         return;
       }
 
-      if (key.leftArrow || key.escape) {
+      if ((key.leftArrow && q.id !== "runtimes") || key.escape) {
         if (stepIndex() > 0) {
           setStepIndex(stepIndex() - 1);
           setCursor(0);
@@ -174,6 +193,7 @@ export async function runSetupTui(
     const leftWidth = 26;
     const rightWidth = twoColumn ? frame.width - leftWidth - 3 : frame.width;
     const isTheme = q.id === "theme";
+    const isRuntimes = q.id === "runtimes";
     const activeKey = q.choices[cursor()]?.key ?? "";
 
     return CenteredScreen(
@@ -233,13 +253,19 @@ export async function runSetupTui(
             Text({}, ""),
             Text({ color: muted }, q.description),
             Text({}, ""),
-            ...q.choices.map((c, i) =>
-              ListItem({
-                primary: `${q.multi ? (selection().includes(c.key) ? "[x] " : "[ ] ") : ""}${c.label}`,
-                secondary: c.note,
+            ...q.choices.map((c, i) => {
+              const runtimeId = selectedRuntimeId(selection(), c.key);
+              const checked = isRuntimes
+                ? selection().includes(runtimeId)
+                : selection().includes(c.key);
+              return ListItem({
+                primary: isRuntimes
+                  ? `${checked ? "[x]" : "[ ]"} ${c.label}  ‹ ${runtimeVersionLabel(runtimeId)} ›`
+                  : `${q.multi ? (checked ? "[x] " : "[ ] ") : ""}${c.label}`,
+                ...(!isRuntimes ? { secondary: c.note } : {}),
                 selected: i === cursor(),
-              }),
-            ),
+              });
+            }),
             // The reason this screen exists: the palette is visible
             // while the cursor moves, not after the choice is made.
             ...(isTheme
@@ -261,8 +287,10 @@ export async function runSetupTui(
           hints: [
             { shortcut: "up/down", action: "move" },
             ...(q.multi ? [{ shortcut: "space", action: "toggle" }] : []),
+            ...(isRuntimes ? [{ shortcut: "left/right", action: "version" }] : []),
             { shortcut: "enter", action: stepIndex() === steps.length - 1 ? "finish" : "next" },
-            ...(stepIndex() > 0 ? [{ shortcut: "left", action: "back" }] : []),
+            ...(stepIndex() > 0 && !isRuntimes ? [{ shortcut: "left", action: "back" }] : []),
+            ...(stepIndex() > 0 && isRuntimes ? [{ shortcut: "esc", action: "back" }] : []),
             { shortcut: "q", action: "skip setup" },
           ],
         }),

--- a/src/unattended.test.ts
+++ b/src/unattended.test.ts
@@ -45,7 +45,7 @@ const expected = {
 
 describe("the unattended provisioning envelope", () => {
   test("translates intercepted TLS failures into the machine-trust remedy", () => {
-    const remedy = "TLS certificate chain is not trusted — install the corporate CA in the machine trust store, then re-run red-dev";
+    const remedy = "TLS certificate chain is not trusted — install the corporate CA in the machine trust store, then retry red-dev";
     expect(tlsTrustFailure("npm error SELF_SIGNED_CERT_IN_CHAIN")).toBe(remedy);
     expect(tlsTrustFailure("invalid peer certificate: UnknownIssuer")).toBe(remedy);
     expect(tlsTrustFailure("unable to get local issuer certificate")).toBe(remedy);

--- a/src/unattended.test.ts
+++ b/src/unattended.test.ts
@@ -5,9 +5,15 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import { readFileSync } from "node:fs";
+import { chmodSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { spawnLoggedCapture } from "./providers.ts";
-import { unattendedShellCommand } from "./unattended.ts";
+import {
+  tlsTrustFailure,
+  unattendedEnvironment,
+  unattendedShellCommand,
+} from "./unattended.ts";
 
 const expected = {
   RED_DEV_UNATTENDED: "1",
@@ -23,7 +29,12 @@ const expected = {
   npm_config_fund: "false",
   npm_config_update_notifier: "false",
   npm_config_progress: "false",
+  npm_config_strict_ssl: "true",
   COREPACK_ENABLE_DOWNLOAD_PROMPT: "0",
+  NODE_USE_SYSTEM_CA: "1",
+  DENO_TLS_CA_STORE: "system,mozilla",
+  UV_SYSTEM_CERTS: "true",
+  UV_NATIVE_TLS: "true",
   PIP_NO_INPUT: "1",
   PIP_DISABLE_PIP_VERSION_CHECK: "1",
   POETRY_NO_INTERACTION: "1",
@@ -33,6 +44,73 @@ const expected = {
 } as const;
 
 describe("the unattended provisioning envelope", () => {
+  test("translates intercepted TLS failures into the machine-trust remedy", () => {
+    const remedy = "TLS certificate chain is not trusted — install the corporate CA in the machine trust store, then re-run red-dev";
+    expect(tlsTrustFailure("npm error SELF_SIGNED_CERT_IN_CHAIN")).toBe(remedy);
+    expect(tlsTrustFailure("invalid peer certificate: UnknownIssuer")).toBe(remedy);
+    expect(tlsTrustFailure("unable to get local issuer certificate")).toBe(remedy);
+    expect(tlsTrustFailure("npm exited non-zero")).toBeNull();
+  });
+
+  test("trusts a private CA from the machine without disabling TLS verification", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "red-dev-ca-"));
+    const key = join(dir, "ca.key");
+    const cert = join(dir, "ca.pem");
+    let server: ReturnType<typeof Bun.serve> | undefined;
+    const runNode = async (probe: string, env: Record<string, string | undefined>) => {
+      const child = Bun.spawn(["node", "-e", probe], { env, stdout: "pipe", stderr: "pipe" });
+      const [stdout, stderr, code] = await Promise.all([
+        new Response(child.stdout).text(),
+        new Response(child.stderr).text(),
+        child.exited,
+      ]);
+      return { stdout, stderr, code };
+    };
+    try {
+      const generated = Bun.spawnSync([
+        "openssl", "req", "-x509", "-newkey", "rsa:2048", "-nodes",
+        "-keyout", key, "-out", cert, "-days", "1", "-subj", "/CN=localhost",
+        "-addext", "subjectAltName=DNS:localhost",
+      ], { stdout: "ignore", stderr: "ignore" });
+      expect(generated.exitCode).toBe(0);
+      chmodSync(key, 0o600);
+
+      server = Bun.serve({
+        port: 0,
+        tls: { key: Bun.file(key), cert: Bun.file(cert) },
+        fetch: () => new Response("trusted"),
+      });
+      const probe = `fetch(${JSON.stringify(`https://localhost:${server.port}`)})` +
+        `.then(async r => { console.log(await r.text()) })` +
+        `.catch(e => { console.error(e.cause?.code ?? e.code ?? e.message); process.exit(2) })`;
+      const plain = await runNode(probe, {
+        ...process.env,
+        NODE_USE_SYSTEM_CA: "0",
+        SSL_CERT_FILE: undefined,
+      });
+      expect(plain.code).toBe(2);
+
+      const trusted = await runNode(
+        probe,
+        unattendedEnvironment(process.env, { SSL_CERT_FILE: cert }),
+      );
+      expect(trusted.code).toBe(0);
+      expect(trusted.stdout.trim()).toBe("trusted");
+
+      const trustedEnvironment = unattendedEnvironment({}, { SSL_CERT_FILE: cert });
+      expect(trustedEnvironment["npm_config_strict_ssl"]).toBe("true");
+      expect(trustedEnvironment["npm_config_cafile"]).toBe(cert);
+      expect(trustedEnvironment["NODE_EXTRA_CA_CERTS"]).toBe(cert);
+      expect(trustedEnvironment["CURL_CA_BUNDLE"]).toBe(cert);
+      expect(trustedEnvironment["REQUESTS_CA_BUNDLE"]).toBe(cert);
+      expect(trustedEnvironment["PIP_CERT"]).toBe(cert);
+      expect(trustedEnvironment["GIT_SSL_CAINFO"]).toBe(cert);
+    } finally {
+      server?.stop(true);
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 15_000);
+
   test("survives a package manager and reaches its lifecycle child", async () => {
     const names = Object.keys(expected);
     const grandchild =
@@ -59,6 +137,17 @@ describe("the unattended provisioning envelope", () => {
     const command = unattendedShellCommand("red-dev install core");
     for (const [name, value] of Object.entries(expected)) {
       expect(command).toContain(`${name}='${value}'`);
+    }
+    for (const name of [
+      "SSL_CERT_FILE",
+      "CURL_CA_BUNDLE",
+      "NODE_EXTRA_CA_CERTS",
+      "REQUESTS_CA_BUNDLE",
+      "PIP_CERT",
+      "GIT_SSL_CAINFO",
+      "npm_config_cafile",
+    ]) {
+      expect(command).toContain(`${name}='/etc/ssl/certs/ca-certificates.crt'`);
     }
   });
 

--- a/src/unattended.ts
+++ b/src/unattended.ts
@@ -7,6 +7,10 @@
  * then carries this contract through second- and third-level installers.
  */
 
+import { existsSync } from "node:fs";
+
+const LINUX_SYSTEM_CA_BUNDLE = "/etc/ssl/certs/ca-certificates.crt";
+
 export const UNATTENDED_ENV = {
   RED_DEV_UNATTENDED: "1",
   // Widely understood by JS package managers and lifecycle scripts.
@@ -33,7 +37,25 @@ export const UNATTENDED_ENV = {
   npm_config_fund: "false",
   npm_config_update_notifier: "false",
   npm_config_progress: "false",
+  // Keep verification on. Trust comes from the machine's CA store below;
+  // accepting every certificate would turn a corporate proxy fix into a
+  // silent man-in-the-middle vulnerability.
+  npm_config_strict_ssl: "true",
   COREPACK_ENABLE_DOWNLOAD_PROMPT: "0",
+
+  // Node 22.19+/24.6+ adds the OS trust store to its bundled Mozilla roots.
+  // npm and its lifecycle descendants inherit this automatically.
+  NODE_USE_SYSTEM_CA: "1",
+
+  // Deno otherwise defaults to Mozilla roots only.
+  DENO_TLS_CA_STORE: "system,mozilla",
+
+  // uv otherwise uses its bundled Mozilla roots. System certificates are
+  // required for managed workstations whose proxy CA lives in the OS store.
+  // Keep the legacy spelling too: older uv releases used it and vendor
+  // installers may bring their own uv binary.
+  UV_SYSTEM_CERTS: "true",
+  UV_NATIVE_TLS: "true",
 
   // Python and mise runtime/plugin installers.
   PIP_NO_INPUT: "1",
@@ -46,12 +68,48 @@ export const UNATTENDED_ENV = {
   YARN_PREFER_INTERACTIVE: "false",
 } as const satisfies Record<string, string>;
 
+const UNTRUSTED_TLS_CHAIN =
+  /SELF_SIGNED_CERT_IN_CHAIN|self[- ]signed certificate in certificate chain|UnknownIssuer|unknown issuer|unable to get local issuer certificate|unable to verify the first certificate|certificate signed by unknown authority/i;
+
+/** Turn the common corporate-proxy TLS failures into one actionable error. */
+export function tlsTrustFailure(output: string): string | null {
+  if (!UNTRUSTED_TLS_CHAIN.test(output)) return null;
+  return "TLS certificate chain is not trusted — install the corporate CA in the machine trust store, then re-run red-dev";
+}
+
+/**
+ * Point OpenSSL/npm/Bun at the CA bundle maintained by update-ca-certificates.
+ *
+ * Windows has no PEM bundle to name: NODE_USE_SYSTEM_CA and Deno's `system`
+ * store read the Windows Certificate Store directly, while native curl uses
+ * Schannel. On Linux and WSL, the bundle contains both public roots and any
+ * private CA the administrator installed into the machine trust chain.
+ */
+function machineTrustEnvironment(
+  current: Record<string, string | undefined>,
+): Record<string, string> {
+  if (process.platform === "win32") return {};
+  const cafile = current["SSL_CERT_FILE"] ??
+    (existsSync(LINUX_SYSTEM_CA_BUNDLE) ? LINUX_SYSTEM_CA_BUNDLE : undefined);
+  if (!cafile) return {};
+  return {
+    ...(current["SSL_CERT_FILE"] ? {} : { SSL_CERT_FILE: cafile }),
+    ...(current["CURL_CA_BUNDLE"] ? {} : { CURL_CA_BUNDLE: cafile }),
+    ...(current["NODE_EXTRA_CA_CERTS"] ? {} : { NODE_EXTRA_CA_CERTS: cafile }),
+    ...(current["REQUESTS_CA_BUNDLE"] ? {} : { REQUESTS_CA_BUNDLE: cafile }),
+    ...(current["PIP_CERT"] ? {} : { PIP_CERT: cafile }),
+    ...(current["GIT_SSL_CAINFO"] ? {} : { GIT_SSL_CAINFO: cafile }),
+    ...(current["npm_config_cafile"] ? {} : { npm_config_cafile: cafile }),
+  };
+}
+
 /** Merge caller-specific values, then enforce the unattended contract. */
 export function unattendedEnvironment(
   current: Record<string, string | undefined> = process.env,
   extra: Record<string, string | undefined> = {},
 ): Record<string, string | undefined> {
-  return { ...current, ...extra, ...UNATTENDED_ENV };
+  const merged = { ...current, ...extra };
+  return { ...merged, ...machineTrustEnvironment(merged), ...UNATTENDED_ENV };
 }
 
 function shellWord(value: string): string {
@@ -66,7 +124,19 @@ export function unattendedShellCommand(
   command: string,
   extra: Record<string, string> = {},
 ): string {
-  const assignments = Object.entries({ ...extra, ...UNATTENDED_ENV })
+  // This function's destination is always an Ubuntu WSL distro. Its bundle
+  // cannot be discovered from the Windows host where this string is built.
+  const assignments = Object.entries({
+    SSL_CERT_FILE: LINUX_SYSTEM_CA_BUNDLE,
+    CURL_CA_BUNDLE: LINUX_SYSTEM_CA_BUNDLE,
+    NODE_EXTRA_CA_CERTS: LINUX_SYSTEM_CA_BUNDLE,
+    REQUESTS_CA_BUNDLE: LINUX_SYSTEM_CA_BUNDLE,
+    PIP_CERT: LINUX_SYSTEM_CA_BUNDLE,
+    GIT_SSL_CAINFO: LINUX_SYSTEM_CA_BUNDLE,
+    npm_config_cafile: LINUX_SYSTEM_CA_BUNDLE,
+    ...extra,
+    ...UNATTENDED_ENV,
+  })
     .map(([name, value]) => `${name}=${shellWord(value)}`)
     .join(" ");
   return `env ${assignments} ${command}`;

--- a/src/unattended.ts
+++ b/src/unattended.ts
@@ -74,7 +74,7 @@ const UNTRUSTED_TLS_CHAIN =
 /** Turn the common corporate-proxy TLS failures into one actionable error. */
 export function tlsTrustFailure(output: string): string | null {
   if (!UNTRUSTED_TLS_CHAIN.test(output)) return null;
-  return "TLS certificate chain is not trusted — install the corporate CA in the machine trust store, then re-run red-dev";
+  return "TLS certificate chain is not trusted — install the corporate CA in the machine trust store, then retry red-dev";
 }
 
 /**


### PR DESCRIPTION
## What changed

- put version selection directly on every runtime row
- use Space to enable/disable and Left/Right to change only that runtime
- offer maintained numbered lines plus moving Latest/Stable channels
- propagate the machine CA chain to curl, Git, npm/Node/Bun, pip/Requests, uv and Deno
- preserve the TLS envelope through npm lifecycle children, vendor scripts, sudo and Windows-to-WSL provisioning
- keep TLS verification and npm strict-ssl enabled
- translate common intercepted-chain errors into an actionable machine-trust remedy

## Root causes

Runtime versions were implemented as one global policy after language selection, so the language page could not express Node 24 alongside Python 3.14 or Node 26.

Nested installers inherited the non-interactive envelope but not every ecosystem-specific CA setting. In particular, uv defaults to Mozilla roots and npm lifecycle scripts could lose the corporate trust path even when Ubuntu trusted the corporate CA.

## Validation

- generated a real private CA and served HTTPS from it in the regression test
- proved an ordinary Node fetch rejects it, then succeeds through the red-dev envelope without disabling verification
- proved the environment reaches an npm lifecycle grandchild and crosses Windows to WSL
- `bun test`
- `bun run typecheck`
- rendered the real Ubuntu setup at 80x24 and 100x30
- `bun scripts/tui-render-smoke.ts`
- `bun run build`