### PR TITLE
fix: preserve Puppeteer environment across sudo

### DIFF
--- a/src/puppeteer.ts
+++ b/src/puppeteer.ts
@@ -5,6 +5,18 @@ import { executablesEnvironment, npmArgv, resolveNpm } from "./agents.ts";
 import { log, RedError } from "./log.ts";
 import type { Platform } from "./platform.ts";
 import { requireSudo, spawnLoggedCapture } from "./providers.ts";
+import { UNATTENDED_ENV } from "./unattended.ts";
+
+const ELEVATED_PUPPETEER_ENV = [
+  "PATH",
+  "PUPPETEER_CACHE_DIR",
+  "SSL_CERT_FILE",
+  "CURL_CA_BUNDLE",
+  "NODE_EXTRA_CA_CERTS",
+  "REQUESTS_CA_BUNDLE",
+  "npm_config_cafile",
+  ...Object.keys(UNATTENDED_ENV),
+] as const;
 
 async function checked(
   argv: string[],
@@ -19,6 +31,19 @@ async function checked(
 /** Global executable path npm creates for Puppeteer's CLI. */
 export function puppeteerCli(prefix: string, p: Platform): string {
   return p.os === "windows" ? `${prefix}/puppeteer.cmd` : `${prefix}/bin/puppeteer`;
+}
+
+/** Keep mise's Node, machine trust and unattended mode across sudo's secure_path. */
+export function elevatedPuppeteerArgv(
+  cli: string,
+  args: string[],
+  env: Record<string, string | undefined>,
+): string[] {
+  const assignments = ELEVATED_PUPPETEER_ENV.flatMap((name) => {
+    const value = env[name];
+    return value === undefined ? [] : [`${name}=${value}`];
+  });
+  return ["sudo", "-E", "/usr/bin/env", ...assignments, ...npmArgv(cli, args)];
 }
 
 export async function installPuppeteer(p: Platform): Promise<void> {
@@ -61,7 +86,7 @@ export async function installPuppeteer(p: Platform): Promise<void> {
     await requireSudo();
     log.info("installing Chrome's Ubuntu libraries through Puppeteer's --install-deps contract");
     await checked(
-      ["sudo", "-E", ...npmArgv(cli, [...browserArgs, "--install-deps"])],
+      elevatedPuppeteerArgv(cli, [...browserArgs, "--install-deps"], env),
       env,
       "Puppeteer could not install Chrome's Ubuntu dependencies",
     );

--- a/src/redcode-puppeteer.test.ts
+++ b/src/redcode-puppeteer.test.ts
@@ -9,7 +9,7 @@ import { setupPlan } from "./firstrun.ts";
 import { providerFor, TOOLS } from "./manifest.ts";
 import type { Platform } from "./platform.ts";
 import { exactGhReleaseUrl } from "./providers.ts";
-import { puppeteerCli } from "./puppeteer.ts";
+import { elevatedPuppeteerArgv, puppeteerCli } from "./puppeteer.ts";
 
 function platform(os: "linux" | "windows", arch: Platform["arch"] = "x64"): Platform {
   return {
@@ -89,5 +89,33 @@ describe("Puppeteer toolchain", () => {
     expect(puppeteerCli("C:/mise/node", platform("windows"))).toBe(
       "C:/mise/node/puppeteer.cmd",
     );
+  });
+
+  test("carries mise Node, corporate CAs and unattended apt settings across sudo", () => {
+    const argv = elevatedPuppeteerArgv(
+      "/home/dev/.local/share/mise/installs/node/24/bin/puppeteer",
+      ["browsers", "install", "chrome", "--install-deps"],
+      {
+        PATH: "/home/dev/.local/share/mise/installs/node/24/bin:/usr/bin",
+        PUPPETEER_CACHE_DIR: "/home/dev/.cache/puppeteer",
+        NODE_EXTRA_CA_CERTS: "/etc/ssl/certs/ca-certificates.crt",
+        DEBIAN_FRONTEND: "noninteractive",
+        GITHUB_TOKEN: "must-not-cross-sudo",
+      },
+    );
+
+    expect(argv.slice(0, 3)).toEqual(["sudo", "-E", "/usr/bin/env"]);
+    expect(argv).toContain("PATH=/home/dev/.local/share/mise/installs/node/24/bin:/usr/bin");
+    expect(argv).toContain("PUPPETEER_CACHE_DIR=/home/dev/.cache/puppeteer");
+    expect(argv).toContain("NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt");
+    expect(argv).toContain("DEBIAN_FRONTEND=noninteractive");
+    expect(argv).not.toContain("GITHUB_TOKEN=must-not-cross-sudo");
+    expect(argv.slice(-5)).toEqual([
+      "/home/dev/.local/share/mise/installs/node/24/bin/puppeteer",
+      "browsers",
+      "install",
+      "chrome",
+      "--install-deps",
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
- preserve mise Node PATH across Ubuntu sudo secure_path
- pass only the Puppeteer cache, machine CA, and unattended variables into the elevated dependency install
- keep unrelated credentials out of the elevated environment

## Validation
- `bun run typecheck`
- `bun test` (1207 pass)
- `bun run build`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/131"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789319983&installation_model_id=20659&pr_number=131&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F131&signature=77c2993829cf5b675b4351de944dcc9730a41bd0a00b64b89b7e17b67d048f33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->