### PR TITLE
fix: #150 The Product skill, installed into every agent host

### DIFF
--- a/src/agents.ts
+++ b/src/agents.ts
@@ -733,6 +733,14 @@ export function repairCopiedRedSkillsCurrent(
  * where it now points.
  */
 export async function updateRedSkills(p: Platform): Promise<void> {
+  // Before the early return below, not after it. The Product skill is
+  // red-dev's own and does not come out of the red-skills tarball, so a
+  // machine with agents and no marketplace still has product knowledge
+  // to refresh — and refreshing it here is what stops it freezing at
+  // whatever the install-day converge wrote.
+  const { refreshProductSkill } = await import("./product-skill.ts");
+  await refreshProductSkill(p);
+
   const { sourceRoot, refreshRedSkillsExtensions } = await import("./red-skills-ext.ts");
   if (!sourceRoot()) {
     log.skip("red-skills: not installed, nothing to advance");
@@ -986,6 +994,13 @@ export async function convergeRedSkills(p: Platform): Promise<void> {
     log.skip("red-skills: no coding agent installed to configure");
     return;
   }
+
+  // Ahead of every early return under it. red-dev owns this file, so it
+  // is current whenever red-dev has run — including on the ordinary
+  // converge where red-skills itself is already wired and there is
+  // nothing else to do here.
+  const { refreshProductSkill } = await import("./product-skill.ts");
+  await refreshProductSkill(p);
 
   // Before asking whether it is wired: a marketplace registered against
   // a local directory is wired and permanently stale, which no amount

--- a/src/product-skill.test.ts
+++ b/src/product-skill.test.ts
@@ -1,0 +1,293 @@
+/**
+ * The Product skill has one failure mode worth testing for, and it is
+ * not "did it write a file".
+ *
+ * It is the frozen copy. RedSkills' own checkout froze at the version
+ * that first wired a machine and stayed there for a week while
+ * everything reported itself current — the failure `updateRedSkills`
+ * exists to fix. A skill installed once and never rewritten would repeat
+ * it exactly, and worse: a document that confidently names the wrong
+ * paths is worse than no document, because an agent will act on it.
+ *
+ * So the tests below pin content rather than existence, and pin the
+ * refresh as its own behaviour rather than trusting that install covers
+ * it.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { AGENTS, SKILL_HOSTS } from "./agents.ts";
+import {
+  MANAGED_MARKER,
+  PRODUCT_SKILL_NAME,
+  SKILL_HOMES,
+  installProductSkill,
+  planProductSkill,
+  productSkillDocument,
+  type MachineFacts,
+} from "./product-skill.ts";
+import type { Platform } from "./platform.ts";
+
+const LINUX: Platform = {
+  os: "linux",
+  distro: "ubuntu",
+  version: "24.04",
+  codename: "noble",
+  env: "desktop",
+  arch: "x64",
+  caps: { apt: true, gui: true, systemd: true, winget: false, flatpak: true },
+} as Platform;
+
+function facts(over: Partial<MachineFacts> = {}): MachineFacts {
+  return {
+    version: "1.0.25",
+    state: "/home/someone/.local/state/red-dev",
+    config: "/home/someone/.config",
+    ...over,
+  };
+}
+
+/** A machine with a home nobody else is writing into. */
+function machine(): string {
+  return mkdtempSync(`${tmpdir()}/red-dev-product-skill-`);
+}
+
+describe("where it goes", () => {
+  test("into every installed host's skills home", async () => {
+    const home = machine();
+    const outcomes = await installProductSkill(LINUX, {
+      home,
+      installed: () => true,
+      facts: facts(),
+    });
+
+    // Every host, not the first one that answered. Installing Codex a
+    // week after Claude has to be enough to get the skill into it, which
+    // is the same lesson SKILL_HOSTS is a table for.
+    expect(outcomes.map((o) => o.state)).toEqual(["written", "written", "written"]);
+    for (const path of [
+      `${home}/.claude/skills/${PRODUCT_SKILL_NAME}/SKILL.md`,
+      `${home}/.codex/skills/${PRODUCT_SKILL_NAME}/SKILL.md`,
+      `${home}/.config/redcode/skills/${PRODUCT_SKILL_NAME}/SKILL.md`,
+    ]) {
+      expect(existsSync(path)).toBe(true);
+      expect(readFileSync(path, "utf8")).toContain(`name: ${PRODUCT_SKILL_NAME}`);
+    }
+  });
+
+  test("every host is a real agent, so the two lists cannot drift", () => {
+    const keys = new Set(AGENTS.map((a) => a.key));
+    for (const h of SKILL_HOMES) expect(keys.has(h.agent)).toBe(true);
+  });
+
+  test("the hosts are the ones red-skills already wires", () => {
+    // Not a coincidence to be maintained by hand: these are the hosts
+    // red-dev knows how to find a skills home for, and a host that
+    // appears in one list and not the other is a machine that gets
+    // RedSkills and no product knowledge, or the reverse.
+    expect(SKILL_HOMES.map((h) => h.cmd).sort()).toEqual(SKILL_HOSTS.map((h) => h.cmd).sort());
+  });
+});
+
+describe("a host with no agent", () => {
+  test("is skipped with a reason", () => {
+    const plans = planProductSkill(SKILL_HOMES, {
+      home: "/home/someone",
+      installed: (cmd) => cmd === "claude",
+    });
+    const skipped = plans.filter((p) => p.state === "skip");
+    expect(skipped.map((p) => p.cmd)).toEqual(["codex", "redcode"]);
+    for (const plan of skipped) {
+      if (plan.state !== "skip") return;
+      expect(plan.reason).toBe("no agent installed");
+    }
+  });
+
+  test("and a skip always carries one — never an empty reason", () => {
+    for (const deps of [
+      { home: null, installed: () => true },
+      { home: "/home/someone", installed: () => false },
+    ]) {
+      for (const plan of planProductSkill(SKILL_HOMES, deps)) {
+        if (plan.state !== "skip") continue;
+        expect(plan.reason.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  test("writes nothing at all when nothing is installed", async () => {
+    const home = machine();
+    const outcomes = await installProductSkill(LINUX, {
+      home,
+      installed: () => false,
+      facts: facts(),
+    });
+    expect(outcomes.every((o) => o.state === "skipped")).toBe(true);
+    expect(existsSync(`${home}/.claude`)).toBe(false);
+  });
+});
+
+describe("the refresh", () => {
+  test("replaces install-day content rather than leaving it", async () => {
+    const home = machine();
+    const path = `${home}/.claude/skills/${PRODUCT_SKILL_NAME}/SKILL.md`;
+
+    await installProductSkill(LINUX, {
+      home,
+      installed: (cmd) => cmd === "claude",
+      facts: facts({ version: "1.0.1", state: "/old/state" }),
+    });
+    expect(readFileSync(path, "utf8")).toContain("/old/state");
+
+    const again = await installProductSkill(LINUX, {
+      home,
+      installed: (cmd) => cmd === "claude",
+      facts: facts({ version: "1.0.25", state: "/new/state" }),
+    });
+
+    expect(again[0]?.state).toBe("written");
+    const body = readFileSync(path, "utf8");
+    expect(body).toContain("/new/state");
+    expect(body).not.toContain("/old/state");
+    expect(body).toContain(`${MANAGED_MARKER} 1.0.25`);
+  });
+
+  test("a second run over identical content is quiet", async () => {
+    const home = machine();
+    const deps = { home, installed: (cmd: string) => cmd === "claude", facts: facts() };
+    await installProductSkill(LINUX, deps);
+    const again = await installProductSkill(LINUX, deps);
+    // Not "written": every converge runs this, and a machine that is
+    // already where it should be must not report a change it did not make.
+    expect(again[0]?.state).toBe("unchanged");
+  });
+
+  test("runs from the same path that refreshes RedSkills", () => {
+    // The freeze this exists to prevent is a copy that only ever gets
+    // written by the install. Both doors — `red-dev update` through
+    // updateRedSkills, and every converge through convergeRedSkills —
+    // have to reach it, or one of them leaves the machine behind.
+    const src = readFileSync("src/agents.ts", "utf8");
+    for (const [from, to] of [
+      ["export async function updateRedSkills", "export interface SkillHost"],
+      ["export async function convergeRedSkills", "\n}\n"],
+    ] as const) {
+      const start = src.indexOf(from);
+      expect(start).toBeGreaterThan(-1);
+      expect(src.slice(start, src.indexOf(to, start))).toContain("refreshProductSkill");
+    }
+  });
+
+  test("refreshes before red-skills can decide there is nothing to advance", () => {
+    // updateRedSkills returns early on a machine with no red-skills
+    // checkout. The Product skill is red-dev's own file and has nothing
+    // to do with that checkout, so it has to be written above the return.
+    const src = readFileSync("src/agents.ts", "utf8");
+    const body = src.slice(
+      src.indexOf("export async function updateRedSkills"),
+      src.indexOf("export interface SkillHost"),
+    );
+    expect(body.indexOf("refreshProductSkill")).toBeLessThan(
+      body.indexOf("nothing to advance"),
+    );
+  });
+});
+
+describe("a file red-dev did not write", () => {
+  test("is left alone, with a reason", async () => {
+    const home = machine();
+    const path = `${home}/.claude/skills/${PRODUCT_SKILL_NAME}/SKILL.md`;
+    mkdirSync(path.replace(/\/[^/]+$/, ""), { recursive: true });
+    writeFileSync(path, "---\nname: red-dev-machine\n---\n\nmine, hand written\n");
+
+    const outcomes = await installProductSkill(LINUX, {
+      home,
+      installed: (cmd) => cmd === "claude",
+      facts: facts(),
+    });
+
+    expect(outcomes[0]?.state).toBe("skipped");
+    expect(outcomes[0]?.reason).toContain("not red-dev's");
+    expect(readFileSync(path, "utf8")).toContain("mine, hand written");
+  });
+
+  test("but a managed one is rewritten without asking", async () => {
+    const home = machine();
+    const path = `${home}/.claude/skills/${PRODUCT_SKILL_NAME}/SKILL.md`;
+    mkdirSync(path.replace(/\/[^/]+$/, ""), { recursive: true });
+    writeFileSync(path, `<!-- ${MANAGED_MARKER} 0.9.0 -->\nstale\n`);
+
+    const outcomes = await installProductSkill(LINUX, {
+      home,
+      installed: (cmd) => cmd === "claude",
+      facts: facts(),
+    });
+    expect(outcomes[0]?.state).toBe("written");
+    expect(readFileSync(path, "utf8")).not.toContain("stale");
+  });
+});
+
+describe("one host's failure", () => {
+  test("does not stop the others", async () => {
+    const outcomes = await installProductSkill(LINUX, {
+      home: "/home/someone",
+      installed: () => true,
+      facts: facts(),
+      read: () => null,
+      write: (path) => {
+        if (path.includes("codex")) throw new Error("read-only skills home");
+      },
+    });
+    expect(outcomes.map((o) => o.state)).toEqual(["written", "failed", "written"]);
+    expect(outcomes[1]?.reason).toBe("read-only skills home");
+  });
+});
+
+describe("what the document says", () => {
+  const body = productSkillDocument(facts());
+
+  test("names this machine's paths, not a developer's", () => {
+    // Generated for a reason: the state directory moves with
+    // XDG_STATE_HOME and with Windows, and the configuration root moves
+    // with a shared root. A static document would be right on exactly
+    // one machine.
+    const elsewhere = productSkillDocument(
+      facts({ state: "C:/Users/someone/AppData/Local/red-dev/logs" }),
+    );
+    expect(body).toContain("/home/someone/.local/state/red-dev");
+    expect(elsewhere).toContain("C:/Users/someone/AppData/Local/red-dev/logs");
+    expect(elsewhere).not.toContain("/home/someone/.local/state/red-dev");
+  });
+
+  test("carries the frontmatter a host reads", () => {
+    expect(body.startsWith("---\n")).toBe(true);
+    expect(body).toContain(`name: ${PRODUCT_SKILL_NAME}`);
+    expect(body).toMatch(/^description: .+/m);
+  });
+
+  test("covers what the product knows and RedSkills does not", () => {
+    for (const subject of [
+      "red-dev doctor",
+      "red-dev logs",
+      "red-dev plan",
+      "red-dev privileged",
+      "crash.log",
+      "grep failed",
+    ]) {
+      expect(body).toContain(subject);
+    }
+  });
+
+  test("says it is managed, so nobody edits it in place", () => {
+    expect(body).toContain(MANAGED_MARKER);
+    expect(body).toContain("red-dev update");
+  });
+
+  test("does not answer for RedSkills", () => {
+    // Two skills that both describe process guidance is how an agent
+    // ends up with contradictory instructions and no way to tell which
+    // is current. This one stays on the product.
+    expect(body).toContain("RedSkills carries the process guidance");
+  });
+});

--- a/src/product-skill.ts
+++ b/src/product-skill.ts
@@ -1,0 +1,392 @@
+/**
+ * The Product skill: what an agent needs to know about a machine red-dev
+ * provisioned, put where every installed agent host can read it.
+ *
+ * RedSkills already teaches agents *how to work* — process, review,
+ * handoff. None of it says where this machine keeps its managed
+ * configuration, which command answers "what is wrong here", what the
+ * rows in a transcript mean, or which acts stop and ask for
+ * administrator. An agent handed a red-dev crash today has to rediscover
+ * all four from the source, on a machine where the source may not even
+ * be checked out. So: RedSkills carries process guidance, this carries
+ * product knowledge, and the two do not overlap by design.
+ *
+ * ## Written, not symlinked
+ *
+ * Omarchy symlinks its skills directory into each host. That does not
+ * survive this product's targets: Git Bash on Windows emulates symlinks
+ * by copying — the failure `repairCopiedRedSkillsCurrent` exists to
+ * repair — and a copy is exactly the freeze this is supposed to avoid.
+ * A written file is the same on every target, and the refresh below is
+ * what keeps it current instead of the link.
+ *
+ * ## Owned, and only what is owned
+ *
+ * A rewrite that overwrote whatever it found would be a tool deleting a
+ * person's work. Every file this writes carries a managed marker, and a
+ * file without one is left alone with a reason — the same rule
+ * `repairCopiedRedSkillsCurrent` follows for the snapshot directory.
+ *
+ * See .red/contexts/agents/CONTEXT.md.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { commandPath } from "./agents.ts";
+import { VERSION } from "./cli.ts";
+import { log } from "./log.ts";
+import type { Platform } from "./platform.ts";
+
+/**
+ * The skill's directory and frontmatter name.
+ *
+ * Not `red-dev`: RedSkills ships `doctor`, `diagnose` and `health` into
+ * the same directories, and a bare product name there reads as "the
+ * red-dev skill" — the ambiguity the context map tells us to avoid. This
+ * names what it describes, which is the machine.
+ */
+export const PRODUCT_SKILL_NAME = "red-dev-machine";
+
+/** What says red-dev wrote a file and may rewrite it. */
+export const MANAGED_MARKER = "managed by red-dev";
+
+/**
+ * Where each host reads user-level skills from.
+ *
+ * A table for the same reason SKILL_HOSTS is one: the hosts do not agree,
+ * and the only way to be wrong quietly is to assume they do. Each of
+ * these was read off a provisioned machine rather than inferred —
+ * ~/.codex/skills and ~/.config/redcode/skills both already held the
+ * skills RedSkills generates, and ~/.claude/skills is Claude Code's
+ * documented personal skills directory whether or not it exists yet.
+ *
+ * HOME-relative rather than through shared-root's configHome, which is
+ * deliberate: a skills home belongs to the host, not to red-dev, and
+ * pointing RedCode's at a Windows share would put the file somewhere
+ * RedCode does not look. It is the same directory `unwiredSkillHosts`
+ * reads RedCode's install manifest from.
+ */
+export interface SkillHome {
+  /** Key in AGENTS, so this list cannot drift from that one. */
+  agent: string;
+  /** Command that proves the host is installed at all. */
+  cmd: string;
+  /** The host's user-level skills home, given a home directory. */
+  dir: (home: string) => string;
+}
+
+export const SKILL_HOMES: SkillHome[] = [
+  { agent: "claude-code", cmd: "claude", dir: (home) => `${home}/.claude/skills` },
+  { agent: "codex", cmd: "codex", dir: (home) => `${home}/.codex/skills` },
+  { agent: "redcode", cmd: "redcode", dir: (home) => `${home}/.config/redcode/skills` },
+];
+
+/**
+ * What is to be done for one host.
+ *
+ * A skip always carries a reason. "Nothing happened" with no explanation
+ * is how a host that has been silently missing for a month gets found by
+ * accident rather than by reading the log.
+ */
+export type ProductSkillPlan =
+  | { state: "write"; agent: string; cmd: string; path: string }
+  | { state: "skip"; agent: string; cmd: string; reason: string };
+
+/** Where the skill goes for every host, and why it does not. PURE. */
+export function planProductSkill(
+  homes: readonly SkillHome[],
+  deps: { home: string | null; installed: (cmd: string) => boolean },
+): ProductSkillPlan[] {
+  return homes.map((h) => {
+    if (!deps.installed(h.cmd)) {
+      // Not "install it": this puts a document where an agent host can
+      // read it, and it has no opinion about which hosts should exist.
+      return { state: "skip" as const, agent: h.agent, cmd: h.cmd, reason: "no agent installed" };
+    }
+    if (!deps.home) {
+      return {
+        state: "skip" as const,
+        agent: h.agent,
+        cmd: h.cmd,
+        reason: "no home directory to write into",
+      };
+    }
+    const dir = h.dir(deps.home.replace(/\\/g, "/"));
+    return {
+      state: "write" as const,
+      agent: h.agent,
+      cmd: h.cmd,
+      path: `${dir}/${PRODUCT_SKILL_NAME}/SKILL.md`,
+    };
+  });
+}
+
+/**
+ * The facts about this machine the document is written from.
+ *
+ * Passed in rather than read inside the template, so the same call that
+ * produces the file for this machine can produce one for a test — and so
+ * that the paths in the skill are this machine's paths rather than the
+ * ones a Linux developer's documentation happened to name.
+ */
+export interface MachineFacts {
+  /** The red-dev that wrote it, so a stale copy identifies itself. */
+  version: string;
+  /** Transcripts, crash logs and cached observations. */
+  state: string;
+  /** Where managed configuration is written. */
+  config: string;
+}
+
+/**
+ * The skill, as the file a host will read.
+ *
+ * Generated rather than shipped as a static asset, because two of the
+ * three things an agent needs here — the state directory and the
+ * configuration root — are answers this machine gives and not constants:
+ * they move with XDG variables, with Windows, and with a shared root.
+ * A static document would be right on the machine it was written on.
+ */
+export function productSkillDocument(facts: MachineFacts): string {
+  return `---
+name: ${PRODUCT_SKILL_NAME}
+description: What this machine's red-dev provisioning looks like — where managed configuration and state live, which commands report it, what the run transcripts and crash log contain, and which acts need administrator. Use when diagnosing a red-dev run, reading a transcript, or changing anything red-dev manages.
+---
+
+<!-- ${MANAGED_MARKER} ${facts.version} — rewritten by \`red-dev update\`; edits here are lost -->
+
+# The machine red-dev provisioned
+
+red-dev converges this machine toward a manifest: every tool it manages
+has a provider chosen per platform, and running it again is meant to be
+uneventful. Read the machine before changing it — most of what looks like
+a broken tool is drift red-dev can already name.
+
+This is product knowledge. RedSkills carries the process guidance; the
+two do not repeat each other.
+
+## Where things are
+
+| What | Where |
+| --- | --- |
+| Managed configuration | \`${facts.config}\` |
+| State: transcripts, crash logs, cached observations | \`${facts.state}\` |
+| RedSkills source snapshot | \`~/.red-skills/current\` (a symlink into a versioned copy) |
+
+Configuration under the managed root is rewritten by the next converge.
+Change it through the command that owns it — \`red-dev theme\`,
+\`red-dev shell\`, \`red-dev agents\` — rather than by editing the file,
+or the edit disappears without anything reporting that it did.
+
+## Commands that report state
+
+Read-only, safe to run at any time, and the right first move:
+
+- \`red-dev platform\` — what red-dev thinks this machine is.
+- \`red-dev plan [scope]\` — what a converge would change, changing nothing.
+- \`red-dev doctor\` — drift against the manifest, host process health,
+  artifact usage, and the recorded Default agent. Lines that name a fix
+  print it on the following line.
+- \`red-dev logs\` — the last run's transcript. \`red-dev logs list\` for
+  every kept run, \`red-dev logs 2\` for the run before last.
+- \`red-dev reclaim\` — what derived artifacts are using, and what a prune
+  would remove. It changes nothing without \`--apply\`.
+- \`red-dev rescue\` — process groups proven to be orphaned. Also inert
+  without \`--apply\`.
+
+## Transcripts
+
+Every mutating run is written to \`${facts.state}\` as
+\`<timestamp>-<command>.log\`; the twenty newest are kept. A transcript
+opens with a header naming the version, the time and the platform, and
+closes with \`# exit <code>\`.
+
+Converge steps are fixed-width rows:
+
+    [ 7/36] zellij                 apt                          ok        412ms
+
+so \`grep failed\` over a transcript is the whole technique for finding
+what went wrong. Child process output is in there whenever something was
+capturing it — the fullscreen converge — and deliberately not on a plain
+terminal run, where apt keeps its progress bar and sudo can still ask for
+a password.
+
+## The crash log
+
+An uncaught failure appends to \`${facts.state}/crash.log\` before the
+process dies, with the previous file kept as \`crash.previous.log\`. Each
+entry is a stack under a header naming the kind, the time, the version
+and the platform. On Windows this is the only copy that survives a
+fullscreen window closing, so it is the first file to read for "it
+crashed and I saw nothing".
+
+Machine-readable observations live beside it as JSON — agent usage per
+provider, the GitHub rate-limit reading. They are caches red-dev writes
+and reads back; read them, and let red-dev be the one to write them.
+
+## What needs privilege
+
+Some manifest items need administrator. A converge does not silently
+escalate: it does what it can unprivileged, then names the rest and
+points at \`red-dev privileged\`, which finishes only that work. Run that
+command as the person, in a session that can prompt.
+
+Do not re-run a whole converge under \`sudo\`. It writes into a home
+directory, and a converge run as root leaves files the user can no longer
+change — a slower failure than the one it was working around.
+`;
+}
+
+/** What became of one host. */
+export interface ProductSkillOutcome {
+  agent: string;
+  cmd: string;
+  state: "written" | "unchanged" | "skipped" | "failed";
+  path?: string;
+  /** Why nothing happened. Always present when nothing did. */
+  reason?: string;
+}
+
+/** Every side of the machine this touches, so a test can hold all of them. */
+export interface ProductSkillDeps {
+  /** The home directory to resolve skills homes against. */
+  home?: string | null;
+  installed?: (cmd: string) => boolean;
+  facts?: MachineFacts;
+  /** Existing content at a path, or null when there is nothing there. */
+  read?: (path: string) => string | null;
+  write?: (path: string, body: string) => void;
+  /** Called as each host settles, so a caller can report while it runs. */
+  report?: (outcome: ProductSkillOutcome) => void;
+}
+
+function defaultRead(path: string): string | null {
+  try {
+    return existsSync(path) ? readFileSync(path, "utf8") : null;
+  } catch {
+    // Unreadable is not "absent". Rewriting on a read error would
+    // overwrite a file whose ownership we could not establish.
+    throw new Error(`could not read ${path}`);
+  }
+}
+
+function defaultWrite(path: string, body: string): void {
+  mkdirSync(path.replace(/\/[^/]+$/, ""), { recursive: true });
+  writeFileSync(path, body);
+}
+
+/**
+ * Where this machine keeps the things the skill names.
+ *
+ * Imported lazily for the same reason the command bodies do it: this is
+ * reached on a converge, and neither module should be loaded by a
+ * `red-dev platform`.
+ */
+async function machineFacts(p: Platform): Promise<MachineFacts> {
+  const [{ transcriptDir }, { configHome }] = await Promise.all([
+    import("./transcript.ts"),
+    import("./shared-root.ts"),
+  ]);
+  return { version: VERSION, state: transcriptDir(), config: configHome(p) };
+}
+
+/**
+ * Put the current Product skill into every installed host.
+ *
+ * Idempotent by content rather than by existence: a file identical to
+ * what would be written is `unchanged`, so running this on every converge
+ * is quiet, and a file that has fallen behind is rewritten without anyone
+ * having to decide it is stale. That is the whole answer to the freeze —
+ * there is no install-day copy, only the copy the last run wrote.
+ *
+ * One host's failure never stops the others. A read-only skills home is a
+ * reason to report that host and move on, not to end a converge.
+ */
+export async function installProductSkill(
+  p: Platform,
+  deps: ProductSkillDeps = {},
+): Promise<ProductSkillOutcome[]> {
+  const home = deps.home !== undefined
+    ? deps.home
+    : (process.env["HOME"] ?? process.env["USERPROFILE"] ?? null);
+  const installed = deps.installed ?? ((cmd: string) => commandPath(cmd) !== null);
+  const plans = planProductSkill(SKILL_HOMES, { home, installed });
+
+  // Only when something is going to be written. Resolving the machine's
+  // paths on a host with no agent installed is work for a document
+  // nobody will read.
+  const writes = plans.filter((plan) => plan.state === "write");
+  const body = writes.length > 0
+    ? productSkillDocument(deps.facts ?? (await machineFacts(p)))
+    : "";
+
+  const read = deps.read ?? defaultRead;
+  const write = deps.write ?? defaultWrite;
+  const outcomes: ProductSkillOutcome[] = [];
+
+  for (const plan of plans) {
+    let outcome: ProductSkillOutcome;
+    if (plan.state === "skip") {
+      outcome = { agent: plan.agent, cmd: plan.cmd, state: "skipped", reason: plan.reason };
+    } else {
+      try {
+        const existing = read(plan.path);
+        if (existing !== null && !existing.includes(MANAGED_MARKER)) {
+          outcome = {
+            agent: plan.agent,
+            cmd: plan.cmd,
+            state: "skipped",
+            path: plan.path,
+            reason: "a skill of this name is already there and is not red-dev's",
+          };
+        } else if (existing === body) {
+          outcome = { agent: plan.agent, cmd: plan.cmd, state: "unchanged", path: plan.path };
+        } else {
+          write(plan.path, body);
+          outcome = { agent: plan.agent, cmd: plan.cmd, state: "written", path: plan.path };
+        }
+      } catch (err) {
+        outcome = {
+          agent: plan.agent,
+          cmd: plan.cmd,
+          state: "failed",
+          path: plan.path,
+          reason: (err as Error).message,
+        };
+      }
+    }
+    outcomes.push(outcome);
+    deps.report?.(outcome);
+  }
+  return outcomes;
+}
+
+/**
+ * The set of outcomes as the log's own lines.
+ *
+ * One line for the hosts that got it, because three "wrote the Product
+ * skill" rows in a converge is noise for a step nobody asked for. A
+ * failure gets its own line: that one is worth interrupting for.
+ */
+export function reportProductSkill(outcomes: readonly ProductSkillOutcome[]): void {
+  const wrote = outcomes.filter((o) => o.state === "written");
+  if (wrote.length > 0) log.ok(`Product skill refreshed for ${wrote.map((o) => o.cmd).join(", ")}`);
+
+  for (const outcome of outcomes.filter((o) => o.state === "skipped" && o.path)) {
+    log.skip(`Product skill for ${outcome.cmd}: ${outcome.reason}`);
+  }
+  for (const outcome of outcomes.filter((o) => o.state === "failed")) {
+    log.err(`Product skill for ${outcome.cmd}: ${outcome.reason ?? "could not be written"}`);
+  }
+}
+
+/**
+ * Refresh the Product skill, and say what happened.
+ *
+ * The pairing every caller wants, so that neither the converge nor the
+ * update path has to know which outcomes are worth a line.
+ */
+export async function refreshProductSkill(p: Platform): Promise<ProductSkillOutcome[]> {
+  const outcomes = await installProductSkill(p);
+  reportProductSkill(outcomes);
+  return outcomes;
+}


### PR DESCRIPTION
Automated AFK landing for #150. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #150

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/165"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789437472&installation_model_id=20659&pr_number=165&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F165&signature=32268d30f98f7e875788e96218bb78ef817636116459f30f1856321e3880bc2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->