### PR TITLE
docs: make RedCode the managed host

### DIFF
--- a/.red/adr/0001-cross-platform-phased-not-a-distro.md
+++ b/.red/adr/0001-cross-platform-phased-not-a-distro.md
@@ -26,6 +26,11 @@ red-dev **stays cross-platform** (Linux, Windows/WSL, and eventually macOS) and 
 
 Cross-cutting: MCP is **optional-with-fallback**: every required capability has a stable CLI path.
 
+**Amendment (2026-08-14):** RedCode replaces OpenCode in the six-host profile.
+The existing OpenCode installation is not removed; recorded selections migrate
+to RedCode and RedSkills writes the compatible surface independently under
+`~/.config/redcode/`.
+
 **Amendment (2026-08-03):** the incremental clean-machine E2E fleet originally decided here was dropped by maintainer decision before any lane was built (#17, #18 closed as not planned). red-dev is a development environment for developers; validation happens by provisioning real environments — converge followed by a second converge with zero planned changes, plus the readiness report — not by CI-hosted clean-VM lanes. A phase closes when its promised behaviors are true on real environments and covered by the unit/integration suite.
 
 ## Consequences

--- a/.red/adr/0003-red-dev-does-not-colour-the-terminal.md
+++ b/.red/adr/0003-red-dev-does-not-colour-the-terminal.md
@@ -61,7 +61,7 @@ converged before this release would otherwise keep importing twenty values
 forever. `RETIRED_PARTS` in `src/alacritty.ts` exists so the import line goes
 with the file.
 
-**Decline to pick.** `bat` and `delta` on `base16`, `opencode` on `"system"`,
+**Decline to pick.** `bat` and `delta` on `base16`, `redcode` on `"system"`,
 `herdr` on `name = "terminal"`, `btop` on `TTY`. Every one of these means
 *render through the host terminal's own colours*. **They are kept**, and that is
 not a contradiction of this ADR: they pick no colour, they are the instruction

--- a/.red/contexts/agents/CONTEXT.md
+++ b/.red/contexts/agents/CONTEXT.md
@@ -4,7 +4,7 @@ Agent hosts, RedSkills, MCPs, and RedDB products' accessibility to agents.
 
 ## Agent host
 
-An agent client program that consumes RedSkills on a provisioned machine. Decided supported set: Claude Code, Codex, OpenCode, Gemini, Pi, and Hermes — all six with shared skills and doctor verification. Hermes depends on official upstream RedSkills support.
+An agent client program that consumes RedSkills on a provisioned machine. Decided supported set: Claude Code, Codex, RedCode, Gemini, Pi, and Hermes — all six with shared skills and doctor verification. RedCode is the installed OpenCode-compatible host; existing OpenCode installations are retained but are no longer selected or managed. Hermes depends on official upstream RedSkills support.
 
 ## MCP posture
 


### PR DESCRIPTION
## Summary
- record RedCode as the managed OpenCode-compatible host
- preserve existing OpenCode installations during migration
- keep the terminal palette decision aligned with the new host

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/129"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789319034&installation_model_id=20659&pr_number=129&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F129&signature=17644a4e3e42ad43c56b22fc7b3a66c64faad12d11f9b4aea239630b20efb764"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->