### PR TITLE
fix: keep XDG_RUNTIME_DIR real through the WSL boot race

### DIFF
--- a/config/bash/rc.sh
+++ b/config/bash/rc.sh
@@ -69,6 +69,73 @@ if [ -z "${COLORTERM:-}" ] &&
   export COLORTERM=truecolor
 fi
 
+# XDG_RUNTIME_DIR, which WSL exports before anything creates it.
+#
+# With systemd on, wsl.exe puts XDG_RUNTIME_DIR=/run/user/<uid> in every
+# shell it starts, and starts that shell immediately — while systemd is
+# still booting. user@<uid>.service is ordered After=systemd-user-sessions
+# .service, so on a cold boot the directory arrives seconds after the
+# first prompt does. `red-dev` already enables linger, and linger does not
+# help: a lingering user still waits for the same barrier.
+#
+# The window is not cosmetic, because of what fills it. Two programs read
+# the variable during this file:
+#
+#   zellij     panics and exits 101, and the terminal comes up as a plain
+#              shell — the failure in the banner above.
+#   ble.sh     prints "XDG_RUNTIME_DIR is not a directory", then falls
+#              back to /tmp/blesh/<uid> and keeps its per-process temp
+#              files there.
+#
+# ble.sh's fallback is the worse half, because /tmp is not stable during
+# this same window: systemd-tmpfiles ships `D /tmp 1777 root root 30d`
+# and systemd-tmpfiles-setup runs --remove at boot, which empties /tmp
+# out from under the already-attached ble.sh. Every keystroke after that
+# writes to a directory that no longer exists, so the session floods with
+#
+#   -bash: /tmp/blesh/<uid>/<pid>.util.assign.tmp.0: No such file...
+#
+# until it is closed. Nothing recovers on its own: _ble_base_run was
+# resolved once, at load.
+#
+# So: wait a moment for the real directory, since on a cold boot it is
+# usually about a second away and joining the real user session is worth
+# far more than the wait — then give up and use one under $HOME, which no
+# boot-time cleaner touches. Both paths end with the variable naming a
+# directory that exists, which is the whole contract. If even $HOME will
+# not take one, unset it: a variable pointing at nothing is worse than no
+# variable, because it is exactly what stops programs from falling back.
+_red_xdg_usable() {
+  [ -n "${XDG_RUNTIME_DIR:-}" ] &&
+    [ -d "$XDG_RUNTIME_DIR" ] &&
+    [ -O "$XDG_RUNTIME_DIR" ] &&
+    [ -w "$XDG_RUNTIME_DIR" ] &&
+    [ -x "$XDG_RUNTIME_DIR" ]
+}
+
+if [ -n "${XDG_RUNTIME_DIR:-}" ] && ! _red_xdg_usable; then
+  # Ten tries at 0.2s. `sleep 0.2` is coreutils and not POSIX, so a shell
+  # whose sleep rejects it breaks out rather than sleeping ten seconds.
+  _red_xdg_tries=0
+  while [ "$_red_xdg_tries" -lt 10 ] && ! _red_xdg_usable; do
+    sleep 0.2 2>/dev/null || break
+    _red_xdg_tries=$((_red_xdg_tries + 1))
+  done
+  unset _red_xdg_tries
+
+  if ! _red_xdg_usable; then
+    _red_xdg_home="$HOME/.local/state/red-dev/run"
+    if mkdir -p "$_red_xdg_home" 2>/dev/null && chmod 700 "$_red_xdg_home" 2>/dev/null; then
+      XDG_RUNTIME_DIR="$_red_xdg_home"
+      export XDG_RUNTIME_DIR
+    else
+      unset XDG_RUNTIME_DIR
+    fi
+    unset _red_xdg_home
+  fi
+fi
+unset -f _red_xdg_usable
+
 # ble.sh, on by default. RED_BLE=0 opts out.
 #
 # It has to load before everything else and attach after everything

--- a/src/xdg-runtime-dir.test.ts
+++ b/src/xdg-runtime-dir.test.ts
@@ -1,0 +1,81 @@
+/**
+ * The runtime directory the shell is told about before it exists.
+ *
+ * wsl.exe exports XDG_RUNTIME_DIR=/run/user/<uid> and starts the shell
+ * while systemd is still booting, so on a cold boot the first prompt
+ * arrives before user@<uid>.service has made the directory. zellij exits
+ * 101 on it, and ble.sh falls back to /tmp/blesh/<uid> — which
+ * systemd-tmpfiles then empties at boot, leaving an attached ble.sh
+ * writing to a directory that is gone for the rest of the session.
+ *
+ * These run rc.sh for real rather than matching strings in it. What is
+ * under test is a fallback chain that has to leave the variable naming a
+ * directory that exists on every path, including the one where it gives
+ * up — and a grep cannot tell those paths apart.
+ *
+ * RED_ROOT and HOME point at an empty temp directory, so the sourcing
+ * loop finds no parts and env.sh and local.sh do not exist, leaving this
+ * block as the only thing under test. HOME is also where the fallback
+ * lands, which is what makes it observable.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(`${tmpdir()}/red-dev-xdg-`);
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+/** Source rc.sh with a controlled environment and report XDG_RUNTIME_DIR. */
+function xdgAfterRc(env: Record<string, string>): string {
+  const out = execFileSync(
+    "bash",
+    ["-c", '. config/bash/rc.sh >/dev/null 2>&1; printf "%s" "${XDG_RUNTIME_DIR:-}"'],
+    {
+      encoding: "utf8",
+      env: { PATH: process.env["PATH"] ?? "", HOME: dir, RED_ROOT: dir, ...env },
+    },
+  );
+  return out.trim();
+}
+
+describe("XDG_RUNTIME_DIR", () => {
+  test("a directory we own is left exactly as it arrived", () => {
+    // The normal case, and the one the whole block must stay out of:
+    // a working systemd user session is the thing we would rather have.
+    expect(xdgAfterRc({ RED_ENV: "wsl", XDG_RUNTIME_DIR: dir })).toBe(dir);
+  });
+
+  test("an unset variable is left unset", () => {
+    // Unset is a defined state that every program handles with its own
+    // fallback. Inventing a value here would take that choice away.
+    expect(xdgAfterRc({ RED_ENV: "wsl" })).toBe("");
+  });
+
+  test("a path that does not exist is replaced by one that does", () => {
+    // The WSL cold-boot failure. `/run/user/<uid>` never appears in the
+    // window this shell lives in, so the shell stops waiting for it.
+    const got = xdgAfterRc({ RED_ENV: "wsl", XDG_RUNTIME_DIR: `${dir}/absent` });
+    expect(got).toBe(`${dir}/.local/state/red-dev/run`);
+    expect(existsSync(got)).toBe(true);
+    expect(statSync(got).mode & 0o777).toBe(0o700);
+  });
+
+  test("a path that exists but is not a directory is no better than an absent one", () => {
+    // ble.sh's own wording for this — "XDG_RUNTIME_DIR is not a
+    // directory" — is the line that opens the flood in the report. -d
+    // rather than -e is what separates the two.
+    writeFileSync(`${dir}/notadir`, "");
+    const got = xdgAfterRc({ RED_ENV: "wsl", XDG_RUNTIME_DIR: `${dir}/notadir` });
+    expect(got).toBe(`${dir}/.local/state/red-dev/run`);
+    expect(existsSync(got)).toBe(true);
+  });
+});


### PR DESCRIPTION
## The failure

A cold WSL boot brings the terminal up before systemd is done, and two
things break in sequence.

`wsl.exe` exports `XDG_RUNTIME_DIR=/run/user/<uid>` into every shell and
starts that shell immediately, while `user@<uid>.service` is still
waiting on `systemd-user-sessions.service`. On the machine this was
found on, `user@1000.service` went active at 16:15:11 and the directory
appeared at 16:16 — after the first prompt. `enable-linger` is already
on and does not help: a lingering user waits for the same barrier.

Two programs read the variable during `rc.sh`:

- **zellij** exits 101, and the terminal comes up as a plain shell.
- **ble.sh** prints `XDG_RUNTIME_DIR is not a directory`, then falls back
  to `/tmp/blesh/<uid>`.

ble.sh's fallback is the worse half, because `/tmp` is not stable in that
same window: systemd ships `D /tmp 1777 root root 30d` and
`systemd-tmpfiles-setup` runs `--remove` at boot, emptying `/tmp` out
from under the already-attached ble.sh. `_ble_base_run` was resolved once
at load, so every keystroke after that writes to a directory that is
gone:

```
-bash: /tmp/blesh/1000/279.util.assign.tmp.0: No such file or directory
```

for the rest of the session. Nothing recovers on its own.

## The change

One block in `config/bash/rc.sh`, ahead of the ble.sh source and
therefore ahead of `zellij.sh`. When the exported path is not a usable
directory it waits up to two seconds for the real one — on a cold boot it
is usually about a second away, and joining the real user session is
worth far more than the wait — and otherwise uses
`~/.local/state/red-dev/run`, which no boot-time cleaner touches. If even
that cannot be made, the variable is unset: pointing at nothing is worse
than not existing, because it is exactly what stops programs from using
their own fallbacks.

This is the shell-side half of what `wsl-runtime-dir` (`src/wsl.ts`)
repairs at converge time. That provider cannot cover this case — `/run`
is a tmpfs, so its repair does not survive a reboot, and it does not run
early enough to win the race.

## Verification

A/B in a real PTY, same broken input:

```
before:  XDG=/run/user/999999            _ble_base_run=/tmp/blesh/1000
after:   XDG=~/.local/state/red-dev/run  _ble_base_run=~/.local/state/red-dev/run/blesh
```

`src/xdg-runtime-dir.test.ts` runs `rc.sh` for real rather than matching
strings in it, following `colorterm.test.ts`: what is under test is a
fallback chain that must leave the variable naming a directory that
exists on every path including the one where it gives up, and a grep
cannot tell those paths apart.

Full suite 1212 pass / 0 fail, `bun run typecheck` clean.

## Not covered

The zellij half is inferred rather than reproduced. `crash-279.log` from
the reported session was already gone, so its exit 101 is attributed to
the cause `src/wsl.ts` documents for exactly this variable, not to a log
read here. The ble.sh half is confirmed end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/132"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789329627&installation_model_id=20659&pr_number=132&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F132&signature=c43c358ecd48f0de9880d26f60a350ce7228c2c4e409d6e87b6938a8552c2c6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->