### PR TITLE
Bound and narrate provider fetches

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,10 @@ Long-running child processes report a heartbeat every five seconds. It names
 the executable, total elapsed time and, where red-dev owns the output stream,
 how long that child has been silent. A quiet compiler or package-manager lock
 therefore stays visibly alive instead of looking identical to a frozen run.
+Network work uses the same heartbeat before response headers and while reading
+the body. Provider downloads have a total 90-second deadline, so a proxy that
+accepts a connection but never completes it becomes an attributed failure
+rather than pinning the whole converge indefinitely.
 Convergence makes the input gestures a workstation contract rather than an
 agent-specific surprise. Shift+Enter is emitted as CSI-u by Alacritty and
 Windows Terminal, mapped to a newline in Claude Code, and stated explicitly in

--- a/src/installer-noninteractive.test.ts
+++ b/src/installer-noninteractive.test.ts
@@ -6,7 +6,7 @@
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { captureTo } from "./log.ts";
-import { providerStdinMode, spawnLoggedCapture } from "./providers.ts";
+import { installerInstall, providerStdinMode, spawnLoggedCapture } from "./providers.ts";
 
 const providers = readFileSync(`${import.meta.dir}/providers.ts`, "utf8");
 const agents = readFileSync(`${import.meta.dir}/agents.ts`, "utf8");
@@ -77,6 +77,59 @@ describe("unattended provider commands", () => {
       await child;
     } finally {
       release();
+    }
+  });
+
+  test("a vendor script fetch stays observable before response headers arrive", async () => {
+    const seen: string[] = [];
+    const server = Bun.serve({
+      port: 0,
+      fetch: async () => {
+        await Bun.sleep(180);
+        return new Response("#!/bin/sh\nexit 0\n");
+      },
+    });
+    const release = captureTo((line) => seen.push(line));
+    try {
+      const install = installerInstall(
+        `http://127.0.0.1:${server.port}/install.sh`,
+        "delayed fixture",
+        [],
+        undefined,
+        { heartbeatMs: 40, timeoutMs: 1_000 },
+      );
+
+      await Bun.sleep(110);
+      const beforeHeaders = [...seen];
+      await install;
+      expect(beforeHeaders.some((line) => line.includes("fetch still running"))).toBe(true);
+      expect(beforeHeaders.some((line) => line.includes("no response data for"))).toBe(true);
+    } finally {
+      release();
+      server.stop(true);
+    }
+  });
+
+  test("a vendor script fetch has a total deadline instead of waiting forever", async () => {
+    const server = Bun.serve({
+      port: 0,
+      fetch: async () => {
+        await Bun.sleep(5_000);
+        return new Response("#!/bin/sh\nexit 0\n");
+      },
+    });
+    try {
+      await expect(
+        installerInstall(
+          `http://127.0.0.1:${server.port}/install.sh`,
+          "stalled fixture",
+          [],
+          undefined,
+          { heartbeatMs: 20, timeoutMs: 80 },
+        ),
+      ).rejects.toThrow(/installer download did not finish within/);
+    } finally {
+      server.stop(true);
     }
   });
 

--- a/src/process-heartbeat.ts
+++ b/src/process-heartbeat.ts
@@ -27,6 +27,7 @@ export function startProcessHeartbeat(
   command: string[],
   intervalMs = PROCESS_HEARTBEAT_MS,
   tracksOutput = true,
+  inactivityLabel = "no output for",
 ): ProcessHeartbeat {
   const started = Date.now();
   let lastActivity = started;
@@ -34,7 +35,7 @@ export function startProcessHeartbeat(
   const timer = setInterval(() => {
     const now = Date.now();
     const silence = tracksOutput
-      ? ` · no output for ${formatDuration(now - lastActivity)}`
+      ? ` · ${inactivityLabel} ${formatDuration(now - lastActivity)}`
       : "";
     log.info(`${name} still running — ${formatDuration(now - started)} elapsed${silence}`);
   }, intervalMs);

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -355,6 +355,60 @@ export interface DownloadOptions {
   /** Injected by tests, so a download can be asserted without a disk. */
   write?: (path: string, bytes: Uint8Array) => Promise<unknown>;
   timeoutMs?: number;
+  /** Test seam; production uses the shared five-second cadence. */
+  heartbeatMs?: number;
+}
+
+interface ObservedFetchOptions {
+  fetcher?: typeof fetch;
+  init?: RequestInit;
+  timeoutMs: number;
+  heartbeatMs?: number;
+}
+
+/** Fetch headers and body while keeping network silence visible. */
+async function fetchObservedBytes(
+  url: string,
+  opts: ObservedFetchOptions,
+): Promise<{ response: Response; body: Uint8Array }> {
+  const heartbeat = startProcessHeartbeat(
+    ["fetch"],
+    opts.heartbeatMs,
+    true,
+    "no response data for",
+  );
+  try {
+    const response = await (opts.fetcher ?? fetch)(url, {
+      ...opts.init,
+      signal: AbortSignal.timeout(opts.timeoutMs),
+    });
+    heartbeat.activity();
+    if (!response.body) return { response, body: new Uint8Array() };
+
+    const reader = response.body.getReader();
+    const chunks: Uint8Array[] = [];
+    let size = 0;
+    for (;;) {
+      const next = await reader.read();
+      if (next.done) break;
+      heartbeat.activity();
+      chunks.push(next.value);
+      size += next.value.byteLength;
+    }
+    const body = new Uint8Array(size);
+    let offset = 0;
+    for (const chunk of chunks) {
+      body.set(chunk, offset);
+      offset += chunk.byteLength;
+    }
+    return { response, body };
+  } finally {
+    heartbeat.stop();
+  }
+}
+
+function requestTimedOut(err: unknown): boolean {
+  return (err as Error).name === "TimeoutError" || (err as Error).name === "AbortError";
 }
 
 /**
@@ -375,12 +429,12 @@ async function publishedChecksum(
   const name = url.split("/").pop() ?? url;
   log.info(`published checksums: ${name}`);
   try {
-    const res = await fetcher(url, { signal: AbortSignal.timeout(timeoutMs) });
+    const { response: res, body } = await fetchObservedBytes(url, { fetcher, timeoutMs });
     if (!res.ok) {
       log.warn(`could not read ${name} (${res.status})`);
       return null;
     }
-    const hash = parseChecksums(await res.text(), file);
+    const hash = parseChecksums(new TextDecoder().decode(body), file);
     if (!hash) log.warn(`${name} has no entry for ${file}`);
     return hash;
   } catch (err) {
@@ -415,15 +469,21 @@ export async function downloadVerified(
   log.info(`saving to ${dest}`);
 
   const started = Date.now();
-  const res = await fetcher(url, { signal: AbortSignal.timeout(timeoutMs) }).catch(
+  const fetched = await fetchObservedBytes(url, {
+    fetcher,
+    timeoutMs,
+    heartbeatMs: opts.heartbeatMs,
+  }).catch(
     (err: unknown) => {
       throw new RedError(
-        `download did not finish within ${timeoutMs / 1000}s: ${url} (${(err as Error).name})`,
+        requestTimedOut(err)
+          ? `download did not finish within ${timeoutMs / 1000}s: ${url}`
+          : `download failed: ${url} (${(err as Error).message})`,
       );
     },
   );
+  const { response: res, body } = fetched;
   if (!res.ok) throw new RedError(`download failed ${res.status}: ${url}`);
-  const body = new Uint8Array(await res.arrayBuffer());
   log.info(`received ${formatBytes(body.byteLength)} in ${formatDuration(Date.now() - started)}`);
 
   const digest = sha256Hex(body);
@@ -515,14 +575,17 @@ export async function resolveGhRelease(
   // and nothing else — never even the "github: …" line, which is logged
   // after this call returns — so the API request was where it sat, with
   // no child process to notice and no error to report.
-  const res = await fetch(releaseApiUrl(repo, version), {
-    headers,
-    signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS),
+  const fetched = await fetchObservedBytes(releaseApiUrl(repo, version), {
+    init: { headers },
+    timeoutMs: DOWNLOAD_TIMEOUT_MS,
   }).catch((err: unknown) => {
     throw new RedError(
-      `GitHub API did not answer within ${DOWNLOAD_TIMEOUT_MS / 1000}s for ${repo} (${(err as Error).name})`,
+      requestTimedOut(err)
+        ? `GitHub API did not answer within ${DOWNLOAD_TIMEOUT_MS / 1000}s for ${repo}`
+        : `GitHub API failed for ${repo} (${(err as Error).message})`,
     );
   });
+  const { response: res, body: responseBody } = fetched;
   if (!res.ok) {
     throw new RedError(
       `GitHub API ${res.status} for ${repo}` +
@@ -535,7 +598,10 @@ export async function resolveGhRelease(
     );
   }
 
-  const body = (await res.json()) as { assets?: GhAsset[]; tag_name?: string };
+  const body = JSON.parse(new TextDecoder().decode(responseBody)) as {
+    assets?: GhAsset[];
+    tag_name?: string;
+  };
   const assets = body.assets ?? [];
   const re = globToRegExp(glob);
   const hit = assets.find((a) => re.test(a.name));
@@ -800,6 +866,7 @@ export async function installerInstall(
   note: string,
   args: string[] = [],
   env?: Record<string, string | undefined>,
+  network: { heartbeatMs?: number; timeoutMs?: number } = {},
 ): Promise<void> {
   log.step(`installer: ${url}`);
   log.plain(`       ${note}`);
@@ -820,9 +887,20 @@ export async function installerInstall(
   const tmp = tempFile(`installer-${Date.now()}.sh`);
   log.info(`fetching the vendor script from ${url}`);
   log.info(`saving to ${tmp}`);
-  const res = await fetch(url);
+  const timeoutMs = network.timeoutMs ?? DOWNLOAD_TIMEOUT_MS;
+  const fetched = await fetchObservedBytes(url, {
+    timeoutMs,
+    heartbeatMs: network.heartbeatMs,
+  }).catch((err: unknown) => {
+    throw new RedError(
+      requestTimedOut(err)
+        ? `installer download did not finish within ${timeoutMs / 1000}s: ${url}`
+        : `installer download failed: ${url} (${(err as Error).message})`,
+    );
+  });
+  const { response: res, body: responseBody } = fetched;
   if (!res.ok) throw new RedError(`installer download failed ${res.status}: ${url}`);
-  const body = await res.text();
+  const body = new TextDecoder().decode(responseBody);
   if (body.trim().length === 0) throw new RedError(`installer at ${url} was empty`);
   // A vendor script publishes no checksum anywhere this can reach, so
   // the hash is a record rather than a comparison — which is still the


### PR DESCRIPTION
## What changed

- keep vendor-script fetches visible before headers and while reading the body
- show `fetch still running`, total elapsed time and time since the last response bytes
- enforce a 90-second total deadline for installer scripts instead of waiting indefinitely
- use the same observable fetch for release metadata, assets and published checksums
- distinguish network errors from deadline expiry

## Root cause

The v1.0.9 heartbeat covered spawned children, including the Hermes shell script, but not the direct `fetch()` that downloads that script. That fetch had no heartbeat and no timeout. A corporate proxy could accept the connection without completing headers or the body, leaving Hermes as the current TUI item for 30 minutes with no new transcript lines. The following red-skills installer used the same blind path.

## Validation

- reproduced a vendor endpoint that delays headers and observed the missing heartbeat before the fix
- regression test proves network heartbeats arrive before headers
- regression test proves a never-completing installer fetch hits its total deadline
- `bun test` — 1199 passed
- `bun run typecheck`
- `bun scripts/tui-render-smoke.ts`
- `bun run build`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/128"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789247506&installation_model_id=20659&pr_number=128&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F128&signature=27548fe61746b1421a69bd4681312d9b91fa02ac8a2a79a79fccca9c05c9d6c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->