### PR TITLE
fix: #148 Launch the Default agent, and prove no path bypasses permissions

### DIFF
--- a/.red/contexts/agents/CONTEXT.md
+++ b/.red/contexts/agents/CONTEXT.md
@@ -10,7 +10,7 @@ An agent client program that consumes RedSkills on a provisioned machine. Decide
 
 The one agent host a person has chosen as the target when red-dev hands work to an agent — a crash to diagnose, a launch shortcut, a profile's required host. It is a choice recorded once, not an inference from what happens to be installed, and red-dev never starts it with a permission bypass or auto-approve flag: unattended mode is the person's decision at the moment they type it, never a default red-dev ships (decision of 2026-08-15, contrasting Omarchy's `omarchy-agent`, which launches its default agent in bypass mode).
 
-It is chosen in the interview right after the agent hosts and changed with `red-dev agents default <key>`; when exactly one CLI host is selected it is that one, without a question. Its update path is part of `red-dev update` (system, red-skills, agents, converge) and also stands alone as `red-dev agents update`, each host by its publisher's own mechanism (decision of 2026-08-15).
+It is started with `red-dev agents run`, which builds the host's plain invocation — the command line the person would have typed, plus whatever they typed after `--` — and is guarded by an enumeration of every host's launch argv, so the promise above is checked rather than described (decision of 2026-08-15). It is chosen in the interview right after the agent hosts and changed with `red-dev agents default <key>`; when exactly one CLI host is selected it is that one, without a question. Its update path is part of `red-dev update` (system, red-skills, agents, converge) and also stands alone as `red-dev agents update`, each host by its publisher's own mechanism (decision of 2026-08-15).
 
 _Avoid_: primary agent, main agent, "the agent"
 

--- a/README.md
+++ b/README.md
@@ -304,6 +304,14 @@ validated against what is installed on every read and never healed: a host that
 has been uninstalled is reported by name in `doctor` rather than quietly
 replaced by whichever host is still there.
 
+`red-dev agents run` starts it. What it runs is the plain invocation — the same
+command line you would have typed — and the suite enumerates every host's launch
+argv to keep it that way, over a fixture host carrying `--yolo` so the check can
+be seen failing. Arguments after `--` are yours and are passed through exactly
+as typed, `red-dev agents run -- --dangerously-skip-permissions` included: the
+promise is that red-dev never adds one, not that it stops you from making that
+call yourself.
+
 RedCode comes from `reddb-io/redcode` release archives through GitHub's stable
 download redirect, so a clean machine does not need `gh` or an API request to
 discover it. Its published `SHA256SUMS` is verified before extraction. Existing

--- a/src/agent-launch.test.ts
+++ b/src/agent-launch.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Launching the Default agent, and the flag red-dev never adds.
+ *
+ * ADR 0001's amendment of 2026-08-15 puts one entry on the do-not-copy
+ * list: Omarchy starts its default agent in bypass/auto-approve mode,
+ * and red-dev's never does. That sentence is a promise until something
+ * reads the argv, so the first half of this file enumerates every host
+ * red-dev can start and asserts what is on its command line — and then
+ * proves the enumeration can fail, by running it over a host that
+ * carries `--yolo`. A guard that cannot fail is a comment.
+ *
+ * The second half pins the other way this goes wrong: launching the
+ * host that happens to be installed rather than the host that was
+ * chosen. The recorded answer decides, or nothing launches.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { AGENTS, type AgentSpec } from "./agents.ts";
+import {
+  hostLaunchArgv,
+  launchTarget,
+  permissionBypassFlags,
+  resolveLaunch,
+} from "./agent-launch.ts";
+import { isDefaultAgentCandidate } from "./default-agent.ts";
+
+/** Every host red-dev can hand work to, and therefore can start. */
+const LAUNCHABLE = AGENTS.filter(isDefaultAgentCandidate);
+
+/** A PATH lookup with no machine behind it. */
+const found = (...commands: string[]) => (command: string): string | null =>
+  commands.includes(command) ? `/usr/bin/${command}` : null;
+
+/**
+ * A host that carries the flag, for the guard to catch.
+ *
+ * Deliberately shaped like a real catalog entry: this is what a future
+ * entry would look like the day someone adds a launch argument without
+ * reading the ADR.
+ */
+const BYPASSING_HOST: AgentSpec = {
+  key: "fixture",
+  label: "Fixture Agent",
+  about: "a host that starts itself unattended",
+  cmd: "fixture",
+  recommended: false,
+  launchArgs: ["--yolo"],
+};
+
+describe("the launch argv of every agent host", () => {
+  test("there are hosts to check", () => {
+    // Guards against the enumeration passing because it enumerated
+    // nothing — the way this test would rot if the catalog moved.
+    expect(LAUNCHABLE.length).toBeGreaterThan(3);
+  });
+
+  test("is the host's plain invocation and nothing else", () => {
+    for (const host of LAUNCHABLE) {
+      expect(hostLaunchArgv(host, `/usr/bin/${host.cmd}`)).toEqual([`/usr/bin/${host.cmd}`]);
+    }
+  });
+
+  test("carries no bypass, auto-approve or yolo flag", () => {
+    const offenders = LAUNCHABLE.filter(
+      (host) => permissionBypassFlags(hostLaunchArgv(host, `/usr/bin/${host.cmd}`)).length > 0,
+    );
+    expect(offenders.map((host) => host.key)).toEqual([]);
+  });
+
+  test("and the same enumeration fails a host that carries one", () => {
+    const offenders = [...LAUNCHABLE, BYPASSING_HOST].filter(
+      (host) => permissionBypassFlags(hostLaunchArgv(host, `/usr/bin/${host.cmd}`)).length > 0,
+    );
+    expect(offenders.map((host) => host.key)).toEqual(["fixture"]);
+  });
+
+  test("refuses to be built at all when it would carry one", () => {
+    // The enumeration above catches a catalog entry before it ships.
+    // This catches the same entry on the machine of whoever ships it
+    // anyway, which is the difference between a test and a guard.
+    expect(() => launchTarget(BYPASSING_HOST, "/usr/bin/fixture")).toThrow(/--yolo/);
+  });
+});
+
+describe("the flags that count as one", () => {
+  test("are recognised in the spellings the hosts actually use", () => {
+    for (
+      const flag of [
+        "--dangerously-skip-permissions",
+        "--dangerously-bypass-approvals-and-sandbox",
+        "--permission-mode=bypassPermissions",
+        "--permission-mode=acceptEdits",
+        "--approval-mode=auto_edit",
+        "--full-auto",
+        "--yolo",
+        "-y",
+        "--sandbox=danger-full-access",
+        "--trust-all-tools",
+      ]
+    ) {
+      expect(permissionBypassFlags([flag])).toEqual([flag]);
+    }
+  });
+
+  test("are recognised when the value arrives as a second token", () => {
+    // `--permission-mode bypassPermissions` hides the answer one token
+    // to the right, which is where a scan of flag names alone misses it.
+    expect(permissionBypassFlags(["--permission-mode", "bypassPermissions"]))
+      .toEqual(["bypassPermissions"]);
+  });
+
+  test("do not swallow the ordinary arguments a host takes", () => {
+    expect(permissionBypassFlags([
+      "--model",
+      "opus",
+      "--permission-mode",
+      "plan",
+      "--resume",
+      "--force-color",
+      "/home/someone/project",
+    ])).toEqual([]);
+  });
+});
+
+describe("launching", () => {
+  test("resolves through the Default agent, not through what is installed", () => {
+    // Both hosts are on this machine and claude-code is first in the
+    // catalog. The record says codex, so codex is what starts.
+    const decision = resolveLaunch(
+      { agents: ["claude-code", "codex"], defaultAgent: "codex" },
+      found("claude", "codex"),
+    );
+    expect(decision.ok).toBe(true);
+    if (!decision.ok) return;
+    expect(decision.target.key).toBe("codex");
+    expect(decision.target.argv).toEqual(["/usr/bin/codex"]);
+  });
+
+  test("follows the record when it changes, with no other input changing", () => {
+    const machine = found("claude", "codex");
+    const selection = ["claude-code", "codex"];
+    const key = (stored: string) => {
+      const decision = resolveLaunch({ agents: selection, defaultAgent: stored }, machine);
+      return decision.ok ? decision.target.key : null;
+    };
+    expect(key("codex")).toBe("codex");
+    expect(key("claude-code")).toBe("claude-code");
+  });
+
+  test("resolves a selection recorded under the host's older name", () => {
+    const decision = resolveLaunch({ agents: ["opencode"], defaultAgent: "opencode" }, found("redcode"));
+    expect(decision.ok).toBe(true);
+    if (!decision.ok) return;
+    expect(decision.target.key).toBe("redcode");
+  });
+
+  test("starts nothing when the recorded host is no longer installed", () => {
+    // Not "start the other one". A machine that has lost Claude Code
+    // says so; it does not quietly become a Codex machine.
+    const decision = resolveLaunch(
+      { agents: ["claude-code", "codex"], defaultAgent: "claude-code" },
+      found("codex"),
+    );
+    expect(decision.ok).toBe(false);
+    if (decision.ok) return;
+    expect(decision.detail).toContain("Claude Code");
+    expect(decision.detail).not.toContain("Codex");
+  });
+
+  test("starts nothing when no Default agent has been chosen", () => {
+    const decision = resolveLaunch({ agents: ["claude-code", "codex"] }, found("claude", "codex"));
+    expect(decision.ok).toBe(false);
+    if (decision.ok) return;
+    expect(decision.detail).toContain("red-dev agents default");
+  });
+
+  test("starts nothing when the record names a host red-dev cannot hand work to", () => {
+    const decision = resolveLaunch({ agents: ["herdr"], defaultAgent: "herdr" }, found("herdr"));
+    expect(decision.ok).toBe(false);
+  });
+
+  test("adds nothing of its own to what it starts", () => {
+    const decision = resolveLaunch({ defaultAgent: "claude-code" }, found("claude"));
+    expect(decision.ok).toBe(true);
+    if (!decision.ok) return;
+    expect(decision.target.added).toEqual([]);
+    expect(permissionBypassFlags(decision.target.argv)).toEqual([]);
+  });
+
+  test("carries what the person typed through untouched, that flag included", () => {
+    // The promise is that red-dev never adds one, not that it refuses
+    // to pass one on: unattended is a decision someone makes at the
+    // moment they type it, and this is them typing it.
+    const decision = resolveLaunch({ defaultAgent: "claude-code" }, found("claude"), [
+      "--dangerously-skip-permissions",
+    ]);
+    expect(decision.ok).toBe(true);
+    if (!decision.ok) return;
+    expect(decision.target.added).toEqual([]);
+    expect(decision.target.argv).toEqual([
+      "/usr/bin/claude",
+      "--dangerously-skip-permissions",
+    ]);
+  });
+});
+
+describe("a host installed as a Windows shim", () => {
+  test("is interpreted rather than exec'd, and gains no arguments by it", () => {
+    // CreateProcess cannot exec a .cmd directly, so the argv grows a
+    // cmd.exe prefix. Pinned because that is the one place red-dev
+    // rewrites a launch command line at all.
+    const claude = AGENTS.find((host) => host.key === "claude-code")!;
+    const argv = hostLaunchArgv(claude, "C:\\npm\\claude.cmd", ["--resume"]);
+    expect(argv).toEqual(["cmd.exe", "/c", "C:\\npm\\claude.cmd", "--resume"]);
+    expect(permissionBypassFlags(argv)).toEqual([]);
+  });
+});

--- a/src/agent-launch.test.ts
+++ b/src/agent-launch.test.ts
@@ -67,6 +67,15 @@ describe("the launch argv of every agent host", () => {
     expect(offenders.map((host) => host.key)).toEqual([]);
   });
 
+  test("and neither does the other command line red-dev builds for a host", () => {
+    // The readiness probe is the only other argv red-dev assembles from
+    // a catalog entry. It asks a host for its version, and a host that
+    // needed a bypass to answer that would be telling us something.
+    for (const host of AGENTS) {
+      expect(permissionBypassFlags(host.probeArgs ?? [])).toEqual([]);
+    }
+  });
+
   test("and the same enumeration fails a host that carries one", () => {
     const offenders = [...LAUNCHABLE, BYPASSING_HOST].filter(
       (host) => permissionBypassFlags(hostLaunchArgv(host, `/usr/bin/${host.cmd}`)).length > 0,

--- a/src/agent-launch.ts
+++ b/src/agent-launch.ts
@@ -1,0 +1,199 @@
+/**
+ * Starting the Default agent — and the one thing red-dev promises not
+ * to put on its command line.
+ *
+ * `red-dev agents run` exists so that "the host red-dev hands work to"
+ * is something a person can actually be handed to: a launch shortcut, a
+ * crash to diagnose, a profile's required host. What it builds is the
+ * plain invocation — the executable and whatever the person typed after
+ * `--`, in that order, with nothing of red-dev's in between.
+ *
+ * That emptiness is the feature. Omarchy launches its default agent in
+ * bypass/auto-approve mode, and ADR 0001's amendment of 2026-08-15 puts
+ * that on the do-not-copy list: unattended is a decision someone makes
+ * at the moment they type it, never one shipped as a default. A promise
+ * of that shape decays quietly — it is one convenience flag away from
+ * being false, and nothing about the flag looks wrong at the moment it
+ * is added. So the promise is checked here rather than described: every
+ * argument red-dev contributes is read before the process starts, and a
+ * bypass among them stops the launch instead of performing it.
+ *
+ * What it does not do is police the person. A flag they typed
+ * themselves is carried through untouched — that is them making the
+ * decision, which is exactly what the ADR reserves for them.
+ *
+ * See .red/contexts/agents/CONTEXT.md and src/default-agent.ts.
+ */
+
+import { AGENTS, npmArgv, type AgentSpec } from "./agents.ts";
+import { isDefaultAgentCandidate, readDefaultAgent, reportDefaultAgent } from "./default-agent.ts";
+import { RedError } from "./log.ts";
+
+/**
+ * What a permission bypass looks like across the hosts red-dev
+ * installs, reduced to the part that survives every spelling.
+ *
+ * Matched as substrings of a folded token rather than as whole flags,
+ * because the same decision arrives under too many names to enumerate:
+ * `--dangerously-skip-permissions` (Claude Code),
+ * `--dangerously-bypass-approvals-and-sandbox` and `--full-auto`
+ * (Codex), `--yolo` (Gemini), `--permission-mode bypassPermissions`,
+ * `--approval-mode auto_edit`, `--sandbox danger-full-access`. A list
+ * of exact flags would pass the day a host renames one, which is the
+ * day this most needs to fail.
+ */
+const BYPASS_MARKERS: readonly string[] = [
+  "danger",
+  "bypass",
+  "yolo",
+  "fullauto",
+  "autoapprove",
+  "autoaccept",
+  "autoedit",
+  "acceptedits",
+  "skippermission",
+  "nopermission",
+  "noconfirm",
+  "noprompt",
+  "nosandbox",
+  "trustall",
+  "unattended",
+];
+
+/** Short forms that carry no word to match on. */
+const BYPASS_TOKENS: readonly string[] = ["-y", "--yes"];
+
+/**
+ * Reduce a token to its letters and digits, so `--auto_edit`,
+ * `--auto-edit` and `autoEdit` are one thing rather than three.
+ */
+function fold(token: string): string {
+  return token.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+/**
+ * Which of these tokens hand a host's permission prompts away. PURE.
+ *
+ * Every token is read whole, flag and value alike: the answer to
+ * `--permission-mode` lives one token to the right, and a scan of flag
+ * names alone would walk straight past `bypassPermissions`.
+ */
+export function permissionBypassFlags(tokens: readonly string[]): string[] {
+  return tokens.filter((token) => {
+    if (BYPASS_TOKENS.includes(token.toLowerCase())) return true;
+    const folded = fold(token);
+    return BYPASS_MARKERS.some((marker) => folded.includes(marker));
+  });
+}
+
+/** The arguments red-dev adds when it starts a host. Empty, and checked. */
+export function hostLaunchArgs(host: AgentSpec): string[] {
+  return [...(host.launchArgs ?? [])];
+}
+
+/**
+ * The whole command line for a host, executable included. PURE.
+ *
+ * npmArgv is the one rewrite: a host installed from npm on Windows
+ * lands as a `.cmd` shim, and CreateProcess cannot exec a batch file —
+ * cmd.exe has to interpret it. It adds a prefix, never an argument.
+ */
+export function hostLaunchArgv(
+  host: AgentSpec,
+  executable: string,
+  passthrough: readonly string[] = [],
+): string[] {
+  return npmArgv(executable, [...hostLaunchArgs(host), ...passthrough]);
+}
+
+export interface LaunchTarget {
+  key: string;
+  label: string;
+  /** The executable as it was found on PATH, exactly as it will be run. */
+  executable: string;
+  /** What red-dev contributes to the command line. The guard reads this. */
+  added: string[];
+  /** What the person typed after `--`, carried through as they typed it. */
+  passthrough: string[];
+  argv: string[];
+}
+
+export type LaunchDecision =
+  | { ok: true; target: LaunchTarget }
+  | { ok: false; detail: string; fix?: string };
+
+/**
+ * Build the command line for a host, refusing to build one that starts
+ * it unattended.
+ *
+ * The enumeration in agent-launch.test.ts catches a catalog entry that
+ * carries such a flag before it ships. This catches it on the machine
+ * of whoever ships it anyway — the difference between a test and a
+ * guard, and the reason the ADR's amendment is executable rather than
+ * aspirational.
+ */
+export function launchTarget(
+  host: AgentSpec,
+  executable: string,
+  passthrough: readonly string[] = [],
+): LaunchTarget {
+  const added = hostLaunchArgs(host);
+  const offending = permissionBypassFlags(added);
+  if (offending.length > 0) {
+    throw new RedError(
+      `red-dev does not start ${host.label} with ${offending.join(" ")} — ` +
+        "unattended is the person's decision at the moment they type it (ADR 0001)",
+    );
+  }
+  return {
+    key: host.key,
+    label: host.label,
+    executable,
+    added,
+    passthrough: [...passthrough],
+    argv: hostLaunchArgv(host, executable, passthrough),
+  };
+}
+
+/**
+ * What to start, read from the recorded choice rather than from the
+ * machine.
+ *
+ * The whole point of resolving here is that no caller gets to name a
+ * host. A surface that reached for `claude` because it is usually there
+ * would be right on most machines and wrong on exactly the machines
+ * where someone bothered to choose — and it would be wrong silently.
+ *
+ * `locate` is injected for the same reason readDefaultAgent takes its
+ * installed test: it is PATH, and PATH is not answerable in a test.
+ */
+export function resolveLaunch(
+  prefs: { defaultAgent?: string | undefined; agents?: string[] | undefined },
+  locate: (command: string) => string | null,
+  passthrough: readonly string[] = [],
+): LaunchDecision {
+  const installed = (host: AgentSpec): boolean =>
+    host.cmd.length > 0 && locate(host.cmd) !== null;
+
+  const reading = readDefaultAgent(prefs.defaultAgent, installed);
+  if (reading.state !== "ready") {
+    // The same words doctor prints, so the machine says one thing about
+    // the Default agent whichever surface is asked.
+    const report = reportDefaultAgent(reading, prefs.agents ?? []);
+    return { ok: false, detail: report.detail, ...(report.fix ? { fix: report.fix } : {}) };
+  }
+
+  const host = AGENTS.find((a) => a.key === reading.key && isDefaultAgentCandidate(a));
+  const executable = host ? locate(host.cmd) : null;
+  if (!host || !executable) {
+    // Unreachable through readDefaultAgent, which only reports `ready`
+    // for a candidate the same lookup just found. Answered rather than
+    // asserted because a launch is not the place to discover that.
+    return {
+      ok: false,
+      detail: `${reading.label ?? reading.recorded} is not on PATH`,
+      fix: `red-dev agents ${reading.key ?? ""}`.trim(),
+    };
+  }
+  return { ok: true, target: launchTarget(host, executable, passthrough) };
+}

--- a/src/agent-launch.ts
+++ b/src/agent-launch.ts
@@ -197,3 +197,26 @@ export function resolveLaunch(
   }
   return { ok: true, target: launchTarget(host, executable, passthrough) };
 }
+
+/**
+ * Hand the terminal over and wait for it back.
+ *
+ * The three streams are inherited because this *is* the person's
+ * session — the host draws a full-screen interface of its own and reads
+ * the keyboard, neither of which survives a pipe. It lives here rather
+ * than in main.ts so the exception to the console-ownership rule is a
+ * file that can never run behind one of red-dev's own frames: nothing
+ * reaches this but `red-dev agents run`, typed at a shell.
+ *
+ * The environment is inherited as it is, not the unattended one:
+ * UNATTENDED_ENV exists to tell package managers that nobody is
+ * watching, and here somebody is.
+ */
+export async function runLaunchTarget(target: LaunchTarget): Promise<number> {
+  const child = Bun.spawn(target.argv, {
+    stdin: "inherit",
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+  return await child.exited;
+}

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -61,6 +61,17 @@ export interface AgentSpec {
   runtimeNeeds?: string[];
   /** A command that must start successfully before presence counts as ready. */
   probeArgs?: string[];
+  /**
+   * Arguments red-dev adds when it starts this host.
+   *
+   * Empty for every host today, which is the point: what a person gets
+   * from `red-dev agents run` is the command line they would have typed
+   * themselves. It exists as a field so that a host which one day needs
+   * one — a profile, a config path — declares it here, where the
+   * permission-bypass guard in src/agent-launch.ts reads it, rather
+   * than having it spliced in at a call site no guard looks at.
+   */
+  launchArgs?: string[];
   /** Desktop applications have no CLI and only exist on some targets. */
   desktopOnly?: boolean;
   /**
@@ -250,7 +261,7 @@ export function availableAgents(p: Platform): AgentSpec[] {
 }
 
 /** Resolve against PATH as it exists now, including tools exposed this run. */
-function commandPath(command: string): string | null {
+export function commandPath(command: string): string | null {
   const path = process.env["Path"] ?? process.env["PATH"] ?? "";
   return Bun.which(command, { PATH: path });
 }

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -23,6 +23,30 @@ describe("command parsing", () => {
     });
   });
 
+  test("reads the agents subcommands as subcommands, not as agent keys", () => {
+    expect(parse(["agents", "default", "codex"])).toMatchObject({
+      agentDefault: true,
+      agentDefaultKey: "codex",
+      agentKeys: undefined,
+      errors: [],
+    });
+    expect(parse(["agents", "run"])).toMatchObject({
+      agentRun: true,
+      agentKeys: undefined,
+      passthrough: [],
+      errors: [],
+    });
+  });
+
+  test("keeps what follows `--` for the program red-dev starts", () => {
+    // Strict mode would otherwise reject these as unknown options of
+    // ours. They are the person's arguments to their own agent — up to
+    // and including the one red-dev will never add itself.
+    const inv = parse(["agents", "run", "--", "--dangerously-skip-permissions", "-p", "hi"]);
+    expect(inv).toMatchObject({ command: "agents", agentRun: true, errors: [] });
+    expect(inv.passthrough).toEqual(["--dangerously-skip-permissions", "-p", "hi"]);
+  });
+
   test("reads a wallpaper independently from the theme", () => {
     expect(parse(["wallpaper", "flare"])).toMatchObject({
       command: "wallpaper",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -192,7 +192,8 @@ export function buildCli(): CLI {
         positional: [
           {
             name: "agent_selection",
-            description: "comma-separated agent keys for an unattended install, or `default`",
+            description:
+              "comma-separated agent keys for an unattended install, or `default`, or `run`",
             required: false,
           },
           {
@@ -289,6 +290,14 @@ export interface Invocation {
    */
   agentDefault: boolean;
   agentDefaultKey: string | undefined;
+  /** `agents run` — start the Default agent. */
+  agentRun: boolean;
+  /**
+   * Everything after `--`: arguments for the program red-dev starts,
+   * not for red-dev. Kept verbatim, including flags red-dev would never
+   * add itself — see src/agent-launch.ts.
+   */
+  passthrough: string[];
   runtimeIds: string[] | undefined;
   /** `lang --latest`: rewrite every selected runtime selector to `latest`. */
   latest: boolean;
@@ -317,7 +326,13 @@ function clampOpacity(raw: unknown, errors: string[]): number {
 }
 
 export function parseArgs(cli: CLI, argv: string[]): Invocation {
-  const r = cli.parse(argv);
+  // `--` ends red-dev's own arguments. What follows belongs to the
+  // program red-dev is about to start, and must never reach the schema
+  // — strict mode would reject `--dangerously-skip-permissions` as an
+  // unknown option, when it is not an option of ours at all.
+  const separator = argv.indexOf("--");
+  const passthrough = separator >= 0 ? argv.slice(separator + 1) : [];
+  const r = cli.parse(separator >= 0 ? argv.slice(0, separator) : argv);
   const opts = r.options as Record<string, unknown>;
   const pos = r.positional as Record<string, unknown>;
   const errors = [...(r.errors ?? [])];
@@ -346,11 +361,12 @@ export function parseArgs(cli: CLI, argv: string[]): Invocation {
   const rawWallpaper = pos["wallpaper_name"] ??
     (literalWallpaper && !literalWallpaper.startsWith("-") ? literalWallpaper : undefined);
 
-  // `default` in the selection slot is the subcommand, not an agent key
-  // — no agent is called that, and reading it as one would try to
-  // install it and fail with a list of the real names.
+  // `default` and `run` in the selection slot are subcommands, not
+  // agent keys — no agent is called either, and reading one as a key
+  // would try to install it and fail with a list of the real names.
   const rawAgents = pos["agent_selection"];
   const agentDefault = rawAgents === "default";
+  const agentRun = rawAgents === "run";
   return {
     command: r.command[0] ?? null,
     // `theme <name>` and `plan <scope>` both land in the positional map
@@ -358,12 +374,14 @@ export function parseArgs(cli: CLI, argv: string[]): Invocation {
     scope: scope ?? (typeof rawName === "string" ? rawName : undefined),
     logsWhich: typeof pos["which"] === "string" ? pos["which"] : undefined,
     agentKeys:
-      typeof rawAgents === "string" && !agentDefault
+      typeof rawAgents === "string" && !agentDefault && !agentRun
         ? rawAgents.split(",").map((value) => value.trim()).filter(Boolean)
         : undefined,
     agentDefault,
     agentDefaultKey:
       agentDefault && typeof pos["agent_key"] === "string" ? pos["agent_key"] : undefined,
+    agentRun,
+    passthrough,
     runtimeIds:
       typeof pos["runtime_selection"] === "string"
         ? pos["runtime_selection"].split(",").map((value) => value.trim()).filter(Boolean)

--- a/src/console-ownership.test.ts
+++ b/src/console-ownership.test.ts
@@ -49,6 +49,10 @@ const ALLOWED = new Map<string, string>([
     "`sudo -v` is the explicit boundary before a human install starts fullscreen rendering; bootstrap and direct install call it before render, while unattended paths never call it.",
   ],
   [
+    "agent-launch.ts",
+    "`red-dev agents run` hands the terminal to the Default agent, which draws its own full-screen interface and reads the keyboard — neither survives a pipe. Nothing reaches it but that command typed at a shell: the menu has no agents entry, and the flag that selects it exists only when `agents run` is parsed from argv.",
+  ],
+  [
     "wsl-provision.ts",
     "`wsl --install` and `--set-version` prompt for a UNIX username and take minutes. They need real stdin, which spawnLogged's captured branch sets to ignore — so routing them through it would hang rather than tear. Known gap: reachable from the TUI menu, where it WOULD tear. Not fixed here because the fix is to refuse the capture, not to pipe it.",
   ],

--- a/src/main.ts
+++ b/src/main.ts
@@ -1304,6 +1304,7 @@ async function cmdAgents(p: Platform, inv: Invocation): Promise<number> {
   const available = availableAgents(p);
 
   if (inv.agentDefault) return await cmdAgentsDefault(p, inv.agentDefaultKey);
+  if (inv.agentRun) return await cmdAgentsRun(p, inv.passthrough);
 
   if (inv.agentKeys !== undefined) {
     inv = { ...inv, agentKeys: currentAgentKeys(inv.agentKeys) };
@@ -1513,6 +1514,45 @@ async function cmdAgentsDefault(p: Platform, key: string | undefined): Promise<n
   log.ok(`default agent: ${spec.label}`);
   if (!isAgentInstalled(spec)) log.warn(`not installed yet — red-dev agents ${spec.key}`);
   return 0;
+}
+
+/**
+ * `red-dev agents run [-- args]` — start the Default agent.
+ *
+ * The terminal is handed over whole and nothing is printed on the way
+ * in: the host draws its own interface, and a red-dev line above it
+ * would be the last thing anyone wanted there. What it starts is the
+ * plain invocation, built and checked in src/agent-launch.ts — the
+ * command the person would have typed, plus whatever they typed after
+ * `--`, and nothing else.
+ */
+async function cmdAgentsRun(p: Platform, passthrough: string[]): Promise<number> {
+  const { commandPath } = await import("./agents.ts");
+  const { resolveLaunch } = await import("./agent-launch.ts");
+  const { readPreferences } = await import("./preferences.ts");
+
+  const prefs = await readPreferences(p);
+  const decision = resolveLaunch(prefs, commandPath, passthrough);
+  if (!decision.ok) {
+    log.err(decision.detail);
+    if (decision.fix) log.plain(`       fix: ${decision.fix}`);
+    return 1;
+  }
+
+  try {
+    // The environment as it is, not the unattended one: this child is
+    // the person's session, and UNATTENDED_ENV exists to tell package
+    // managers nobody is watching. Here somebody is.
+    const child = Bun.spawn(decision.target.argv, {
+      stdin: "inherit",
+      stdout: "inherit",
+      stderr: "inherit",
+    });
+    return await child.exited;
+  } catch {
+    log.err(`${decision.target.label} could not be started: ${decision.target.executable}`);
+    return 1;
+  }
 }
 
 /** Choose which language runtimes mise manages. */
@@ -1744,18 +1784,23 @@ if (process.argv[2] !== "statusline") {
 async function main(): Promise<number> {
   const cli = buildCli();
   const argv = process.argv.slice(2);
+  // Everything after `--` is meant for the program red-dev starts, so
+  // it is not scanned for red-dev's own flags either: `agents run --
+  // --help` asks the agent for its help, not red-dev for ours.
+  const separator = argv.indexOf("--");
+  const ours = separator >= 0 ? argv.slice(0, separator) : argv;
 
   // Handled before parsing: the schema runs in strict mode, so an
   // undeclared --help would be rejected as an unknown option before we
   // ever got the chance to honour it. Declaring them as real options
   // would instead make them appear in every command's option list,
   // which is noise.
-  if (argv.includes("--version") || argv.includes("-V")) {
+  if (ours.includes("--version") || ours.includes("-V")) {
     log.plain(VERSION);
     return 0;
   }
-  if (argv.includes("--help") || argv.includes("-h")) {
-    const verb = argv.find((a) => !a.startsWith("-"));
+  if (ours.includes("--help") || ours.includes("-h")) {
+    const verb = ours.find((a) => !a.startsWith("-"));
     log.plain(cli.help(verb ? [verb] : undefined));
     return 0;
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1528,7 +1528,7 @@ async function cmdAgentsDefault(p: Platform, key: string | undefined): Promise<n
  */
 async function cmdAgentsRun(p: Platform, passthrough: string[]): Promise<number> {
   const { commandPath } = await import("./agents.ts");
-  const { resolveLaunch } = await import("./agent-launch.ts");
+  const { resolveLaunch, runLaunchTarget } = await import("./agent-launch.ts");
   const { readPreferences } = await import("./preferences.ts");
 
   const prefs = await readPreferences(p);
@@ -1540,15 +1540,7 @@ async function cmdAgentsRun(p: Platform, passthrough: string[]): Promise<number>
   }
 
   try {
-    // The environment as it is, not the unattended one: this child is
-    // the person's session, and UNATTENDED_ENV exists to tell package
-    // managers nobody is watching. Here somebody is.
-    const child = Bun.spawn(decision.target.argv, {
-      stdin: "inherit",
-      stdout: "inherit",
-      stderr: "inherit",
-    });
-    return await child.exited;
+    return await runLaunchTarget(decision.target);
   } catch {
     log.err(`${decision.target.label} could not be started: ${decision.target.executable}`);
     return 1;


### PR DESCRIPTION
Automated AFK landing for #148. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #148

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/160"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789434651&installation_model_id=20659&pr_number=160&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F160&signature=8a4ad2d7312d1c80a5884e58ac478cf047f07358c0b266340ef4685f430ee16b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->