### PR TITLE
fix: #136 The semantic action registry, with the chord guard and the global hotkeys migrated

### DIFF
--- a/src/actions/agents.ts
+++ b/src/actions/agents.ts
@@ -1,0 +1,13 @@
+/**
+ * Reaching the agents — the default one, and the multiplexer that runs
+ * several.
+ *
+ * Born empty; the agents slice fills it. An action here has to survive
+ * being absent: the multiplexer is not installed on every machine, and
+ * an adapter reports such an action unbound rather than dropping it, so
+ * the keys viewer can say "not installed here" instead of going quiet.
+ */
+
+import type { SemanticAction } from "./types.ts";
+
+export const AGENT_ACTIONS: readonly SemanticAction[] = [];

--- a/src/actions/apps.ts
+++ b/src/actions/apps.ts
@@ -1,0 +1,13 @@
+/**
+ * Applications red-dev can open — web apps in their own window, and the
+ * host panels it hands a subsystem back to where no first-party CLI
+ * exists.
+ *
+ * Born empty, and likely to stay thin: a web app gets a chord only when
+ * the person gives it one. Shipping a default chord per catalogue item
+ * would spend the `Ctrl+Alt` family on taste, and the family is small.
+ */
+
+import type { SemanticAction } from "./types.ts";
+
+export const APP_ACTIONS: readonly SemanticAction[] = [];

--- a/src/actions/capture.ts
+++ b/src/actions/capture.ts
@@ -1,0 +1,13 @@
+/**
+ * Taking a picture of the screen, and whatever else red-dev learns to
+ * capture from it.
+ *
+ * Born empty; the slice that builds capture fills it. The area exists
+ * from the start because a capture chord is the kind of thing that
+ * otherwise gets hard-coded wherever the screenshot tool is invoked,
+ * which is the failure the registry was created to end.
+ */
+
+import type { SemanticAction } from "./types.ts";
+
+export const CAPTURE_ACTIONS: readonly SemanticAction[] = [];

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -1,0 +1,46 @@
+/**
+ * The registry: every semantic action red-dev knows, in one list.
+ *
+ * Every area is imported here from the first commit, empty ones
+ * included. The alternative — adding an import when an area first grows
+ * an action — is how two slices end up editing the same three lines of
+ * the same file, and how an area quietly never gets aggregated at all.
+ *
+ * This module is the only thing consumers import. Where an action lives
+ * is an authoring convenience; that it is in `ACTIONS` is the contract.
+ */
+
+import { AGENT_ACTIONS } from "./agents.ts";
+import { APP_ACTIONS } from "./apps.ts";
+import { CAPTURE_ACTIONS } from "./capture.ts";
+import { PANEL_ACTIONS } from "./panels.ts";
+import { TERMINAL_ACTIONS } from "./terminal.ts";
+import { TERMINAL_SURFACE_ACTIONS } from "./terminal-surfaces.ts";
+import type { SemanticAction } from "./types.ts";
+
+export type { Chord, SemanticAction } from "./types.ts";
+export { chordText, parseChord } from "./types.ts";
+export type { ActionProblem } from "./validate.ts";
+export { validateActions } from "./validate.ts";
+export { GNOME_RESERVED, WINDOWS_RESERVED } from "./reserved.ts";
+
+export const ACTIONS: readonly SemanticAction[] = [
+  ...TERMINAL_ACTIONS,
+  ...TERMINAL_SURFACE_ACTIONS,
+  ...PANEL_ACTIONS,
+  ...APP_ACTIONS,
+  ...CAPTURE_ACTIONS,
+  ...AGENT_ACTIONS,
+];
+
+/**
+ * By id, because ids are what other modules store.
+ *
+ * Undefined rather than a throw: a caller that has lost its action needs
+ * to decide what that means — the Windows adapter drops the shortcut
+ * rather than writing one with no key, which would clear the binding on
+ * every machine that already had it.
+ */
+export function actionById(id: string): SemanticAction | undefined {
+  return ACTIONS.find((a) => a.id === id);
+}

--- a/src/actions/panels.ts
+++ b/src/actions/panels.ts
@@ -1,0 +1,14 @@
+/**
+ * Panels — a red-dev terminal surface over one host subsystem: network
+ * and DNS first, then audio, power and bluetooth.
+ *
+ * Born empty; the Panels slice fills it. Worth knowing before it does:
+ * a Panel that needs rights asks inline, at the moment the operator
+ * changes something, so the action that *opens* a Panel is never
+ * privileged — `privileged` on these entries describes opening, not
+ * everything the Panel can go on to do.
+ */
+
+import type { SemanticAction } from "./types.ts";
+
+export const PANEL_ACTIONS: readonly SemanticAction[] = [];

--- a/src/actions/registry.test.ts
+++ b/src/actions/registry.test.ts
@@ -1,0 +1,190 @@
+/**
+ * The rules ADR 0006 wrote down, run against the registry and against
+ * actions that break each rule on purpose.
+ *
+ * A validator is only worth having if it fails, so every rule is checked
+ * twice here: once against the real list, which must be clean, and once
+ * against a fixture action built to violate exactly that rule. The
+ * reserved-key rule is the one that motivated the whole check — a chord
+ * that collides with GNOME or Windows is invisible until it is on
+ * somebody's machine, and by then it is in a release.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { ACTIONS, actionById } from "./index.ts";
+import { GNOME_RESERVED, WINDOWS_RESERVED } from "./reserved.ts";
+import { chordText, parseChord } from "./types.ts";
+import type { SemanticAction } from "./types.ts";
+import { validateActions } from "./validate.ts";
+
+/** An action that is fine in every way except the one under test. */
+function fixture(overrides: Partial<SemanticAction>): SemanticAction {
+  return {
+    id: "fixture.one",
+    label: "A fixture",
+    platforms: ["desktop"],
+    mutates: false,
+    privileged: false,
+    chord: "Ctrl+Alt+J",
+    ...overrides,
+  };
+}
+
+/** The problems reported for one fixture, as sentences. */
+function problems(...actions: SemanticAction[]): string[] {
+  return validateActions(actions).map((p) => p.problem);
+}
+
+describe("the registry itself", () => {
+  test("passes its own validation", () => {
+    expect(validateActions(ACTIONS)).toEqual([]);
+  });
+
+  test("carries the actions the areas have so far", () => {
+    // Empty areas are aggregated too, so this is the whole list and not
+    // just the module that happens to be filled.
+    expect(ACTIONS.map((a) => a.id)).toEqual(["terminal.new", "terminal.elevated"]);
+  });
+
+  test("gives every action exactly one chord, in the Ctrl+Alt family", () => {
+    for (const action of ACTIONS) {
+      const chord = parseChord(action.chord);
+      expect(chord).not.toBeNull();
+      expect(chord?.ctrl).toBe(true);
+      expect(chord?.alt).toBe(true);
+      expect(chord?.win).toBe(false);
+    }
+  });
+
+  test("has unique ids", () => {
+    expect(new Set(ACTIONS.map((a) => a.id)).size).toBe(ACTIONS.length);
+  });
+
+  test("has unique chords", () => {
+    const chords = ACTIONS.map((a) => chordText(parseChord(a.chord) as never));
+    expect(new Set(chords).size).toBe(chords.length);
+  });
+
+  test("finds an action by its id, and says nothing when there is none", () => {
+    expect(actionById("terminal.new")?.label).toBe("Terminal");
+    expect(actionById("terminal.gone")).toBeUndefined();
+  });
+});
+
+describe("a chord that collides with the host", () => {
+  test("from GNOME's reserved list fails validation", () => {
+    // Ctrl+Alt+Left is a workspace switch on every GNOME session; an
+    // action claiming it would fight the desktop for the key.
+    expect(problems(fixture({ chord: "Ctrl+Alt+Left" }))).toEqual([
+      "chord CTRL+ALT+LEFT is reserved by GNOME",
+      "chord CTRL+ALT+LEFT is reserved by Windows",
+    ]);
+  });
+
+  test("from GNOME alone fails too", () => {
+    expect(problems(fixture({ chord: "Ctrl+Alt+L" }))).toEqual([
+      "chord CTRL+ALT+L is reserved by GNOME",
+    ]);
+  });
+
+  test("from Windows' reserved list fails validation", () => {
+    expect(problems(fixture({ chord: "Ctrl+Alt+Tab" }))).toEqual([
+      "chord CTRL+ALT+TAB is reserved by GNOME",
+      "chord CTRL+ALT+TAB is reserved by Windows",
+    ]);
+  });
+
+  test("is caught whichever way it is spelled", () => {
+    // Del and Delete are the same key; a check that only knew one
+    // spelling would pass the other straight through.
+    expect(problems(fixture({ chord: "ctrl+alt+del" }))).toEqual([
+      "chord CTRL+ALT+DELETE is reserved by GNOME",
+      "chord CTRL+ALT+DELETE is reserved by Windows",
+    ]);
+  });
+
+  test("but the family red-dev lives in is not itself reserved", () => {
+    // GNOME ships Ctrl+Alt+T as launch-terminal, which is the same act
+    // terminal.new performs. Adopting it is not colliding with it, and
+    // pinning it as reserved would fail the registry on its own chord.
+    expect(GNOME_RESERVED.has("CTRL+ALT+T")).toBe(false);
+    expect(WINDOWS_RESERVED.has("CTRL+ALT+T")).toBe(false);
+    expect(WINDOWS_RESERVED.has("CTRL+ALT+SHIFT+T")).toBe(false);
+  });
+
+  test("and every pinned entry is spelled the way a parsed chord is", () => {
+    // A reserved entry nothing can ever match is a check that silently
+    // does nothing.
+    for (const entry of [...GNOME_RESERVED, ...WINDOWS_RESERVED]) {
+      const chord = parseChord(entry);
+      expect(chord).not.toBeNull();
+      expect(chordText(chord as never)).toBe(entry);
+    }
+  });
+});
+
+describe("the rest of the rules", () => {
+  test("a chord outside the Ctrl+Alt family fails", () => {
+    expect(problems(fixture({ chord: "Ctrl+Shift+T" }))).toEqual([
+      "chord CTRL+SHIFT+T is outside the Ctrl+Alt family",
+    ]);
+  });
+
+  test("a Super chord fails, and is named as the host's", () => {
+    expect(problems(fixture({ chord: "Super+Space" }))).toEqual([
+      "chord WIN+SPACE claims Super/Win, which ADR 0006 leaves to the host",
+    ]);
+  });
+
+  test("two chords on one action is not two chords, it is no chord", () => {
+    expect(problems(fixture({ chord: "Ctrl+Alt+J+K" }))).toEqual([
+      'chord "Ctrl+Alt+J+K" is not one readable chord',
+    ]);
+  });
+
+  test("an action with no chord fails", () => {
+    expect(problems(fixture({ chord: "" }))).toEqual([
+      'chord "" is not one readable chord',
+    ]);
+  });
+
+  test("modifiers alone are not a chord", () => {
+    expect(problems(fixture({ chord: "Ctrl+Alt" }))).toEqual([
+      'chord "Ctrl+Alt" is not one readable chord',
+    ]);
+  });
+
+  test("a repeated id fails, and both actions are named", () => {
+    const twice = problems(
+      fixture({ id: "fixture.one", chord: "Ctrl+Alt+J" }),
+      fixture({ id: "fixture.one", chord: "Ctrl+Alt+K" }),
+    );
+    expect(twice).toEqual(['id "fixture.one" is used twice']);
+  });
+
+  test("an id that is not a lowercase dotted name fails", () => {
+    expect(problems(fixture({ id: "Fixture" }))).toEqual([
+      'id "Fixture" is not a lowercase dotted name',
+    ]);
+  });
+
+  test("two actions reaching for the same chord fails", () => {
+    expect(
+      problems(fixture({ id: "fixture.one" }), fixture({ id: "fixture.two" })),
+    ).toEqual(["chord CTRL+ALT+J already belongs to fixture.one"]);
+  });
+
+  test("an action that applies nowhere fails", () => {
+    expect(problems(fixture({ platforms: [] }))).toEqual(["applies to no platform"]);
+  });
+
+  test("an action with no label fails", () => {
+    expect(problems(fixture({ label: "  " }))).toEqual(["has no label"]);
+  });
+
+  test("every problem names the action it belongs to", () => {
+    const found = validateActions([fixture({ id: "fixture.two", chord: "Ctrl+Alt+Delete" })]);
+    expect(found.length).toBeGreaterThan(0);
+    expect(found.every((p) => p.id === "fixture.two")).toBe(true);
+  });
+});

--- a/src/actions/reserved.ts
+++ b/src/actions/reserved.ts
@@ -1,0 +1,74 @@
+/**
+ * The chords the hosts have already taken, pinned.
+ *
+ * ADR 0006 sends every red-dev chord into the `Ctrl+Alt` family, and
+ * that family is finite and partly spoken for on both hosts. The ADR
+ * says the check "lives in the schema"; this is the half of it that is
+ * evidence rather than rule — two lists of keys that GNOME and Windows
+ * claim, written down here so a new action collides in a test rather
+ * than on somebody's machine.
+ *
+ * Pinned deliberately, not detected. A collision has to be visible while
+ * a chord is being chosen, which is months before the code ever runs on
+ * the host in question, and probing a live GNOME would say nothing at
+ * all about the Windows laptop the same chord has to work on.
+ *
+ * Only the `Ctrl+Alt` family is listed. Both hosts reserve far more than
+ * this — most of the Super/Win space, which is exactly why ADR 0006
+ * refuses to enter it — but a list of keys red-dev may never reach for
+ * is a list nothing consults; these are the ones a chord could plausibly
+ * be chosen from tomorrow.
+ *
+ * `Ctrl+Alt+T` is not here, on either side, and its absence is the
+ * decision. GNOME does ship it as launch-terminal — that is the same act
+ * red-dev's `terminal.new` performs, and adopting the key people already
+ * press is the opposite of colliding with it.
+ *
+ * Spelled canonically — uppercase, modifiers in `chordText` order — so
+ * membership is a plain set lookup after a chord has been parsed.
+ */
+
+/**
+ * GNOME, from its own Keyboard Shortcuts panel on Ubuntu.
+ *
+ * Workspaces take the arrows and moving a window takes them with Shift;
+ * `Ctrl+Alt+Del` is the log-out dialog on Ubuntu; `Ctrl+Alt+L` locks the
+ * screen; `Ctrl+Alt+Tab` switches system controls; and `Ctrl+Alt+F1..F12`
+ * belong to the virtual terminals underneath the session, which no
+ * desktop setting can take back.
+ */
+export const GNOME_RESERVED: ReadonlySet<string> = new Set([
+  "CTRL+ALT+LEFT",
+  "CTRL+ALT+RIGHT",
+  "CTRL+ALT+UP",
+  "CTRL+ALT+DOWN",
+  "CTRL+ALT+SHIFT+LEFT",
+  "CTRL+ALT+SHIFT+RIGHT",
+  "CTRL+ALT+SHIFT+UP",
+  "CTRL+ALT+SHIFT+DOWN",
+  "CTRL+ALT+DELETE",
+  "CTRL+ALT+L",
+  "CTRL+ALT+TAB",
+  "CTRL+ALT+ESC",
+  ...Array.from({ length: 12 }, (_, i) => `CTRL+ALT+F${i + 1}`),
+]);
+
+/**
+ * Windows.
+ *
+ * `Ctrl+Alt+Del` is the secure attention sequence: no application may
+ * register it, and nothing an installer does can change that.
+ * `Ctrl+Alt+Tab` is the sticky task switcher. The arrows are not
+ * Windows' own — they are the Intel and AMD display drivers' screen
+ * rotation, shipped on a large share of the laptops this project runs
+ * on, and a chord that rotates the screen on those machines is a
+ * collision whatever the ownership.
+ */
+export const WINDOWS_RESERVED: ReadonlySet<string> = new Set([
+  "CTRL+ALT+DELETE",
+  "CTRL+ALT+TAB",
+  "CTRL+ALT+LEFT",
+  "CTRL+ALT+RIGHT",
+  "CTRL+ALT+UP",
+  "CTRL+ALT+DOWN",
+]);

--- a/src/actions/terminal-surfaces.ts
+++ b/src/actions/terminal-surfaces.ts
@@ -1,0 +1,14 @@
+/**
+ * The surfaces red-dev draws in a terminal of its own — the menu, the
+ * keys viewer, the emoji picker.
+ *
+ * Born empty, and that is the point. The registry is a directory with a
+ * module per area from its first commit so that the slices which build
+ * these surfaces add a line to their own file, rather than six slices
+ * queueing behind one another over the same list. An empty area is a
+ * declaration of where its actions will go.
+ */
+
+import type { SemanticAction } from "./types.ts";
+
+export const TERMINAL_SURFACE_ACTIONS: readonly SemanticAction[] = [];

--- a/src/actions/terminal.ts
+++ b/src/actions/terminal.ts
@@ -1,0 +1,48 @@
+/**
+ * Opening a shell — the two acts red-dev already binds.
+ *
+ * These are not new. They have existed as literals inside the Windows
+ * hotkeys module since the Start Menu shortcuts were written, and the
+ * README has printed them in a table for as long. Moving them here
+ * changes nothing about what the keys do; it makes the module that
+ * writes the shortcuts a consumer of the list rather than a second
+ * source of it, which is the whole point of the registry.
+ *
+ * The labels are neutral on purpose. `PowerShell (Administrator)` is the
+ * name of a Start Menu entry on one host, not the name of the act; the
+ * Windows adapter keeps that name, this list keeps the meaning.
+ */
+
+import type { SemanticAction } from "./types.ts";
+
+/**
+ * Everywhere with a display, WSL included.
+ *
+ * WSL is listed because a person working inside WSL presses the key and
+ * expects a terminal — the registration happens on the Windows host on
+ * that install's behalf, which is a fact about the adapter, not about
+ * where the action applies. `server` is absent for the opposite reason:
+ * there is nothing there to press a key on.
+ */
+const WITH_A_DISPLAY = ["desktop", "wsl", "windows"] as const;
+
+export const TERMINAL_ACTIONS: readonly SemanticAction[] = [
+  {
+    id: "terminal.new",
+    label: "Terminal",
+    platforms: WITH_A_DISPLAY,
+    mutates: false,
+    privileged: false,
+    chord: "Ctrl+Alt+T",
+  },
+  {
+    id: "terminal.elevated",
+    label: "Elevated shell",
+    platforms: WITH_A_DISPLAY,
+    mutates: false,
+    // The shell it opens can do anything; opening it is the privileged
+    // part, and it is where the consent prompt happens.
+    privileged: true,
+    chord: "Ctrl+Alt+Shift+T",
+  },
+];

--- a/src/actions/types.ts
+++ b/src/actions/types.ts
@@ -1,0 +1,155 @@
+/**
+ * What a semantic action is, before any platform has seen it.
+ *
+ * The registry is data first: a list of the things red-dev can do, each
+ * one identified by a name that never changes, described in a sentence a
+ * person can read, and carrying exactly one chord. Everything that
+ * consumes it — the keys viewer, the GNOME adapter, the Start Menu
+ * shortcuts on Windows — reads this shape; nothing writes its own copy
+ * of "which key opens the terminal" ever again.
+ *
+ * A chord lives here as text, in the spelling a person would say it:
+ * `Ctrl+Alt+T`. Keeping it as text rather than as a parsed record is
+ * what lets a malformed chord reach validation and be reported, instead
+ * of throwing while a module is still loading — and it is the only form
+ * that reads the same in the source, in the viewer and in the README.
+ * `parseChord` is the one place that knows how to read it.
+ *
+ * ADR 0006 is the law this shape exists to make executable: one chord
+ * per action, identical on every target, drawn from the `Ctrl+Alt`
+ * family, never from `Super`/`Win`.
+ */
+
+import type { Env } from "../platform.ts";
+
+export interface SemanticAction {
+  /**
+   * The stable id: lowercase, dotted, area first — `terminal.new`.
+   *
+   * It is the name other things store, so it outlives labels, chords and
+   * whichever module the action currently lives in. Renaming one is a
+   * breaking change, which is why the shape is checked rather than
+   * merely suggested.
+   */
+  id: string;
+  /** What a person sees in the keys viewer and in the menu. */
+  label: string;
+  /**
+   * Where the action means anything at all.
+   *
+   * Not where it happens to be registered today: `terminal.new` applies
+   * to every environment that has a display, including WSL, where the
+   * key is registered on the Windows host on the WSL install's behalf.
+   * An adapter that cannot honour an action reports it unbound (ADR
+   * 0006); it does not get to delete it from the list.
+   */
+  platforms: readonly Env[];
+  /** True when running it changes the machine rather than showing it. */
+  mutates: boolean;
+  /** True when it needs sudo or UAC to do its job. */
+  privileged: boolean;
+  /** The single chord, in readable spelling: `Ctrl+Alt+Shift+T`. */
+  chord: string;
+}
+
+/** A chord after `parseChord` has read it. */
+export interface Chord {
+  ctrl: boolean;
+  alt: boolean;
+  shift: boolean;
+  /** `Super` on GNOME, `Win` on Windows. ADR 0006 forbids claiming one. */
+  win: boolean;
+  /** The single non-modifier key, canonically spelled: `T`, `LEFT`, `F1`. */
+  key: string;
+}
+
+/**
+ * The names a non-modifier key may carry, and the spellings that mean
+ * the same key.
+ *
+ * Two spellings of one key is how a reserved-list check quietly stops
+ * working: `Ctrl+Alt+Del` is not in a list that pins `CTRL+ALT+DELETE`,
+ * and nothing says so. Everything is folded to one spelling here, and
+ * comparison happens only after folding.
+ */
+const KEY_ALIASES: Record<string, string> = {
+  DEL: "DELETE",
+  ESCAPE: "ESC",
+  RETURN: "ENTER",
+  PGUP: "PAGEUP",
+  PGDN: "PAGEDOWN",
+  PRINTSCREEN: "PRINT",
+  PRTSC: "PRINT",
+};
+
+const NAMED_KEYS = new Set([
+  "LEFT",
+  "RIGHT",
+  "UP",
+  "DOWN",
+  "DELETE",
+  "TAB",
+  "ESC",
+  "ENTER",
+  "SPACE",
+  "BACKSPACE",
+  "HOME",
+  "END",
+  "PAGEUP",
+  "PAGEDOWN",
+  "INSERT",
+  "PRINT",
+]);
+
+function readKey(token: string): string | null {
+  const name = KEY_ALIASES[token] ?? token;
+  if (/^[A-Z0-9]$/.test(name)) return name;
+  if (/^F([1-9]|1[0-9]|2[0-4])$/.test(name)) return name;
+  return NAMED_KEYS.has(name) ? name : null;
+}
+
+/**
+ * Read a chord, or say it cannot be read.
+ *
+ * Null rather than a throw, and null rather than a partial chord: the
+ * caller is validation, whose job is to name every problem in one pass
+ * rather than to stop at the first. "Exactly one chord" is enforced
+ * here too — two keys, or none, is not a chord this returns.
+ */
+export function parseChord(text: string): Chord | null {
+  const parts = text.toUpperCase().split("+").map((s) => s.trim());
+  if (parts.some((p) => p === "")) return null;
+
+  const chord: Chord = { ctrl: false, alt: false, shift: false, win: false, key: "" };
+  for (const part of parts) {
+    if (part === "CTRL" || part === "CONTROL") chord.ctrl = true;
+    else if (part === "ALT") chord.alt = true;
+    else if (part === "SHIFT") chord.shift = true;
+    else if (part === "WIN" || part === "SUPER" || part === "META") chord.win = true;
+    else {
+      const key = readKey(part);
+      // A second key is not a second chord to choose between; it is a
+      // line nobody can bind. Rejected rather than silently keeping one.
+      if (!key || chord.key !== "") return null;
+      chord.key = key;
+    }
+  }
+  return chord.key === "" ? null : chord;
+}
+
+/**
+ * One spelling of a chord, for comparing and for Windows.
+ *
+ * Uppercase and in modifier order — `CTRL+ALT+SHIFT+T` — which is both
+ * how the reserved lists are pinned and, not by coincidence, the exact
+ * spelling the Start Menu shortcuts have always been written with.
+ */
+export function chordText(chord: Chord): string {
+  const parts: string[] = [];
+  if (chord.ctrl) parts.push("CTRL");
+  if (chord.alt) parts.push("ALT");
+  if (chord.shift) parts.push("SHIFT");
+  if (chord.win) parts.push("WIN");
+  parts.push(chord.key);
+  return parts.join("+");
+}

--- a/src/actions/validate.ts
+++ b/src/actions/validate.ts
@@ -1,0 +1,75 @@
+/**
+ * ADR 0006, executable.
+ *
+ * The ADR says every semantic action has one chord, that the chord is
+ * the same on every target, that it comes from the `Ctrl+Alt` family,
+ * that red-dev never claims `Super`/`Win`, and that "every new chord is
+ * checked against both hosts' reserved lists before it ships, and the
+ * schema is where that check lives". This is that check.
+ *
+ * It returns problems instead of throwing, and it collects all of them
+ * instead of stopping at the first. Someone adding six actions wants the
+ * six answers in one run; and a registry that threw while loading would
+ * take the whole program down over a typo in a key name.
+ */
+
+import type { SemanticAction } from "./types.ts";
+import { chordText, parseChord } from "./types.ts";
+
+export interface ActionProblem {
+  /** The action the problem belongs to. */
+  id: string;
+  /** One sentence, phrased for whoever just added the action. */
+  problem: string;
+}
+
+/**
+ * Area first, lowercase, dotted: `terminal.new`, `panel.network`.
+ *
+ * Stability is the reason for a shape at all — an id is what other
+ * things store — and a shape is what makes "stable" checkable rather
+ * than merely intended.
+ */
+const STABLE_ID = /^[a-z][a-z0-9]*(?:\.[a-z0-9]+)+$/;
+
+export function validateActions(actions: readonly SemanticAction[]): ActionProblem[] {
+  const problems: ActionProblem[] = [];
+  const ids = new Set<string>();
+  const chords = new Map<string, string>();
+
+  for (const action of actions) {
+    const { id } = action;
+
+    if (!STABLE_ID.test(id)) {
+      problems.push({ id, problem: `id ${JSON.stringify(id)} is not a lowercase dotted name` });
+    }
+    if (ids.has(id)) problems.push({ id, problem: `id ${JSON.stringify(id)} is used twice` });
+    ids.add(id);
+
+    if (action.label.trim() === "") problems.push({ id, problem: "has no label" });
+    if (action.platforms.length === 0) problems.push({ id, problem: "applies to no platform" });
+
+    // One chord, and one that can be read. Empty text, two keys, a
+    // modifier on its own — none of those is a chord an adapter could
+    // register, and each has to be named here rather than discovered by
+    // an adapter shrugging at runtime.
+    const chord = parseChord(action.chord);
+    if (!chord) {
+      problems.push({ id, problem: `chord ${JSON.stringify(action.chord)} is not one readable chord` });
+      continue;
+    }
+
+    const text = chordText(chord);
+    if (chord.win) {
+      problems.push({ id, problem: `chord ${text} claims Super/Win, which ADR 0006 leaves to the host` });
+    } else if (!chord.ctrl || !chord.alt) {
+      problems.push({ id, problem: `chord ${text} is outside the Ctrl+Alt family` });
+    }
+
+    const owner = chords.get(text);
+    if (owner !== undefined) problems.push({ id, problem: `chord ${text} already belongs to ${owner}` });
+    else chords.set(text, id);
+  }
+
+  return problems;
+}

--- a/src/actions/validate.ts
+++ b/src/actions/validate.ts
@@ -13,6 +13,7 @@
  * take the whole program down over a typo in a key name.
  */
 
+import { GNOME_RESERVED, WINDOWS_RESERVED } from "./reserved.ts";
 import type { SemanticAction } from "./types.ts";
 import { chordText, parseChord } from "./types.ts";
 
@@ -65,6 +66,14 @@ export function validateActions(actions: readonly SemanticAction[]): ActionProbl
     } else if (!chord.ctrl || !chord.alt) {
       problems.push({ id, problem: `chord ${text} is outside the Ctrl+Alt family` });
     }
+
+    // Both hosts, always, whichever platforms the action names. A chord
+    // is the same on every target by decision, so a collision anywhere
+    // is a collision — an action that applies to Windows alone still
+    // cannot take a key GNOME holds, because tomorrow it applies to
+    // both and nobody re-runs this thought.
+    if (GNOME_RESERVED.has(text)) problems.push({ id, problem: `chord ${text} is reserved by GNOME` });
+    if (WINDOWS_RESERVED.has(text)) problems.push({ id, problem: `chord ${text} is reserved by Windows` });
 
     const owner = chords.get(text);
     if (owner !== undefined) problems.push({ id, problem: `chord ${text} already belongs to ${owner}` });

--- a/src/hotkeys.test.ts
+++ b/src/hotkeys.test.ts
@@ -12,6 +12,7 @@
  */
 
 import { describe, expect, test } from "bun:test";
+import { actionById } from "./actions/index.ts";
 import { resolveScript, WINDOWS_HOTKEYS } from "./hotkeys.ts";
 
 const claimed = WINDOWS_HOTKEYS.filter((h) => h.combo !== null).map((h) => h.combo);
@@ -57,6 +58,41 @@ describe("the shortcuts written", () => {
     // The elevated one spent a version as a Start Menu entry with no
     // binding. It has Ctrl+Alt+Shift+T now.
     expect(WINDOWS_HOTKEYS.every((h) => h.combo !== null)).toBe(true);
+  });
+});
+
+describe("the two keys come from the action registry", () => {
+  // The migration this pins: the combos used to be literals in
+  // hotkeys.ts and are now read from the registry. Behaviour is
+  // unchanged, which is exactly the thing worth pinning — the values
+  // above are what shipped, and they have to survive the move.
+  test("each Start Menu entry names the action it registers", () => {
+    expect(WINDOWS_HOTKEYS.map((h) => h.id)).toEqual(["terminal.new", "terminal.elevated"]);
+  });
+
+  test("and carries that action's chord, spelled the way Windows is given it", () => {
+    expect(actionById("terminal.new")?.chord).toBe("Ctrl+Alt+T");
+    expect(actionById("terminal.elevated")?.chord).toBe("Ctrl+Alt+Shift+T");
+    const by = (id: string) => WINDOWS_HOTKEYS.find((h) => h.id === id)?.combo;
+    expect(by("terminal.new")).toBe("CTRL+ALT+T");
+    expect(by("terminal.elevated")).toBe("CTRL+ALT+SHIFT+T");
+  });
+
+  test("the .lnk names stay Windows' own, because machines already have them", () => {
+    // The registry calls the elevated one "Elevated shell"; renaming the
+    // shortcut would leave the old .lnk — and its key — behind.
+    expect(actionById("terminal.elevated")?.label).toBe("Elevated shell");
+    expect(WINDOWS_HOTKEYS.find((h) => h.id === "terminal.elevated")?.label)
+      .toBe("PowerShell (Administrator)");
+  });
+
+  test("and the written script carries those chords, not its own copy", () => {
+    const script = resolveScript(null);
+    expect(script).toContain("New-Hot 'Terminal' 'CTRL+ALT+T'");
+    expect(script).toContain("New-Hot 'PowerShell (Administrator)' 'CTRL+ALT+SHIFT+T'");
+    // The post-write probe asks about the terminal chord: MOD_CONTROL |
+    // MOD_ALT is 3, and 0x54 is T.
+    expect(script).toContain("RegisterHotKey([IntPtr]::Zero, 9004, 3, 0x54)");
   });
 });
 

--- a/src/hotkeys.ts
+++ b/src/hotkeys.ts
@@ -22,8 +22,15 @@
  * Assigning an empty HotKey to an existing .lnk clears its binding,
  * verified on Windows — which is what lets a converge correct a machine
  * that still carries an old one.
+ *
+ * Which two keys they are is no longer decided here. This module is the
+ * Windows adapter for two entries in the semantic action registry: it
+ * owns how a chord is registered — a .lnk in the Start Menu, byte 21 for
+ * elevation — and reads which chord it is from the registry, per ADR
+ * 0006. The keys are the same ones it always wrote.
  */
 
+import { actionById, chordText, parseChord } from "./actions/index.ts";
 import type { DriftStatus } from "./drift.ts";
 import { log, RedError } from "./log.ts";
 import type { Platform } from "./platform.ts";
@@ -36,16 +43,55 @@ import type { Platform } from "./platform.ts";
  * happens on the Windows side; this is the contract.
  */
 export interface Hotkey {
+  /** The semantic action this shortcut registers. */
+  id: string;
   label: string;
   /** null for a Start Menu entry that deliberately has no key. */
   combo: string | null;
   note: string;
 }
 
-export const WINDOWS_HOTKEYS: Hotkey[] = [
-  { label: "Terminal", combo: "CTRL+ALT+T", note: "bash inside WSL, through Alacritty when it is there" },
-  { label: "PowerShell (Administrator)", combo: "CTRL+ALT+SHIFT+T", note: "elevated" },
+/**
+ * The Windows half of two registry actions.
+ *
+ * What the entry is called belongs to Windows and stays here:
+ * `PowerShell (Administrator)` is the name of a .lnk that already exists
+ * on people's machines, not the name of the act — the registry calls
+ * that one "Elevated shell". Which key it carries belongs to the
+ * registry, and is read from it rather than repeated here. That is the
+ * migration: the values are identical, the source of truth moved.
+ */
+const START_MENU: readonly { id: string; label: string; note: string }[] = [
+  { id: "terminal.new", label: "Terminal", note: "bash inside WSL, through Alacritty when it is there" },
+  { id: "terminal.elevated", label: "PowerShell (Administrator)", note: "elevated" },
 ];
+
+/** An action's chord, spelled the way Windows has always been given it. */
+function comboFromRegistry(id: string): string | null {
+  const action = actionById(id);
+  if (!action) return null;
+  const chord = parseChord(action.chord);
+  return chord ? chordText(chord) : null;
+}
+
+export const WINDOWS_HOTKEYS: Hotkey[] = START_MENU.flatMap((entry) => {
+  const combo = comboFromRegistry(entry.id);
+  // A Start Menu entry written with no key *clears* the binding on
+  // every machine that already had one, so an action that went missing
+  // from the registry drops its shortcut rather than unbinding it. The
+  // registry test is what keeps that unreachable; this is what it would
+  // cost if it ever were not.
+  return combo === null ? [] : [{ id: entry.id, label: entry.label, combo, note: entry.note }];
+});
+
+/** The entry for an action, or a loud failure rather than a silent unbind. */
+function hotkeyFor(id: string): Hotkey & { combo: string } {
+  const found = WINDOWS_HOTKEYS.find((h) => h.id === id);
+  if (!found || found.combo === null) {
+    throw new RedError(`the action registry no longer carries ${id}, so its shortcut cannot be written`);
+  }
+  return { ...found, combo: found.combo };
+}
 
 export type HotkeyState = "held" | "free" | "unknown";
 
@@ -105,6 +151,14 @@ export function hotkeyVerdict(shortcutExists: boolean, state: HotkeyState): Drif
  */
 export function resolveScript(distro: string | null): string {
   const d = distro ? `-d ${distro} ` : "";
+  const terminal = hotkeyFor("terminal.new");
+  const elevated = hotkeyFor("terminal.elevated");
+  // The post-write probe asks Windows about the terminal key itself, so
+  // its modifiers and virtual key come from the same chord the shortcut
+  // was written with rather than from a 0x54 nobody would think to
+  // change if the chord ever did.
+  const probe = hotkeyArgs(terminal.combo);
+  if (!probe) throw new RedError(`${terminal.combo} is not a chord Windows can register`);
   return `
 $ErrorActionPreference = 'Stop'
 $dir = Join-Path $env:APPDATA 'Microsoft\\Windows\\Start Menu\\Programs\\red-dev'
@@ -167,12 +221,12 @@ function New-Hot($name, $combo, $target, $argv, $admin) {
 }
 
 if ($alacritty) {
-  New-Hot 'Terminal' 'CTRL+ALT+T' $alacritty '' $false
+  New-Hot '${terminal.label}' '${terminal.combo}' $alacritty '' $false
 } else {
-  New-Hot 'Terminal' 'CTRL+ALT+T' (Join-Path $env:SystemRoot 'System32\\wsl.exe') '${d}--cd ~' $false
+  New-Hot '${terminal.label}' '${terminal.combo}' (Join-Path $env:SystemRoot 'System32\\wsl.exe') '${d}--cd ~' $false
 }
 
-New-Hot 'PowerShell (Administrator)' 'CTRL+ALT+SHIFT+T' (Join-Path $env:SystemRoot 'System32\\WindowsPowerShell\\v1.0\\powershell.exe') '-NoLogo' $true
+New-Hot '${elevated.label}' '${elevated.combo}' (Join-Path $env:SystemRoot 'System32\\WindowsPowerShell\\v1.0\\powershell.exe') '-NoLogo' $true
 
 # When something was rewritten, make sure the key came back.
 #
@@ -189,7 +243,7 @@ if ($script:wrote) {
   $sig = 'using System; using System.Runtime.InteropServices; public class RedHK { [DllImport("user32.dll", SetLastError=true)] public static extern bool RegisterHotKey(IntPtr h, int id, uint fs, uint vk); [DllImport("user32.dll")] public static extern bool UnregisterHotKey(IntPtr h, int id); }'
   Add-Type -TypeDefinition $sig
   Start-Sleep -Milliseconds 500
-  $free = [RedHK]::RegisterHotKey([IntPtr]::Zero, 9004, 3, 0x54)
+  $free = [RedHK]::RegisterHotKey([IntPtr]::Zero, 9004, ${probe.mods}, 0x${probe.vk.toString(16).toUpperCase()})
   if ($free) {
     [RedHK]::UnregisterHotKey([IntPtr]::Zero, 9004) | Out-Null
     Stop-Process -Name explorer -Force -ErrorAction SilentlyContinue


### PR DESCRIPTION
Automated AFK landing for #136. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #136

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/156"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789430933&installation_model_id=20659&pr_number=156&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F156&signature=9d840d64dbf06d6252ecf79426e9449d265a0ddfb830d2fa20d3a6b35cc302ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->