### PR TITLE
fix: #146 The Default agent: chosen, recorded, reported

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,18 @@ a third-party wrapper and winget's `T3Tools.T3Code` is the publisher's own.
 Picking any CLI agent then offers
 [red-skills](https://github.com/reddb-io/red-skills), which registers its
 marketplace in Claude Code and Codex and generates plugin modules for RedCode.
+**The Default agent** is the one installed host red-dev hands work to — a crash
+to diagnose, a launch shortcut, a profile's required host. It is asked
+immediately after the hosts and only when the answer is a real choice: tick one
+CLI agent and that one is it, with no question, because a question with one
+answer is not a question. red-dev never starts it with a permission bypass or
+auto-approve flag — unattended is a decision made at the moment someone types
+it, not one shipped as a default. Change it later with `red-dev agents default
+<key>`, and run that with no key to see what is recorded. The record is
+validated against what is installed on every read and never healed: a host that
+has been uninstalled is reported by name in `doctor` rather than quietly
+replaced by whichever host is still there.
+
 RedCode comes from `reddb-io/redcode` release archives through GitHub's stable
 download redirect, so a clean machine does not need `gh` or an API request to
 discover it. Its published `SHA256SUMS` is verified before extraction. Existing
@@ -421,6 +433,8 @@ red-dev lang --latest node,python # newest release of each
 red-dev shell                # Windows + WSL: where a terminal lands
 red-dev agents               # choose coding agents, wire in red-skills
 red-dev agents claude-code,codex # unattended agent selection
+red-dev agents default       # which host red-dev hands work to
+red-dev agents default codex # change it
 red-dev share [path]         # one directory both WSL and Windows read
 red-dev share adopt <tool>   # move that tool's configuration into it
 red-dev uninstall            # remove tools, or red-dev's own config
@@ -503,6 +517,7 @@ deliberately:
 | `red-dev lang` | which runtimes mise should manage, then recommended or latest versions — Java, Ruby and Go start off; the rest are opt-out |
 | `red-dev shell` | whether a terminal lands in WSL or Git Bash |
 | `red-dev agents` | which coding agents — all ticked; untick to opt out, then offers red-skills |
+| `red-dev agents` | which of them is the Default agent, asked only when more than one CLI host is selected |
 | `red-dev uninstall` | what to remove — and confirms before removing it |
 | `red-dev wsl` | whether to set WSL up on a fresh Windows machine |
 | `red-dev rescue --apply` | whether to end the exact proven-orphan groups in the preview |

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -63,6 +63,13 @@ export interface AgentSpec {
   probeArgs?: string[];
   /** Desktop applications have no CLI and only exist on some targets. */
   desktopOnly?: boolean;
+  /**
+   * Runs agents rather than being one, so it is never the Default agent
+   * — see src/default-agent.ts. It belongs in this list because it is
+   * installed and offered alongside them; it just cannot answer a
+   * prompt.
+   */
+  multiplexer?: boolean;
 }
 
 export const AGENTS: AgentSpec[] = [
@@ -153,6 +160,7 @@ export const AGENTS: AgentSpec[] = [
     cmd: "herdr",
     recommended: false,
     installer: "https://herdr.dev/install.sh",
+    multiplexer: true,
   },
   {
     key: "openclaw",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -184,10 +184,20 @@ export function buildCli(): CLI {
       },
       agents: {
         description: "choose coding agents, and wire red-skills into them",
+        // Two positionals of its own, for the reason `share adopt
+        // <tool>` has two: a comma-separated selection and a
+        // subcommand's single argument are different shapes, and one
+        // positional would swallow only the first word of
+        // `agents default claude-code`.
         positional: [
           {
             name: "agent_selection",
-            description: "comma-separated agent keys for an unattended install",
+            description: "comma-separated agent keys for an unattended install, or `default`",
+            required: false,
+          },
+          {
+            name: "agent_key",
+            description: "with `default`: the one host red-dev hands work to",
             required: false,
           },
         ],
@@ -272,6 +282,13 @@ export interface Invocation {
   logsWhich: string | undefined;
   /** Explicit selections make agents/lang safe to invoke across WSL unattended. */
   agentKeys: string[] | undefined;
+  /**
+   * `agents default [key]` — naming the subcommand and naming a host
+   * are separate facts, because with no key the command reports the
+   * recorded choice rather than changing it.
+   */
+  agentDefault: boolean;
+  agentDefaultKey: string | undefined;
   runtimeIds: string[] | undefined;
   /** `lang --latest`: rewrite every selected runtime selector to `latest`. */
   latest: boolean;
@@ -328,6 +345,12 @@ export function parseArgs(cli: CLI, argv: string[]): Invocation {
   const literalWallpaper = wallpaperCommand >= 0 ? argv[wallpaperCommand + 1] : undefined;
   const rawWallpaper = pos["wallpaper_name"] ??
     (literalWallpaper && !literalWallpaper.startsWith("-") ? literalWallpaper : undefined);
+
+  // `default` in the selection slot is the subcommand, not an agent key
+  // — no agent is called that, and reading it as one would try to
+  // install it and fail with a list of the real names.
+  const rawAgents = pos["agent_selection"];
+  const agentDefault = rawAgents === "default";
   return {
     command: r.command[0] ?? null,
     // `theme <name>` and `plan <scope>` both land in the positional map
@@ -335,9 +358,12 @@ export function parseArgs(cli: CLI, argv: string[]): Invocation {
     scope: scope ?? (typeof rawName === "string" ? rawName : undefined),
     logsWhich: typeof pos["which"] === "string" ? pos["which"] : undefined,
     agentKeys:
-      typeof pos["agent_selection"] === "string"
-        ? pos["agent_selection"].split(",").map((value) => value.trim()).filter(Boolean)
+      typeof rawAgents === "string" && !agentDefault
+        ? rawAgents.split(",").map((value) => value.trim()).filter(Boolean)
         : undefined,
+    agentDefault,
+    agentDefaultKey:
+      agentDefault && typeof pos["agent_key"] === "string" ? pos["agent_key"] : undefined,
     runtimeIds:
       typeof pos["runtime_selection"] === "string"
         ? pos["runtime_selection"].split(",").map((value) => value.trim()).filter(Boolean)

--- a/src/default-agent.test.ts
+++ b/src/default-agent.test.ts
@@ -1,0 +1,245 @@
+/**
+ * The Default agent: chosen, recorded, reported.
+ *
+ * The four things that have to stay true are the four ways this goes
+ * wrong. One host must not produce a question nobody needed. Several
+ * hosts must not produce an answer nobody gave. A host that has been
+ * uninstalled must be named, not replaced. And the recorded answer must
+ * survive the next converge, which rewrites the file it lives in.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { describe, expect, test } from "bun:test";
+import { AGENTS, type AgentSpec } from "./agents.ts";
+import {
+  defaultAgentCandidates,
+  defaultAgentFrom,
+  impliedDefaultAgent,
+  needsDefaultAgentChoice,
+  readDefaultAgent,
+  reportDefaultAgent,
+} from "./default-agent.ts";
+import { checkDefaultAgent } from "./drift.ts";
+import { preferencesFromAnswers } from "./firstrun.ts";
+import type { Platform } from "./platform.ts";
+import { readPreferences, writePreferences } from "./preferences.ts";
+import { questions, stepChoices, stepAvailable, type SetupAnswers } from "./tui-setup-model.ts";
+
+const LINUX: Platform = {
+  os: "linux",
+  distro: "ubuntu",
+  version: "24.04",
+  codename: "noble",
+  env: "desktop",
+  arch: "x64",
+  caps: { apt: true, gui: true, systemd: true, winget: false, flatpak: true },
+};
+
+/** A machine with no preferences on it, torn down with the test. */
+async function onFreshMachine<T>(run: () => Promise<T>): Promise<T> {
+  const previous = process.env["HOME"];
+  const home = mkdtempSync(`${tmpdir()}/red-dev-default-agent-`);
+  process.env["HOME"] = home;
+  try {
+    return await run();
+  } finally {
+    if (previous === undefined) delete process.env["HOME"];
+    else process.env["HOME"] = previous;
+    rmSync(home, { recursive: true, force: true });
+  }
+}
+
+/** The interview's Default step, built over the real host catalog. */
+function defaultStep(selected: string[]) {
+  const hosts = AGENTS.filter((agent) => agent.cmd.length > 0).map((agent) => ({
+    key: agent.key,
+    label: agent.label,
+    note: agent.about,
+  }));
+  const step = questions(LINUX, hosts, [], []).find((q) => q.id === "default-agent");
+  if (!step) throw new Error("no 'default-agent' step");
+  const picked = (id: string): string[] => (id === "agents" ? selected : []);
+  return {
+    shown: stepAvailable(step, picked),
+    choices: stepChoices(step, picked).map((choice) => choice.key),
+    step,
+  };
+}
+
+function answers(overrides: Partial<SetupAnswers> = {}): SetupAnswers {
+  return {
+    theme: "dark",
+    font: "firacode",
+    apps: [],
+    runtimes: [],
+    agents: [],
+    blesh: false,
+    redwall: true,
+    share: false,
+    completed: true,
+    ...overrides,
+  };
+}
+
+const installed = (...keys: string[]) => (agent: AgentSpec): boolean => keys.includes(agent.key);
+
+describe("one CLI host", () => {
+  test("is the Default agent without being asked about", () => {
+    expect(impliedDefaultAgent(["claude-code"])).toBe("claude-code");
+    expect(needsDefaultAgentChoice(["claude-code"])).toBe(false);
+  });
+
+  test("closes the question in the interview rather than posing it", () => {
+    // Not "the step is answered for you" — the step is not drawn at
+    // all. A one-answer question is a keypress asking for nothing.
+    expect(defaultStep(["claude-code"]).shown).toBe(false);
+  });
+
+  test("is still the one host when the rest of the selection cannot answer prompts", () => {
+    // Claude Desktop has no command and Herdr runs agents rather than
+    // being one, so neither makes this a choice.
+    expect(impliedDefaultAgent(["claude-code", "claude-desktop", "herdr"])).toBe("claude-code");
+    expect(defaultStep(["claude-code", "herdr"]).shown).toBe(false);
+  });
+
+  test("is settled the same way whichever name the selection was recorded under", () => {
+    // OpenCode was renamed RedCode; a selection recorded before that is
+    // one host, not an unknown one.
+    expect(impliedDefaultAgent(["opencode"])).toBe("redcode");
+  });
+});
+
+describe("several CLI hosts", () => {
+  test("require an explicit choice", () => {
+    expect(needsDefaultAgentChoice(["claude-code", "codex"])).toBe(true);
+    expect(impliedDefaultAgent(["claude-code", "codex"])).toBeNull();
+  });
+
+  test("leave the Default agent unset until someone answers", () => {
+    // The failure this pins is a silent first-in-the-list default,
+    // which records the same value whether or not anyone was asked.
+    expect(defaultAgentFrom(["claude-code", "codex"])).toBeUndefined();
+    expect(defaultAgentFrom(["claude-code", "codex"], "codex")).toBe("codex");
+  });
+
+  test("do not accept an answer that is not one of them", () => {
+    expect(defaultAgentFrom(["claude-code", "codex"], "gemini")).toBeUndefined();
+  });
+
+  test("are the interview's choices, and nothing else on the catalog", () => {
+    const step = defaultStep(["claude-code", "codex"]);
+    expect(step.shown).toBe(true);
+    expect(step.choices).toEqual(["claude-code", "codex"]);
+  });
+
+  test("are asked about immediately after the hosts", () => {
+    const ids = questions(LINUX, [{ key: "claude-code", label: "Claude Code", note: "" }], [], [])
+      .map((step) => step.id);
+    expect(ids[ids.indexOf("agents") + 1]).toBe("default-agent");
+  });
+
+  test("narrowing back to one drops the question and the stale answer with it", () => {
+    // Someone who answers, goes back and unticks a host has not chosen
+    // the one they removed.
+    expect(defaultAgentFrom(["claude-code"], "codex")).toBe("claude-code");
+  });
+});
+
+describe("a stored Default agent that is no longer installed", () => {
+  test("is reported under its own name", () => {
+    const reading = readDefaultAgent("claude-code", installed("codex"));
+    expect(reading.state).toBe("absent");
+    expect(reading.key).toBe("claude-code");
+  });
+
+  test("is never silently re-chosen as the host that is still there", () => {
+    const reading = readDefaultAgent("claude-code", installed("codex", "redcode"));
+    const report = reportDefaultAgent(reading, ["claude-code", "codex", "redcode"]);
+    expect(report.status).toBe("drift");
+    expect(report.detail).toContain("Claude Code");
+    expect(report.detail).not.toContain("Codex");
+    expect(report.detail).not.toContain("RedCode");
+  });
+
+  test("is reported by doctor, with the host it is still waiting for", async () => {
+    await onFreshMachine(async () => {
+      await writePreferences(LINUX, {
+        agents: ["claude-code", "codex"],
+        defaultAgent: "claude-code",
+      });
+      const check = await checkDefaultAgent(LINUX, installed("codex"));
+      expect(check.status).toBe("drift");
+      expect(check.detail).toContain("Claude Code");
+      expect(check.fix).toContain("red-dev agents claude-code");
+    });
+  });
+
+  test("is distinguished from a record that names nothing red-dev knows", () => {
+    const reading = readDefaultAgent("kubernetes", installed("codex"));
+    expect(reading.state).toBe("unknown");
+    expect(reportDefaultAgent(reading, ["codex"]).status).toBe("drift");
+  });
+
+  test("is not the same as never having chosen one", () => {
+    // Unset is a legitimate state, so doctor does not report a fault
+    // for a question this machine was never asked.
+    expect(readDefaultAgent(undefined, installed("codex")).state).toBe("unset");
+    expect(reportDefaultAgent(readDefaultAgent(undefined, () => true), []).status).toBe("n/a");
+    expect(
+      reportDefaultAgent(readDefaultAgent("  ", () => true), ["claude-code", "codex"]).status,
+    ).toBe("n/a");
+  });
+});
+
+describe("the recorded choice", () => {
+  test("survives a converge and is readable by doctor", async () => {
+    await onFreshMachine(async () => {
+      await writePreferences(
+        LINUX,
+        preferencesFromAnswers(
+          answers({ agents: ["claude-code", "codex"], defaultAgent: "codex" }),
+        ),
+      );
+
+      // What a converge does to this file: rewrite the answers it knows
+      // about. An interview that settled on nothing must not take the
+      // recorded host down with it.
+      await writePreferences(
+        LINUX,
+        preferencesFromAnswers(answers({ theme: "cobalt", agents: ["claude-code", "codex"] })),
+      );
+
+      expect((await readPreferences(LINUX)).defaultAgent).toBe("codex");
+      const check = await checkDefaultAgent(LINUX, installed("claude-code", "codex"));
+      expect(check.status).toBe("ok");
+      expect(check.detail).toContain("Codex CLI");
+      expect(check.detail).toContain("codex");
+    });
+  });
+
+  test("is what the interview writes down when the selection settles it alone", () => {
+    const prefs = preferencesFromAnswers(
+      answers({ agents: ["claude-code"], defaultAgent: "claude-code" }),
+    );
+    expect(prefs.defaultAgent).toBe("claude-code");
+  });
+
+  test("is absent from a write that has nothing to say about it", () => {
+    // Present-and-undefined would erase the stored value on merge,
+    // which is the same bug as choosing a replacement, arrived at by
+    // accident.
+    expect("defaultAgent" in preferencesFromAnswers(answers({ agents: ["a", "b"] }))).toBe(false);
+  });
+});
+
+describe("the hosts a Default agent may be", () => {
+  test("exclude desktop applications and the multiplexer", () => {
+    const keys = defaultAgentCandidates(AGENTS.map((agent) => agent.key)).map((a) => a.key);
+    expect(keys).toContain("claude-code");
+    expect(keys).not.toContain("claude-desktop");
+    expect(keys).not.toContain("codex-desktop");
+    expect(keys).not.toContain("t3code");
+    expect(keys).not.toContain("herdr");
+  });
+});

--- a/src/default-agent.ts
+++ b/src/default-agent.ts
@@ -1,0 +1,170 @@
+/**
+ * The Default agent: the one installed agent host red-dev hands work to.
+ *
+ * A crash to diagnose, a launch shortcut, a profile's required host —
+ * they all need a target, and until now each surface would have had to
+ * guess one from whatever happened to be on PATH. A guess is not a
+ * choice, and the difference shows the day a second host is installed
+ * and the answer moves without anyone deciding it should.
+ *
+ * Two rules do the work here and they pull in opposite directions on
+ * purpose:
+ *
+ *   - Where there is a real choice, ask. More than one CLI host means
+ *     more than one plausible answer, and picking the first in a list is
+ *     the guess this exists to remove.
+ *   - Where there is no choice, say nothing. One CLI host is not a
+ *     decision, and a question with one possible answer is noise.
+ *
+ * And once recorded it is never quietly replaced. A machine that has
+ * lost claude-code reports claude-code as gone; it does not start
+ * answering as codex, because the person who reads "default agent:
+ * Codex CLI" has no way to tell that from a choice they made.
+ *
+ * See .red/contexts/agents/CONTEXT.md.
+ */
+
+import { AGENTS, currentAgentKeys, type AgentSpec } from "./agents.ts";
+
+/**
+ * Which hosts may be the Default agent.
+ *
+ * Desktop applications are out because red-dev hands work to a command
+ * and they have none — that is what `cmd: ""` means. A multiplexer is
+ * out because it runs agents rather than being one; see herdr's entry
+ * in agents.ts, which says so in its own words.
+ */
+export function isDefaultAgentCandidate(a: AgentSpec): boolean {
+  return !a.desktopOnly && !a.multiplexer && a.cmd.length > 0;
+}
+
+/** The hosts in a selection that could be the Default agent. */
+export function defaultAgentCandidates(selected: readonly string[]): AgentSpec[] {
+  const keys = currentAgentKeys(selected);
+  return AGENTS.filter((a) => keys.includes(a.key) && isDefaultAgentCandidate(a));
+}
+
+/**
+ * The Default agent a selection settles on by itself, or null when
+ * there is something to ask.
+ */
+export function impliedDefaultAgent(selected: readonly string[]): string | null {
+  const candidates = defaultAgentCandidates(selected);
+  return candidates.length === 1 ? candidates[0]!.key : null;
+}
+
+/** Whether the person has to be asked which host is the Default agent. */
+export function needsDefaultAgentChoice(selected: readonly string[]): boolean {
+  return defaultAgentCandidates(selected).length > 1;
+}
+
+/**
+ * What to record for a selection, given whatever answer was collected.
+ *
+ * An unanswered choice stays unanswered. Returning the first candidate
+ * here would make the interview's question decorative — the recorded
+ * value would be the same whether or not anyone looked at it.
+ */
+export function defaultAgentFrom(
+  selected: readonly string[],
+  answer?: string | undefined,
+): string | undefined {
+  const implied = impliedDefaultAgent(selected);
+  if (implied) return implied;
+  return defaultAgentCandidates(selected).some((a) => a.key === answer) ? answer : undefined;
+}
+
+export type DefaultAgentState =
+  /** Nothing recorded. A legitimate state, not a fault. */
+  | "unset"
+  /** Recorded, known, and installed. */
+  | "ready"
+  /** Recorded and known, but no longer on this machine. */
+  | "absent"
+  /** Recorded and not a host red-dev can hand work to. */
+  | "unknown";
+
+export interface DefaultAgentReading {
+  state: DefaultAgentState;
+  /** The host the record resolves to, under its own name. */
+  key: string | null;
+  label: string | null;
+  /** What was written down, verbatim, whatever became of it. */
+  recorded: string | null;
+}
+
+/**
+ * Read the recorded choice against the installed set.
+ *
+ * The installed test is injected rather than reached for, so a caller
+ * that already knows what is present does not probe PATH again — and so
+ * this is answerable in a test without installing an agent.
+ */
+export function readDefaultAgent(
+  stored: string | undefined,
+  installed: (a: AgentSpec) => boolean,
+): DefaultAgentReading {
+  const recorded = typeof stored === "string" ? stored.trim() : "";
+  if (recorded === "") return { state: "unset", key: null, label: null, recorded: null };
+
+  // Through currentAgentKeys, so a selection recorded before OpenCode
+  // was renamed resolves to RedCode. That is the same host under a new
+  // name, which is the one substitution that is not a replacement.
+  const key = currentAgentKeys([recorded])[0];
+  const spec = AGENTS.find((a) => a.key === key);
+  if (!spec || !isDefaultAgentCandidate(spec)) {
+    return { state: "unknown", key: null, label: null, recorded };
+  }
+  return {
+    state: installed(spec) ? "ready" : "absent",
+    key: spec.key,
+    label: spec.label,
+    recorded,
+  };
+}
+
+export interface DefaultAgentReport {
+  status: "ok" | "drift" | "n/a";
+  detail: string;
+  /** What to run. Omitted when there is nothing to do. */
+  fix?: string;
+}
+
+/**
+ * The recorded choice as a line `doctor` can print.
+ *
+ * Unset is `n/a` rather than drift: the Default agent is allowed to be
+ * unset, and a machine nobody has answered for should not report a
+ * fault for a question it was never asked.
+ */
+export function reportDefaultAgent(
+  reading: DefaultAgentReading,
+  selected: readonly string[],
+): DefaultAgentReport {
+  switch (reading.state) {
+    case "ready":
+      return { status: "ok", detail: `${reading.label} (${reading.key})` };
+    case "absent":
+      // Named under the recorded host and nothing else. Suggesting a
+      // replacement here is one keystroke away from performing one.
+      return {
+        status: "drift",
+        detail: `${reading.label} is recorded and no longer installed`,
+        fix: `red-dev agents ${reading.key} — or choose another: red-dev agents default <key>`,
+      };
+    case "unknown":
+      return {
+        status: "drift",
+        detail: `'${reading.recorded}' is not a host red-dev can hand work to`,
+        fix: "red-dev agents default <key>",
+      };
+    case "unset": {
+      const candidates = defaultAgentCandidates(selected);
+      if (candidates.length === 0) return { status: "n/a", detail: "no CLI agent host selected" };
+      return {
+        status: "n/a",
+        detail: `not chosen — red-dev agents default <${candidates.map((a) => a.key).join("|")}>`,
+      };
+    }
+  }
+}

--- a/src/drift.ts
+++ b/src/drift.ts
@@ -13,6 +13,7 @@
  */
 
 import { existsSync, readFileSync } from "node:fs";
+import type { AgentSpec } from "./agents.ts";
 import type { Platform } from "./platform.ts";
 import { missingRights } from "./rights.ts";
 
@@ -535,6 +536,39 @@ async function checkRedSkillsSource(): Promise<DriftCheck> {
   }
 }
 
+/**
+ * Which host red-dev hands work to, and whether it is still there.
+ *
+ * The recorded choice is validated against the installed set on every
+ * read and never healed: an agent that has been uninstalled is reported
+ * under its own name. Substituting whichever host remains would make
+ * the report agree with the machine by changing the answer, which is
+ * the one outcome a recorded decision exists to prevent.
+ *
+ * The installed test is a parameter so a caller that has already
+ * probed does not probe again — and so this is answerable without an
+ * agent on PATH.
+ */
+export async function checkDefaultAgent(
+  p: Platform,
+  installed?: (a: AgentSpec) => boolean,
+): Promise<DriftCheck> {
+  const [{ readPreferences }, { readDefaultAgent, reportDefaultAgent }, agents] = await Promise.all([
+    import("./preferences.ts"),
+    import("./default-agent.ts"),
+    import("./agents.ts"),
+  ]);
+  const prefs = await readPreferences(p);
+  const reading = readDefaultAgent(prefs.defaultAgent, installed ?? agents.isAgentInstalled);
+  const report = reportDefaultAgent(reading, prefs.agents ?? []);
+  return {
+    name: "default agent",
+    status: report.status,
+    detail: report.detail,
+    ...(report.fix ? { fix: report.fix } : {}),
+  };
+}
+
 export async function collectDrift(p: Platform): Promise<DriftCheck[]> {
   const checks: DriftCheck[] = [];
   checks.push(await checkDotfiles());
@@ -546,6 +580,7 @@ export async function collectDrift(p: Platform): Promise<DriftCheck[]> {
   checks.push(await checkFont(p));
   checks.push(await checkWslDistro(p));
   checks.push(await checkRedSkillsSource());
+  checks.push(await checkDefaultAgent(p));
   checks.push(await checkDelta());
   checks.push(await checkRuntimes());
   checks.push(await checkDocker(p));

--- a/src/firstrun.ts
+++ b/src/firstrun.ts
@@ -75,6 +75,12 @@ export function preferencesFromAnswers(answers: SetupAnswers): Preferences {
     redwall: answers.redwall,
     agents: answers.agents,
     runtimes: answers.runtimes,
+    // Conditional, and that is the whole of how the choice survives a
+    // converge: writePreferences merges, but a key present and
+    // undefined overwrites the stored value with nothing. An interview
+    // that settled on no Default agent must leave the recorded one
+    // alone rather than erase it.
+    ...(answers.defaultAgent ? { defaultAgent: answers.defaultAgent } : {}),
     ...(answers.terminalShell ? { terminalShell: answers.terminalShell } : {}),
     ...(answers.terminalShell === "wsl" && process.env["WSL_DISTRO_NAME"]
       ? { distro: process.env["WSL_DISTRO_NAME"] }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1303,6 +1303,8 @@ async function cmdAgents(p: Platform, inv: Invocation): Promise<number> {
     await import("./agents.ts");
   const available = availableAgents(p);
 
+  if (inv.agentDefault) return await cmdAgentsDefault(p, inv.agentDefaultKey);
+
   if (inv.agentKeys !== undefined) {
     inv = { ...inv, agentKeys: currentAgentKeys(inv.agentKeys) };
   }
@@ -1345,6 +1347,10 @@ async function cmdAgents(p: Platform, inv: Invocation): Promise<number> {
     if (p.os === "windows") {
       const { writePreferences } = await import("./preferences.ts");
       await writePreferences(p, { agents: inv.agentKeys });
+      // ask: false — this branch is the bridge into WSL and is
+      // deliberately prompt-free, so a selection with a real choice in
+      // it stays unanswered rather than being answered by a machine.
+      await settleDefaultAgent(p, inv.agentKeys, false);
       const { syncSelectedTooling } = await import("./wsl-sync.ts");
       failures += await syncSelectedTooling(p);
     }
@@ -1377,6 +1383,7 @@ async function cmdAgents(p: Platform, inv: Invocation): Promise<number> {
 
   const { writePreferences } = await import("./preferences.ts");
   await writePreferences(p, { agents: keys });
+  await settleDefaultAgent(p, keys, true);
 
   for (const key of keys) {
     const agent = available.find((a) => a.key === key);
@@ -1417,6 +1424,95 @@ async function cmdAgents(p: Platform, inv: Invocation): Promise<number> {
   }
 
   return failures > 0 ? 1 : 0;
+}
+
+/**
+ * Settle the Default agent for a selection that was just recorded.
+ *
+ * Silent when the selection holds one CLI host, because there is
+ * nothing to decide. A question when it holds several — unless the
+ * recorded answer is still one of them, in which case re-running
+ * `red-dev agents` would be asking someone to repeat themselves.
+ */
+async function settleDefaultAgent(p: Platform, keys: string[], ask: boolean): Promise<void> {
+  const { defaultAgentCandidates, impliedDefaultAgent } = await import("./default-agent.ts");
+  const { readPreferences, writePreferences } = await import("./preferences.ts");
+
+  const implied = impliedDefaultAgent(keys);
+  if (implied) {
+    await writePreferences(p, { defaultAgent: implied });
+    return;
+  }
+
+  const candidates = defaultAgentCandidates(keys);
+  if (candidates.length === 0) return;
+  const recorded = (await readPreferences(p)).defaultAgent;
+  if (candidates.some((agent) => agent.key === recorded)) return;
+
+  if (!ask || !interactive()) {
+    log.skip("more than one agent host — name the default: red-dev agents default <key>");
+    return;
+  }
+
+  const { select } = await import("./ui.ts");
+  const labels = candidates.map((agent) => `${agent.key} — ${agent.label}`);
+  const picked = await select(
+    "Which one does red-dev hand work to?",
+    labels as [string, ...string[]],
+    labels[0]!,
+  );
+  await writePreferences(p, { defaultAgent: picked.split(" ")[0]! });
+}
+
+/**
+ * `red-dev agents default [key]` — report the recorded host, or record
+ * a different one.
+ *
+ * Naming a host that is not installed is allowed and warned about
+ * rather than refused: someone setting a machine up in the order they
+ * choose is not making a mistake, and `doctor` says the same thing
+ * afterwards until the host arrives.
+ */
+async function cmdAgentsDefault(p: Platform, key: string | undefined): Promise<number> {
+  const { AGENTS, availableAgents, currentAgentKeys, isAgentInstalled } = await import(
+    "./agents.ts"
+  );
+  const { isDefaultAgentCandidate, readDefaultAgent, reportDefaultAgent } = await import(
+    "./default-agent.ts"
+  );
+  const { readPreferences, writePreferences } = await import("./preferences.ts");
+  const offered = availableAgents(p).filter(isDefaultAgentCandidate);
+
+  if (key === undefined) {
+    const prefs = await readPreferences(p);
+    const report = reportDefaultAgent(
+      readDefaultAgent(prefs.defaultAgent, isAgentInstalled),
+      prefs.agents ?? [],
+    );
+    if (report.status === "ok") log.ok(report.detail);
+    else if (report.status === "n/a") log.skip(report.detail);
+    else log.err(report.detail);
+    if (report.fix) log.plain(`       fix: ${report.fix}`);
+    log.plain(`     hosts here: ${offered.map((agent) => agent.key).join(", ")}`);
+    return report.status === "drift" ? 1 : 0;
+  }
+
+  const resolved = currentAgentKeys([key])[0];
+  const spec = AGENTS.find((agent) => agent.key === resolved);
+  if (!spec || !isDefaultAgentCandidate(spec)) {
+    log.err(`'${key}' is not a host red-dev can hand work to`);
+    log.plain(`     hosts here: ${offered.map((agent) => agent.key).join(", ")}`);
+    return 1;
+  }
+  if (!offered.some((agent) => agent.key === spec.key)) {
+    log.err(`${spec.label} has no installer for this side`);
+    return 1;
+  }
+
+  await writePreferences(p, { defaultAgent: spec.key });
+  log.ok(`default agent: ${spec.label}`);
+  if (!isAgentInstalled(spec)) log.warn(`not installed yet — red-dev agents ${spec.key}`);
+  return 0;
 }
 
 /** Choose which language runtimes mise manages. */

--- a/src/preferences.ts
+++ b/src/preferences.ts
@@ -59,6 +59,15 @@ export interface Preferences {
   redwallInterface?: string;
   /** Agent keys chosen for this workstation, mirrored into WSL when selected. */
   agents?: string[];
+  /**
+   * The one host red-dev hands work to — see src/default-agent.ts.
+   *
+   * Recorded here beside the selection it comes from rather than
+   * derived from it on every read, because "which of these did you
+   * choose" is not answerable from the list. Absent is unset, and unset
+   * is a state red-dev reports rather than fills in.
+   */
+  defaultAgent?: string;
   /** mise runtime ids chosen for this workstation. */
   runtimes?: string[];
   /** Ids of one-off repairs already applied; see src/migrations.ts. */

--- a/src/tui-setup-model.ts
+++ b/src/tui-setup-model.ts
@@ -26,6 +26,11 @@ import {
 import { createWizard } from "tuiuiu.js/hooks";
 import type { Platform } from "./platform.ts";
 import { summary } from "./platform.ts";
+import {
+  defaultAgentCandidates,
+  defaultAgentFrom,
+  needsDefaultAgentChoice,
+} from "./default-agent.ts";
 import { CenteredScreen, centeredFrame, Surface } from "./tui-chrome.ts";
 import { muted, ui } from "./tui-theme.ts";
 import { DEFAULT_THEME, swatches, THEMES, themeNames } from "./themes.ts";
@@ -46,6 +51,8 @@ export interface SetupAnswers {
   apps: string[];
   runtimes: string[];
   agents: string[];
+  /** The one host red-dev hands work to. Absent when nothing was chosen. */
+  defaultAgent?: string;
   blesh: boolean;
   /** Whether the wallpaper carries live machine state. On unless opted out. */
   redwall: boolean;
@@ -62,6 +69,9 @@ export interface Choice {
   note: string;
 }
 
+/** How a step reads the answers given so far. */
+export type Picked = (id: string) => string[];
+
 /** One step: a question, its choices, and how many may be picked. */
 export interface Question {
   id: string;
@@ -69,10 +79,33 @@ export interface Question {
   description: string;
   multi: boolean;
   choices: Choice[];
+  /**
+   * Choices that depend on an earlier answer, used instead of `choices`
+   * when present — the Default agent is one of the hosts the Agents
+   * step selected, and that list is not known when the steps are built.
+   */
+  choicesFrom?: (picked: Picked) => Choice[];
   /** Pre-selected keys. */
   preset: string[];
   /** Hidden when this returns false — the WSL steps on a Linux desktop. */
   applies: (p: Platform) => boolean;
+  /**
+   * Hidden when an earlier answer left nothing to decide, as distinct
+   * from `applies`, which is settled before the interview starts. The
+   * Default agent step disappears the moment the selection narrows to
+   * one CLI host, because a question with one answer is not a question.
+   */
+  available?: (picked: Picked) => boolean;
+}
+
+/** The choices a step is offering right now. */
+export function stepChoices(q: Question, picked: Picked): Choice[] {
+  return q.choicesFrom ? q.choicesFrom(picked) : q.choices;
+}
+
+/** Whether a step has anything to ask, given the answers so far. */
+export function stepAvailable(q: Question, picked: Picked): boolean {
+  return q.available?.(picked) ?? true;
 }
 
 const FONTS: Choice[] = [
@@ -88,7 +121,10 @@ export function questions(
   apps: Choice[],
   runtimes: Choice[],
 ): Question[] {
-  return [
+  // Annotated rather than inferred: the return type does not reach
+  // through `.filter` to type a step's callbacks, so `choicesFrom` and
+  // `available` would arrive with implicit `any` parameters.
+  const all: Question[] = [
     {
       // First, and before anything that writes a file.
       //
@@ -144,6 +180,33 @@ export function questions(
       choices: agents,
       preset: agents.map((agent) => agent.key),
       applies: () => true,
+    },
+    {
+      // Immediately after the hosts, because it is a question about the
+      // answer just given and about nothing else.
+      //
+      // Shown only when the selection left a real choice. Tick one CLI
+      // host and this step is never drawn — that host is the Default
+      // agent and there was nothing to ask. See src/default-agent.ts.
+      id: "default-agent",
+      title: "Default",
+      description:
+        "The one host red-dev hands work to: a crash to diagnose, a launch shortcut, " +
+        "a profile's required host. red-dev never starts it with a permission bypass " +
+        "— unattended is a decision you make when you type it, not one shipped as a " +
+        "default. Change it later with `red-dev agents default <key>`.",
+      multi: false,
+      choices: [],
+      // From the hosts on the previous screen rather than the catalog,
+      // so a host reads the same on both — including whether it is
+      // already installed.
+      choicesFrom: (picked) => {
+        const keys = defaultAgentCandidates(picked("agents")).map((agent) => agent.key);
+        return agents.filter((agent) => keys.includes(agent.key));
+      },
+      preset: [],
+      applies: () => true,
+      available: (picked) => needsDefaultAgentChoice(picked("agents")),
     },
     {
       id: "runtimes",
@@ -264,7 +327,8 @@ export function questions(
       preset: ["yes"],
       applies: () => true,
     },
-  ].filter((q) => q.applies(p));
+  ];
+  return all.filter((q) => q.applies(p));
 }
 
 
@@ -311,6 +375,23 @@ export function useSetupModel(steps: Question[], wizard: ReturnType<typeof creat
   const step = (): Question => steps[stepIndex()]!;
   const selection = (): string[] => picked()[step().id] ?? [];
   const get = (id: string): string[] => picked()[id] ?? [];
+  const choices = (): Choice[] => stepChoices(step(), get);
+
+  /**
+   * The next step in a direction that still has something to ask, or
+   * null when there is none.
+   *
+   * Takes the answers explicitly rather than reading the signal,
+   * because the step being left may have just changed them — and
+   * whether the following step applies can depend on exactly that.
+   */
+  const adjacent = (from: number, dir: 1 | -1, state: Record<string, string[]>): number | null => {
+    const at = (id: string): string[] => state[id] ?? [];
+    for (let i = from + dir; i >= 0 && i < steps.length; i += dir) {
+      if (stepAvailable(steps[i]!, at)) return i;
+    }
+    return null;
+  };
 
   return {
     steps,
@@ -319,24 +400,33 @@ export function useSetupModel(steps: Question[], wizard: ReturnType<typeof creat
     selection,
     pickedFor: get,
     wizard,
-    answers: () => ({
-      theme: get("theme")[0] ?? DEFAULT_THEME,
-      ...(get("wallpaper")[0] && get("wallpaper")[0] !== "theme"
-        ? { wallpaper: get("wallpaper")[0] as ThemeSlug }
-        : {}),
-      font: get("font")[0] ?? "firacode",
-      apps: get("apps"),
-      runtimes: get("runtimes"),
-      agents: get("agents"),
-      blesh: get("plugins").includes("blesh"),
-      redwall: get("redwall")[0] === "yes",
-      share: get("share")[0] === "yes",
-      ...(get("shell")[0] ? { terminalShell: get("shell")[0] as "wsl" | "gitbash" } : {}),
-      completed: true,
-    }),
+    answers: () => {
+      // Resolved rather than read straight out of the step, because the
+      // step may never have been drawn: one CLI host answers this
+      // question by existing, and someone who narrowed the selection
+      // after answering it leaves a key here that is no longer chosen.
+      const defaultAgent = defaultAgentFrom(get("agents"), get("default-agent")[0]);
+      return {
+        theme: get("theme")[0] ?? DEFAULT_THEME,
+        ...(get("wallpaper")[0] && get("wallpaper")[0] !== "theme"
+          ? { wallpaper: get("wallpaper")[0] as ThemeSlug }
+          : {}),
+        font: get("font")[0] ?? "firacode",
+        apps: get("apps"),
+        runtimes: get("runtimes"),
+        agents: get("agents"),
+        ...(defaultAgent ? { defaultAgent } : {}),
+        blesh: get("plugins").includes("blesh"),
+        redwall: get("redwall")[0] === "yes",
+        share: get("share")[0] === "yes",
+        ...(get("shell")[0] ? { terminalShell: get("shell")[0] as "wsl" | "gitbash" } : {}),
+        completed: true,
+      };
+    },
     handleKey: (input, key) => {
       const q = step();
-      const max = q.choices.length - 1;
+      const options = choices();
+      const max = options.length - 1;
 
       if (key.upArrow || input === "k") {
         setCursor(Math.max(0, cursor() - 1));
@@ -347,7 +437,7 @@ export function useSetupModel(steps: Question[], wizard: ReturnType<typeof creat
         return "handled";
       }
       if (q.id === "runtimes" && (key.leftArrow || key.rightArrow || input === "h" || input === "l")) {
-        const choice = q.choices[cursor()];
+        const choice = options[cursor()];
         if (choice) {
           setPicked({
             ...picked(),
@@ -361,7 +451,7 @@ export function useSetupModel(steps: Question[], wizard: ReturnType<typeof creat
         return "handled";
       }
       if (input === " " && q.multi) {
-        const k = q.choices[cursor()]!.key;
+        const k = options[cursor()]!.key;
         const cur = selection();
         setPicked({
           ...picked(),
@@ -372,21 +462,30 @@ export function useSetupModel(steps: Question[], wizard: ReturnType<typeof creat
         return "handled";
       }
       if (key.return) {
+        const from = stepIndex();
         // Single-choice steps take whatever the cursor is on, so there is
         // no separate "select then confirm" for a one-of-N answer.
-        if (!q.multi) setPicked({ ...picked(), [q.id]: [q.choices[cursor()]!.key] });
-        wizard.markCompleted(stepIndex());
-        if (stepIndex() >= steps.length - 1) return "done";
-        setStepIndex(stepIndex() + 1);
+        const answered = q.multi || !options[cursor()]
+          ? picked()
+          : { ...picked(), [q.id]: [options[cursor()]!.key] };
+        if (answered !== picked()) setPicked(answered);
+        wizard.markCompleted(from);
+        const next = adjacent(from, 1, answered);
+        if (next === null) return "done";
+        setStepIndex(next);
         setCursor(0);
-        wizard.next();
+        // Once per step crossed, so the wizard's own position keeps up
+        // with a jump over a question that had nothing to ask.
+        for (let i = from; i < next; i++) wizard.next();
         return "handled";
       }
       if ((key.leftArrow && q.id !== "runtimes") || key.escape) {
-        if (stepIndex() > 0) {
-          setStepIndex(stepIndex() - 1);
+        const from = stepIndex();
+        const back = adjacent(from, -1, picked());
+        if (back !== null) {
+          setStepIndex(back);
           setCursor(0);
-          wizard.prev();
+          for (let i = back; i < from; i++) wizard.prev();
         }
         return "handled";
       }
@@ -426,7 +525,15 @@ export function SetupLayout(m: SetupModel, p: Platform, width: number, height: n
   const rightWidth = twoColumn ? frame.width - leftWidth - 3 : frame.width;
   const isTheme = q.id === "theme";
   const isRuntimes = q.id === "runtimes";
-  const activeKey = q.choices[m.cursor()]?.key ?? "";
+  const options = stepChoices(q, m.pickedFor);
+  const activeKey = options[m.cursor()]?.key ?? "";
+  // A step the answers have ruled out is not a step someone is going to
+  // reach, so it does not belong in the timeline or in the count of how
+  // much is left.
+  const timeline = m.steps
+    .map((s, i) => ({ step: s, index: i }))
+    .filter(({ step }) => stepAvailable(step, m.pickedFor));
+  const position = timeline.findIndex(({ index }) => index === m.stepIndex());
 
   return CenteredScreen(
     width,
@@ -443,8 +550,8 @@ export function SetupLayout(m: SetupModel, p: Platform, width: number, height: n
     Box(
       { marginTop: 1, marginBottom: 1 },
       ProgressBar({
-        value: m.stepIndex(),
-        max: m.steps.length,
+        value: Math.max(0, position),
+        max: timeline.length,
         width: Math.min(frame.width - 8, 48),
         style: "block",
         color: ui.accent,
@@ -459,13 +566,13 @@ export function SetupLayout(m: SetupModel, p: Platform, width: number, height: n
             Box(
               { flexDirection: "column", width: leftWidth },
               Text({ color: muted, bold: true }, "Steps"),
-              ...m.steps.map((s, i) =>
+              ...timeline.map(({ step, index }) =>
                 ListItem({
-                  primary: s.title,
-                  selected: i === m.stepIndex(),
-                  status: m.wizard.isCompleted(i)
+                  primary: step.title,
+                  selected: index === m.stepIndex(),
+                  status: m.wizard.isCompleted(index)
                     ? "success"
-                    : i === m.stepIndex()
+                    : index === m.stepIndex()
                       ? "running"
                       : "pending",
                 }),
@@ -483,7 +590,7 @@ export function SetupLayout(m: SetupModel, p: Platform, width: number, height: n
           Text({}, ""),
           Text({ color: muted }, q.description),
           Text({}, ""),
-          ...q.choices.map((c, i) => {
+          ...options.map((c, i) => {
             const runtimeId = selectedRuntimeId(m.selection(), c.key);
             const checked = isRuntimes
               ? m.selection().includes(runtimeId)
@@ -520,7 +627,7 @@ export function SetupLayout(m: SetupModel, p: Platform, width: number, height: n
           ...(isRuntimes ? [{ shortcut: "left/right", action: "version" }] : []),
           {
             shortcut: "enter",
-            action: m.stepIndex() === m.steps.length - 1 ? "install" : "next",
+            action: position === timeline.length - 1 ? "install" : "next",
           },
           ...(m.stepIndex() > 0 && !isRuntimes ? [{ shortcut: "left", action: "back" }] : []),
           ...(m.stepIndex() > 0 && isRuntimes ? [{ shortcut: "esc", action: "back" }] : []),


### PR DESCRIPTION
Automated AFK landing for #146. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #146

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/159"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789432736&installation_model_id=20659&pr_number=159&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F159&signature=a5260b1ad7d7f75b1e1a160de5aab21e40ac133c0d009114fdbdde80383341a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->