### PR TITLE
fix: #149 red-dev agents update, and red-dev update runs it

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,16 @@ validated against what is installed on every read and never healed: a host that
 has been uninstalled is reported by name in `doctor` rather than quietly
 replaced by whichever host is still there.
 
+`red-dev agents update` refreshes the hosts, each one by its own publisher's
+mechanism rather than through a single path red-dev invented: an npm global
+reinstall, a GitHub release re-resolved and checksum-verified, a `winget
+upgrade`, or the vendor's own self-update where the vendor ships one. A host
+that is already current is a skip carrying the reason — not a reinstall, and
+not a failure, since winget reports exactly that state with a non-zero exit. A
+host that fails is named and the others still run. `red-dev update` runs it as
+one stage of updating the machine: system packages, RedSkills, mise's tools,
+the agents, then the converge.
+
 `red-dev agents run` starts it. What it runs is the plain invocation — the same
 command line you would have typed — and the suite enumerates every host's launch
 argv to keep it that way, over a fixture host carrying `--yolo` so the check can
@@ -430,7 +440,7 @@ red-dev platform             # what red-dev thinks this machine is
 red-dev plan [scope]         # what would change, changes nothing
 red-dev install [scope]      # converge toward the manifest
 red-dev install --dry-run    # print the plan, touch nothing
-red-dev update               # upgrade the package managers, mise's tools and red-dev itself
+red-dev update               # package managers, RedSkills, mise's tools, the agents, then converge
 red-dev theme [name]         # dark | light | obsidian | marble | cobalt | flare
 red-dev wallpaper [source]   # theme | Red artwork | absolute PNG path | HTTPS URL
 red-dev redwall              # redraw the wallpaper carrying this machine's state
@@ -443,6 +453,8 @@ red-dev agents               # choose coding agents, wire in red-skills
 red-dev agents claude-code,codex # unattended agent selection
 red-dev agents default       # which host red-dev hands work to
 red-dev agents default codex # change it
+red-dev agents run           # start the Default agent
+red-dev agents update        # refresh each host by its publisher's mechanism
 red-dev share [path]         # one directory both WSL and Windows read
 red-dev share adopt <tool>   # move that tool's configuration into it
 red-dev uninstall            # remove tools, or red-dev's own config

--- a/src/agent-npm-reshim.test.ts
+++ b/src/agent-npm-reshim.test.ts
@@ -83,4 +83,89 @@ console.log("INSTALL_SETTLED=" + isAgentInstalled(fixture));
     expect(result.stdout).toContain("INSTALL_SETTLED=true");
     expect(result.stdout + result.stderr).not.toContain("Reshimming mise");
   });
+
+  test("and neither does updating them, which spawns the same npm again", async () => {
+    // `red-dev agents update` reinstalls the package globally, which is
+    // the same mise-wrapped npm call with the same unbounded reshim
+    // waiting behind it. Suppressing it on the install path and not on
+    // the update path would put the hang straight back, in the command
+    // people run most often.
+    const dir = mkdtempSync(join(tmpdir(), "red-dev-agent-npm-update-"));
+    created.push(dir);
+    const pathDir = join(dir, "path");
+    const nodeBin = join(dir, "node-bin");
+    mkdirSync(pathDir);
+    mkdirSync(nodeBin);
+    const fakeNpm = join(nodeBin, "npm");
+    const fakeMise = join(pathDir, "mise");
+
+    writeFileSync(
+      fakeNpm,
+      `#!/usr/bin/env bash
+set -euo pipefail
+printf 'npm-argv: %s\\n' "$*"
+printf 'changed 7 packages in 10s\\n'
+if [ -z "\${MISE_SKIP_RESHIM:-}" ]; then
+  printf 'Reshimming mise 24...\\n' >&2
+  sleep 30
+fi
+printf '#!/usr/bin/env bash\\nexit 0\\n' > "$(dirname "$0")/fixture-agent"
+chmod +x "$(dirname "$0")/fixture-agent"
+`,
+    );
+    writeFileSync(
+      fakeMise,
+      `#!/usr/bin/env bash
+if [ "\${1:-}" = which ] && [ "\${2:-}" = npm ]; then
+  printf '%s\\n' ${JSON.stringify(fakeNpm)}
+  exit 0
+fi
+exit 1
+`,
+    );
+    chmodSync(fakeNpm, 0o755);
+    chmodSync(fakeMise, 0o755);
+
+    const harness = join(dir, "harness.ts");
+    const agents = join(import.meta.dir, "agents.ts");
+    const update = join(import.meta.dir, "agent-update.ts");
+    writeFileSync(
+      harness,
+      `import { installAgent } from ${JSON.stringify(agents)};
+import { updateAgents } from ${JSON.stringify(update)};
+const fixture = {
+  key: "fixture",
+  label: "Fixture agent",
+  about: "fixture",
+  cmd: "fixture-agent",
+  recommended: false,
+  npm: "fixture-agent",
+};
+const platform = {
+  os: "linux",
+  distro: "ubuntu",
+  version: "24.04",
+  codename: "noble",
+  env: "wsl",
+  arch: "x64",
+  caps: { apt: true, gui: false, systemd: true, winget: true, flatpak: false },
+};
+await installAgent(fixture, platform);
+const outcomes = await updateAgents([fixture], platform);
+console.log("UPDATE_STATE=" + outcomes[0].state);
+`,
+    );
+
+    const result = await runBounded([process.execPath, harness], {
+      timeoutMs: 3_000,
+      env: { ...process.env, PATH: `${pathDir}:${process.env.PATH ?? ""}` },
+    });
+
+    expect(result.timedOut).toBe(false);
+    expect(result.exitCode).toBe(0);
+    // The update ran its own npm call, pinned to latest, and settled.
+    expect(result.stdout).toContain("npm-argv: install -g fixture-agent@latest");
+    expect(result.stdout).toContain("UPDATE_STATE=updated");
+    expect(result.stdout + result.stderr).not.toContain("Reshimming mise");
+  });
 });

--- a/src/agent-update.test.ts
+++ b/src/agent-update.test.ts
@@ -1,0 +1,379 @@
+/**
+ * `red-dev agents update`, and the three promises it makes.
+ *
+ * Every host is refreshed by its own publisher's mechanism, so the first
+ * half of this file pins the command line each mechanism produces — the
+ * npm argv, the winget argv, the Microsoft Store argv, the vendor's own
+ * self-update, the release archive and the vendor script. An update path
+ * that quietly became one uniform reinstall would still pass a test that
+ * only asked whether it succeeded.
+ *
+ * The second half pins the two behaviours that make running this twice
+ * safe: a host that is already current is a skip carrying a reason, and
+ * a host that fails is named without taking the rest of the run with it.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { agentInstallMethod, AGENTS, availableAgents, type AgentSpec } from "./agents.ts";
+import {
+  agentUpdateMechanism,
+  planAgentUpdate,
+  readUpdateOutcome,
+  releaseTagFromLocation,
+  sameRelease,
+  updateAgents,
+  type AgentUpdateOutcome,
+} from "./agent-update.ts";
+import type { Platform } from "./platform.ts";
+
+const CAPS = { apt: true, gui: false, systemd: true, winget: false, flatpak: false };
+
+const LINUX: Platform = {
+  os: "linux",
+  distro: "ubuntu",
+  version: "24.04",
+  codename: "noble",
+  env: "desktop",
+  arch: "x64",
+  caps: CAPS,
+};
+
+const WSL: Platform = { ...LINUX, env: "wsl", caps: { ...CAPS, winget: true } };
+
+const WINDOWS: Platform = {
+  os: "windows",
+  distro: null,
+  version: null,
+  codename: null,
+  env: "windows",
+  arch: "x64",
+  caps: { apt: false, gui: true, systemd: false, winget: true, flatpak: false },
+};
+
+/** A PATH lookup with no machine behind it. */
+const found = (...commands: string[]) => (command: string): string | null =>
+  commands.includes(command) ? `/usr/bin/${command}` : null;
+
+const host = (key: string): AgentSpec => AGENTS.find((a) => a.key === key) as AgentSpec;
+
+/** Resolve one host's plan, with everything it could ask the machine answered. */
+function plan(key: string, p: Platform, overrides: Partial<{ npm: string | null }> = {}) {
+  const spec = host(key);
+  return planAgentUpdate(spec, p, {
+    locate: found(spec.cmd),
+    npm: overrides.npm === undefined ? "/home/u/.local/share/mise/shims/npm" : overrides.npm,
+    platform: p.os === "windows" ? "win32" : "linux",
+  });
+}
+
+describe("the update argv of each per-host mechanism", () => {
+  test("npm reinstalls the package globally, pinned to latest", () => {
+    const p = plan("gemini", LINUX);
+    expect(p.state).toBe("ready");
+    if (p.state !== "ready") return;
+    expect(p.mechanism).toBe("npm");
+    expect(p.step).toEqual({
+      kind: "command",
+      argv: [
+        "/home/u/.local/share/mise/shims/npm",
+        "install",
+        "-g",
+        "@google/gemini-cli@latest",
+      ],
+      env: { MISE_SKIP_RESHIM: "1" },
+    });
+  });
+
+  test("the npm path still suppresses mise's implicit reshim", () => {
+    // The unbounded second command that can strand a WSL converge at
+    // "Reshimming mise 24..." forever. The install path suppresses it;
+    // an update path that spawned the same npm without this would have
+    // reintroduced exactly the hang that suppression was added for.
+    for (const key of ["codex", "gemini", "openclaw"]) {
+      const p = plan(key, WSL);
+      expect(p.state).toBe("ready");
+      if (p.state !== "ready" || p.step.kind !== "command") continue;
+      expect(p.mechanism).toBe("npm");
+      expect(p.step.env["MISE_SKIP_RESHIM"]).toBe("1");
+    }
+  });
+
+  test("winget upgrades the package, silently and without interaction", () => {
+    const p = plan("codex", WINDOWS);
+    expect(p.state).toBe("ready");
+    if (p.state !== "ready") return;
+    expect(p.mechanism).toBe("winget");
+    expect(p.step).toEqual({
+      kind: "command",
+      argv: [
+        "cmd.exe",
+        "/c",
+        "winget",
+        "upgrade",
+        "--id",
+        "OpenAI.Codex",
+        "--exact",
+        "--silent",
+        "--accept-package-agreements",
+        "--accept-source-agreements",
+        "--disable-interactivity",
+      ],
+      env: {},
+    });
+  });
+
+  test("the Microsoft Store path names its source, as the install path does", () => {
+    // Without --source msstore the id resolves against the community
+    // repository, where the ChatGPT entries belong to third parties.
+    const p = plan("codex-desktop", WINDOWS);
+    expect(p.state).toBe("ready");
+    if (p.state !== "ready" || p.step.kind !== "command") return;
+    expect(p.mechanism).toBe("msstore");
+    expect(p.step.argv).toEqual([
+      "cmd.exe",
+      "/c",
+      "winget",
+      "upgrade",
+      "--id",
+      "9PLM9XGG6VKS",
+      "--source",
+      "msstore",
+      "--exact",
+      "--accept-package-agreements",
+      "--accept-source-agreements",
+      "--disable-interactivity",
+    ]);
+  });
+
+  test("a host that updates itself is asked to, not reinstalled", () => {
+    // Claude Code's installer leaves a self-updating binary behind, so
+    // `claude update` is the publisher's own door. Re-running install.sh
+    // would be red-dev going around it.
+    const p = plan("claude-code", LINUX);
+    expect(p.state).toBe("ready");
+    if (p.state !== "ready") return;
+    expect(p.mechanism).toBe("self-update");
+    expect(p.step).toEqual({ kind: "command", argv: ["/usr/bin/claude", "update"], env: {} });
+  });
+
+  test("a GitHub release is re-resolved as an archive, not as a command", () => {
+    const p = plan("redcode", LINUX);
+    expect(p.state).toBe("ready");
+    if (p.state !== "ready") return;
+    expect(p.mechanism).toBe("github-release");
+    expect(p.step).toEqual({
+      kind: "release",
+      repo: "reddb-io/redcode",
+      asset: "redcode-linux-x64.tar.gz",
+      bin: "redcode",
+    });
+  });
+
+  test("a vendor script host re-runs the publisher's script", () => {
+    const p = plan("muse", LINUX);
+    expect(p.state).toBe("ready");
+    if (p.state !== "ready") return;
+    expect(p.mechanism).toBe("installer");
+    expect(p.step).toEqual({ kind: "script", url: "https://dev.meta.ai/install.sh" });
+  });
+
+  test("the mechanism follows how the host was installed, not the catalog order", () => {
+    // Codex carries a winget id and an npm package. Under WSL the
+    // install path takes npm, so the update path must not reach for
+    // winget just because the id is sitting in the same entry.
+    expect(agentUpdateMechanism(host("codex"), WSL)).toBe("npm");
+    expect(agentUpdateMechanism(host("codex"), WINDOWS)).toBe("winget");
+    expect(agentUpdateMechanism(host("claude-code"), WINDOWS)).toBe("winget");
+  });
+
+  test("every host red-dev can install on a target also has a way to be updated", () => {
+    // The mechanisms are derived from the install method, so this cannot
+    // silently drift — but a future entry installed one way and updated
+    // none would be a host that freezes on the version it arrived with.
+    for (const p of [LINUX, WSL, WINDOWS]) {
+      for (const spec of availableAgents(p)) {
+        if (agentInstallMethod(spec, p) === null) continue;
+        expect(agentUpdateMechanism(spec, p)).not.toBeNull();
+      }
+    }
+  });
+});
+
+describe("a host with nothing to do", () => {
+  test("is a skip with a reason when it is not installed at all", () => {
+    const spec = host("gemini");
+    const p = planAgentUpdate(spec, LINUX, { locate: () => null, npm: "/usr/bin/npm" });
+    expect(p.state).toBe("skip");
+    if (p.state !== "skip") return;
+    expect(p.reason).toBe("not installed");
+  });
+
+  test("is a skip with a reason when the publisher says it is current", () => {
+    // winget answers this with a non-zero exit — the steady state of an
+    // idempotent machine, which a caller reading the code first reports
+    // as a failure.
+    expect(readUpdateOutcome({ code: 1, output: "No available upgrade found." })).toMatchObject({
+      state: "skipped",
+      reason: "already current",
+    });
+    expect(readUpdateOutcome({ code: 0, output: "changed 0 packages in 902ms" })).toMatchObject({
+      state: "skipped",
+      reason: "already current",
+    });
+    expect(readUpdateOutcome({ code: 0, output: "up to date in 431ms" })).toMatchObject({
+      state: "skipped",
+      reason: "already current",
+    });
+    expect(
+      readUpdateOutcome({ code: 0, output: "Claude Code is already up to date (2.0.14)" }),
+    ).toMatchObject({ state: "skipped", reason: "already current" });
+  });
+
+  test("is a skip with a reason when winget has no such package installed", () => {
+    expect(
+      readUpdateOutcome({
+        code: 20,
+        output: "No installed package found matching input criteria.",
+      }),
+    ).toMatchObject({ state: "skipped", reason: "not installed" });
+  });
+
+  test("and a skip always carries one — never an empty reason", () => {
+    const skips = [
+      readUpdateOutcome({ code: 1, output: "No available upgrade found." }),
+      readUpdateOutcome({ code: 20, output: "No installed package found." }),
+    ];
+    for (const skip of skips) expect(skip.reason?.length ?? 0).toBeGreaterThan(0);
+  });
+
+  test("but a real failure stays a failure", () => {
+    const outcome = readUpdateOutcome({
+      code: 20,
+      output: "No package found matching input criteria.",
+    });
+    expect(outcome.state).toBe("failed");
+    expect(outcome.detail).toContain("No package found");
+  });
+
+  test("a release host already carrying the published tag is not re-downloaded", async () => {
+    // 33 MB fetched to arrive where the machine already was. The tag
+    // comes from the same redirect the download would have followed, so
+    // asking costs nothing the install would not have spent anyway.
+    let downloads = 0;
+    const outcomes = await updateAgents([host("redcode")], LINUX, {
+      locate: found("redcode"),
+      releaseTag: async () => "v0.4.2",
+      version: async () => "redcode 0.4.2",
+      release: async () => {
+        downloads++;
+      },
+    });
+    expect(downloads).toBe(0);
+    expect(outcomes[0]).toMatchObject({ state: "skipped", reason: "already at v0.4.2" });
+  });
+
+  test("and one carrying an older version is", async () => {
+    let downloads = 0;
+    const outcomes = await updateAgents([host("redcode")], LINUX, {
+      locate: found("redcode"),
+      releaseTag: async () => "v0.4.2",
+      version: async () => "redcode 0.4.1",
+      release: async () => {
+        downloads++;
+      },
+    });
+    expect(downloads).toBe(1);
+    expect(outcomes[0]).toMatchObject({ state: "updated" });
+  });
+
+  test("and one whose version cannot be read is updated rather than assumed current", async () => {
+    let downloads = 0;
+    await updateAgents([host("redcode")], LINUX, {
+      locate: found("redcode"),
+      releaseTag: async () => null,
+      version: async () => null,
+      release: async () => {
+        downloads++;
+      },
+    });
+    expect(downloads).toBe(1);
+  });
+});
+
+describe("one host failing", () => {
+  test("does not abort the hosts after it", async () => {
+    // The failure that motivates this: ghInstallExactArchive throws on a
+    // 404 and installerInstall throws on a TLS failure, either of which
+    // would otherwise end an update with four working hosts still in
+    // front of it.
+    const order: string[] = [];
+    const outcomes = await updateAgents(
+      [host("claude-code"), host("redcode"), host("gemini")],
+      LINUX,
+      {
+        locate: found("claude", "redcode", "gemini"),
+        npm: async () => "/usr/bin/npm",
+        releaseTag: async () => null,
+        version: async () => null,
+        command: async (argv) => {
+          order.push(argv.join(" "));
+          return { code: 0, output: "updated" };
+        },
+        release: async () => {
+          order.push("release");
+          throw new Error("GitHub API 404 for reddb-io/redcode");
+        },
+      },
+    );
+
+    expect(outcomes.map((o) => o.state)).toEqual(["updated", "failed", "updated"]);
+    expect(outcomes[1]).toMatchObject({
+      key: "redcode",
+      detail: "GitHub API 404 for reddb-io/redcode",
+    });
+    // The host after the failure ran, and ran its own mechanism.
+    expect(order[2]).toContain("@google/gemini-cli@latest");
+  });
+
+  test("is named, so a run of eleven hosts says which one it was", async () => {
+    const reported: AgentUpdateOutcome[] = [];
+    await updateAgents([host("muse")], LINUX, {
+      locate: found("muse"),
+      script: async () => {
+        throw new Error("installer exited 1: https://dev.meta.ai/install.sh");
+      },
+      report: (outcome) => reported.push(outcome),
+    });
+    expect(reported).toHaveLength(1);
+    expect(reported[0]).toMatchObject({ key: "muse", label: "Muse", state: "failed" });
+  });
+
+  test("and a host that cannot be updated at all names the fix", async () => {
+    const outcomes = await updateAgents([host("gemini")], LINUX, {
+      locate: found("gemini"),
+      npm: async () => null,
+      command: async () => {
+        throw new Error("npm should never have been reached");
+      },
+    });
+    expect(outcomes[0]).toMatchObject({ state: "failed", fix: "red-dev install core" });
+  });
+});
+
+describe("reading a release", () => {
+  test("takes the tag out of the redirect the publisher answers with", () => {
+    expect(
+      releaseTagFromLocation(
+        "https://github.com/reddb-io/redcode/releases/download/v0.4.2/redcode-linux-x64.tar.gz",
+      ),
+    ).toBe("v0.4.2");
+    expect(releaseTagFromLocation("https://github.com/reddb-io/redcode/releases")).toBeNull();
+  });
+
+  test("compares it to what the host says it is, past the v and the noise", () => {
+    expect(sameRelease("redcode 0.4.2 (linux-x64)", "v0.4.2")).toBe(true);
+    expect(sameRelease("0.4.2", "0.4.2")).toBe(true);
+    expect(sameRelease("redcode 0.4.1", "v0.4.2")).toBe(false);
+    expect(sameRelease("no version here", "v0.4.2")).toBe(false);
+  });
+});

--- a/src/agent-update.ts
+++ b/src/agent-update.ts
@@ -1,0 +1,499 @@
+/**
+ * Updating the agent hosts — each one by its own publisher's mechanism.
+ *
+ * There is no uniform update path here, and that is the decision rather
+ * than an omission. A host installed from npm is refreshed by npm; one
+ * that came from a GitHub release is re-resolved against that release
+ * and verified against the checksum published beside it; a winget
+ * package is upgraded by winget; and a host whose publisher ships a
+ * self-update is asked to update itself. Routing all four through the
+ * runtime manager's package backend would put red-dev between a vendor
+ * and its own binary, deciding on their behalf what "current" means —
+ * which is how a machine ends up holding a version nobody upstream
+ * recognises.
+ *
+ * Two rules hold across every mechanism:
+ *
+ *   A host that is already current is a skip carrying a reason, in the
+ *   publisher's own words where it gave one. Not a reinstall — 33 MB
+ *   re-downloaded to arrive where we started — and not a failure, since
+ *   winget reports exactly that state with a non-zero exit code.
+ *
+ *   A host that fails is named, and the rest still run. An update that
+ *   abandons four hosts because the first vendor script was briefly
+ *   unreachable is worse than no update at all: it is an update that
+ *   reports itself as having happened.
+ */
+
+import {
+  agentInstallMethod,
+  agentRuntimeEnvironment,
+  commandPath,
+  npmArgv,
+  resolveNpm,
+  type AgentSpec,
+} from "./agents.ts";
+import { runBounded } from "./bounded-command.ts";
+import { log } from "./log.ts";
+import type { Platform } from "./platform.ts";
+import {
+  exactGhReleaseUrl,
+  ghInstallExactArchive,
+  installerInstall,
+  spawnLoggedCapture,
+  wingetArgv,
+} from "./providers.ts";
+
+/**
+ * How a host is refreshed, which is how it was installed — plus the one
+ * case where the publisher owns the update and not the install.
+ */
+export type AgentUpdateMechanism =
+  | "self-update"
+  | "npm"
+  | "winget"
+  | "msstore"
+  | "github-release"
+  | "installer";
+
+/**
+ * What a mechanism does, in the shape the runner needs to do it.
+ *
+ * Three kinds rather than one argv, because two of these are not
+ * commands: a release is a download whose checksum is verified in this
+ * process, and a vendor script is fetched, hashed and interpreted by
+ * providers.ts. Flattening them into a command line would mean inventing
+ * one, and an invented argv is exactly what a test cannot pin.
+ */
+export type AgentUpdateStep =
+  | { kind: "command"; argv: string[]; env: Record<string, string> }
+  | { kind: "release"; repo: string; asset: string; bin: string }
+  | { kind: "script"; url: string };
+
+export type AgentUpdatePlan =
+  | {
+    state: "ready";
+    key: string;
+    label: string;
+    mechanism: AgentUpdateMechanism;
+    /** Where the host was found on PATH, when it has a command at all. */
+    executable: string | null;
+    step: AgentUpdateStep;
+  }
+  /** Nothing to do, and why. Never a failure. */
+  | { state: "skip"; key: string; label: string; reason: string }
+  /** Something to do that this machine cannot do yet, and the fix. */
+  | { state: "blocked"; key: string; label: string; reason: string; fix: string };
+
+/** PATH and npm, both injected: neither is answerable in a test. */
+export interface UpdateResolution {
+  locate: (command: string) => string | null;
+  npm: string | null;
+  /** process.platform, for the one argv that is rewritten on Windows. */
+  platform?: string;
+}
+
+/**
+ * The mechanism for this host on this machine.
+ *
+ * Read off the install method, because the publisher that installed a
+ * host is the publisher that updates it: a Codex installed from npm on
+ * WSL is not upgraded by winget just because a winget id exists in the
+ * same catalog entry. The single divergence is a vendor self-update,
+ * which replaces re-running the vendor's install script — the same
+ * publisher, through the door they built for exactly this.
+ */
+export function agentUpdateMechanism(a: AgentSpec, p: Platform): AgentUpdateMechanism | null {
+  const method = agentInstallMethod(a, p);
+  if (method === null) return null;
+  if (method === "installer" && a.selfUpdate) return "self-update";
+  return method;
+}
+
+/** What updating one host would run, decided without running anything. PURE. */
+export function planAgentUpdate(
+  a: AgentSpec,
+  p: Platform,
+  res: UpdateResolution,
+): AgentUpdatePlan {
+  const { key, label } = a;
+  const mechanism = agentUpdateMechanism(a, p);
+  if (!mechanism) return { state: "skip", key, label, reason: "no update mechanism here" };
+
+  // A host with a command that is not on PATH is not installed, and
+  // update does not install: `red-dev agents <key>` is that command, and
+  // silently widening this one into it would turn an update of four
+  // hosts into an install of eleven.
+  const executable = a.cmd.length > 0 ? res.locate(a.cmd) : null;
+  if (a.cmd.length > 0 && !executable) {
+    return { state: "skip", key, label, reason: "not installed" };
+  }
+
+  const ready = (step: AgentUpdateStep): AgentUpdatePlan => ({
+    state: "ready",
+    key,
+    label,
+    mechanism,
+    executable,
+    step,
+  });
+
+  switch (mechanism) {
+    case "self-update":
+      return ready({
+        kind: "command",
+        argv: npmArgv(executable as string, a.selfUpdate as string[]),
+        env: {},
+      });
+
+    case "npm": {
+      if (!res.npm) {
+        return {
+          state: "blocked",
+          key,
+          label,
+          reason: "no npm anywhere — not on PATH, and mise has no node",
+          fix: "red-dev install core",
+        };
+      }
+      return ready({
+        kind: "command",
+        // Pinned to @latest rather than left bare: npm treats an
+        // already-installed global as satisfied under some resolutions,
+        // and an update that can decide it has nothing to fetch is not
+        // an update.
+        argv: npmArgv(res.npm, ["install", "-g", `${a.npm}@latest`]),
+        // The same suppression the install path carries. Mise wraps a
+        // global npm install with an implicit reshim that has no
+        // deadline, and a WSL update stranded at "Reshimming mise 24..."
+        // is indistinguishable from one that hung.
+        env: { MISE_SKIP_RESHIM: "1" },
+      });
+    }
+
+    case "winget":
+      return ready({
+        kind: "command",
+        argv: wingetArgv(
+          [
+            "upgrade",
+            "--id",
+            a.winget as string,
+            "--exact",
+            "--silent",
+            "--accept-package-agreements",
+            "--accept-source-agreements",
+            // See wingetInstall: winget's progress UI is drawn against
+            // CONOUT$ and ignores a redirected stdout, so without this it
+            // paints over whatever frame is on the screen.
+            "--disable-interactivity",
+          ],
+          res.platform,
+        ),
+        env: {},
+      });
+
+    case "msstore":
+      return ready({
+        kind: "command",
+        argv: wingetArgv(
+          [
+            "upgrade",
+            "--id",
+            a.msstore as string,
+            // As on the install path: without an explicit source the id
+            // resolves against the community repository, where the
+            // ChatGPT entries belong to third parties rather than OpenAI.
+            "--source",
+            "msstore",
+            "--exact",
+            "--accept-package-agreements",
+            "--accept-source-agreements",
+            "--disable-interactivity",
+          ],
+          res.platform,
+        ),
+        env: {},
+      });
+
+    case "github-release": {
+      const asset = p.os === "windows" ? a.release?.windows[p.arch] : a.release?.linux[p.arch];
+      if (!asset) {
+        return { state: "skip", key, label, reason: `no ${p.os}/${p.arch} release asset` };
+      }
+      return ready({ kind: "release", repo: a.release?.repo as string, asset, bin: a.cmd });
+    }
+
+    case "installer":
+      return ready({ kind: "script", url: a.installer as string });
+  }
+}
+
+/**
+ * The states a publisher's answer reduces to.
+ *
+ * "skipped" is not a weaker "updated": it is the machine already being
+ * where the update was trying to take it, which is the ordinary outcome
+ * of running this twice.
+ */
+export interface AgentUpdateOutcome {
+  key: string;
+  label: string;
+  mechanism: AgentUpdateMechanism | null;
+  state: "updated" | "skipped" | "failed";
+  /** Why nothing happened. Always present when nothing did. */
+  reason?: string;
+  /** The publisher's own words, kept for the log. */
+  detail?: string;
+  /** What the operator can type to unblock this host. */
+  fix?: string;
+}
+
+/**
+ * The ways a publisher says "you already have this".
+ *
+ * Read before the exit code, not after it, because winget answers this
+ * question with a non-zero exit — the steady state of an idempotent
+ * machine, reported as an error by every caller that checks the code
+ * first.
+ */
+const ALREADY_CURRENT: readonly RegExp[] = [
+  /No available upgrade found/i,
+  /No newer package versions?/i,
+  /already installed/i,
+  /already current/i,
+  /already up[ -]to[ -]date/i,
+  /\bup[ -]to[ -]date\b/i,
+  /already (?:at|on) (?:the )?latest/i,
+  /is the latest version/i,
+  /changed 0 packages/i,
+  /nothing to update/i,
+];
+
+/** winget's way of saying the package this id names is not on the machine. */
+const NOT_INSTALLED = /No installed package(?:s)? found/i;
+
+/** The last thing the child said that was not a progress spinner. */
+function lastWords(output: string): string {
+  return output
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !/^[-\\|/]+$/.test(line))
+    .slice(-2)
+    .join(" ");
+}
+
+/** What a mechanism's exit code and output mean. PURE. */
+export function readUpdateOutcome(result: { code: number; output: string }): {
+  state: "updated" | "skipped" | "failed";
+  reason?: string;
+  detail?: string;
+} {
+  const { code, output } = result;
+  if (NOT_INSTALLED.test(output)) {
+    return { state: "skipped", reason: "not installed", detail: lastWords(output) };
+  }
+  if (ALREADY_CURRENT.some((marker) => marker.test(output))) {
+    return { state: "skipped", reason: "already current", detail: lastWords(output) };
+  }
+  if (code === 0) return { state: "updated", detail: lastWords(output) };
+  const detail = lastWords(output);
+  return { state: "failed", detail: detail || `exited ${code}` };
+}
+
+/** The version inside whatever a host prints when asked. PURE. */
+export function versionIn(text: string): string | null {
+  return text.match(/\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?/)?.[0] ?? null;
+}
+
+/** Whether an installed host is already the release this tag names. PURE. */
+export function sameRelease(versionOutput: string, tag: string): boolean {
+  const installed = versionIn(versionOutput);
+  const published = versionIn(tag);
+  return installed !== null && published !== null && installed === published;
+}
+
+/**
+ * The tag a release redirect currently points at. PURE.
+ *
+ * `/releases/latest/download/<asset>` answers with a Location naming the
+ * tag it resolved to, which is the whole of the re-resolution this needs
+ * — and it costs no GitHub API quota, the same reason the install path
+ * downloads through that redirect rather than through the API.
+ */
+export function releaseTagFromLocation(location: string): string | null {
+  const match = location.match(/\/releases\/download\/([^/]+)\//);
+  return match?.[1] ? decodeURIComponent(match[1]) : null;
+}
+
+async function resolveReleaseTag(repo: string, asset: string): Promise<string | null> {
+  try {
+    const res = await fetch(exactGhReleaseUrl(repo, asset), {
+      method: "HEAD",
+      redirect: "manual",
+      signal: AbortSignal.timeout(20_000),
+    });
+    const location = res.headers.get("location");
+    return location ? releaseTagFromLocation(location) : null;
+  } catch {
+    // No answer is not "already current". Returning null makes the
+    // caller update rather than assume, which is the safe direction:
+    // the worst case is a download the machine did not strictly need.
+    return null;
+  }
+}
+
+async function probeVersion(executable: string): Promise<string | null> {
+  try {
+    const result = await runBounded([executable, "--version"], { timeoutMs: 5_000 });
+    if (result.timedOut || result.exitCode !== 0) return null;
+    return versionIn(result.stdout + result.stderr);
+  } catch {
+    return null;
+  }
+}
+
+/** Every side of the machine this touches, so a test can hold all of them. */
+export interface AgentUpdateDeps {
+  locate?: (command: string) => string | null;
+  npm?: () => Promise<string | null>;
+  command?: (
+    argv: string[],
+    env: Record<string, string | undefined>,
+  ) => Promise<{ code: number; output: string }>;
+  release?: (step: { repo: string; asset: string; bin: string }, p: Platform) => Promise<void>;
+  script?: (url: string, note: string) => Promise<void>;
+  /** The tag the publisher's stable redirect resolves to right now. */
+  releaseTag?: (repo: string, asset: string) => Promise<string | null>;
+  /** What the installed host answers when asked for its version. */
+  version?: (executable: string) => Promise<string | null>;
+  /** Called as each host settles, so a caller can report while it runs. */
+  report?: (outcome: AgentUpdateOutcome) => void;
+}
+
+async function defaultCommand(
+  argv: string[],
+  env: Record<string, string | undefined>,
+): Promise<{ code: number; output: string }> {
+  const result = await spawnLoggedCapture(argv, { env });
+  return { code: result.code, output: result.out + result.err };
+}
+
+/**
+ * Run one host's plan, in the mechanism's own currency.
+ *
+ * A release and a vendor script throw on failure and answer nothing on
+ * success, so they report `updated` by having returned. A command is
+ * read: its exit code and its output are what says whether anything
+ * moved.
+ */
+async function performUpdate(
+  plan: Extract<AgentUpdatePlan, { state: "ready" }>,
+  host: AgentSpec,
+  p: Platform,
+  npm: string | null,
+  deps: AgentUpdateDeps,
+): Promise<AgentUpdateOutcome> {
+  const base = { key: plan.key, label: plan.label, mechanism: plan.mechanism };
+
+  if (plan.step.kind === "release") {
+    const { repo, asset, bin } = plan.step;
+    const tag = await (deps.releaseTag ?? resolveReleaseTag)(repo, asset);
+    if (tag && plan.executable) {
+      const installed = await (deps.version ?? probeVersion)(plan.executable);
+      if (installed && sameRelease(installed, tag)) {
+        return { ...base, state: "skipped", reason: `already at ${tag}` };
+      }
+    }
+    await (deps.release ?? ((step, platform) =>
+      ghInstallExactArchive(step.repo, step.asset, step.bin, platform)))(
+        { repo, asset, bin },
+        p,
+      );
+    return { ...base, state: "updated", detail: tag ?? undefined };
+  }
+
+  if (plan.step.kind === "script") {
+    const { url } = plan.step;
+    await (deps.script ?? installerInstall)(url, `${plan.label} official installer`);
+    return { ...base, state: "updated" };
+  }
+
+  // npm's child needs the directory npm itself lives in, or the
+  // lifecycle scripts it spawns look `node` up on a PATH this process
+  // was born without. Built from the resolved npm rather than from
+  // argv[0], which on Windows is cmd.exe. Same environment the install
+  // path builds, with the step's own variables on top of it.
+  const env: Record<string, string | undefined> = plan.mechanism === "npm" && npm
+    ? { ...(await agentRuntimeEnvironment(npm, host)), ...plan.step.env }
+    : plan.step.env;
+  const result = await (deps.command ?? defaultCommand)(plan.step.argv, env);
+  return { ...base, ...readUpdateOutcome(result) };
+}
+
+/**
+ * Update every host given, and let none of them stop the others.
+ *
+ * The try/catch is the whole point of the loop being here rather than at
+ * a call site: `ghInstallExactArchive` throws on a 404, `installerInstall`
+ * throws on a TLS failure, and either would otherwise end an update that
+ * still had four working hosts in front of it.
+ */
+export async function updateAgents(
+  hosts: readonly AgentSpec[],
+  p: Platform,
+  deps: AgentUpdateDeps = {},
+): Promise<AgentUpdateOutcome[]> {
+  const locate = deps.locate ?? commandPath;
+  // Resolved once, and only when something on this machine needs it.
+  const wantsNpm = hosts.some((host) => agentUpdateMechanism(host, p) === "npm");
+  const npm = wantsNpm ? await (deps.npm ?? resolveNpm)() : null;
+
+  const outcomes: AgentUpdateOutcome[] = [];
+  for (const host of hosts) {
+    const plan = planAgentUpdate(host, p, { locate, npm });
+    let outcome: AgentUpdateOutcome;
+    if (plan.state === "skip") {
+      outcome = { key: plan.key, label: plan.label, mechanism: null, state: "skipped", reason: plan.reason };
+    } else if (plan.state === "blocked") {
+      outcome = {
+        key: plan.key,
+        label: plan.label,
+        mechanism: agentUpdateMechanism(host, p),
+        state: "failed",
+        reason: plan.reason,
+        fix: plan.fix,
+      };
+    } else {
+      try {
+        outcome = await performUpdate(plan, host, p, npm, deps);
+      } catch (err) {
+        outcome = {
+          key: plan.key,
+          label: plan.label,
+          mechanism: plan.mechanism,
+          state: "failed",
+          detail: (err as Error).message,
+        };
+      }
+    }
+    outcomes.push(outcome);
+    deps.report?.(outcome);
+  }
+  return outcomes;
+}
+
+/** One host's outcome, in the log's own three columns. */
+export function reportAgentUpdate(outcome: AgentUpdateOutcome): void {
+  const where = outcome.mechanism ? ` (${outcome.mechanism})` : "";
+  if (outcome.state === "updated") {
+    log.ok(`${outcome.label}${where}${outcome.detail ? ` — ${outcome.detail}` : ""}`);
+    return;
+  }
+  if (outcome.state === "skipped") {
+    log.skip(`${outcome.label}: ${outcome.reason ?? "nothing to do"}`);
+    return;
+  }
+  log.err(`${outcome.label}${where}: ${outcome.reason ?? outcome.detail ?? "update failed"}`);
+  if (outcome.fix) log.plain(`       fix: ${outcome.fix}`);
+}

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -57,6 +57,17 @@ export interface AgentSpec {
     linux: Partial<Record<Platform["arch"], string>>;
     windows: Partial<Record<Platform["arch"], string>>;
   };
+  /**
+   * The publisher's own update command, appended to this host's binary.
+   *
+   * Only for a host that manages its own installation — Claude Code's
+   * install.sh puts a self-updating binary on the machine, so `claude
+   * update` is the door its publisher built for exactly this, and
+   * re-running the install script would be red-dev going around it.
+   * A host whose package manager owns the version (npm, winget, a
+   * release archive) leaves this unset: see src/agent-update.ts.
+   */
+  selfUpdate?: string[];
   /** Runtimes an npm lifecycle script needs in addition to Node itself. */
   runtimeNeeds?: string[];
   /** A command that must start successfully before presence counts as ready. */
@@ -92,6 +103,7 @@ export const AGENTS: AgentSpec[] = [
     recommended: true,
     installer: "https://claude.ai/install.sh",
     winget: "Anthropic.ClaudeCode",
+    selfUpdate: ["update"],
   },
   {
     key: "codex",
@@ -372,7 +384,12 @@ export function npmEnvironment(
   return executableEnvironment(npm, platform, current);
 }
 
-async function agentRuntimeEnvironment(
+/**
+ * Exported for the update path, which spawns the same npm against the
+ * same host and must not grow a second answer to "what does this child
+ * need on its PATH" — see src/agent-update.ts.
+ */
+export async function agentRuntimeEnvironment(
   executable: string,
   agent: AgentSpec,
 ): Promise<Record<string, string | undefined>> {

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -36,6 +36,19 @@ describe("command parsing", () => {
       passthrough: [],
       errors: [],
     });
+    expect(parse(["agents", "update"])).toMatchObject({
+      agentUpdate: true,
+      agentRun: false,
+      agentDefault: false,
+      agentKeys: undefined,
+      errors: [],
+    });
+  });
+
+  test("`agents update` is a command a person can find without being told", () => {
+    // A subcommand that parses and appears nowhere in --help exists only
+    // for whoever already knew about it.
+    expect(buildCli().help(["agents"])).toContain("update");
   });
 
   test("keeps what follows `--` for the program red-dev starts", () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -183,7 +183,8 @@ export function buildCli(): CLI {
         description: "choose optional tools to install",
       },
       agents: {
-        description: "choose coding agents, and wire red-skills into them",
+        description:
+          "choose coding agents, wire red-skills into them, or `update` each by its publisher's mechanism",
         // Two positionals of its own, for the reason `share adopt
         // <tool>` has two: a comma-separated selection and a
         // subcommand's single argument are different shapes, and one
@@ -193,7 +194,7 @@ export function buildCli(): CLI {
           {
             name: "agent_selection",
             description:
-              "comma-separated agent keys for an unattended install, or `default`, or `run`",
+              "comma-separated agent keys for an unattended install, or `default`, `run`, `update`",
             required: false,
           },
           {
@@ -292,6 +293,8 @@ export interface Invocation {
   agentDefaultKey: string | undefined;
   /** `agents run` — start the Default agent. */
   agentRun: boolean;
+  /** `agents update` — refresh every installed host, each its own way. */
+  agentUpdate: boolean;
   /**
    * Everything after `--`: arguments for the program red-dev starts,
    * not for red-dev. Kept verbatim, including flags red-dev would never
@@ -361,12 +364,14 @@ export function parseArgs(cli: CLI, argv: string[]): Invocation {
   const rawWallpaper = pos["wallpaper_name"] ??
     (literalWallpaper && !literalWallpaper.startsWith("-") ? literalWallpaper : undefined);
 
-  // `default` and `run` in the selection slot are subcommands, not
-  // agent keys — no agent is called either, and reading one as a key
-  // would try to install it and fail with a list of the real names.
+  // `default`, `run` and `update` in the selection slot are
+  // subcommands, not agent keys — no agent is called any of them
+  // either, and reading one as a key would try to install it and fail
+  // with a list of the real names.
   const rawAgents = pos["agent_selection"];
   const agentDefault = rawAgents === "default";
   const agentRun = rawAgents === "run";
+  const agentUpdate = rawAgents === "update";
   return {
     command: r.command[0] ?? null,
     // `theme <name>` and `plan <scope>` both land in the positional map
@@ -374,13 +379,14 @@ export function parseArgs(cli: CLI, argv: string[]): Invocation {
     scope: scope ?? (typeof rawName === "string" ? rawName : undefined),
     logsWhich: typeof pos["which"] === "string" ? pos["which"] : undefined,
     agentKeys:
-      typeof rawAgents === "string" && !agentDefault && !agentRun
+      typeof rawAgents === "string" && !agentDefault && !agentRun && !agentUpdate
         ? rawAgents.split(",").map((value) => value.trim()).filter(Boolean)
         : undefined,
     agentDefault,
     agentDefaultKey:
       agentDefault && typeof pos["agent_key"] === "string" ? pos["agent_key"] : undefined,
     agentRun,
+    agentUpdate,
     passthrough,
     runtimeIds:
       typeof pos["runtime_selection"] === "string"

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,6 +25,7 @@ import { applyContextForEntry, type ApplyContextEntryPath } from "./preferences.
 import { themeFor, themeNames } from "./themes.ts";
 import { transcriptDir } from "./transcript.ts";
 import { interactive, select, text } from "./ui.ts";
+import type { UpdateStage } from "./update-order.ts";
 
 function resolveScopes(p: Platform, arg?: string): Scope[] {
   return arg ? [arg as Scope] : applicableScopes(p);
@@ -703,48 +704,67 @@ async function cmdPrivileged(p: Platform, inv: Invocation): Promise<number> {
   return code;
 }
 
+/**
+ * Update the machine: the package managers, then everything they do not
+ * own, then the converge that checks the result against the manifest.
+ *
+ * The order is declared in src/update-order.ts rather than written out
+ * as a run of statements here, because it is the part of this that is
+ * load-bearing and the part a reader has to be able to see whole. This
+ * function is what each stage *is*; that file is what order they come
+ * in and which of them may fail without ending the run.
+ */
 async function cmdUpdate(p: Platform, inv: Invocation): Promise<number> {
-  try {
-    await systemUpdate(p);
-  } catch (err) {
-    log.err((err as Error).message);
-    return 1;
-  }
-  // Before the converge, because the converge builds out of this tree:
-  // convergeRedSkills stops at "already wired", which is correct for
-  // install and leaves the checkout frozen forever under update.
-  if (!inv.dryRun) {
-    try {
+  const { runUpdate } = await import("./update-order.ts");
+
+  const stages: Record<UpdateStage, () => Promise<number | void>> = {
+    system: () => systemUpdate(p),
+
+    // Before the converge, because the converge builds out of this tree:
+    // convergeRedSkills stops at "already wired", which is correct for
+    // install and leaves the checkout frozen forever under update.
+    "red-skills": async () => {
+      if (inv.dryRun) return;
       const { updateRedSkills } = await import("./agents.ts");
       await updateRedSkills(p);
-    } catch (err) {
-      // Never fatal: the rest of the machine still has an update to do.
-      log.warn(`red-skills: ${(err as Error).message}`);
-    }
-  }
+    },
 
-  // The reddb-io suite, which until now no update path reached at all.
-  //
-  // apt and winget own their packages and upgrade them above; the tools
-  // this organisation publishes were installed once by a release
-  // download or a vendor script and then stayed at that version until
-  // somebody re-ran the installer by hand. mise is what closes that,
-  // and one `mise upgrade` covers every tool the generated fragment
-  // declares rather than one call per tool.
-  if (!inv.dryRun) {
-    try {
+    // The reddb-io suite, which until now no update path reached at all.
+    //
+    // apt and winget own their packages and upgrade them above; the
+    // tools this organisation publishes were installed once by a release
+    // download or a vendor script and then stayed at that version until
+    // somebody re-ran the installer by hand. mise is what closes that,
+    // and one `mise upgrade` covers every tool the generated fragment
+    // declares rather than one call per tool.
+    suite: async () => {
+      if (inv.dryRun) return;
       const { miseUpgradeSuite } = await import("./providers.ts");
       await miseUpgradeSuite(p);
-    } catch (err) {
-      // Same reasoning as red-skills above: an unreachable GitHub is not
-      // a reason to abandon the rest of the update.
-      log.warn(`mise: ${(err as Error).message}`);
-    }
-  }
+    },
 
-  // Upgrading can leave the manifest unsatisfied (a package removed, a
-  // binary replaced), so always re-converge afterwards.
-  return await cmdInstall(p, inv, "update");
+    // The agent hosts, which mise does not own either — and which are
+    // deliberately not handed to it. Each publisher updates its own.
+    agents: async () => {
+      if (inv.dryRun) return;
+      await cmdAgentsUpdate(p);
+    },
+
+    // Upgrading can leave the manifest unsatisfied (a package removed, a
+    // binary replaced), so always re-converge afterwards.
+    converge: () => cmdInstall(p, inv, "update"),
+  };
+
+  const run = await runUpdate(
+    (stage) => stages[stage](),
+    (stage, message, fatal) => {
+      // A stage that may be walked past is a warning; one that ends the
+      // update is the error that ended it.
+      if (fatal) log.err(message);
+      else log.warn(`${stage}: ${message}`);
+    },
+  );
+  return run.code;
 }
 
 async function cmdTheme(p: Platform, inv: Invocation, name?: string): Promise<number> {
@@ -1305,6 +1325,7 @@ async function cmdAgents(p: Platform, inv: Invocation): Promise<number> {
 
   if (inv.agentDefault) return await cmdAgentsDefault(p, inv.agentDefaultKey);
   if (inv.agentRun) return await cmdAgentsRun(p, inv.passthrough);
+  if (inv.agentUpdate) return await cmdAgentsUpdate(p);
 
   if (inv.agentKeys !== undefined) {
     inv = { ...inv, agentKeys: currentAgentKeys(inv.agentKeys) };
@@ -1545,6 +1566,36 @@ async function cmdAgentsRun(p: Platform, passthrough: string[]): Promise<number>
     log.err(`${decision.target.label} could not be started: ${decision.target.executable}`);
     return 1;
   }
+}
+
+/**
+ * `red-dev agents update` — every installed host, by its own
+ * publisher's mechanism.
+ *
+ * Deliberately not routed through the runtime manager's package
+ * backend, and deliberately not one uniform path: see the header of
+ * src/agent-update.ts. This surface is the reporting half of it — the
+ * decisions all live there, so `red-dev update` running the same thing
+ * as a stage cannot report it differently.
+ */
+async function cmdAgentsUpdate(p: Platform): Promise<number> {
+  const { availableAgents } = await import("./agents.ts");
+  const { reportAgentUpdate, updateAgents } = await import("./agent-update.ts");
+
+  const hosts = availableAgents(p);
+  log.step(`agents: updating ${hosts.length} known hosts, each by its publisher`);
+  const outcomes = await updateAgents(hosts, p, { report: reportAgentUpdate });
+
+  const failed = outcomes.filter((outcome) => outcome.state === "failed");
+  const updated = outcomes.filter((outcome) => outcome.state === "updated").length;
+  // Counted rather than narrated: a machine where nothing moved is the
+  // ordinary result of running this twice, and it should read like one.
+  if (failed.length === 0) {
+    log.ok(updated === 0 ? "every agent host was already current" : `${updated} agent host(s) updated`);
+    return 0;
+  }
+  log.err(`${failed.length} agent host(s) failed: ${failed.map((f) => f.key).join(", ")}`);
+  return 1;
 }
 
 /** Choose which language runtimes mise manages. */

--- a/src/update-order.test.ts
+++ b/src/update-order.test.ts
@@ -1,0 +1,74 @@
+/**
+ * The order `red-dev update` advances a machine in.
+ *
+ * Pinned by walking it rather than by reading main.ts, because the order
+ * is only worth anything if it is the one that executes: system
+ * packages, then RedSkills, then the agent hosts, then the converge that
+ * checks the result against the manifest. Every one of those depends on
+ * what ran before it, and the converge depends on all of them.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { runUpdate, updateStageOrder, UPDATE_STAGES, type UpdateStage } from "./update-order.ts";
+
+/** Walk the stages, recording which ones were reached. */
+async function walk(
+  fail: Partial<Record<UpdateStage, string>> = {},
+  converge = 0,
+): Promise<{ ran: UpdateStage[]; code: number; failures: string[] }> {
+  const failures: string[] = [];
+  const run = await runUpdate(
+    async (stage) => {
+      const message = fail[stage];
+      if (message) throw new Error(message);
+      return stage === "converge" ? converge : undefined;
+    },
+    (stage, message, fatal) => failures.push(`${stage}${fatal ? "!" : ""}: ${message}`),
+  );
+  return { ...run, failures };
+}
+
+describe("an update", () => {
+  test("runs system, RedSkills, agents, then the converge, in that order", async () => {
+    const { ran } = await walk();
+    expect(ran.indexOf("system")).toBeLessThan(ran.indexOf("red-skills"));
+    expect(ran.indexOf("red-skills")).toBeLessThan(ran.indexOf("agents"));
+    expect(ran.indexOf("agents")).toBeLessThan(ran.indexOf("converge"));
+    // The whole sequence, so the mise-managed suite cannot be moved
+    // after the agents that may be installed on top of it without this
+    // saying so.
+    expect(ran).toEqual(["system", "red-skills", "suite", "agents", "converge"]);
+    expect(updateStageOrder()).toEqual(ran);
+  });
+
+  test("declares each stage exactly once", () => {
+    const stages = UPDATE_STAGES.map((spec) => spec.stage);
+    expect(new Set(stages).size).toBe(stages.length);
+  });
+
+  test("ends when the package managers themselves fail", async () => {
+    // Everything below system is installed on top of what it owns, so
+    // there is nothing honest to do after it has failed.
+    const { ran, code, failures } = await walk({ system: "apt-get update exited 100" });
+    expect(ran).toEqual(["system"]);
+    expect(code).toBe(1);
+    expect(failures).toEqual(["system!: apt-get update exited 100"]);
+  });
+
+  test("carries past a stage that is allowed to fail, and names it", async () => {
+    // An unreachable GitHub is not a reason to abandon an apt upgrade
+    // that already succeeded. A machine that stops updating the moment
+    // one vendor is down never finishes updating.
+    const { ran, failures } = await walk({ "red-skills": "GitHub API 503", agents: "codex failed" });
+    expect(ran).toEqual(["system", "red-skills", "suite", "agents", "converge"]);
+    expect(failures).toEqual(["red-skills: GitHub API 503", "agents: codex failed"]);
+  });
+
+  test("answers with the converge's own exit code", async () => {
+    // The question `red-dev update` answers is whether this machine is
+    // now converged, and the converge is what knows.
+    expect((await walk({}, 0)).code).toBe(0);
+    expect((await walk({}, 2)).code).toBe(2);
+    expect((await walk({ agents: "one host failed" }, 0)).code).toBe(0);
+  });
+});

--- a/src/update-order.ts
+++ b/src/update-order.ts
@@ -1,0 +1,84 @@
+/**
+ * The order `red-dev update` advances a machine in, as data.
+ *
+ * It was a run of statements in main.ts, which is a fine way to express
+ * an order and a poor way to keep one: every stage was added by
+ * somebody solving a different problem, and the reason each sits where
+ * it does lived in whichever commit message put it there. The order is
+ * load-bearing —
+ *
+ *   system    the package managers first, because everything below is
+ *             installed on top of what they own
+ *   red-skills  before the converge, which builds out of the red-skills
+ *             checkout: convergeRedSkills stops at "already wired",
+ *             correct for install and permanently frozen under update
+ *   suite     the reddb-io tools mise manages, which no update path
+ *             reached at all until one asked it to
+ *   agents    each host by its own publisher's mechanism, after the
+ *             runtimes it may need have been advanced above it
+ *   converge  last, always: upgrading can leave the manifest unsatisfied
+ *             — a package removed, a binary replaced — and the converge
+ *             is what notices
+ *
+ * — so it is declared once, in one place, and executed by walking it.
+ */
+
+export type UpdateStage = "system" | "red-skills" | "suite" | "agents" | "converge";
+
+export interface UpdateStageSpec {
+  stage: UpdateStage;
+  /**
+   * A failure here ends the update. Everywhere else it is named and
+   * walked past: an unreachable GitHub is not a reason to abandon the
+   * apt upgrade that already succeeded, and a machine that stops
+   * updating the moment one vendor is down never finishes updating.
+   */
+  fatal?: boolean;
+}
+
+export const UPDATE_STAGES: readonly UpdateStageSpec[] = [
+  { stage: "system", fatal: true },
+  { stage: "red-skills" },
+  { stage: "suite" },
+  { stage: "agents" },
+  { stage: "converge", fatal: true },
+];
+
+/** The stages in order, for a caller that only wants the sequence. */
+export function updateStageOrder(): UpdateStage[] {
+  return UPDATE_STAGES.map((spec) => spec.stage);
+}
+
+export interface UpdateRun {
+  /** Which stages were reached, in the order they were reached. */
+  ran: UpdateStage[];
+  /** The exit code of the update, which is the converge's own. */
+  code: number;
+}
+
+/**
+ * Walk the stages, in order, with one stage's failure kept to itself.
+ *
+ * `perform` returns a number only where a stage has an exit code of its
+ * own to contribute — the converge does, and nothing else does. Any
+ * stage may throw; `onFailure` is told, and the walk continues unless
+ * the stage was declared fatal.
+ */
+export async function runUpdate(
+  perform: (stage: UpdateStage) => Promise<number | void>,
+  onFailure: (stage: UpdateStage, message: string, fatal: boolean) => void,
+): Promise<UpdateRun> {
+  const ran: UpdateStage[] = [];
+  let code = 0;
+  for (const spec of UPDATE_STAGES) {
+    ran.push(spec.stage);
+    try {
+      const result = await perform(spec.stage);
+      if (typeof result === "number") code = result;
+    } catch (err) {
+      onFailure(spec.stage, (err as Error).message, spec.fatal === true);
+      if (spec.fatal) return { ran, code: 1 };
+    }
+  }
+  return { ran, code };
+}


### PR DESCRIPTION
Automated AFK landing for #149. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #149

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/163"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789435820&installation_model_id=20659&pr_number=163&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F163&signature=9adc62b240481b2d2f57607d3f46560c2eba88f1178d21a7c97d7fe90ccb702d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->