### PR TITLE
fix: #153 doctor reports the Default agent, agent freshness and usage detail

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,15 @@ host that fails is named and the others still run. `red-dev update` runs it as
 one stage of updating the machine: system packages, RedSkills, mise's tools,
 the agents, then the converge.
 
+`doctor` has an `[agents]` section holding the whole posture: which host is the
+Default agent, how long ago each installed host's copy on PATH last changed, and
+per-provider usage with the reset times the Redwall's one compact line has no
+room for. It reports and does nothing else — no vendor is asked what the newest
+version is, no host is started to interrogate it, and the usage numbers are read
+from the snapshot some other run wrote or reported unknown. A host whose copy
+has sat unchanged for 30 days is drift pointing at `red-dev agents update`;
+one whose copy cannot be read is unknown rather than stale.
+
 `red-dev agents run` starts it. What it runs is the plain invocation — the same
 command line you would have typed — and the suite enumerates every host's launch
 argv to keep it that way, over a fixture host carrying `--yolo` so the check can

--- a/src/agent-posture.test.ts
+++ b/src/agent-posture.test.ts
@@ -125,6 +125,15 @@ describe("agent freshness", () => {
     expect(rows.some((candidate) => candidate.name === "Gemini CLI")).toBe(false);
   });
 
+  test("says today rather than nought days for a host installed this morning", () => {
+    const found = row(
+      posture({ locate: locates("claude-code"), modifiedAtMs: written(0) }),
+      "Claude Code",
+    );
+    expect(found.status).toBe("ok");
+    expect(found.detail).toBe("the copy on PATH changed today");
+  });
+
   test("is drift once a host that moves weekly has stopped moving", () => {
     const found = row(
       posture({ locate: locates("claude-code"), modifiedAtMs: written(AGENT_STALE_DAYS + 5) }),

--- a/src/agent-posture.test.ts
+++ b/src/agent-posture.test.ts
@@ -1,0 +1,260 @@
+/**
+ * The agent posture `doctor` reports, and the two things it may not do.
+ *
+ * Three questions are answered here and none of them is answered by
+ * asking a vendor: which host red-dev hands work to, how old each
+ * installed host's copy is, and how much of each provider's allowance is
+ * left with the reset times the Redwall card has no room for.
+ *
+ * The claim under test is that reporting is all this does. `doctor` is
+ * the command people run when a machine is already misbehaving, and a
+ * doctor that authenticates, takes a collector's lock or rewrites a
+ * preference is a diagnostic that changes the patient. So the collect
+ * path is asserted absent three ways — no network call, not one byte
+ * written, and nothing in the module that names an entry point which
+ * could do either.
+ */
+
+import { existsSync, mkdtempSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, test } from "bun:test";
+import type { AgentUsageSnapshot } from "./agent-usage.ts";
+import {
+  agentPosture,
+  AGENT_STALE_DAYS,
+  type AgentPostureRow,
+} from "./agent-posture.ts";
+import { AGENTS } from "./agents.ts";
+
+const dir = mkdtempSync(`${tmpdir()}/red-dev-agent-posture-`);
+const NOW = 1_760_000_000_000;
+const DAY = 86_400_000;
+
+/** A `locate` that answers for the named hosts and for nothing else. */
+function locates(...keys: string[]): (cmd: string) => string | null {
+  const commands = new Set(
+    AGENTS.filter((agent) => keys.includes(agent.key)).map((agent) => agent.cmd),
+  );
+  return (cmd) => (commands.has(cmd) ? `/opt/agents/${cmd}` : null);
+}
+
+/** Every host's copy written the same number of days ago. */
+function written(daysAgo: number): () => number {
+  return () => NOW - daysAgo * DAY;
+}
+
+const snapshot: AgentUsageSnapshot = {
+  schemaVersion: 1,
+  provider: "claude",
+  updatedAtMs: NOW - 60_000,
+  windows: [
+    { kind: "five_hour", usedPercent: 42, resetsAtMs: NOW + 2 * 3_600_000 + 1_800_000 },
+    { kind: "seven_day", usedPercent: 18, resetsAtMs: null },
+  ],
+};
+
+function posture(
+  overrides: Parameters<typeof agentPosture>[0] = {},
+): AgentPostureRow[] {
+  return agentPosture({
+    nowMs: NOW,
+    locate: locates(),
+    modifiedAtMs: () => null,
+    usage: () => null,
+    ...overrides,
+  });
+}
+
+function row(rows: AgentPostureRow[], name: string): AgentPostureRow {
+  const found = rows.find((candidate) => candidate.name === name);
+  if (!found) throw new Error(`no '${name}' row in ${rows.map((r) => r.name).join(", ")}`);
+  return found;
+}
+
+describe("the Default agent", () => {
+  test("is reported under its own name and key when it is installed", () => {
+    const rows = posture({
+      defaultAgent: "codex",
+      selected: ["claude-code", "codex"],
+      locate: locates("claude-code", "codex"),
+      modifiedAtMs: written(1),
+    });
+    const found = row(rows, "default agent");
+    expect(found.status).toBe("ok");
+    expect(found.detail).toContain("Codex CLI");
+    expect(found.detail).toContain("codex");
+  });
+
+  test("is still reported under its own name once the host is gone", () => {
+    // The failure this pins is a doctor that agrees with the machine by
+    // changing the answer: a recorded host that has been uninstalled is
+    // named, never replaced by whichever host is still there.
+    const rows = posture({
+      defaultAgent: "claude-code",
+      selected: ["claude-code", "codex"],
+      locate: locates("codex"),
+      modifiedAtMs: written(1),
+    });
+    const found = row(rows, "default agent");
+    expect(found.status).toBe("drift");
+    expect(found.detail).toContain("Claude Code");
+    expect(found.detail).not.toContain("Codex");
+    expect(found.fix).toContain("red-dev agents claude-code");
+  });
+
+  test("is not a fault on a machine nobody has answered for", () => {
+    const found = row(posture({ selected: ["claude-code", "codex"] }), "default agent");
+    expect(found.status).toBe("n/a");
+    expect(found.detail).toContain("red-dev agents default");
+  });
+});
+
+describe("agent freshness", () => {
+  test("is the age of the copy on PATH, reported per installed host", () => {
+    const rows = posture({
+      locate: locates("claude-code", "codex"),
+      modifiedAtMs: written(3),
+    });
+    const found = row(rows, "Claude Code");
+    expect(found.status).toBe("ok");
+    expect(found.detail).toContain("3 day(s) ago");
+    expect(rows.some((candidate) => candidate.name === "Codex CLI")).toBe(true);
+    // A host that is not on this machine is not a row: doctor reports
+    // the hosts that are installed, and eleven "not installed" lines
+    // would bury the two that are.
+    expect(rows.some((candidate) => candidate.name === "Gemini CLI")).toBe(false);
+  });
+
+  test("is drift once a host that moves weekly has stopped moving", () => {
+    const found = row(
+      posture({ locate: locates("claude-code"), modifiedAtMs: written(AGENT_STALE_DAYS + 5) }),
+      "Claude Code",
+    );
+    expect(found.status).toBe("drift");
+    expect(found.detail).toContain(`${AGENT_STALE_DAYS + 5} day(s)`);
+    expect(found.fix).toBe("red-dev agents update");
+  });
+
+  test("is unknown rather than stale when the copy cannot be read", () => {
+    // Unreadable is not old. Reporting it as drift would send someone
+    // updating a host that may well be current.
+    const found = row(
+      posture({ locate: locates("claude-code"), modifiedAtMs: () => null }),
+      "Claude Code",
+    );
+    expect(found.status).toBe("n/a");
+    expect(found.detail).toContain("cannot be read");
+    expect(found.fix).toBeUndefined();
+  });
+
+  test("says so plainly when this machine carries no host at all", () => {
+    const found = row(posture(), "agent hosts");
+    expect(found.status).toBe("n/a");
+    expect(found.detail).toContain("none installed");
+  });
+});
+
+describe("agent usage", () => {
+  test("is the per-window detail, with the reset times the card has no room for", () => {
+    const found = row(posture({ usage: () => snapshot }), "claude usage");
+    expect(found.status).toBe("ok");
+    expect(found.detail).toContain("five_hour 58% left");
+    expect(found.detail).toContain("resets in 2h 30m");
+    // A window the provider gave no reset for says that, rather than
+    // borrowing the reset of the window beside it.
+    expect(found.detail).toContain("seven_day 82% left");
+    expect(found.detail).toContain("reset time not published");
+    // Stale-but-honest is the contract, so the age of the observation is
+    // part of the reading rather than an implied "just now".
+    expect(found.detail).toContain("observed 1m ago");
+  });
+
+  test("is unknown where there is no snapshot, and never a number", () => {
+    const found = row(posture({ usage: () => null }), "claude usage");
+    expect(found.status).toBe("n/a");
+    expect(found.detail).toContain("unknown");
+    expect(found.detail).not.toMatch(/\d+%/);
+  });
+
+  test("is unknown for a snapshot too old to vouch for", () => {
+    // An hour is the ceiling agent-usage.ts sets on stale-but-honest,
+    // and doctor does not refresh what has passed it.
+    const aged = { ...snapshot, updatedAtMs: NOW - 3_600_000 };
+    const found = row(posture({ usage: () => aged }), "claude usage");
+    expect(found.status).toBe("n/a");
+    expect(found.detail).toContain("unknown");
+  });
+});
+
+const realFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+describe("reporting the posture", () => {
+  test("collects nothing: no network, and not one byte written", () => {
+    const path = `${dir}/agent-usage-claude.json`;
+    writeFileSync(path, `${JSON.stringify(snapshot)}\n`);
+    const before = readFileSync(path, "utf8");
+    const listing = readdirSync(dir).sort();
+
+    let calls = 0;
+    globalThis.fetch = ((): never => {
+      calls += 1;
+      throw new Error("doctor reached the network to report agent usage");
+    }) as unknown as typeof fetch;
+
+    const rows = agentPosture({
+      nowMs: NOW,
+      defaultAgent: "claude-code",
+      selected: ["claude-code"],
+      locate: locates("claude-code"),
+      modifiedAtMs: written(2),
+      // The real reader, against a real file, so this is the collect
+      // path's own leavings that the assertions below would catch.
+      usagePath: (provider) => `${dir}/agent-usage-${provider}.json`,
+    });
+
+    expect(row(rows, "claude usage").status).toBe("ok");
+    expect(calls).toBe(0);
+    // A `.lock` while a collector holds one, a `.tmp` mid-write, a
+    // rewritten snapshot: the directory is exactly as it was found.
+    expect(readdirSync(dir).sort()).toEqual(listing);
+    expect(readFileSync(path, "utf8")).toBe(before);
+  });
+
+  test("reads an absent snapshot without creating one", () => {
+    const path = `${dir}/agent-usage-nobody.json`;
+    expect(existsSync(path)).toBe(false);
+    const rows = agentPosture({
+      nowMs: NOW,
+      locate: locates(),
+      modifiedAtMs: () => null,
+      providers: ["nobody"],
+      usagePath: (provider) => `${dir}/agent-usage-${provider}.json`,
+    });
+    expect(row(rows, "nobody usage").status).toBe("n/a");
+    expect(existsSync(path)).toBe(false);
+  });
+
+  test("cannot collect or mutate: nothing in its path names an entry point that could", () => {
+    // The behavioural tests above prove this run did not. This is what
+    // keeps it true — `readAgentUsage` is a probe, a lock and a write,
+    // and `writePreferences` is the mutation a report has no business
+    // performing.
+    const src = readFileSync(`${import.meta.dir}/agent-posture.ts`, "utf8");
+    expect(src).toContain("agentUsageSnapshot");
+    expect(src).toContain("agentUsageReading");
+    expect(src).not.toContain("readAgentUsage");
+    expect(src).not.toContain("claudeUsageCollector");
+    expect(src).not.toContain("writePreferences");
+    expect(src).not.toContain("writeFileSync");
+    expect(src).not.toContain("Bun.spawn");
+  });
+
+  test("is what doctor prints, under a section of its own", () => {
+    const src = readFileSync(`${import.meta.dir}/main.ts`, "utf8");
+    expect(src).toContain('log.plain("\\n[agents]")');
+    expect(src).toContain("agentPostureFor(p)");
+  });
+});

--- a/src/agent-posture.ts
+++ b/src/agent-posture.ts
@@ -157,7 +157,11 @@ export function reportAgentFreshness(
   return {
     name: host.label,
     status: "ok",
-    detail: `the copy on PATH changed ${days} day(s) ago`,
+    // A host installed this morning is not "0 day(s) ago", which reads
+    // like a number that failed to be computed.
+    detail: days === 0
+      ? "the copy on PATH changed today"
+      : `the copy on PATH changed ${days} day(s) ago`,
   };
 }
 

--- a/src/agent-posture.ts
+++ b/src/agent-posture.ts
@@ -1,0 +1,273 @@
+/**
+ * The machine's agent posture, as `doctor` reports it.
+ *
+ * Three questions, one section, and the same rule over all of them: this
+ * reports and does nothing else. `doctor` is what people run when a
+ * machine is already misbehaving, so a report that authenticates, takes
+ * the usage collector's lock or rewrites a preference would be a
+ * diagnostic that changes the patient — and the collector this reads
+ * from is the one whose whole design memo is that a display surface must
+ * never be able to start one. See src/agent-usage.ts and
+ * .red/contexts/agents/CONTEXT.md.
+ *
+ * Which host is the Default agent comes from the recorded choice read
+ * against what is installed, which is src/default-agent.ts's job and not
+ * repeated here.
+ *
+ * Whether an installed host is current is answered from the copy on
+ * PATH and nothing else. Asking each vendor what their newest version is
+ * would be a network call per host on a command that is supposed to be
+ * cheap, and running `<host> --version` would be the agent process this
+ * project spent a release learning not to start from a status surface.
+ * So freshness is the age of the file that would run — evidence rather
+ * than a verdict, with the verdict left to the threshold below and the
+ * evidence printed beside it.
+ *
+ * Agent usage is the per-provider detail that does not fit on the
+ * Redwall's compact line: every window the provider defines, what is
+ * left of it, and when it comes back. Unknown is an answer — no
+ * snapshot, or one too old to vouch for, reads as unknown and never as a
+ * number.
+ */
+
+import { statSync } from "node:fs";
+import {
+  agentUsageReading,
+  agentUsageSnapshot,
+  type AgentUsageReading,
+  type AgentUsageSnapshot,
+} from "./agent-usage.ts";
+import { AGENTS, commandPath, type AgentSpec } from "./agents.ts";
+import { readDefaultAgent, reportDefaultAgent } from "./default-agent.ts";
+import type { Platform } from "./platform.ts";
+
+/** One line of the section, in the shape drift checks already use. */
+export interface AgentPostureRow {
+  readonly name: string;
+  readonly status: "ok" | "drift" | "n/a";
+  readonly detail: string;
+  /** What to run. Omitted when there is nothing to do. */
+  readonly fix?: string;
+}
+
+/**
+ * How long a host may sit unchanged before it is worth saying so.
+ *
+ * Agent CLIs move several times a week, so a month without the file on
+ * PATH changing is not a machine that happens to be current — it is one
+ * nothing has updated. Deliberately generous: this is a report, and the
+ * cost of being wrong is an update nobody needed rather than a host left
+ * frozen for a season.
+ */
+export const AGENT_STALE_DAYS = 30;
+
+/**
+ * The providers whose allowance this section reports.
+ *
+ * One, and it is the one with a read path that costs no process — the
+ * same provider the Redwall draws. A second name here would be a
+ * permanent "unknown" line about a provider red-dev cannot read.
+ */
+export const AGENT_USAGE_PROVIDERS: readonly string[] = ["claude"];
+
+export interface AgentPostureSeams {
+  /** The recorded Default agent, verbatim. */
+  readonly defaultAgent?: string | undefined;
+  /** The agent hosts this machine selected, for the unset wording. */
+  readonly selected?: readonly string[];
+  /** The catalog to walk. Injected so a test needs no real host. */
+  readonly hosts?: readonly AgentSpec[];
+  readonly providers?: readonly string[];
+  /** Where a host's command is on PATH, or null. */
+  readonly locate?: (cmd: string) => string | null;
+  /** When that file last changed, or null when it cannot be read. */
+  readonly modifiedAtMs?: (path: string) => number | null;
+  /** Where a provider's snapshot lives, so a test writes no real state. */
+  readonly usagePath?: (provider: string) => string;
+  /** The snapshot itself. A read, never a collect. */
+  readonly usage?: (provider: string) => AgentUsageSnapshot | null;
+  readonly nowMs?: number;
+}
+
+/** When a file last changed, with every way of not knowing as null. */
+function modifiedAtMs(path: string): number | null {
+  try {
+    return statSync(path).mtimeMs;
+  } catch {
+    return null;
+  }
+}
+
+/** Whole days, floored: "3 days ago" must not round a 3-day-old file to 4. */
+function wholeDays(ms: number): number {
+  return Math.floor(Math.max(ms, 0) / 86_400_000);
+}
+
+/**
+ * A duration a person reads rather than converts.
+ *
+ * Coarse on purpose — nobody plans a session around the seconds, and a
+ * reset time printed to the minute past a day out is precision the
+ * snapshot it came from does not have.
+ */
+export function humanDuration(ms: number): string {
+  const minutes = Math.max(Math.round(ms / 60_000), 0);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) {
+    const rest = minutes % 60;
+    return rest === 0 ? `${hours}h` : `${hours}h ${rest}m`;
+  }
+  const days = Math.floor(hours / 24);
+  const rest = hours % 24;
+  return rest === 0 ? `${days}d` : `${days}d ${rest}h`;
+}
+
+/**
+ * One installed host's freshness, from the age of what would run.
+ *
+ * The detail always carries the evidence and the status carries the
+ * reading of it, which is what keeps this honest: red-dev has not asked
+ * the publisher anything, and a line that said "out of date" would be
+ * claiming it had.
+ */
+export function reportAgentFreshness(
+  host: AgentSpec,
+  writtenAtMs: number | null,
+  nowMs: number,
+): AgentPostureRow {
+  if (writtenAtMs === null) {
+    // Unreadable is not old, and reporting it as drift would send
+    // someone updating a host that may well be current.
+    return {
+      name: host.label,
+      status: "n/a",
+      detail: "on PATH, and when its copy last changed cannot be read",
+    };
+  }
+  const days = wholeDays(nowMs - writtenAtMs);
+  if (days >= AGENT_STALE_DAYS) {
+    return {
+      name: host.label,
+      status: "drift",
+      detail: `the copy on PATH last changed ${days} day(s) ago`,
+      fix: "red-dev agents update",
+    };
+  }
+  return {
+    name: host.label,
+    status: "ok",
+    detail: `the copy on PATH changed ${days} day(s) ago`,
+  };
+}
+
+/** One window, spelled the way its provider spells it. */
+function windowDetail(
+  window: AgentUsageReading["windows"][number],
+  nowMs: number,
+): string {
+  const resets = window.resetsAtMs === null
+    ? "reset time not published"
+    : window.resetsAtMs <= nowMs
+      ? "resets now"
+      : `resets in ${humanDuration(window.resetsAtMs - nowMs)}`;
+  return `${window.kind} ${window.remainingPercent}% left, ${resets}`;
+}
+
+/**
+ * One provider's allowance detail, or the honest absence of it.
+ *
+ * A spent window is `ok` rather than drift: an allowance nobody has left
+ * is a fact about a week's work, not a fault in the machine, and
+ * doctor's failure column is for things a person can act on here.
+ */
+export function reportAgentUsage(
+  provider: string,
+  reading: AgentUsageReading | null,
+  nowMs: number,
+): AgentPostureRow {
+  const name = `${provider} usage`;
+  if (reading === null || reading.windows.length === 0) {
+    return {
+      name,
+      status: "n/a",
+      detail: "unknown — no usage snapshot on this machine, or none recent enough to trust",
+    };
+  }
+  const windows = reading.windows.map((window) => windowDetail(window, nowMs));
+  return {
+    name,
+    status: "ok",
+    detail: `${windows.join(" · ")} — observed ${humanDuration(nowMs - reading.updatedAtMs)} ago`,
+  };
+}
+
+/**
+ * The whole section, from what the machine already wrote down. PURE of
+ * side effects: every default here opens a file or looks at PATH.
+ */
+export function agentPosture(seams: AgentPostureSeams = {}): AgentPostureRow[] {
+  const nowMs = seams.nowMs ?? Date.now();
+  const locate = seams.locate ?? commandPath;
+  const written = seams.modifiedAtMs ?? modifiedAtMs;
+  const usage = seams.usage ??
+    ((provider: string): AgentUsageSnapshot | null =>
+      agentUsageSnapshot({
+        provider,
+        ...(seams.usagePath ? { path: seams.usagePath(provider) } : {}),
+      }));
+
+  const hosts = seams.hosts ?? AGENTS;
+  const found = hosts
+    .filter((host) => host.cmd.length > 0)
+    .map((host) => ({ host, path: locate(host.cmd) }))
+    .filter((entry): entry is { host: AgentSpec; path: string } => entry.path !== null);
+  const installed = (host: AgentSpec): boolean =>
+    found.some((entry) => entry.host.key === host.key);
+
+  const rows: AgentPostureRow[] = [];
+  const chosen = reportDefaultAgent(
+    readDefaultAgent(seams.defaultAgent, installed),
+    seams.selected ?? [],
+  );
+  rows.push({
+    name: "default agent",
+    status: chosen.status,
+    detail: chosen.detail,
+    ...(chosen.fix ? { fix: chosen.fix } : {}),
+  });
+
+  if (found.length === 0) {
+    rows.push({ name: "agent hosts", status: "n/a", detail: "none installed" });
+  } else {
+    for (const entry of found) {
+      rows.push(reportAgentFreshness(entry.host, written(entry.path), nowMs));
+    }
+  }
+
+  for (const provider of seams.providers ?? AGENT_USAGE_PROVIDERS) {
+    rows.push(reportAgentUsage(provider, agentUsageReading(usage(provider), nowMs), nowMs));
+  }
+  return rows;
+}
+
+/**
+ * The same section, for a caller that has a platform and no preferences
+ * in hand — which is `doctor`.
+ *
+ * The preferences are read and never written back: the recorded choice
+ * is evidence here, and a report that healed it would be making the
+ * decision it exists to describe.
+ */
+export async function agentPostureFor(
+  p: Platform,
+  seams: AgentPostureSeams = {},
+): Promise<AgentPostureRow[]> {
+  const { readPreferences } = await import("./preferences.ts");
+  const prefs = await readPreferences(p);
+  return agentPosture({
+    ...seams,
+    defaultAgent: seams.defaultAgent ?? prefs.defaultAgent,
+    selected: seams.selected ?? prefs.agents ?? [],
+  });
+}

--- a/src/default-agent.test.ts
+++ b/src/default-agent.test.ts
@@ -20,7 +20,7 @@ import {
   readDefaultAgent,
   reportDefaultAgent,
 } from "./default-agent.ts";
-import { checkDefaultAgent } from "./drift.ts";
+import { agentPostureFor, type AgentPostureRow } from "./agent-posture.ts";
 import { preferencesFromAnswers } from "./firstrun.ts";
 import type { Platform } from "./platform.ts";
 import { readPreferences, writePreferences } from "./preferences.ts";
@@ -83,6 +83,22 @@ function answers(overrides: Partial<SetupAnswers> = {}): SetupAnswers {
 }
 
 const installed = (...keys: string[]) => (agent: AgentSpec): boolean => keys.includes(agent.key);
+
+/** The same machine seen the way `doctor` sees it: through PATH. */
+const onPath = (...keys: string[]) => (cmd: string): string | null =>
+  AGENTS.some((agent) => keys.includes(agent.key) && agent.cmd === cmd) ? `/opt/agents/${cmd}` : null;
+
+/** The Default agent line of doctor's agent section. */
+async function doctorDefaultAgent(...keys: string[]): Promise<AgentPostureRow> {
+  const rows = await agentPostureFor(LINUX, {
+    locate: onPath(...keys),
+    modifiedAtMs: () => null,
+    usage: () => null,
+  });
+  const found = rows.find((row) => row.name === "default agent");
+  if (!found) throw new Error("doctor reported no Default agent");
+  return found;
+}
 
 describe("one CLI host", () => {
   test("is the Default agent without being asked about", () => {
@@ -168,7 +184,7 @@ describe("a stored Default agent that is no longer installed", () => {
         agents: ["claude-code", "codex"],
         defaultAgent: "claude-code",
       });
-      const check = await checkDefaultAgent(LINUX, installed("codex"));
+      const check = await doctorDefaultAgent("codex");
       expect(check.status).toBe("drift");
       expect(check.detail).toContain("Claude Code");
       expect(check.fix).toContain("red-dev agents claude-code");
@@ -211,7 +227,7 @@ describe("the recorded choice", () => {
       );
 
       expect((await readPreferences(LINUX)).defaultAgent).toBe("codex");
-      const check = await checkDefaultAgent(LINUX, installed("claude-code", "codex"));
+      const check = await doctorDefaultAgent("claude-code", "codex");
       expect(check.status).toBe("ok");
       expect(check.detail).toContain("Codex CLI");
       expect(check.detail).toContain("codex");

--- a/src/drift.ts
+++ b/src/drift.ts
@@ -13,7 +13,6 @@
  */
 
 import { existsSync, readFileSync } from "node:fs";
-import type { AgentSpec } from "./agents.ts";
 import type { Platform } from "./platform.ts";
 import { missingRights } from "./rights.ts";
 
@@ -536,39 +535,6 @@ async function checkRedSkillsSource(): Promise<DriftCheck> {
   }
 }
 
-/**
- * Which host red-dev hands work to, and whether it is still there.
- *
- * The recorded choice is validated against the installed set on every
- * read and never healed: an agent that has been uninstalled is reported
- * under its own name. Substituting whichever host remains would make
- * the report agree with the machine by changing the answer, which is
- * the one outcome a recorded decision exists to prevent.
- *
- * The installed test is a parameter so a caller that has already
- * probed does not probe again — and so this is answerable without an
- * agent on PATH.
- */
-export async function checkDefaultAgent(
-  p: Platform,
-  installed?: (a: AgentSpec) => boolean,
-): Promise<DriftCheck> {
-  const [{ readPreferences }, { readDefaultAgent, reportDefaultAgent }, agents] = await Promise.all([
-    import("./preferences.ts"),
-    import("./default-agent.ts"),
-    import("./agents.ts"),
-  ]);
-  const prefs = await readPreferences(p);
-  const reading = readDefaultAgent(prefs.defaultAgent, installed ?? agents.isAgentInstalled);
-  const report = reportDefaultAgent(reading, prefs.agents ?? []);
-  return {
-    name: "default agent",
-    status: report.status,
-    detail: report.detail,
-    ...(report.fix ? { fix: report.fix } : {}),
-  };
-}
-
 export async function collectDrift(p: Platform): Promise<DriftCheck[]> {
   const checks: DriftCheck[] = [];
   checks.push(await checkDotfiles());
@@ -580,7 +546,12 @@ export async function collectDrift(p: Platform): Promise<DriftCheck[]> {
   checks.push(await checkFont(p));
   checks.push(await checkWslDistro(p));
   checks.push(await checkRedSkillsSource());
-  checks.push(await checkDefaultAgent(p));
+  // The Default agent is deliberately not here. It is one of three
+  // things doctor says about this machine's agent posture, and the other
+  // two — host freshness, per-provider usage — have no home in
+  // configuration drift; reporting the choice twice under two headings
+  // is how a reader ends up wondering which line is the real one. See
+  // src/agent-posture.ts.
   checks.push(await checkDelta());
   checks.push(await checkRuntimes());
   checks.push(await checkDocker(p));

--- a/src/main.ts
+++ b/src/main.ts
@@ -292,10 +292,30 @@ async function cmdDoctor(p: Platform, inv: Invocation): Promise<number> {
     }
   }
 
+  // The machine's agent posture, in the one place that already answers
+  // "is this machine ready": which host red-dev hands work to, how old
+  // each installed host's copy is, and the per-provider allowance detail
+  // the Redwall's single line has no room for. Every row is read from
+  // what some other run wrote down — nothing here probes a provider,
+  // starts a host or writes a preference.
+  log.plain("\n[agents]");
+  const { agentPostureFor } = await import("./agent-posture.ts");
+  let agentProblems = 0;
+  for (const row of await agentPostureFor(p)) {
+    const detail = `${row.name} — ${row.detail}`;
+    if (row.status === "ok") log.ok(detail);
+    else if (row.status === "n/a") log.skip(detail);
+    else {
+      log.err(detail);
+      agentProblems++;
+    }
+    if (row.fix) log.plain(`       fix: ${row.fix}`);
+  }
+
   log.plain("");
   if (
     missing > 0 || outdated > 0 || mismatched > 0 || drifted > 0 || hostProblems > 0 ||
-    shadowedCount > 0
+    shadowedCount > 0 || agentProblems > 0
   ) {
     const parts = [`${missing} tool(s) missing`];
     if (outdated > 0) parts.push(`${outdated} outdated`);
@@ -308,6 +328,7 @@ async function cmdDoctor(p: Platform, inv: Invocation): Promise<number> {
     if (shadowedCount > 0) parts.push(`${shadowedCount} shadowed by another copy on PATH`);
     parts.push(`${drifted} config drift(s)`);
     if (hostProblems > 0) parts.push(`${hostProblems} host health problem(s)`);
+    if (agentProblems > 0) parts.push(`${agentProblems} agent posture problem(s)`);
     log.warn(parts.join(", "));
     return 1;
   }


### PR DESCRIPTION
Automated AFK landing for #153. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #153

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789436628&installation_model_id=20659&pr_number=164&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F164&signature=c6957a5ff1261327c14448f48d1a2b5b6c9a5c37e97874abd3b73f542438f7c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->