### PR TITLE
docs: record the Omarchy Quattro comparison

### DIFF
--- a/.red/adr/0001-cross-platform-phased-not-a-distro.md
+++ b/.red/adr/0001-cross-platform-phased-not-a-distro.md
@@ -31,6 +31,16 @@ The existing OpenCode installation is not removed; recorded selections migrate
 to RedCode and RedSkills writes the compatible surface independently under
 `~/.config/redcode/`.
 
+**Amendment (2026-08-15):** reaffirmed after Omarchy Quattro (v4.0.0,
+2026-08-14) shipped. Quattro's new shape — Omarchy as a system package with
+user overrides layered on top, Quickshell plugins with clone-to-override, a
+default agent with crash capture, an agent-usage bar panel, `mup` for
+out-of-band agent updates — changes *what* red-dev absorbs, not *how*: still
+contracts + adapters + profiles, still no distro, still no Hyprland-specific
+key map as the portable abstraction. The "do not copy" list gains one entry:
+Omarchy launches its default agent in bypass/auto-approve mode by default;
+red-dev's default agent (see `.red/contexts/agents/CONTEXT.md`) never does.
+
 **Amendment (2026-08-03):** the incremental clean-machine E2E fleet originally decided here was dropped by maintainer decision before any lane was built (#17, #18 closed as not planned). red-dev is a development environment for developers; validation happens by provisioning real environments — converge followed by a second converge with zero planned changes, plus the readiness report — not by CI-hosted clean-VM lanes. A phase closes when its promised behaviors are true on real environments and covered by the unit/integration suite.
 
 ## Consequences

--- a/.red/adr/0004-reclaim-is-asked-for-never-scheduled.md
+++ b/.red/adr/0004-reclaim-is-asked-for-never-scheduled.md
@@ -45,6 +45,14 @@ uncommitted work, and not a value an operator wrote into their own configuration
 The test is what losing it costs: if only time, it is Reclaim's to take; if work,
 it is not.
 
+**Amendment (2026-08-15):** the premise "red-dev schedules nothing today" no
+longer holds — since 2026-08-12 the Redwall repaint runs on a systemd user
+timer / Task Scheduler task (`src/redwall-schedule.ts`). That is a deliberate
+exception, not a reopening: a Redwall tick is derived and idempotent, touches
+nothing a person authored, and costs nothing when it surprises someone. The
+prohibition here is scoped to Reclaim and Rescue (ADR 0005) — acts that delete
+or interrupt — and stays in force for them.
+
 ## Consequences
 
 An operator with a full disk and no memory of this feature stays stuck. That is

--- a/.red/adr/0006-one-chord-family-on-every-target.md
+++ b/.red/adr/0006-one-chord-family-on-every-target.md
@@ -1,0 +1,44 @@
+# 0006 — One chord family on every target, and it is not Super
+
+- Status: accepted
+- Date: 2026-08-15
+- Sources: `.red/contexts/interaction/CONTEXT.md`, the Omarchy Quattro comparison session of 2026-08-15
+
+## Context
+
+Omarchy Quattro's interaction model is Super-centric — `Super+Return` terminal,
+`Super+Space` menu, `Super+K` keybinding viewer, `Super+W` close, `Super+Ctrl+W`
+network panel — and it is the most praised part of the product. red-dev is
+about to grow its own semantic actions (menu, keys viewer, panels, emoji, default
+agent) and needs default chords for them on Ubuntu desktop and on Windows.
+
+Both hosts reserve most of the Super/Win space. GNOME takes `Super` itself
+(overview), `Super+Space` (input source), `Super+A/V/L`, `Super+arrows`,
+`Super+1..9`. Windows takes `Win+Space` (language), `Win+V` (clipboard history),
+`Win+K` (cast), `Win+W`, `Win+C` (Copilot), `Win+E/R/L/D/X/I/A/N/H/P/S/G/Tab`,
+`Win+arrows`, `Win+1..9`. Copying Omarchy's map literally collides on both, and
+choosing "the nearest free chord" per host gives every action a different key on
+every machine.
+
+## Decision
+
+**Every semantic action has one default chord, identical on every target, drawn
+from the `Ctrl+Alt` family** — where `Ctrl+Alt+T` (terminal) and
+`Ctrl+Alt+Shift+T` (elevated shell) already live. red-dev never claims a
+`Super`/`Win` chord. A platform adapter changes how a chord is registered
+(GNOME custom keybinding, Windows Start Menu `.lnk` hotkey, PowerToys); it never
+changes which chord it is. Where a host cannot register the chord, the adapter
+reports the action unbound and does not invent a local substitute.
+
+## Consequences
+
+- "The same experience on each target" stays literally true for the keyboard,
+  which is the surface a person's hands remember across machines.
+- Someone arriving from Omarchy or from stock GNOME will reach for `Super` and
+  find nothing; the keys viewer (`red-dev keys`) is the remedy, not a second map.
+- The `Ctrl+Alt` family is finite and partly spoken for on GNOME
+  (`Ctrl+Alt+arrows` workspaces, `Ctrl+Alt+Del`, `Ctrl+Alt+L`); every new chord
+  is checked against both hosts' reserved lists before it ships, and the schema
+  is where that check lives.
+- Universal clipboard (`Super+C/V/X`) is out of scope for the same reason and
+  because the terminal layer already unifies copy/paste everywhere.

--- a/.red/adr/0007-the-user-layer.md
+++ b/.red/adr/0007-the-user-layer.md
@@ -1,0 +1,45 @@
+# 0007 — Every owned file has a user layer a converge never writes
+
+- Status: accepted
+- Date: 2026-08-15
+- Sources: `.red/contexts/visual/CONTEXT.md` (Config ownership modes, User layer), the Omarchy Quattro comparison session of 2026-08-15
+
+## Context
+
+Omarchy Quattro's biggest structural change is "everything is a package":
+Omarchy lives in `/usr/share/omarchy`, the person's changes live in
+`~/.config/omarchy/*` and `~/.config/hypr/*.lua`, plugins are cloned to
+override, and an update can replace every shipped file without touching a
+person's work. That is the fix for what Omarchy 1–3 got wrong (a git checkout
+in the home directory that updates trampled).
+
+red-dev already has the ownership vocabulary — `owned`, `merged`, `adopted`,
+`external` — but not the layer. `alacritty.toml` is the one surface done right:
+written once, loaded after the regenerated `keys.toml`, so anything the person
+puts there wins. `~/.config/red-dev/env.sh` does the same for bash. zellij's
+`config.kdl` is owned and regenerated on every converge, and zellij has no
+include mechanism, so any edit a person makes to it is silently lost.
+
+## Decision
+
+**For every `owned` file there is a user layer: a companion the person authors,
+loaded after red-dev's, that a converge never writes.** Where the program can
+include (Alacritty, bash, git), the layer is a real file the program reads last.
+Where it cannot (zellij), red-dev composes base + layer into the file it owns
+and treats the layer as the source of truth for the person's half. Each owned
+surface documents where its layer lives; a converge may replace everything
+red-dev wrote and must leave the layer untouched.
+
+## Consequences
+
+- This is Omarchy's clone-to-override without a plugin system, which red-dev
+  does not have and does not need: there is no shell to plug into.
+- Regenerating an owned file stops being a data-loss risk, so the ownership
+  warning currently attached to `keys.toml` becomes the rule rather than the
+  exception.
+- The composition path (zellij) makes red-dev responsible for merge semantics
+  it did not have before; the test is that a converge is a no-op on a machine
+  where only the layer changed.
+- Adopting an existing file (`adopted`) now means: take over the owned half and
+  move what the person had into the layer, with their consent and a plan — not
+  overwrite.

--- a/.red/contexts/agents/CONTEXT.md
+++ b/.red/contexts/agents/CONTEXT.md
@@ -6,6 +6,32 @@ Agent hosts, RedSkills, MCPs, and RedDB products' accessibility to agents.
 
 An agent client program that consumes RedSkills on a provisioned machine. Decided supported set: Claude Code, Codex, RedCode, Gemini, Pi, and Hermes — all six with shared skills and doctor verification. RedCode is the installed OpenCode-compatible host; existing OpenCode installations are retained but are no longer selected or managed. Hermes depends on official upstream RedSkills support.
 
+## Default agent
+
+The one agent host a person has chosen as the target when red-dev hands work to an agent — a crash to diagnose, a launch shortcut, a profile's required host. It is a choice recorded once, not an inference from what happens to be installed, and red-dev never starts it with a permission bypass or auto-approve flag: unattended mode is the person's decision at the moment they type it, never a default red-dev ships (decision of 2026-08-15, contrasting Omarchy's `omarchy-agent`, which launches its default agent in bypass mode).
+
+It is chosen in the interview right after the agent hosts and changed with `red-dev agents default <key>`; when exactly one CLI host is selected it is that one, without a question. Its update path is part of `red-dev update` (system, red-skills, agents, converge) and also stands alone as `red-dev agents update`, each host by its publisher's own mechanism (decision of 2026-08-15).
+
+_Avoid_: primary agent, main agent, "the agent"
+
+## Agent usage
+
+How much of an agent provider's allowance this machine has consumed, per window the provider defines (Claude's five-hour and weekly windows, Codex's rate limits, GitHub's `api`/`gql` budgets). It is an observation red-dev caches and reads back — a surface that shows it never queries a provider live, never launches an agent process to learn it, and prefers a stale reading to no reading. Shown compact on the Redwall and in detail by `doctor` / `red-dev agents status` (decision of 2026-08-15).
+
+_Avoid_: quota, limits panel, budget (reserved for GitHub's rate-limit share)
+
+## Product skill
+
+red-dev's own agent skill — how the product lays out managed paths and state, what `doctor --json`, `red-dev logs` and the transcripts say, when a step needs privilege — installed into each agent host's skills home the way Omarchy symlinks `default/agents/skills`. It is what the **Default agent** receives when asked to diagnose a crash, and it complements RedSkills' process skills rather than duplicating them (decision of 2026-08-15).
+
+_Avoid_: red-dev skill (ambiguous with RedSkills), diagnose skill (one use of it, not the thing)
+
 ## MCP posture
 
 CLI-first: every required capability has a stable CLI path; MCP is optional acceleration. An MCP failure never brings down a required item's readiness — the item stays `healthy` with a `degraded(reason, fallback, remediation)` state pointing at the CLI fallback.
+
+## Relationships
+
+- The **Default agent** is exactly one of the installed **Agent hosts**, or unset.
+- **Agent usage** is observed per **Agent host** provider; the Redwall reads it, it never produces it. The first collectors cover only what can be read without launching a process (Claude from local credentials over HTTP; Codex once its CLI exposes limits) — never an app-server.
+- The **Product skill** is installed for every **Agent host**; the **Default agent** is the one red-dev briefs with it.

--- a/.red/contexts/interaction/CONTEXT.md
+++ b/.red/contexts/interaction/CONTEXT.md
@@ -4,4 +4,38 @@ Interacting with the machine — actions, hotkeys, tiling, workspaces, launcher.
 
 ## Semantic action
 
-A portable unit of interaction (`terminal.new`, `window.tile.left`, `workspace.goto.N`…): identity and meaning are defined platform-neutrally; each platform provides a bindings adapter — GNOME and PowerToys/FancyZones are the first two, born together to prove the contract's portability. Hotkeys, cheat sheets, and conflict detection derive from the schema, never the other way around.
+A portable unit of interaction (`terminal.new`, `window.tile.left`, `workspace.goto.N`…): identity and meaning are defined platform-neutrally; each platform provides a bindings adapter — GNOME and PowerToys/FancyZones are the first two, born together to prove the contract's portability. Hotkeys, cheat sheets, and conflict detection derive from the schema, never the other way around. The schema is born now, seeded with the bindings red-dev already writes (zellij, Alacritty, Windows Terminal, readline, agent hosts, the global hotkeys), and `red-dev keys` — the searchable viewer, where Enter fires the action — is its first consumer (decision of 2026-08-15). The first schema carries what already exists (terminal, elevated shell, Shift+Enter/Alt+V, zellij) plus the menu, the keys viewer, the Panels, the Emoji picker, and two agent actions — `agent.launch` (the Default agent) and `agent.multiplex` (herdr, reported absent where it is not installed); per-web-app chords are catalogue, not default. The `red-dev` menu grows by flat sections — Keys, Panels, Agents (default · usage · update), Learn (README by anchor, RedSkills, keys) — not by Omarchy's tree.
+
+## Chord
+
+The key combination a bindings adapter attaches to a semantic action. The default chord for an action is **the same on every target**, drawn from the `Ctrl+Alt` family where `Ctrl+Alt+T` already lives; red-dev never claims `Super`/`Win` chords, because GNOME and Windows both reserve most of them and an identical experience across machines outranks matching Omarchy's muscle memory (decision of 2026-08-15). The adapter changes *how* a chord is registered, never *which* chord it is.
+
+_Avoid_: hotkey (the colloquial term — fine in prose, not as the concept), shortcut, keybinding (reserved for the file a program reads)
+
+## Panel
+
+A red-dev terminal surface for one host subsystem — network and DNS, audio input/output, power, bluetooth — driving the platform's first-party CLI so the same panel behaves the same on every target. Where a target has no first-party CLI for that subsystem (audio devices and bluetooth on Windows), the action opens the host's native panel instead of promising a red-dev one. When an act inside a Panel needs rights (changing DNS), the Panel asks inline, at that moment — sudo or UAC — because it is an operator asking; it never queues the act into the converge's privileged batch (decision of 2026-08-15).
+
+_Avoid_: applet, widget, control center (Omarchy's Quickshell vocabulary — a red-dev Panel is a TUI, not a bar plugin)
+
+## Emoji picker
+
+A red-dev terminal surface that searches emoji and puts one on the clipboard through the same three-route clipboard the terminal layer already uses — identical on every target, opened by a semantic action. Keyboard compose sequences (Omarchy's CapsLock `m s` → 😄) are out of scope: they exist only on Linux (decision of 2026-08-15).
+
+## Web app
+
+A page in its own window, with its own icon and alt-tab entry, installed and removed from the catalogue like any optional item; desktop sessions only, because it needs a menu (Linux `.desktop`) or a shortcut (Windows `--app`) to live in. Three are recommended and pre-ticked — ChatGPT, Claude, GitHub — the rest (Google Photos, Google Contacts, Tailscale, custom URLs) stay in the catalogue (decision of 2026-08-15).
+
+_Avoid_: PWA (a browser feature red-dev does not rely on), web2app (the retired shell function)
+
+## Relationships
+
+- A **Semantic action** has at most one default **Chord**, identical on every target; a platform adapter may leave it unbound when the host cannot honour it, and says so.
+- A **Panel** is opened by a **Semantic action** and reached from the `red-dev` menu as well; so is the **Emoji picker**.
+- A **Web app** is a catalogue item, and may be given a chord by the person — never by default.
+- Universal clipboard (Omarchy's terminal-aware `Super+C/V/X`) is **out of scope**: the terminal layer already unifies copy/paste on every target and Windows makes `Ctrl+C/V` universal by itself (decision of 2026-08-15).
+
+## Example dialogue
+
+> **Dev:** "On GNOME I'd bind the network **Panel** to `Super+Ctrl+W` like Omarchy."
+> **Maintainer:** "No — the **Chord** is `Ctrl+Alt+…` on GNOME *and* on Windows, or it isn't a chord we ship. If GNOME can't register it, the adapter reports it unbound; it doesn't invent a local one."

--- a/.red/contexts/provisioning/CONTEXT.md
+++ b/.red/contexts/provisioning/CONTEXT.md
@@ -18,6 +18,12 @@ The current resource and lifecycle posture of the machine: process and task coun
 
 Evidence-driven online recovery of process groups whose owner has disappeared. Rescue is distinct from Reclaim: it may run while Workers are alive, but it protects every registered Worker, active unit, terminal, daemon descendant, and the current command ancestry. Preview is the default. Apply requires multiple independent orphan signals, a private forensic snapshot, PID start-time revalidation, group-wide TERM/KILL, and a verification snapshot. There is deliberately no force mode.
 
+## Catalogue
+
+The list of items a person ticks rather than receives — `optional` tools, web apps, services — offered by `red-dev apps` and the interview. Ticking installs; **unticking an installed item removes it**, after naming what goes, so the place where a person looks at the list is also where they take something out. Whole-product removal stays `red-dev uninstall`; the manifest's `core`/`desktop`/`wsl` scopes are not catalogue and are never unticked (decision of 2026-08-15).
+
+_Avoid_: optional list, extras, pre-installs (Omarchy's word for the same tier)
+
 ## E2E lane
 
 A clean machine (VM) for one target platform that walks the full journey — install → second convergence with zero drift → theme/font switch → N-1 update → rollback → uninstall. Incremental definition of done: each phase only closes with lanes covering what it shipped; no item is ever declared ready by mere file existence.

--- a/.red/contexts/visual/CONTEXT.md
+++ b/.red/contexts/visual/CONTEXT.md
@@ -4,7 +4,7 @@ Visual system — themes, fonts, wallpapers, and the ownership of the configs th
 
 ## Redwall
 
-The selected wallpaper with live machine state drawn over it. The artwork underneath is unchanged — Redwall composes on top of it, never in place of it. It reaches two surfaces from one image: the desktop background and the lock screen. What it carries is state a person reads at a glance without unlocking — active Workers, queue and capacity, GitHub budget, the address this machine answers on, and the current year's progress. Year progress is a week-column grid of day squares plus a continuous bar; elapsed days use the theme signal, today uses strong ink, and future days stay muted.
+The selected wallpaper with live machine state drawn over it. The artwork underneath is unchanged — Redwall composes on top of it, never in place of it. It reaches two surfaces from one image: the desktop background and the lock screen. What it carries is state a person reads at a glance without unlocking — active Workers, queue and capacity, GitHub budget, agent usage (compact — the detail lives in `doctor`), the address this machine answers on, and the current year's progress. Year progress is a week-column grid of day squares plus a continuous bar; elapsed days use the theme signal, today uses strong ink, and future days stay muted.
 
 A Redwall is derived, never authored: the wallpaper is the source and the Redwall is regenerated whenever the state it displays changes. It therefore lives apart from the wallpapers, which are immutable per theme and content-addressed; a Redwall that shared that directory would make "retired" and "chosen by hand" indistinguishable to the sweep.
 
@@ -15,3 +15,9 @@ Redwall is part of the default desktop experience. A missing preference means on
 ## Config ownership modes
 
 Every configuration file touched by an adapter declares a mode: `owned` (red-dev owns and converges it), `merged` (red-dev manages only explicitly-owned fields), `adopted` (pre-existing; red-dev took over management with consent and a plan), or `external` (red-dev never touches it; at most themes it when present). Editors follow the *adoptable starter* model: install when absent, never overwrite what exists.
+
+## User layer
+
+For every `owned` file, a companion the person authors that red-dev loads after its own and never writes: what `alacritty.toml` already is to the regenerated `keys.toml`, and what `~/.config/red-dev/env.sh` is to the shipped bash. Where the program has no include mechanism (zellij), red-dev composes base + user layer into the file it owns rather than asking the person to edit the generated one. It is Omarchy's clone-to-override without a plugin system: a converge may replace everything red-dev wrote and must leave the layer untouched (decision of 2026-08-15).
+
+_Avoid_: override file, local config, dotfile (too broad), plugin

--- a/.red/researches/2026-08-15-omarchy-quattro-post-release-delta-and-decisions.md
+++ b/.red/researches/2026-08-15-omarchy-quattro-post-release-delta-and-decisions.md
@@ -1,0 +1,222 @@
+# Omarchy Quattro After Release — Delta and red-dev Decisions
+
+**Date:** 2026-08-15
+
+**Query:** Now that Omarchy Quattro (v4.0.0) has shipped, what actually changed
+against the 2026-08-03 study, and what does red-dev adopt — across hotkeys,
+programs, integrations and philosophy — versus leave alone?
+
+**Scope:** The Quattro launch tour (transcript, ~11k words, read inline), the
+`basecamp/omarchy` repository at `7be59e1f` (default branch `quattro`, 17
+commits past the `v4.0.0` tag published 2026-08-14T16:35Z, read from a shallow
+clone), and red-dev at 1.0.13 on branch `agent/npm-mise-reshim`. The three
+2026-08-03 studies and the 2026-08-11 agent-surfaces note remain the baseline;
+this note records only the delta and the decisions taken in the grilling
+session of 2026-08-15. It is **not cached in `.red/wiki/`** — `/wiki-init` has
+not been run in this repository.
+
+## Executive Summary
+
+Quattro is the architectural rewrite the 2026-08-03 study warned not to treat
+as released. It is released now, and the shape it settled on is: Omarchy as a
+**system package** (`omarchy` + `omarchy-settings`) with the person's changes
+layered in `~/.config/omarchy` and `~/.config/hypr/*.lua`; **Quickshell** as the
+one shell (bar, menu, launcher, notifications, clipboard, emoji, panels —
+Waybar, Walker, Mako, SwayOSD, hyprlock, hypridle all removed); a **plugin
+system** with `manifest.json`, clone-to-override and `shell.json` persistence;
+a **default agent** with crash capture and an **agents usage panel**; and
+**mise as the agent installer**, so `mup` updates every agent out of band.
+Foot is the default terminal. Bindings moved to Lua. The menu is JSONC data.
+
+None of it changes red-dev's course. ADR 0001 (cross-platform, contracts +
+adapters + profiles, not a distro) was **reaffirmed**, and the session decided
+thirty things — the important ones being: **one chord family (`Ctrl+Alt`) on
+every target, never Super/Win** (ADR 0006); **a user layer for every owned file**
+(ADR 0007); a **default agent that never launches in bypass mode**; **agent usage
+on the Redwall and in `doctor`**, read from bounded collectors that never
+launch an agent process; **Panels** as TUIs over first-party CLIs; a **keys
+viewer that executes**; **web apps wired** from the orphaned module; an **emoji
+picker** as a TUI; **`red-dev agents update`** inside `red-dev update`;
+**catalogue symmetry** (untick removes); and a **product skill** the default
+agent is briefed with. What was explicitly not adopted is listed at the end.
+
+## Official Sources
+
+- [Omarchy repository](https://github.com/basecamp/omarchy) — read at
+  `7be59e1f` (2026-08-15); default branch `quattro`; MIT.
+- [Omarchy v4.0.0 release](https://github.com/basecamp/omarchy/releases/tag/v4.0.0)
+  — "The Quattro Release", 2026-08-14.
+- [Omarchy manual](https://learn.omacom.io/2/the-omarchy-manual) — 51
+  chapters shipped in `manual/`.
+- [omarchy.org](https://omarchy.org) — "Omarchy Quattro has been released!"
+- [herdr.dev](https://herdr.dev) — Herdr, Inc.; Apache 2.0; the "Herder" of
+  the video.
+- The launch tour video — transcript read inline; auto-captioned, see
+  the naming corrections below.
+- Local: `.red/researches/2026-08-03-omarchy-deep-dive-and-red-dev-opportunities.md`,
+  `.red/researches/2026-08-11-unified-agent-input-and-usage-surfaces.md`,
+  ADRs 0001–0007, `.red/contexts/**`.
+
+## Naming Corrections (transcript → repository)
+
+The captions garble most product names. Read them as:
+
+| Transcript | Actual | Where |
+|---|---|---|
+| Umachi / Amachi / Omachi / Amethyst / Ulauncher | **Omarchy** | — |
+| Quick Shell | **Quickshell** | `shell/` (95 QML files) |
+| Hyperland | **Hyprland** | `default/hypr/` |
+| Herder | **herdr** | `config/herdr`, `Super+Ctrl+Return` |
+| Mees / Meece | **mise** | `install/user/mise.sh`, alias `mup` |
+| Ether | **Aether** (theme extractor GUI) | `omarchy-other.packages` |
+| Vox Type | **Voxtype** (dictation) | `bindings/voxtype.lua` |
+| Clipped | **Cliamp** (music TUI) | `Super+Shift+Alt+M` |
+| Amorite | **Omawrite** | `Super+Shift+W` |
+| Tupperole / Topperole | **Typora** (replaced by Omawrite) | release notes |
+| Limnoria | **Limine** (bootloader; snapshots) | `default/limine` |
+| Amacon | **omacom** (GitHub org) | — |
+| OMP | **omp** (oh-my-pi) | `install/user/mise.sh` |
+| Twey | **TUI** (Install › TUI) | `omarchy-tui-install` |
+| Amakub | **Omakub** (the original wallpaper) | `themes/` |
+| Omasign | **not in the repository** (announced, unshipped) | — |
+| "Ohmyzsh.com plugin site" | **omarchyplugins.com** | `manual/32-shell-plugins.md` |
+
+## Key Findings
+
+### What Quattro changed since the 2026-08-03 study
+
+| Area | Stable 3.8.x (studied 08-03) | Quattro (`7be59e1f`) |
+|---|---|---|
+| Shell | Waybar + Walker + Mako + SwayOSD + hyprlock/hypridle | **Quickshell** for everything (`shell.qml` 1,031 lines; plugins in `shell/plugins/`) |
+| Delivery | git checkout in `~/.local/share/omarchy` | **system packages** `omarchy`, `omarchy-settings`, `omarchy-keyring`, `omarchy-nvim`; `/usr/share/omarchy` immutable; `/etc/skel` seed → user layer |
+| Config language | Hyprland `.conf` | **Lua** (`hyprland.lua`, `bindings.lua`; `hl.unbind` for user overrides; two switches to disable default/preinstalled bindings) |
+| Menu | shell script tree | **JSONC** (`default/omarchy/omarchy-menu.jsonc`, user overlay `~/.config/omarchy/extensions/`) |
+| Terminal | Alacritty → Ghostty | **foot** default; Alacritty/Ghostty/Kitty installable and themed |
+| Plugins | none | `manifest.json` kinds (bar-widget, panel, overlay, menu, service, bar); `omarchy plugin add|clone|enable|disable|remove|update|validate`; `~/.config/omarchy/shell.json` |
+| Agents | aliases | **default agent** (`omarchy default agent`, `Super+Shift+Ctrl+A`, launched with `--permission-mode auto`/`--yolo`/`--approve-for-me`), `omarchy-crash-watch.service` → `omarchy-agent-crash`, skills `default/agents/skills/{omarchy,diagnose-crash}` symlinked into `~/.claude/skills`, `~/.codex/skills`, `~/.pi/agent/skills`; usage panel (Claude / Codex / Fireworks, 15-min collectors; the Codex collector **starts the app-server**) |
+| Agent install | pacman/AUR | **mise stubs** in `~/.local/bin` (`omarchy-mise-install`, `MISE_MINIMUM_RELEASE_AGE=0`); `mup` = `mise up`; `omarchy update` runs it |
+| Channels | stable/dev | stable / rc / edge / dev; `stable-mirror.omarchy.org` one month behind; ALPM hook blocks direct `pacman -Syu` |
+| Recovery | snapshots | snapper + limine, snapshot before update, **factory reset** from `@factory` (ISO installs only) |
+| Themes | 19 | **22** (`last-horizon`, `lupine`, `solitude`); `colors.toml` → 17 templates; Aether extracts a theme from an image |
+| Bin surface | ~350 scripts | **424** `omarchy-*` scripts + the `omarchy` router (~30.7k lines) |
+| Removed | — | Waybar, Walker, Mako, SwayOSD, hyprlock, hypridle, swaybg, polkit-gnome, iwd/impala/bluetui/wiremix, Typora, Satty, GNOME Calculator |
+| Own apps | — | Omawrite, Omacalc, Omacut, ttfx (Rust screensaver), Aether, Cliamp, tensaku (annotator) |
+
+Interaction details worth keeping in mind: `Super+K` viewer filters and **Enter
+executes**; `Super+C/V/X` are terminal-aware (send `Ctrl+Insert`/`Shift+Insert`
+to windows tagged `terminal`); CapsLock is compose (`m s` → 😄, `space n` →
+name, `space e` → e-mail); `Super+Ctrl+1..9` toggles the nth bar panel;
+Panels on `Super+Ctrl+A/B/D/Alt+D/W/P`; DNS under Setup › Network › DNS
+{DHCP, Cloudflare, Google, Custom} plus a network QR code; SSH server
+authorizes `github.com/<user>.keys` and `ufw limit 22`; `Remove › Preinstalls`
+sweeps every web app, TUI wrapper, mise stub and bundled GUI app in one go.
+
+### Where red-dev stands on the same four axes
+
+| Axis | red-dev 1.0.13 |
+|---|---|
+| Hotkeys | Global chords only on a Windows host: `Ctrl+Alt+T`, `Ctrl+Alt+Shift+T` (`src/hotkeys.ts`). Zero GNOME bindings. Terminal layer identical on all five targets: zellij `locked` with `Ctrl-g`, Shift+Enter → CSI-u and Alt+V → raw `Ctrl+V` in Alacritty, Windows Terminal, readline, Claude, RedCode (`src/shift-enter.test.ts`). No keys viewer; the semantic-action schema was promised, nothing generated. |
+| Programs | Manifest scopes `core` 41 · `desktop` 9 · `wsl` 5 · `optional` 11; agents 11 (three recommended); runtimes via mise (`node@24` default). Web apps: `src/webapps.ts` complete and **imported nowhere**; the shipped path is the `web2app` bash function, hard-coded to `google-chrome`. |
+| Integrations | `red-dev update` = apt/winget + red-skills + converge; installed agents are skipped, so on Linux/WSL codex, gemini, hermes (npm under mise's node) and redcode (GitHub release) are **never updated by red-dev**. Redwall already carries GitHub `api/gql` budgets and Worker state; Codex statusline shows its own limits. `ssh-server` opens the port and installs the service, authorizes no key. No default agent. Crash logs, `logs`, transcripts, migrations exist. |
+| Philosophy | ADR 0001 (not a distro; contracts + adapters + profiles), ADR 0003 (red-dev does not colour the terminal), ADR 0004/0005 (Reclaim asked for; Rescue evidence-driven), "chosen, not assumed" agents, install never prompts, `Ctrl+Shift+T` deliberately unclaimed. |
+
+### Convergences
+
+- **herdr.** Omarchy adopted it (`Super+Ctrl+Return`, Learn › Herdr keybindings,
+  `config/herdr`); red-dev already installs it and builds the RedSkills herdr
+  extension. Same tool, same reason (agents alive over SSH).
+- **Shift+Enter.** Both emit `ESC[13;2u`; Quattro also enables tmux extended
+  keys. Already covered by the 08-11 note.
+- **mise** owns runtimes on both sides.
+- **"Chosen, not assumed."** Omarchy: "it doesn't pick a favorite for you"
+  (no default agent out of the box). red-dev: agents are a pre-ticked choice.
+
+## Decisions (2026-08-15 grilling session)
+
+Every question below was put to the maintainer with a recommendation; the
+maintainer accepted the recommendation in each case. "Recorded in" is where the
+decision now lives — this note is a log, not the source of truth.
+
+| # | Decision | Recorded in |
+|---|---|---|
+| Q01 | Cache sources in `/wiki` — **blocked**: `/wiki-init` is user-invocable only and asks which of `CLAUDE.md`/`AGENTS.md` to create (neither exists). Material stays uncached until it is run. | this note |
+| Q02 | Decisions inline + this dated research note. | — |
+| Q03 | ADR 0001 **reaffirmed** post-Quattro; the "do not copy" list gains "default agent in bypass mode". | ADR 0001 amendment |
+| Q04 | Agent usage: **compact on the Redwall, detail in `doctor` / `red-dev agents status`**. | `agents/CONTEXT.md` (Agent usage), `visual/CONTEXT.md` (Redwall) |
+| Q05 | Adopt a **Default agent**: one chosen host, target of crash diagnosis and of a launch chord; **never** started with a permission bypass. | `agents/CONTEXT.md` (Default agent) |
+| Q06 | Answer to `mup`: **`red-dev agents update`**, each host by its publisher's path (npm `-g`, GitHub release, winget, self-update). Not the mise `npm:` backend — this branch just contained mise's unbounded reshim. | `agents/CONTEXT.md` |
+| Q07 | ADR 0004's "red-dev schedules nothing" is stale since the Redwall timer; **amend**, scoping the prohibition to Reclaim/Rescue. | ADR 0004 amendment |
+| Q08 | **Panels** (network/DNS, audio in/out, power, bluetooth) as red-dev TUIs over first-party CLIs; fall back to the host's native panel where none exists (audio devices, bluetooth on Windows). | `interaction/CONTEXT.md` (Panel) |
+| Q09 | **One chord family on every target — `Ctrl+Alt` — never Super/Win.** | ADR 0006, `interaction/CONTEXT.md` (Chord) |
+| Q10 | The semantic-action **schema is born now**, seeded with today's bindings; **`red-dev keys`** is its first consumer. | `interaction/CONTEXT.md` (Semantic action) |
+| Q11 | Universal clipboard (`Super+C/V/X`) — **out of scope**. | `interaction/CONTEXT.md` (Relationships) |
+| Q12 | New `optional` groups: **services** (Tailscale, 1Password, Bitwarden, LocalSend) and **dev CLIs** (`try`, `dua`, `yt-dlp`). Not Omarchy's own GUI apps. | this note; manifest work |
+| Q13 | **Wire `src/webapps.ts`** into `red-dev apps` (install/remove; Linux `.desktop`, Windows `--app` shortcut); retire the `web2app` bash function. | `interaction/CONTEXT.md` (Web app) |
+| Q14 | **User layer** for every owned file, loaded after red-dev's, never written by a converge; composed where the program cannot include (zellij). | ADR 0007, `visual/CONTEXT.md` (User layer) |
+| Q15 | Usage collectors cover **only what can be read without launching a process** — Claude via local credentials/HTTP first; Codex when its CLI exposes limits; never an app-server. | `agents/CONTEXT.md` (Relationships) |
+| Q16 | SSH server **authorizes keys from a GitHub username**, asked in the interview / `red-dev shell`, never in a plain converge; removal reverts. | this note; `src/ssh-server.ts` work |
+| Q17 | Phase-3 capture actions: **screenshot only** (OCR / recording are a later phase if asked). | this note |
+| Q18 | ADRs for chord family and user layer — **both written**. | ADR 0006, ADR 0007 |
+| Q19 | **Emoji picker as a TUI** (search → clipboard through the three-route clipboard); compose sequences out of scope. | `interaction/CONTEXT.md` (Emoji picker) |
+| Q20 | First schema set: what exists + menu, keys viewer, Panels, emoji (+ Q30's agent actions); per-web-app chords are catalogue, not default. | `interaction/CONTEXT.md` |
+| Q21 | `red-dev keys` **executes on Enter**. | `interaction/CONTEXT.md` |
+| Q22 | Web apps default: **ChatGPT, Claude, GitHub pre-ticked**; Photos/Contacts/Tailscale in the catalogue. | `interaction/CONTEXT.md` (Web app) |
+| Q23 | `red-dev update` **includes** the agents update (system → red-skills → agents → converge). | `agents/CONTEXT.md` |
+| Q24 | Default agent chosen in the **interview after the hosts** + `red-dev agents default <key>`; **automatic when exactly one CLI host** is selected. | `agents/CONTEXT.md` |
+| Q25 | The default agent is briefed with a **product skill** shipped by red-dev (managed paths, `doctor --json`, logs, privilege), installed into agent skills homes; complements RedSkills. | `agents/CONTEXT.md` (Product skill) |
+| Q26 | Aether-style **theme from image — no**; six brand themes, imported wallpaper is art only. | this note (ADR 0002/0003 lineage) |
+| Q27 | A Panel that needs rights **asks inline** (sudo/UAC) — never queued into `red-dev privileged`. | `interaction/CONTEXT.md` (Panel) |
+| Q28 | Menu grows by **flat sections** — Keys, Panels, Agents (default · usage · update), Learn — not Omarchy's tree. | `interaction/CONTEXT.md` |
+| Q29 | **Catalogue symmetry**: unticking an installed optional/web app in `red-dev apps` removes it, after naming it. | `provisioning/CONTEXT.md` (Catalogue) |
+| Q30 | Agent chords: **`agent.launch`** (default agent) and **`agent.multiplex`** (herdr, reported absent where not installed). | `interaction/CONTEXT.md` |
+
+## Not Adopted, and Why
+
+| Quattro feature | Verdict | Reason |
+|---|---|---|
+| Hyprland + Quickshell shell, bar plugins | no | Not a distro (ADR 0001); red-dev has no shell to plug into — Panels are TUIs, the Redwall is the status surface |
+| Super-centric key map | no | Collides with GNOME and Windows reserved chords; identical `Ctrl+Alt` family instead (ADR 0006) |
+| Universal clipboard `Super+C/V/X` | no | Hyprland-specific; the terminal layer already unifies copy/paste; Windows is universal by itself |
+| CapsLock compose (emoji, name, e-mail) | no | Linux-only; breaks the identical layer |
+| Omawrite / Omacalc / Omacut / Aether / Cliamp / ttfx | no | Linux GUI, personal taste (ADR 0001) |
+| Aether theme-from-image | no | ADR 0002/0003 removed invented colour from the product; six brand themes stay |
+| Agents as mise `npm:` stubs + `mup` | no | This branch just bounded mise's implicit reshim; publisher paths + `red-dev agents update` instead |
+| Codex usage via app-server | no | 08-11 note: no repaint may launch a process; collectors read cached observations only |
+| Default agent in bypass/auto-approve | no | Added to ADR 0001's "do not copy" list |
+| Omarchy's menu tree (Learn/Trigger/Style/…) | no | Sized for 424 scripts; red-dev grows flat sections |
+| Docker DB installers | no | Already decided in `profiles/CONTEXT.md` |
+| Update channels rc/edge, one-month-behind mirror, snapshots, factory reset | not now | Lifecycle context, own track; nothing decided here |
+| Web app per-app default chords | no | Catalogue, not default (Q20/Q22) |
+
+## Gotchas
+
+- The transcript's names are unreliable — use the corrections table.
+- README drift found while reading: it says web apps ship (only the bash
+  function does), and that ble.sh is "installed but not enabled" while
+  `config/bash/rc.sh:72` makes it on by default since commit `6513dbc`.
+- ADR 0004's premise was stale for three days before the amendment; the
+  Redwall timer is the only scheduled thing red-dev installs.
+- Nothing in this session was cached in the wiki; re-ingest after `/wiki-init`.
+
+## Open Questions
+
+1. Codex usage without an app-server — waits on the Codex CLI exposing limits.
+2. Which `Ctrl+Alt+*` chords are actually free on both GNOME and Windows for
+   menu, keys, panels, emoji, agent — the schema's conflict check answers this
+   before any chord ships.
+3. Windows audio-device switching has no first-party CLI; the Panel falls back
+   to `ms-settings:` there — revisit if a first-party command appears.
+4. Whether the product skill and RedSkills' `dev:diagnose` overlap enough to
+   share text — decide when writing the skill.
+
+## Recommended Next Steps
+
+1. `/to-spec` on this session: the natural vertical slices are (i) the
+   semantic-action schema + `red-dev keys`, (ii) default agent + product skill
+   + `agents update`, (iii) agent usage on Redwall/doctor with the Claude
+   collector, (iv) Panels network/DNS first, (v) web apps wired + catalogue
+   symmetry, (vi) user layer for zellij, (vii) emoji picker, (viii) SSH keys
+   from GitHub.
+2. Fix the two README drifts (web apps, ble.sh) as part of (v) and separately.
+3. Run `/wiki-init`, then re-ingest the transcript and the repository at
+   `7be59e1f` so the next Quattro comparison starts cached.


### PR DESCRIPTION
Doc landing from the 2026-08-15 grilling session comparing red-dev with Omarchy Quattro (v4.0.0, released 2026-08-14) across hotkeys, programs, integrations and philosophy.

- ADR 0006 — one chord family (`Ctrl+Alt`) on every target, never Super/Win
- ADR 0007 — every owned file has a user layer a converge never writes
- ADR 0001 amended: reaffirmed post-Quattro; "default agent in bypass mode" joins the do-not-copy list
- ADR 0004 amended: the scheduling prohibition is scoped to Reclaim/Rescue; the Redwall timer is a deliberate exception
- Glossaries: Default agent, Agent usage, Product skill (`agents`); Semantic action, Chord, Panel, Emoji picker, Web app (`interaction`); Catalogue (`provisioning`); User layer + Redwall (`visual`)
- Research note: Quattro delta vs the 2026-08-03 study, transcript naming corrections, the 30 decisions, what was not adopted and why

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/133"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789418291&installation_model_id=20659&pr_number=133&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F133&signature=ef4feceeaa473bf7f609702c35c67c4381bc6e305634454df9e6381aec4422ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->