### PR TITLE
feat: install RedCode and Puppeteer

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,8 @@ Picking any CLI agent then offers
 marketplace in Claude Code and Codex and generates plugin modules for RedCode.
 RedCode comes from `reddb-io/redcode` release archives through GitHub's stable
 download redirect, so a clean machine does not need `gh` or an API request to
-discover it. Existing OpenCode binaries and configuration are left untouched;
+discover it. Its published `SHA256SUMS` is verified before extraction. Existing
+OpenCode binaries and configuration are left untouched;
 an old recorded `opencode` selection migrates to `redcode` side-by-side.
 On native Windows, a WSL terminal choice makes the selection a workstation
 choice: compatible CLI agents and runtimes are installed on Windows **and** in

--- a/README.md
+++ b/README.md
@@ -253,7 +253,11 @@ that one is npm, while T3 Code went the other way, because npm's `t3code-cli` is
 a third-party wrapper and winget's `T3Tools.T3Code` is the publisher's own.
 Picking any CLI agent then offers
 [red-skills](https://github.com/reddb-io/red-skills), which registers its
-marketplace in Claude Code and Codex and generates plugin modules for OpenCode.
+marketplace in Claude Code and Codex and generates plugin modules for RedCode.
+RedCode comes from `reddb-io/redcode` release archives through GitHub's stable
+download redirect, so a clean machine does not need `gh` or an API request to
+discover it. Existing OpenCode binaries and configuration are left untouched;
+an old recorded `opencode` selection migrates to `redcode` side-by-side.
 On native Windows, a WSL terminal choice makes the selection a workstation
 choice: compatible CLI agents and runtimes are installed on Windows **and** in
 the selected WSL 2 distro. Desktop applications remain on Windows. Choosing Git
@@ -282,7 +286,7 @@ rather than pinning the whole converge indefinitely.
 Convergence makes the input gestures a workstation contract rather than an
 agent-specific surprise. Shift+Enter is emitted as CSI-u by Alacritty and
 Windows Terminal, mapped to a newline in Claude Code, and stated explicitly in
-OpenCode's `tui.json`; Codex receives the same terminal sequence. Alt+V sends
+RedCode's OpenCode-compatible `tui.json`; Codex receives the same terminal sequence. Alt+V sends
 the raw image-paste gesture on Alacritty and Windows Terminal, while
 Ctrl+Shift+V remains text paste. Plain Shift+V cannot be used because it is the
 ordinary uppercase `V`. Every config merge is non-destructive: malformed JSON
@@ -292,7 +296,10 @@ and explicit conflicting bindings are left alone, and re-running is a no-op.
 
 **Optional**, never installed by a plain converge — `red-dev apps` offers them,
 and so does the interview: `just` · `duf` · `dust` · `hyperfine` · `glow` ·
-`gitui`, plus `powertoys` on Windows.
+`gitui` and `puppeteer`, plus `powertoys` on Windows. Puppeteer installs its
+global CLI, the matching Chrome for Testing and Ubuntu's browser libraries,
+then proves the browser can launch headless. Projects that import Puppeteer
+still declare `puppeteer` in their own package dependencies.
 
 **Runtimes** are mise's, not the distro's, so `node` resolves the same way in
 WSL, on the desktop, and in Git Bash. `red-dev lang` chooses which. A version
@@ -451,7 +458,7 @@ each can arrive later:
 | --- | --- | --- |
 | Claude Code | marketplace | `claude plugin marketplace list` |
 | Codex CLI | marketplace | `codex plugin marketplace list` |
-| OpenCode | generated plugins and skills | its uninstall manifest |
+| RedCode | generated plugins and skills | its uninstall manifest under `~/.config/redcode` |
 
 Installing Codex a week after Claude is enough to get the marketplace into it —
 one unwired host is reason enough to run the installer, which configures every
@@ -915,7 +922,7 @@ text = 'CellBackground'
 foreground are yours, in your own `alacritty.toml` or your Windows Terminal
 scheme, and nothing here will touch them.
 
-The tools that can defer still do: `bat` and `delta` on `base16`, `opencode` on
+The tools that can defer still do: `bat` and `delta` on `base16`, `redcode` on
 `system`, `herdr` on `terminal`, `btop` on `TTY`. Those settings pick no colour
 — they are what stops each program picking one, so removing them is how you get
 a purple pager inside a terminal you just chose the colours for.

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -8,7 +8,7 @@
  *
  * red-skills is the reason this is a group rather than loose entries:
  * it registers a marketplace in Claude Code and Codex CLI and generates
- * plugin modules for OpenCode, so it is only meaningful once at least
+ * plugin modules for RedCode, so it is only meaningful once at least
  * one agent exists. Installing it alone would configure nothing.
  */
 
@@ -51,6 +51,12 @@ export interface AgentSpec {
   msstore?: string;
   /** npm package, when neither of the above fits the platform. */
   npm?: string;
+  /** GitHub release archives whose stable filenames are part of our contract. */
+  release?: {
+    repo: string;
+    linux: Partial<Record<Platform["arch"], string>>;
+    windows: Partial<Record<Platform["arch"], string>>;
+  };
   /** Runtimes an npm lifecycle script needs in addition to Node itself. */
   runtimeNeeds?: string[];
   /** A command that must start successfully before presence counts as ready. */
@@ -79,13 +85,22 @@ export const AGENTS: AgentSpec[] = [
     npm: "@openai/codex",
   },
   {
-    key: "opencode",
-    label: "OpenCode",
-    about: "SST's terminal agent",
-    cmd: "opencode",
+    key: "redcode",
+    label: "RedCode",
+    about: "RedDB's OpenCode-compatible terminal agent",
+    cmd: "redcode",
     recommended: true,
-    installer: "https://opencode.ai/install",
-    winget: "SST.opencode",
+    release: {
+      repo: "reddb-io/redcode",
+      linux: {
+        x64: "redcode-linux-x64.tar.gz",
+        arm64: "redcode-linux-arm64.tar.gz",
+      },
+      windows: {
+        x64: "redcode-windows-x64.zip",
+        arm64: "redcode-windows-arm64.zip",
+      },
+    },
   },
   {
     // npm only, and that is not an oversight: winget's repository has no
@@ -207,6 +222,11 @@ export const AGENTS: AgentSpec[] = [
   },
 ];
 
+/** Translate the retired OpenCode selection without uninstalling OpenCode itself. */
+export function currentAgentKeys(keys: readonly string[]): string[] {
+  return [...new Set(keys.map((key) => key === "opencode" ? "redcode" : key))];
+}
+
 /** Which agents can be installed here. */
 export function availableAgents(p: Platform): AgentSpec[] {
   return AGENTS.filter((a) => {
@@ -216,8 +236,8 @@ export function availableAgents(p: Platform): AgentSpec[] {
       // installing onto a host this scope does not own.
       return p.os === "windows";
     }
-    if (p.os === "windows") return Boolean(a.winget ?? a.msstore ?? a.npm);
-    return Boolean(a.installer ?? a.npm);
+    if (p.os === "windows") return Boolean(a.release?.windows[p.arch] ?? a.winget ?? a.msstore ?? a.npm);
+    return Boolean(a.release?.linux[p.arch] ?? a.installer ?? a.npm);
   });
 }
 
@@ -391,7 +411,7 @@ async function runWinget(argv: string[], label: string): Promise<void> {
  * batch file directly — the same story as winget's reparse point, with
  * the same answer: cmd.exe interprets it.
  */
-function npmArgv(npm: string, args: string[]): string[] {
+export function npmArgv(npm: string, args: string[]): string[] {
   const lower = npm.toLowerCase();
   return lower.endsWith(".cmd") || lower.endsWith(".bat")
     ? ["cmd.exe", "/c", npm, ...args]
@@ -406,7 +426,7 @@ function npmArgv(npm: string, args: string[]): string[] {
  * still "not on PATH" in the very same run. runtimeTool asks mise,
  * whose answer does not depend on when this process was born.
  */
-async function resolveNpm(): Promise<string | null> {
+export async function resolveNpm(): Promise<string | null> {
   const { runtimeTool } = await import("./runtimes.ts");
   return await runtimeTool("npm");
 }
@@ -474,10 +494,12 @@ async function exposeWindowsAgentCommand(a: AgentSpec): Promise<void> {
   log.ok("Codex CLI command exposed as codex");
 }
 
-export type AgentInstallMethod = "msstore" | "winget" | "npm" | "installer";
+export type AgentInstallMethod = "msstore" | "winget" | "npm" | "installer" | "github-release";
 
 /** Choose a method that can run unattended on this target. */
 export function agentInstallMethod(a: AgentSpec, p: Platform): AgentInstallMethod | null {
+  const release = p.os === "windows" ? a.release?.windows[p.arch] : a.release?.linux[p.arch];
+  if (release) return "github-release";
   if (p.os === "windows" && a.msstore) return "msstore";
   if (p.os === "windows" && a.winget) return "winget";
   if (p.os === "windows" && a.npm) return "npm";
@@ -491,6 +513,14 @@ export function agentInstallMethod(a: AgentSpec, p: Platform): AgentInstallMetho
 
 export async function installAgent(a: AgentSpec, p: Platform): Promise<void> {
   const method = agentInstallMethod(a, p);
+
+  if (method === "github-release" && a.release) {
+    const asset = p.os === "windows" ? a.release.windows[p.arch] : a.release.linux[p.arch];
+    if (!asset) throw new RedError(`no ${p.os}/${p.arch} release asset for ${a.label}`);
+    const { ghInstallExactArchive } = await import("./providers.ts");
+    await ghInstallExactArchive(a.release.repo, asset, a.cmd, p);
+    return;
+  }
 
   if (method === "msstore" && a.msstore) {
     // --source msstore is load-bearing, not a detail: without it winget
@@ -586,7 +616,7 @@ export async function installRedSkills(): Promise<void> {
   const node = await runtimeTool("node");
   log.step("red-skills");
   log.plain("     Registers the RedSkills marketplace in Claude Code and Codex,");
-  log.plain("     and generates plugin modules for OpenCode. User-level, global.");
+  log.plain("     and generates plugin modules for RedCode/OpenCode. User-level, global.");
   const home = process.env["USERPROFILE"] ?? process.env["HOME"];
   if (home && repairCopiedRedSkillsCurrent(home)) {
     log.plain("       replacing Git Bash's copied current snapshot with the managed source");
@@ -680,7 +710,7 @@ export async function updateRedSkills(p: Platform): Promise<void> {
  *
  *   claude    `claude plugin marketplace list`  names red-skills
  *   codex     `codex plugin marketplace list`   names red-skills
- *   opencode  no such command — the installer leaves an uninstall
+ *   redcode   no such command — the installer leaves an uninstall
  *             manifest, which is the only artifact that means "we did
  *             this" rather than "a directory exists"
  */
@@ -860,14 +890,14 @@ export const SKILL_HOSTS: SkillHost[] = [
     wired: () => cliNamesRedSkills(["codex", "plugin", "marketplace", "list"]),
   },
   {
-    agent: "opencode",
-    cmd: "opencode",
-    // OpenCode has no marketplace to list: red-skills generates plugin
+    agent: "redcode",
+    cmd: "redcode",
+    // RedCode has no marketplace to list: red-skills generates plugin
     // and skill modules into its config directory and records them in an
     // uninstall manifest. That file is the claim; the directory existing
-    // is not, since opencode makes it itself.
+    // is not, since redcode makes it itself.
     wired: async () =>
-      existsSync(`${configHome()}/opencode/redskills-install-manifest.txt`),
+      existsSync(`${configHome()}/redcode/redskills-install-manifest.txt`),
   },
 ];
 
@@ -897,7 +927,6 @@ export async function unwiredSkillHosts(): Promise<SkillHost[]> {
  * and with no agent to configure it has nothing to do.
  */
 export async function convergeRedSkills(p: Platform): Promise<void> {
-  void p;
   const present = SKILL_HOSTS.filter((h) => Bun.which(h.cmd));
   if (present.length === 0) {
     log.skip("red-skills: no coding agent installed to configure");
@@ -922,4 +951,11 @@ export async function convergeRedSkills(p: Platform): Promise<void> {
 
   log.step(`red-skills: not wired into ${missing.map((h) => h.cmd).join(", ")}`);
   await installRedSkills();
+  // The RedSkills generator owns the provider/MCP portions of opencode.json;
+  // red-dev owns terminal-following theme/input defaults. Re-apply our small
+  // merge after generation so a first RedCode migration converges in one run.
+  if (Bun.which("redcode")) {
+    const { applyRedcode } = await import("./terminal-surfaces.ts");
+    await applyRedcode(p);
+  }
 }

--- a/src/firstrun.ts
+++ b/src/firstrun.ts
@@ -93,7 +93,9 @@ export async function setupPlan(p: Platform, choices: SetupChoices): Promise<Set
 
   const runtimes = [...choices.runtimes];
   if (!runtimes.some((runtime) => runtime.startsWith("node"))) {
-    const needsNpm = chosen.some((agent) => agentInstallMethod(agent, p) === "npm");
+    const needsNpm =
+      chosen.some((agent) => agentInstallMethod(agent, p) === "npm") ||
+      choices.apps.includes("puppeteer");
     if (needsNpm) runtimes.unshift("node@24");
   }
   for (const runtime of chosen.flatMap((agent) => agent.runtimeNeeds ?? [])) {
@@ -196,7 +198,7 @@ export async function applySetupAnswers(
  * This lived inside cmdInstall's first-run branch and nowhere else, so
  * the fullscreen menu — the path the one-liner takes — asked which
  * agents you wanted and then installed none of them. You picked
- * claude-code, codex and opencode, the interview closed, the converge
+ * claude-code, codex and redcode, the interview closed, the converge
  * ran, and nothing had happened.
  *
  * red-skills runs once at the end rather than per agent, because its

--- a/src/main.ts
+++ b/src/main.ts
@@ -963,7 +963,7 @@ async function cmdApps(p: Platform, inv: Invocation): Promise<number> {
   for (const name of names) {
     const tool = available.find((t) => t.name === name);
     if (!tool) continue;
-    if (isInstalled(tool)) {
+    if (isInstalled(tool) && !tool.managed) {
       log.skip(`${name} already present`);
       continue;
     }
@@ -1249,9 +1249,13 @@ async function cmdWsl(p: Platform): Promise<number> {
  * assumed.
  */
 async function cmdAgents(p: Platform, inv: Invocation): Promise<number> {
-  const { AGENTS, availableAgents, isAgentInstalled, isAgentReady, installAgent, installRedSkills } =
+  const { AGENTS, availableAgents, currentAgentKeys, isAgentInstalled, isAgentReady, installAgent, installRedSkills } =
     await import("./agents.ts");
   const available = availableAgents(p);
+
+  if (inv.agentKeys !== undefined) {
+    inv = { ...inv, agentKeys: currentAgentKeys(inv.agentKeys) };
+  }
 
   // This is the path the Windows side uses to reproduce the selection
   // inside WSL. It is deliberately prompt-free and accepts only keys

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -140,6 +140,7 @@ type ProviderSpec =
         | "codex-statusline"
         | "claude-keybindings"
         | "redwall-schedule"
+        | "puppeteer"
         | "ssh-server";
     }
   /** Not installed here, deliberately. The reason is required. */
@@ -340,6 +341,7 @@ const builtin = (
     | "codex-statusline"
     | "claude-keybindings"
     | "redwall-schedule"
+    | "puppeteer"
     | "ssh-server",
 ): Provider => ({ kind: "builtin", name });
 const skip = (reason: string): Provider => ({ kind: "skip", reason });
@@ -812,6 +814,15 @@ export const TOOLS: Tool[] = [
   // ------------------------------------------------------ optional
   // Chosen, never assumed. `red-dev apps` offers these; a plain
   // converge ignores them entirely.
+  {
+    name: "puppeteer",
+    about: "browser automation CLI + Chrome for Testing + Ubuntu libraries — about 280 MB",
+    cmd: ["puppeteer"],
+    scope: "optional",
+    managed: true,
+    u24: sudoProvider(builtin("puppeteer")),
+    win: builtin("puppeteer"),
+  },
   {
     // Microsoft's own, and the closest Windows gets to the desktop half
     // of omakub. FancyZones is the analogue of tactile — a keyboard-

--- a/src/migrations.ts
+++ b/src/migrations.ts
@@ -264,6 +264,27 @@ return {}
       log.plain("       Neovim is yours again — LazyVim picks its own colorscheme");
     },
   },
+  {
+    id: "2026-08-14-opencode-to-redcode",
+    describe: "move the selected terminal agent from OpenCode to RedCode",
+    applies: async (p) => {
+      if ((await readPreferences(p)).agents?.includes("opencode") !== true) return false;
+      const { availableAgents } = await import("./agents.ts");
+      return availableAgents(p).some((agent) => agent.key === "redcode");
+    },
+    run: async (p) => {
+      const { availableAgents, currentAgentKeys, installAgent, isAgentReady } = await import(
+        "./agents.ts"
+      );
+      const prefs = await readPreferences(p);
+      const redcode = availableAgents(p).find((agent) => agent.key === "redcode");
+      if (!redcode) throw new Error(`RedCode has no release for ${p.os}/${p.arch}`);
+      if (!(await isAgentReady(redcode))) await installAgent(redcode, p);
+      const agents = currentAgentKeys(prefs.agents ?? []);
+      await writePreferences(p, { agents });
+      log.plain("       installed and selected RedCode; the existing OpenCode binary and config were left untouched");
+    },
+  },
 ];
 
 /**

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -718,13 +718,15 @@ export async function ghInstallExactArchive(
   bin: string,
   p: Platform,
   tag = "latest",
+  checksumAsset = "SHA256SUMS",
 ): Promise<void> {
   const url = exactGhReleaseUrl(repo, asset, tag);
+  const checksumUrl = exactGhReleaseUrl(repo, checksumAsset, tag);
   const tmp = tempDir(`gh-exact-${Date.now()}`);
   const downloaded = `${tmp}/${asset}`;
   log.step(`github: ${repo} -> ${asset}`);
   log.info(`${tag === "latest" ? "stable release redirect" : `release ${tag}`} — no GitHub API lookup`);
-  await downloadVerified(url, downloaded);
+  await downloadVerified(url, downloaded, { checksumUrl });
 
   if (asset.endsWith(".tar.gz") || asset.endsWith(".tgz")) {
     log.info(`extracting ${asset}`);

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -9,7 +9,7 @@
  */
 
 import { removeTemp, tempDir, tempFile } from "./temp.ts";
-import { chmodSync, copyFileSync, existsSync, mkdirSync, rmSync } from "node:fs";
+import { chmodSync, copyFileSync, existsSync, mkdirSync, readdirSync, rmSync } from "node:fs";
 import { formatBytes, formatDuration, log, logIsCaptured, RedError } from "./log.ts";
 import { parseChecksums, pickChecksumAsset, sha256Hex, verifyChecksum } from "./checksum.ts";
 import type { Provider } from "./manifest.ts";
@@ -686,6 +686,84 @@ export async function ghInstall(
 }
 
 /**
+ * A stable release asset whose filename is known exactly.
+ *
+ * GitHub serves this redirect from github.com rather than the REST API, so a
+ * fresh machine cannot spend an anonymous API quota merely discovering a name
+ * already declared in our catalog. RedCode owns its asset contract, making an
+ * exact URL both cheaper and stricter than resolving a glob through /latest.
+ */
+export function exactGhReleaseUrl(repo: string, asset: string, tag = "latest"): string {
+  const release = tag === "latest" ? "latest/download" : `download/${tag}`;
+  return `https://github.com/${repo}/releases/${release}/${asset}`;
+}
+
+function findNamedFile(root: string, wanted: string): string | null {
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    const path = `${root}/${entry.name}`;
+    if (entry.isDirectory()) {
+      const nested = findNamedFile(path, wanted);
+      if (nested) return nested;
+    } else if (entry.name.toLowerCase() === wanted.toLowerCase()) {
+      return path;
+    }
+  }
+  return null;
+}
+
+/** Install one exact archive asset without consulting the GitHub API. */
+export async function ghInstallExactArchive(
+  repo: string,
+  asset: string,
+  bin: string,
+  p: Platform,
+  tag = "latest",
+): Promise<void> {
+  const url = exactGhReleaseUrl(repo, asset, tag);
+  const tmp = tempDir(`gh-exact-${Date.now()}`);
+  const downloaded = `${tmp}/${asset}`;
+  log.step(`github: ${repo} -> ${asset}`);
+  log.info(`${tag === "latest" ? "stable release redirect" : `release ${tag}`} — no GitHub API lookup`);
+  await downloadVerified(url, downloaded);
+
+  if (asset.endsWith(".tar.gz") || asset.endsWith(".tgz")) {
+    log.info(`extracting ${asset}`);
+    await run(["tar", "-xzf", downloaded, "-C", tmp]);
+  } else if (asset.endsWith(".zip") && p.os === "windows") {
+    log.info(`extracting ${asset} with Windows PowerShell`);
+    await run([
+      "powershell.exe",
+      "-NoProfile",
+      "-NonInteractive",
+      "-Command",
+      "Expand-Archive -LiteralPath $args[0] -DestinationPath $args[1] -Force",
+      downloaded,
+      tmp,
+    ]);
+  } else if (asset.endsWith(".zip")) {
+    log.info(`extracting ${asset}`);
+    await run(["unzip", "-qo", downloaded, "-d", tmp]);
+  } else {
+    removeTemp(tmp);
+    throw new RedError(`exact GitHub asset must be an archive: ${asset}`);
+  }
+
+  const filename = p.os === "windows" ? `${bin}.exe` : bin;
+  const source = findNamedFile(tmp, filename);
+  if (!source) {
+    removeTemp(tmp);
+    throw new RedError(`${asset} did not contain ${filename}`);
+  }
+  const dir = p.os === "windows" ? windowsBinDir() : userBinDir();
+  const target = `${dir}/${filename}`;
+  mkdirSync(dir, { recursive: true });
+  copyFileSync(source, target);
+  if (p.os !== "windows") chmodSync(target, 0o755);
+  log.ok(`installed ${target}`);
+  removeTemp(tmp);
+}
+
+/**
  * The same release, onto Windows.
  *
  * Neither of the two RedDB tools is on winget, and every other `gh`
@@ -1172,6 +1250,7 @@ const BUILTIN_INTENT: Partial<Record<BuiltinName, string>> = {
   "codex-statusline": "writing project, branch, model, effort, context and quotas into the Codex statusline",
   "claude-keybindings": "writing the Claude Code keybindings",
   "redwall-schedule": "scheduling the wallpaper rotation",
+  puppeteer: "installing Puppeteer, its matching Chrome for Testing and browser dependencies",
   "ssh-server": "installing and enabling the SSH server",
 };
 
@@ -1301,6 +1380,11 @@ export async function applyProvider(pr: Provider, ctx: ApplyContext): Promise<vo
         // printed one. Throwing is reserved for a machine that could
         // hold a schedule and refused to.
         await applyRedwallSchedule(ctx.platform);
+        return;
+      }
+      if (pr.name === "puppeteer") {
+        const { installPuppeteer } = await import("./puppeteer.ts");
+        await installPuppeteer(ctx.platform);
         return;
       }
       if (pr.name === "ssh-server") {

--- a/src/puppeteer.ts
+++ b/src/puppeteer.ts
@@ -1,0 +1,80 @@
+/** Puppeteer CLI, its matching Chrome for Testing, and a launch smoke test. */
+
+import { existsSync } from "node:fs";
+import { executablesEnvironment, npmArgv, resolveNpm } from "./agents.ts";
+import { log, RedError } from "./log.ts";
+import type { Platform } from "./platform.ts";
+import { requireSudo, spawnLoggedCapture } from "./providers.ts";
+
+async function checked(
+  argv: string[],
+  env: Record<string, string | undefined>,
+  failure: string,
+): Promise<string> {
+  const result = await spawnLoggedCapture(argv, { env });
+  if (result.code !== 0) throw new RedError(`${failure} (exit ${result.code})`);
+  return result.out.trim();
+}
+
+/** Global executable path npm creates for Puppeteer's CLI. */
+export function puppeteerCli(prefix: string, p: Platform): string {
+  return p.os === "windows" ? `${prefix}/puppeteer.cmd` : `${prefix}/bin/puppeteer`;
+}
+
+export async function installPuppeteer(p: Platform): Promise<void> {
+  const { runtimeTool, useRuntimes } = await import("./runtimes.ts");
+  let npm = await resolveNpm();
+  let node = await runtimeTool("node");
+  if (!npm || !node) {
+    log.info("Puppeteer needs Node; installing node@24 through mise first");
+    await useRuntimes(["node@24"]);
+    npm = await resolveNpm();
+    node = await runtimeTool("node");
+  }
+  if (!npm || !node) throw new RedError("mise installed Node, but npm/node still cannot be resolved");
+
+  const home = process.env["HOME"] ?? process.env["USERPROFILE"] ?? "";
+  const env = executablesEnvironment([npm, node], process.platform, {
+    ...process.env,
+    ...(home ? { PUPPETEER_CACHE_DIR: `${home.replace(/\\/g, "/")}/.cache/puppeteer` } : {}),
+  });
+  log.info("installing the Puppeteer CLI globally (browser download is the next explicit step)");
+  await checked(
+    npmArgv(npm, ["install", "-g", "puppeteer@latest", "--ignore-scripts", "--no-audit", "--no-fund"]),
+    { ...env, PUPPETEER_SKIP_DOWNLOAD: "true" },
+    "npm could not install Puppeteer",
+  );
+
+  const prefix = await checked(npmArgv(npm, ["prefix", "-g"]), env, "npm could not report its global prefix");
+  const cli = puppeteerCli(prefix.replace(/\\/g, "/"), p);
+  if (!existsSync(cli)) throw new RedError(`Puppeteer installed, but its CLI is missing at ${cli}`);
+
+  const browserArgs = ["browsers", "install", "chrome"];
+  log.info("downloading the matching Chrome for Testing into the user's cache");
+  await checked(npmArgv(cli, browserArgs), env, "Puppeteer could not install Chrome for Testing");
+
+  if (p.os !== "windows") {
+    // Puppeteer's documented --install-deps contract requires root. Download
+    // as the user first, then point the elevated dependency pass at that same
+    // cache: the CLI explicitly installs deps even when Chrome is already
+    // present, without leaving a second root-owned browser under /root.
+    await requireSudo();
+    log.info("installing Chrome's Ubuntu libraries through Puppeteer's --install-deps contract");
+    await checked(
+      ["sudo", "-E", ...npmArgv(cli, [...browserArgs, "--install-deps"])],
+      env,
+      "Puppeteer could not install Chrome's Ubuntu dependencies",
+    );
+  }
+
+  const root = await checked(npmArgv(npm, ["root", "-g"]), env, "npm could not report its global module root");
+  const packageRoot = `${root.replace(/\\/g, "/")}/puppeteer`;
+  log.info("launching the installed browser once in headless mode");
+  const smoke =
+    "const p=require(process.argv[1]);" +
+    "p.launch({headless:true,args:['--no-sandbox']})" +
+    ".then(async b=>{console.log(await b.version());await b.close()})" +
+    ".catch(e=>{console.error(e);process.exit(1)})";
+  await checked([node, "-e", smoke, packageRoot], env, "Chrome was downloaded but its headless launch failed");
+  log.ok("Puppeteer CLI + Chrome for Testing are ready");
+}

--- a/src/red-skills.test.ts
+++ b/src/red-skills.test.ts
@@ -4,7 +4,7 @@
  * It ran in exactly two places: the first-run interview, and behind a
  * confirm inside `red-dev agents`. A plain `install core` — which is
  * what the install script runs, and what anyone re-running red-dev
- * gets — never touched it. This machine carried claude, codex, opencode
+ * gets — never touched it. This machine carried claude, codex, redcode
  * and herdr with no marketplace registered in any of them.
  *
  * The readiness check is the other half. `~/.red-skills` had existed for
@@ -120,7 +120,7 @@ describe("how it decides it is already done", () => {
     // Install Codex a week after Claude and the check says "wired",
     // skips, and Codex never gets a marketplace — which is the case
     // that prompted this and the reason the probe is a table.
-    expect(SKILL_HOSTS.map((h) => h.cmd).sort()).toEqual(["claude", "codex", "opencode"]);
+    expect(SKILL_HOSTS.map((h) => h.cmd).sort()).toEqual(["claude", "codex", "redcode"]);
   });
 
   test("every host is a real agent, so the two lists cannot drift", () => {
@@ -136,9 +136,9 @@ describe("how it decides it is already done", () => {
   });
 
   test("and reads the manifest where it cannot", () => {
-    // OpenCode has no marketplace to list. The installer records what
+    // RedCode has no marketplace to list. The installer records what
     // it generated in an uninstall manifest; the config directory
-    // existing means nothing, since opencode creates that itself.
+    // existing means nothing, since redcode creates that itself.
     expect(src).toContain("redskills-install-manifest.txt");
   });
 

--- a/src/redcode-puppeteer.test.ts
+++ b/src/redcode-puppeteer.test.ts
@@ -44,6 +44,9 @@ describe("RedCode", () => {
     expect(exactGhReleaseUrl("reddb-io/redcode", "redcode-linux-x64.tar.gz")).toBe(
       "https://github.com/reddb-io/redcode/releases/latest/download/redcode-linux-x64.tar.gz",
     );
+    expect(exactGhReleaseUrl("reddb-io/redcode", "SHA256SUMS")).toEndWith(
+      "/releases/latest/download/SHA256SUMS",
+    );
   });
 
   test("offers only architectures for which the release exists", () => {

--- a/src/redcode-puppeteer.test.ts
+++ b/src/redcode-puppeteer.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "bun:test";
+import {
+  AGENTS,
+  agentInstallMethod,
+  availableAgents,
+  currentAgentKeys,
+} from "./agents.ts";
+import { setupPlan } from "./firstrun.ts";
+import { providerFor, TOOLS } from "./manifest.ts";
+import type { Platform } from "./platform.ts";
+import { exactGhReleaseUrl } from "./providers.ts";
+import { puppeteerCli } from "./puppeteer.ts";
+
+function platform(os: "linux" | "windows", arch: Platform["arch"] = "x64"): Platform {
+  return {
+    os,
+    distro: os === "linux" ? "ubuntu" : undefined,
+    version: os === "linux" ? "24.04" : "11",
+    codename: os === "linux" ? "noble" : undefined,
+    env: os === "linux" ? "desktop" : "windows",
+    arch,
+    caps: {
+      apt: os === "linux",
+      gui: true,
+      systemd: os === "linux",
+      winget: os === "windows",
+      flatpak: os === "linux",
+    },
+  } as Platform;
+}
+
+describe("RedCode", () => {
+  const redcode = AGENTS.find((agent) => agent.key === "redcode")!;
+
+  test("replaces OpenCode in the selectable catalog", () => {
+    expect(redcode.cmd).toBe("redcode");
+    expect(AGENTS.some((agent) => agent.key === "opencode")).toBe(false);
+  });
+
+  test("uses exact public release archives without a GitHub API lookup", () => {
+    expect(agentInstallMethod(redcode, platform("linux"))).toBe("github-release");
+    expect(redcode.release?.linux.x64).toBe("redcode-linux-x64.tar.gz");
+    expect(redcode.release?.windows.x64).toBe("redcode-windows-x64.zip");
+    expect(exactGhReleaseUrl("reddb-io/redcode", "redcode-linux-x64.tar.gz")).toBe(
+      "https://github.com/reddb-io/redcode/releases/latest/download/redcode-linux-x64.tar.gz",
+    );
+  });
+
+  test("offers only architectures for which the release exists", () => {
+    expect(availableAgents(platform("linux", "x64"))).toContain(redcode);
+    expect(availableAgents(platform("windows", "arm64"))).toContain(redcode);
+    expect(availableAgents(platform("linux", "unsupported"))).not.toContain(redcode);
+  });
+
+  test("migrates old selections side-by-side and deduplicates", () => {
+    expect(currentAgentKeys(["opencode", "codex", "redcode"])).toEqual(["redcode", "codex"]);
+  });
+});
+
+describe("Puppeteer toolchain", () => {
+  const tool = TOOLS.find((candidate) => candidate.name === "puppeteer")!;
+
+  test("is an optional managed tool with Linux-only sudo requirements", () => {
+    expect(tool.scope).toBe("optional");
+    expect(tool.managed).toBe(true);
+    expect(providerFor(tool, platform("linux"))).toEqual({
+      kind: "builtin",
+      name: "puppeteer",
+      needsSudo: true,
+    });
+    expect(providerFor(tool, platform("linux")).needsSudo).toBe(true);
+    expect(providerFor(tool, platform("windows")).needsSudo).toBeUndefined();
+  });
+
+  test("brings Node when selected without a runtime", async () => {
+    const plan = await setupPlan(platform("linux"), {
+      agents: [],
+      runtimes: [],
+      apps: ["puppeteer"],
+    });
+    expect(plan[0]).toMatchObject({ key: "node@24", kind: "runtime" });
+  });
+
+  test("resolves the npm global CLI on either platform", () => {
+    expect(puppeteerCli("/opt/node", platform("linux"))).toBe("/opt/node/bin/puppeteer");
+    expect(puppeteerCli("C:/mise/node", platform("windows"))).toBe(
+      "C:/mise/node/puppeteer.cmd",
+    );
+  });
+});

--- a/src/terminal-surfaces.ts
+++ b/src/terminal-surfaces.ts
@@ -13,7 +13,7 @@
  *
  * ## Defer, for the tools that can
  *
- * bat, delta, opencode, herdr and btop all ship a setting meaning
+ * bat, delta, redcode, herdr and btop all ship a setting meaning
  * *render through the host terminal's own colours* — `base16`,
  * `"system"`, `"terminal"`, `TTY`. Those settings are kept, and that is
  * not a contradiction of "stop applying themes": they pick no colour.
@@ -145,7 +145,7 @@ async function clearZellijDir(dir: string): Promise<boolean> {
  * `TTY` is a builtin — btop.conf documents it beside `Default` — and it
  * renders through the terminal's sixteen ANSI slots rather than the
  * twenty-four-bit table `Default` carries. So it is the same answer bat
- * and opencode give, spelled in btop's vocabulary.
+ * and RedCode give, spelled in btop's vocabulary.
  *
  * Not simply deleting the `color_theme` line, which would leave btop on
  * `Default` and painting its own greens and blues over a terminal the
@@ -263,7 +263,7 @@ export async function applyDelta(): Promise<boolean> {
   return (await proc.exited) === 0;
 }
 
-// -------------------------------------------------- opencode, herdr
+// --------------------------------------------------- redcode, herdr
 
 const OPENCODE_INPUT = {
   input_newline: "shift+return,ctrl+return,alt+return,ctrl+j",
@@ -278,7 +278,7 @@ function sameJson(left: unknown, right: unknown): boolean {
 }
 
 /**
- * State the workstation's input contract in OpenCode's own keymap.
+ * State the workstation's input contract in the OpenCode-compatible keymap.
  *
  * These happen to be OpenCode's defaults today. Writing them is still useful:
  * the behavior becomes a red-dev invariant that can be diagnosed, and an
@@ -293,14 +293,14 @@ export async function convergeOpenCodeInput(path: string): Promise<OpenCodeInput
       if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) throw new Error();
       cfg = parsed as Record<string, unknown>;
     } catch {
-      log.skip("opencode tui.json is not valid JSON — left alone");
+      log.skip("RedCode tui.json is not valid JSON — left alone");
       return { input_newline: "malformed", input_paste: "malformed" };
     }
   }
 
   const existing = cfg["keybinds"];
   if (existing !== undefined && (typeof existing !== "object" || existing === null || Array.isArray(existing))) {
-    log.skip("opencode tui.json keybinds is not an object — left alone");
+    log.skip("RedCode tui.json keybinds is not an object — left alone");
     return { input_newline: "malformed", input_paste: "malformed" };
   }
   const keybinds = { ...((existing ?? {}) as Record<string, unknown>) };
@@ -317,7 +317,7 @@ export async function convergeOpenCodeInput(path: string): Promise<OpenCodeInput
       result[key] = "already-set";
     } else {
       result[key] = "conflict";
-      log.skip(`opencode ${key} is already bound — left alone`);
+      log.skip(`RedCode ${key} is already bound — left alone`);
     }
   }
 
@@ -329,16 +329,16 @@ export async function convergeOpenCodeInput(path: string): Promise<OpenCodeInput
 }
 
 /**
- * opencode, following omarchy's lead.
+ * RedCode, following omarchy's OpenCode-compatible config contract.
  *
  * DHH sets `"theme": "system"` so the agent tracks whatever the terminal
  * is doing rather than pinning a palette that will drift. That was right
  * when the terminal had one fixed palette and it is more right now that
  * the terminal has the user's.
  */
-export async function applyOpencode(p: Platform): Promise<boolean> {
-  if (!Bun.which("opencode")) return false;
-  const dir = `${configHome(p, "opencode")}/opencode`;
+export async function applyRedcode(p: Platform): Promise<boolean> {
+  if (!Bun.which("redcode")) return false;
+  const dir = `${configHome(p, "redcode")}/redcode`;
   mkdirSync(dir, { recursive: true });
   const path = `${dir}/opencode.json`;
 
@@ -347,7 +347,7 @@ export async function applyOpencode(p: Platform): Promise<boolean> {
     try {
       cfg = JSON.parse(await Bun.file(path).text()) as Record<string, unknown>;
     } catch {
-      log.skip("opencode.json is not valid JSON — left alone");
+      log.skip("RedCode opencode.json is not valid JSON — left alone");
       return false;
     }
   }
@@ -431,7 +431,7 @@ export async function applyTerminalDefaults(p: Platform): Promise<TerminalSurfac
   const defers: [string, () => Promise<boolean>][] = [
     ["bat", () => applyBat(p)],
     ["delta", () => applyDelta()],
-    ["opencode", () => applyOpencode(p)],
+    ["redcode", () => applyRedcode(p)],
     ["herdr", () => applyHerdr(p)],
   ];
 

--- a/src/theme-apply.test.ts
+++ b/src/theme-apply.test.ts
@@ -63,7 +63,7 @@ describe("theme surfaces", () => {
   });
 
   test("no terminal program is a theme surface any more", () => {
-    const inTheTerminal = ["zellij", "btop", "neovim", "bat", "delta", "lazygit", "opencode", "herdr"];
+    const inTheTerminal = ["zellij", "btop", "neovim", "bat", "delta", "lazygit", "redcode", "herdr"];
     for (const p of [windows, wsl]) {
       for (const name of inTheTerminal) {
         expect(themeSurfaceNames(p, redwallOn)).not.toContain(name);

--- a/src/tui-setup-model.ts
+++ b/src/tui-setup-model.ts
@@ -139,7 +139,7 @@ export function questions(
       title: "Agents",
       description:
         "Picking any CLI agent also installs red-skills, which registers its " +
-        "marketplace in Claude Code and Codex and generates plugin modules for OpenCode.",
+        "marketplace in Claude Code and Codex and generates plugin modules for RedCode.",
       multi: true,
       choices: agents,
       preset: agents.map((agent) => agent.key),


### PR DESCRIPTION
## Summary
- replace the selectable OpenCode installer with RedCode release archives while leaving existing OpenCode state untouched
- migrate recorded OpenCode selections and wire RedSkills under `~/.config/redcode`
- add an opt-out Puppeteer toolchain with global CLI, matching Chrome for Testing, Ubuntu dependencies, and a headless launch smoke
- fetch exact RedCode assets through the stable GitHub redirect without an API lookup

## Validation
- `bun test` (1206 passing)
- `bun run typecheck`
- `bun run build`
- `./dist/red-dev-linux-x64 plan optional`
- RedCode v0.1.0 Linux archive: `redcode --version` => `0.1.0`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/130"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789319164&installation_model_id=20659&pr_number=130&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F130&signature=99ee9b0b0f5f81628559eea88219d1c140cb375b539c2b7f944016edef6b1f40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->