### PR TITLE
Show liveness for silent installers

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,10 @@ lets a corporate interception proxy work after its CA has been registered by
 the administrator, including inside npm lifecycle scripts and other nested
 installers. If the CA is absent, the result names the untrusted certificate
 chain instead of reducing it to `npm exited non-zero`.
+Long-running child processes report a heartbeat every five seconds. It names
+the executable, total elapsed time and, where red-dev owns the output stream,
+how long that child has been silent. A quiet compiler or package-manager lock
+therefore stays visibly alive instead of looking identical to a frozen run.
 Convergence makes the input gestures a workstation contract rather than an
 agent-specific surprise. Shift+Enter is emitted as CSI-u by Alacritty and
 Windows Terminal, mapped to a newline in Claude Code, and stated explicitly in

--- a/src/installer-noninteractive.test.ts
+++ b/src/installer-noninteractive.test.ts
@@ -55,6 +55,31 @@ describe("unattended provider commands", () => {
     }
   });
 
+  test("a silent child reports that it is alive before it finishes", async () => {
+    const seen: string[] = [];
+    const release = captureTo((line) => seen.push(line));
+    try {
+      const child = spawnLoggedCapture(
+        [
+          process.execPath,
+          "-e",
+          'setTimeout(() => console.log("FINISHED"), 180)',
+        ],
+        { heartbeatMs: 40 },
+      );
+
+      await Bun.sleep(110);
+      expect(seen.some((line) => line.includes("still running"))).toBe(true);
+      expect(seen.some((line) => line.includes("no output for"))).toBe(true);
+      expect(
+        seen.filter((line) => line.includes("still running")).length,
+      ).toBeGreaterThanOrEqual(2);
+      await child;
+    } finally {
+      release();
+    }
+  });
+
   test("every winget path uses the observable capture helper", () => {
     expect(providers).toContain("await spawnLoggedCapture(");
     expect(agents).toContain("await spawnLoggedCapture(argv)");

--- a/src/process-heartbeat.ts
+++ b/src/process-heartbeat.ts
@@ -1,0 +1,49 @@
+/**
+ * Liveness narration for child processes that may legitimately be silent.
+ *
+ * A child that emits progress is already observable through the shared
+ * logger. A child that compiles, waits on a package-manager lock, or downloads
+ * through a quiet vendor script otherwise looks exactly like a dead process.
+ */
+
+import { formatDuration, log } from "./log.ts";
+
+export const PROCESS_HEARTBEAT_MS = 5_000;
+
+function executableName(command: string[]): string {
+  const executable = (command[0] ?? "command").replaceAll("\\", "/");
+  return executable.split("/").at(-1) || "command";
+}
+
+export interface ProcessHeartbeat {
+  /** Record bytes arriving even when they only redraw an unfinished line. */
+  activity: () => void;
+  /** Stop the timer. Always call this after the process settles. */
+  stop: () => void;
+}
+
+/** Narrate elapsed and silent time until the caller says the child settled. */
+export function startProcessHeartbeat(
+  command: string[],
+  intervalMs = PROCESS_HEARTBEAT_MS,
+  tracksOutput = true,
+): ProcessHeartbeat {
+  const started = Date.now();
+  let lastActivity = started;
+  const name = executableName(command);
+  const timer = setInterval(() => {
+    const now = Date.now();
+    const silence = tracksOutput
+      ? ` · no output for ${formatDuration(now - lastActivity)}`
+      : "";
+    log.info(`${name} still running — ${formatDuration(now - started)} elapsed${silence}`);
+  }, intervalMs);
+  timer.unref?.();
+
+  return {
+    activity: () => {
+      lastActivity = Date.now();
+    },
+    stop: () => clearInterval(timer),
+  };
+}

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -14,6 +14,7 @@ import { formatBytes, formatDuration, log, logIsCaptured, RedError } from "./log
 import { parseChecksums, pickChecksumAsset, sha256Hex, verifyChecksum } from "./checksum.ts";
 import type { Provider } from "./manifest.ts";
 import type { Platform } from "./platform.ts";
+import { startProcessHeartbeat } from "./process-heartbeat.ts";
 import { missingRights } from "./rights.ts";
 import { tlsTrustFailure, unattendedEnvironment } from "./unattended.ts";
 
@@ -36,7 +37,10 @@ export const providerStdinMode = (
  * line that rewrites itself becomes the last thing it said, rather than
  * every state it passed through concatenated into one unreadable row.
  */
-async function pumpToLog(stream: ReadableStream<Uint8Array> | null): Promise<string> {
+async function pumpToLog(
+  stream: ReadableStream<Uint8Array> | null,
+  activity: () => void = () => {},
+): Promise<string> {
   if (!stream) return "";
   const decoder = new TextDecoder();
   let raw = "";
@@ -46,6 +50,7 @@ async function pumpToLog(stream: ReadableStream<Uint8Array> | null): Promise<str
     if (line) log.plain(line);
   };
   for await (const chunk of stream) {
+    activity();
     const text = decoder.decode(chunk as Uint8Array, { stream: true });
     raw += text;
     rest += text;
@@ -73,9 +78,14 @@ async function pumpToLog(stream: ReadableStream<Uint8Array> | null): Promise<str
 /** Stream both child outputs through the logger and retain them for classification. */
 export async function spawnLoggedCapture(
   cmd: string[],
-  extra: { env?: Record<string, string | undefined>; cwd?: string } = {},
+  extra: {
+    env?: Record<string, string | undefined>;
+    cwd?: string;
+    /** Test seam; production uses the shared five-second cadence. */
+    heartbeatMs?: number;
+  } = {},
 ): Promise<{ code: number; out: string; err: string }> {
-  const { env, ...spawnOptions } = extra;
+  const { env, heartbeatMs, ...spawnOptions } = extra;
   const proc = Bun.spawn(cmd, {
     stdout: "pipe",
     stderr: "pipe",
@@ -83,12 +93,17 @@ export async function spawnLoggedCapture(
     ...spawnOptions,
     env: unattendedEnvironment(process.env, env),
   });
-  const [out, err, code] = await Promise.all([
-    pumpToLog(proc.stdout),
-    pumpToLog(proc.stderr),
-    proc.exited,
-  ]);
-  return { code, out, err };
+  const heartbeat = startProcessHeartbeat(cmd, heartbeatMs);
+  try {
+    const [out, err, code] = await Promise.all([
+      pumpToLog(proc.stdout, heartbeat.activity),
+      pumpToLog(proc.stderr, heartbeat.activity),
+      proc.exited,
+    ]);
+    return { code, out, err };
+  } finally {
+    heartbeat.stop();
+  }
 }
 
 /**
@@ -107,10 +122,14 @@ export async function spawnLoggedCapture(
  */
 export async function spawnLogged(
   cmd: string[],
-  extra: { env?: Record<string, string | undefined>; cwd?: string } = {},
+  extra: {
+    env?: Record<string, string | undefined>;
+    cwd?: string;
+    heartbeatMs?: number;
+  } = {},
 ): Promise<number> {
   if (!logIsCaptured()) {
-    const { env, ...spawnOptions } = extra;
+    const { env, heartbeatMs, ...spawnOptions } = extra;
     const proc = Bun.spawn(cmd, {
       stdout: "inherit",
       stderr: "inherit",
@@ -118,7 +137,14 @@ export async function spawnLogged(
       ...spawnOptions,
       env: unattendedEnvironment(process.env, env),
     });
-    return await proc.exited;
+    // Inherited output cannot be observed here, so do not claim it has been
+    // silent. The elapsed heartbeat still proves the child is alive.
+    const heartbeat = startProcessHeartbeat(cmd, heartbeatMs, false);
+    try {
+      return await proc.exited;
+    } finally {
+      heartbeat.stop();
+    }
   }
 
   return (await spawnLoggedCapture(cmd, extra)).code;

--- a/src/runtimes.ts
+++ b/src/runtimes.ts
@@ -19,6 +19,7 @@
  */
 
 import { log, RedError } from "./log.ts";
+import { startProcessHeartbeat } from "./process-heartbeat.ts";
 import type { Platform } from "./platform.ts";
 import { unattendedEnvironment } from "./unattended.ts";
 
@@ -335,18 +336,24 @@ async function run(
     stdin: "ignore",
     env: unattendedEnvironment(process.env, extraEnv),
   });
-  const [out, err, code] = await Promise.all([
-    readRuntimeOutput(proc.stdout, live),
-    readRuntimeOutput(proc.stderr, live),
-    proc.exited,
-  ]);
-  return { code, out, err };
+  const heartbeat = live ? startProcessHeartbeat(cmd) : null;
+  try {
+    const [out, err, code] = await Promise.all([
+      readRuntimeOutput(proc.stdout, live, heartbeat?.activity),
+      readRuntimeOutput(proc.stderr, live, heartbeat?.activity),
+      proc.exited,
+    ]);
+    return { code, out, err };
+  } finally {
+    heartbeat?.stop();
+  }
 }
 
 /** Forward mise progress without surrendering the error text needed by callers. */
 async function readRuntimeOutput(
   stream: ReadableStream<Uint8Array>,
   live: boolean,
+  activity: (() => void) | undefined = undefined,
 ): Promise<string> {
   const decoder = new TextDecoder();
   let raw = "";
@@ -358,6 +365,7 @@ async function readRuntimeOutput(
   };
 
   for await (const chunk of stream) {
+    activity?.();
     const text = decoder.decode(chunk as Uint8Array, { stream: true });
     raw += text;
     rest += text;

--- a/src/ssh-server.ts
+++ b/src/ssh-server.ts
@@ -42,7 +42,12 @@ interface Ran {
   out: string;
 }
 
-async function run(cmd: string[]): Promise<Ran> {
+async function run(cmd: string[], live = false): Promise<Ran> {
+  if (live) {
+    const { spawnLoggedCapture } = await import("./providers.ts");
+    const result = await spawnLoggedCapture(cmd);
+    return { ok: result.code === 0, out: (result.out + result.err).trim() };
+  }
   const proc = Bun.spawn(cmd, {
     stdout: "pipe",
     stderr: "pipe",
@@ -91,7 +96,7 @@ export async function installSshServerLinux(p: Platform): Promise<void> {
     "install",
     "-y",
     "openssh-server",
-  ]);
+  ], true);
   if (!install.ok) {
     // Raised rather than warned past, and this is the item that made
     // the distinction necessary. Warning and returning left the converge


### PR DESCRIPTION
## What changed

- emit a liveness heartbeat every five seconds for long-running provider commands
- show total elapsed time and time since the last captured output
- route mise runtime installs and the Ubuntu SSH apt transaction through the same observable path
- stop every heartbeat as soon as its child settles

## Root cause

The shared executor only emitted a line when a child wrote bytes. A healthy but quiet installer and a frozen installer therefore produced the same screen after the initial step narration. Mise and the SSH builtin also had private process runners that bypassed the observable provider executor.

## User impact

The TUI and transcript now keep proving that the current command is alive. A quiet run reads like: `info npm still running — 15.0s elapsed · no output for 8.2s`.

## Validation

- regression test with a real silent child and accelerated heartbeats
- `bun test` — 1197 passed
- `bun run typecheck`
- `bun scripts/tui-render-smoke.ts`
- `bun run build`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/127"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789246594&installation_model_id=20659&pr_number=127&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F127&signature=0bf2de1765b8ec93e934ea354682d0859463347168ad106c36a0c53d489b6f72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->