### PR TITLE
fix: #140 red-dev keys: the searchable viewer that executes, and the Learn section

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,6 +454,8 @@ red-dev theme [name]         # dark | light | obsidian | marble | cobalt | flare
 red-dev wallpaper [source]   # theme | Red artwork | absolute PNG path | HTTPS URL
 red-dev redwall              # redraw the wallpaper carrying this machine's state
 red-dev apps                 # choose optional tools
+red-dev keys                 # search every action and its chord, and run one
+red-dev learn                # the README by anchor, RedSkills, and the keys viewer
 red-dev lang                 # choose runtimes for mise to manage
 red-dev lang node@24,bun@1.3 # unattended, independently selected versions
 red-dev lang --latest node,python # newest release of each

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -51,6 +51,23 @@ describe("command parsing", () => {
     expect(buildCli().help(["agents"])).toContain("update");
   });
 
+  test("the keys viewer and Learn are commands, and findable in --help", () => {
+    // Reachable non-interactively, like everything else the menu
+    // offers: a section that exists only inside the interface is a
+    // section nobody can put in a script, a bug report or a remedy.
+    expect(parse(["keys"])).toMatchObject({ command: "keys", errors: [] });
+    expect(parse(["learn"])).toMatchObject({ command: "learn", errors: [] });
+    const help = buildCli().help();
+    expect(help).toContain("keys");
+    expect(help).toContain("learn");
+  });
+
+  test("the keys viewer takes no arguments, and says so rather than ignoring them", () => {
+    // The search is typed into the viewer. A query silently swallowed
+    // here would look like a viewer that cannot search.
+    expect(parse(["keys", "--query", "terminal"]).errors.length).toBeGreaterThan(0);
+  });
+
   test("keeps what follows `--` for the program red-dev starts", () => {
     // Strict mode would otherwise reject these as unknown options of
     // ours. They are the person's arguments to their own agent — up to

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -182,6 +182,18 @@ export function buildCli(): CLI {
       apps: {
         description: "choose optional tools to install",
       },
+      keys: {
+        // No positional and no flags. What it lists comes from the
+        // action registry and what it says about each row comes from
+        // this machine, so there is nothing here for a caller to decide
+        // — and the search is typed into the viewer, not onto the
+        // command line, because the point of the thing is to find a
+        // chord you cannot name yet.
+        description: "search every action and its chord, and run one",
+      },
+      learn: {
+        description: "the README by anchor, RedSkills, and the keys viewer",
+      },
       agents: {
         description:
           "choose coding agents, wire red-skills into them, or `update` each by its publisher's mechanism",

--- a/src/keys-view.test.ts
+++ b/src/keys-view.test.ts
@@ -1,0 +1,132 @@
+/**
+ * The viewer, driven through the real renderer.
+ *
+ * keys.test.ts proves the decisions: which rows are visible, where the
+ * cursor is, what Enter chooses. None of that is worth anything if the
+ * component never hands its keystrokes to the decider — a viewer wired
+ * to nothing draws a correct first frame, ignores the keyboard, and
+ * passes every test about its model. So this one writes real bytes into
+ * a real render and reads the frames back out.
+ *
+ * The streams are PassThroughs dressed as a TTY, the same harness
+ * tui-scroll.test.ts uses to cross the renderer boundary.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { PassThrough } from "node:stream";
+import { runKeysViewer } from "./keys-view.ts";
+import { keyEntries, type FireOutcome, type KeyEntry } from "./keys.ts";
+import type { Platform } from "./platform.ts";
+
+const windows: Platform = {
+  os: "windows",
+  distro: null,
+  version: null,
+  codename: null,
+  env: "windows",
+  arch: "x64",
+  caps: { apt: false, gui: true, systemd: false, winget: true, flatpak: false },
+};
+
+const strip = (s: string): string => s.replace(/\x1b\[[0-9;]*m/g, "");
+
+const ESC = "\x1b";
+const ENTER = "\r";
+
+interface Driven {
+  /** Everything the viewer drew, with the colour sequences taken out. */
+  frames: string;
+  fired: KeyEntry[];
+}
+
+/**
+ * Open the viewer, type, and wait for it to close.
+ *
+ * Escape at the end of every script: the render owns the process's
+ * attention until it exits, so a test that never sends one hangs rather
+ * than fails.
+ */
+async function drive(keys: string[]): Promise<Driven> {
+  const stdin = new PassThrough() as PassThrough & NodeJS.ReadStream;
+  const stdout = new PassThrough() as PassThrough & NodeJS.WriteStream;
+  Object.assign(stdin, { isTTY: true, isRaw: false, setRawMode: () => stdin });
+  Object.assign(stdout, { isTTY: true, columns: 96, rows: 30 });
+
+  let frames = "";
+  stdout.on("data", (chunk: Buffer | string) => {
+    frames += chunk.toString();
+  });
+
+  const fired: KeyEntry[] = [];
+  const fire = async (entry: KeyEntry): Promise<FireOutcome> => {
+    fired.push(entry);
+    return { fired: true, detail: `${entry.label} — started` };
+  };
+
+  const done = runKeysViewer(windows, keyEntries(windows), fire, { stdin, stdout });
+  for (const key of keys) {
+    stdin.write(key);
+    // A pause per keystroke, and it has to be this generous because of
+    // Escape. A lone `\x1b` is the first byte of every arrow key, so the
+    // parser holds it until either another byte arrives or enough time
+    // passes — two escapes written close together arrive as one sequence
+    // that means neither of them. Real fingers are slower than that;
+    // this is the harness matching them, not a race being papered over.
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  await done;
+  return { frames: strip(frames), fired };
+}
+
+describe("the drawn viewer", () => {
+  test("lists every action with its chord before anything is typed", async () => {
+    const { frames } = await drive([ESC]);
+    expect(frames).toContain("Ctrl+Alt+T");
+    expect(frames).toContain("Terminal");
+    expect(frames).toContain("Elevated shell");
+    expect(frames).toContain("red-dev keys");
+  });
+
+  test("typing reaches the filter — a query with no matches says so", async () => {
+    // The wiring test. If useInput never reached viewerStep, the first
+    // frame would still be right, both rows would still be listed, and
+    // this line would never be drawn.
+    //
+    // Asserted on a line the viewer draws whole. The renderer patches
+    // changed cells rather than repainting, so a row that was narrowed
+    // one keystroke at a time never appears in the output as one string
+    // — which is why the rest of these read behaviour instead.
+    const { frames } = await drive([..."zzz", ESC, ESC]);
+    expect(frames).toContain("nothing matches");
+  });
+
+  test("enter runs the action the search left highlighted", async () => {
+    // `elevated` is the second row. Firing it means the cursor was
+    // indexing the filtered list, which is the one thing that has to be
+    // true for a search-then-enter to be a launcher rather than a
+    // coin toss.
+    const { fired } = await drive([..."elev", ENTER, ESC, ESC]);
+    expect(fired.map((e) => e.id)).toEqual(["terminal.elevated"]);
+  });
+
+  test("and with nothing typed it runs the first row instead", async () => {
+    // The other half of the previous test: without it, a viewer that
+    // ignored the query and always fired row one would pass.
+    const { fired } = await drive([ENTER, ESC]);
+    expect(fired.map((e) => e.id)).toEqual(["terminal.new"]);
+  });
+
+  test("and says what it started, rather than going quiet", async () => {
+    const { frames } = await drive([..."elev", ENTER, ESC, ESC]);
+    expect(frames).toContain("Elevated shell — started");
+  });
+
+  test("escape clears the search before it closes, so a typo is not an exit", async () => {
+    // If the first escape had quit, nothing would be listening for the
+    // enter that follows and nothing would fire. That it fires the first
+    // row is also the proof that the cleared query brought the whole
+    // list back.
+    const { fired } = await drive([..."elev", ESC, ENTER, ESC]);
+    expect(fired.map((e) => e.id)).toEqual(["terminal.new"]);
+  });
+});

--- a/src/keys-view.ts
+++ b/src/keys-view.ts
@@ -1,0 +1,189 @@
+/**
+ * The keys viewer, drawn.
+ *
+ * Everything this reacts to is decided in src/keys.ts — which rows are
+ * visible, where the cursor is, what a keystroke means, what Enter
+ * starts. What is left here is the part a test cannot read anyway: a
+ * frame, a list, and a status line. That split is deliberate and is the
+ * same one tui.ts makes with its install model: a viewer whose
+ * behaviour only exists inside a render is a viewer nothing can pin.
+ *
+ * One render, like everywhere else in this codebase. The command starts
+ * it, the person leaves it, and the terminal they may have just opened
+ * is a detached process of its own rather than something drawn in here.
+ */
+
+import {
+  Box,
+  ListItem,
+  Text,
+  render,
+  useApp,
+  useInput,
+  useState,
+  useTerminalSize,
+} from "tuiuiu.js";
+import { VERSION } from "./cli.ts";
+import {
+  detach,
+  fireEntry,
+  keyColumns,
+  keyRow,
+  searchKeys,
+  VIEWER_START,
+  viewerStep,
+  type FireOutcome,
+  type KeyEntry,
+  type ViewerState,
+} from "./keys.ts";
+import type { Platform } from "./platform.ts";
+import { CenteredScreen, centeredFrame, Header, StatusLine, Surface } from "./tui-chrome.ts";
+import { muted, subtle, text } from "./tui-theme.ts";
+import { withConsoleSelectionSuspended } from "./windows-console-mode.ts";
+
+/**
+ * The slice of a long list that fits, kept around the cursor.
+ *
+ * The registry is two actions today and will not stay that way; a list
+ * that draws past the bottom of the frame overwrites what is already
+ * there rather than clipping, which is the failure Surface's comment
+ * describes.
+ */
+function windowOf(items: readonly KeyEntry[], index: number, rows: number): KeyEntry[] {
+  if (items.length <= rows) return [...items];
+  const from = Math.max(0, Math.min(items.length - rows, index - Math.floor(rows / 2)));
+  return items.slice(from, from + rows);
+}
+
+/** What the panel under the list says about the highlighted row. */
+function verdict(entry: KeyEntry | undefined): { line: string; color: string } {
+  if (!entry) return { line: "", color: muted };
+  if (entry.state === "bound") return { line: `bound — ${entry.chord}`, color: text };
+  return { line: `unbound — ${entry.reason}`, color: muted };
+}
+
+/**
+ * The terminal to draw on, when it is not this process's own.
+ *
+ * Only a test passes these, and the reason is the failure mode a model
+ * test cannot see: a viewer whose keystrokes are decided perfectly and
+ * never handed to the decider draws a list that ignores the keyboard,
+ * and every unit test still passes. Feeding real bytes through the real
+ * renderer is the only thing that catches it.
+ */
+export interface ViewerIo {
+  stdin: NodeJS.ReadStream;
+  stdout: NodeJS.WriteStream;
+}
+
+/**
+ * Draw it, and return when the person leaves.
+ *
+ * `fire` is a parameter for the same reason the model injects its spawn:
+ * it is the one thing in here that starts a process, and a caller that
+ * wants the viewer without that — a screenshot, a smoke test — should
+ * not have to open a terminal to get it.
+ */
+export async function runKeysViewer(
+  p: Platform,
+  entries: readonly KeyEntry[],
+  fire: (entry: KeyEntry) => Promise<FireOutcome> = (entry) => fireEntry(entry, p, detach),
+  io?: ViewerIo,
+): Promise<void> {
+  function App() {
+    // exit() from useApp rather than process.exit, so waitUntilExit
+    // resolves and the caller gets its terminal back — the same rule
+    // tui.ts follows.
+    const { exit } = useApp();
+    const size = useTerminalSize();
+    const [state, setState] = useState<ViewerState>(VIEWER_START);
+    const [status, setStatus] = useState("");
+
+    useInput((input, key) => {
+      const step = viewerStep(entries, state(), input, key);
+      setState(step.state);
+      if (step.quit) {
+        exit();
+        return;
+      }
+      const chosen = step.fire;
+      if (!chosen) return;
+      // Said before it is done: starting a Windows terminal crosses the
+      // WSL boundary and takes a moment, and a viewer that shows nothing
+      // in that moment reads as a key that did not register.
+      setStatus(`starting ${chosen.label}…`);
+      void fire(chosen)
+        .then((outcome) => setStatus(outcome.detail))
+        .catch((err: unknown) => setStatus(`failed: ${(err as Error).message}`));
+    });
+
+    const width = Math.max(size.columns ?? 80, 60);
+    const height = Math.max(size.rows ?? 24, 16);
+    const frame = centeredFrame(width, height, 112, 34);
+    const rows = Math.max(4, frame.height - 12);
+
+    const query = state().query;
+    const visible = searchKeys(entries, query);
+    // Clamped for drawing only. The model clamps what it stores; a
+    // filter that shrank the list under a cursor still holds an index
+    // one frame too large, and reading past the end here would draw an
+    // empty highlight.
+    const index = Math.min(state().index, Math.max(0, visible.length - 1));
+    const cols = keyColumns(entries);
+    const shown = windowOf(visible, index, rows);
+    const chosen = visible[index];
+    const said = verdict(chosen);
+
+    return CenteredScreen(
+      width,
+      height,
+      112,
+      34,
+
+      Header("red-dev keys", `${visible.length}/${entries.length}`),
+      Text({}, ""),
+
+      // The search box, always visible and never modal: this is a
+      // viewer you type into, so the query is part of the frame rather
+      // than a prompt that has to be opened first.
+      Text(
+        { color: query === "" ? subtle : text },
+        query === "" ? "search: type to filter" : `search: ${query}`,
+      ),
+      Text({}, ""),
+
+      Box(
+        {},
+        Surface(
+          frame.width,
+          rows + 2,
+          ...(shown.length === 0
+            ? [Text({ color: muted }, `nothing matches ${query}`)]
+            : shown.map((entry) =>
+                ListItem({
+                  primary: keyRow(entry, cols),
+                  selected: entry.id === chosen?.id,
+                }),
+              )),
+        ),
+      ),
+
+      Text({}, ""),
+      Text({ color: said.color }, said.line),
+      // The outcome of the last Enter, kept on screen until the next
+      // one. A launcher that says nothing after launching is
+      // indistinguishable from one that did nothing.
+      Text({ color: muted }, status()),
+
+      StatusLine(
+        "type to search · up/down move · enter run · esc clear, then quit",
+        `red-dev ${VERSION}`,
+      ),
+    );
+  }
+
+  await withConsoleSelectionSuspended(async () => {
+    const { waitUntilExit } = render(App, { fullHeight: true, ...io });
+    await waitUntilExit();
+  });
+}

--- a/src/keys.test.ts
+++ b/src/keys.test.ts
@@ -1,0 +1,315 @@
+/**
+ * The viewer's two promises, held against machines it cannot be run on.
+ *
+ * The first is that nothing is hidden: every action in the registry is
+ * on the list on every target, and the ones this machine does not bind
+ * carry the reason. The second is that Enter fires the action that is
+ * highlighted — which is the whole claim of "the viewer is also a
+ * launcher", and the one that would fail silently, by starting the
+ * neighbouring row's command, if the search and the selection ever
+ * disagreed about which list they are indexing.
+ *
+ * Every platform here is a fixture. The interesting cases are the
+ * targets this test process is not running on — a Windows host binds
+ * both terminal actions, a Linux desktop binds neither because no GNOME
+ * adapter exists yet, and a server has no display to press a key on —
+ * and none of those is answerable by asking the machine underneath.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { ACTIONS } from "./actions/index.ts";
+import type { SemanticAction } from "./actions/index.ts";
+import {
+  fireEntry,
+  firePlan,
+  keyEntries,
+  keyLines,
+  searchKeys,
+  VIEWER_START,
+  viewerStep,
+  type KeyEntry,
+  type ViewerKey,
+  type ViewerState,
+} from "./keys.ts";
+import type { Platform } from "./platform.ts";
+
+function machine(over: Partial<Platform>): Platform {
+  return {
+    os: "linux",
+    distro: "ubuntu",
+    version: "24.04",
+    codename: "noble",
+    env: "desktop",
+    arch: "x64",
+    caps: { apt: true, gui: true, systemd: true, winget: false, flatpak: true },
+    ...over,
+  };
+}
+
+const desktop = machine({});
+const server = machine({ env: "server", caps: { apt: true, gui: false, systemd: true, winget: false, flatpak: false } });
+const windows = machine({ os: "windows", env: "windows", distro: null, version: null, codename: null });
+
+/** Nothing is on PATH unless a test says it is. */
+const nothing = (): string | null => null;
+const anything = (cmd: string): string => `/usr/bin/${cmd}`;
+
+/** A whole registry of one, so a fault can exist without shipping one. */
+function only(over: Partial<SemanticAction>): readonly SemanticAction[] {
+  return [
+    {
+      id: "fixture.one",
+      label: "A fixture",
+      platforms: ["desktop", "windows"],
+      mutates: false,
+      privileged: false,
+      chord: "Ctrl+Alt+J",
+      ...over,
+    },
+  ];
+}
+
+/** No key pressed; each test turns on the one it means. */
+function press(over: Partial<ViewerKey> = {}): ViewerKey {
+  return {
+    upArrow: false,
+    downArrow: false,
+    return: false,
+    escape: false,
+    backspace: false,
+    delete: false,
+    ctrl: false,
+    ...over,
+  };
+}
+
+/** Type a string into the viewer, one keystroke at a time. */
+function typed(entries: readonly KeyEntry[], text: string): ViewerState {
+  let state = VIEWER_START;
+  for (const ch of text) state = viewerStep(entries, state, ch, press()).state;
+  return state;
+}
+
+describe("the list", () => {
+  test("carries every action, on every target", () => {
+    for (const p of [desktop, server, windows]) {
+      expect(keyEntries(p).map((e) => e.id)).toEqual(ACTIONS.map((a) => a.id));
+    }
+  });
+
+  test("says which chord each action carries, in the spelling a person says", () => {
+    const terminal = keyEntries(windows).find((e) => e.id === "terminal.new");
+    expect(terminal?.chord).toBe("Ctrl+Alt+T");
+    expect(terminal?.label).toBe("Terminal");
+  });
+
+  test("on Windows, the two terminal actions are bound and carry no reason", () => {
+    for (const entry of keyEntries(windows)) {
+      expect(entry.state).toBe("bound");
+      expect(entry.reason).toBe("");
+    }
+  });
+});
+
+describe("an action this target does not bind", () => {
+  test("is listed, not hidden, and the reason says the target has no adapter", () => {
+    // Ubuntu desktop today: terminal.new applies here — GNOME ships the
+    // same chord for the same act — and nothing red-dev owns registers
+    // it, because the GNOME adapter is not written. Reporting that is
+    // the ADR's rule; dropping the row would make the viewer agree with
+    // a machine that is missing a feature.
+    const entry = keyEntries(desktop).find((e) => e.id === "terminal.new");
+    expect(entry?.state).toBe("unsupported");
+    expect(entry?.reason).toContain("no bindings adapter for desktop");
+  });
+
+  test("that does not apply here at all says so, and names where it does", () => {
+    const entry = keyEntries(server).find((e) => e.id === "terminal.new");
+    expect(entry?.state).toBe("unsupported");
+    expect(entry?.reason).toContain("does not apply to server");
+    expect(entry?.reason).toContain("desktop, wsl, windows");
+  });
+
+  test("and the reason reaches the printed list, on the row", () => {
+    const lines = keyLines(keyEntries(server));
+    expect(lines).toHaveLength(ACTIONS.length);
+    const line = lines.find((l) => l.includes("terminal.new"));
+    expect(line).toContain("unbound");
+    expect(line).toContain("does not apply to server");
+  });
+
+  test("a bound row is printed without a reason trailing it", () => {
+    const line = keyLines(keyEntries(windows)).find((l) => l.includes("terminal.new"));
+    expect(line).toContain("bound");
+    expect(line).not.toContain("—");
+  });
+});
+
+describe("broken and not-supported are different news", () => {
+  test("a chord nothing can read is broken, in the validator's own words", () => {
+    // Not "unsupported": this is wrong everywhere and somebody has to
+    // fix it, which is exactly the distinction the two states exist to
+    // keep. The sentence is the validator's so the viewer and `doctor`
+    // cannot describe one fault two ways.
+    const [entry] = keyEntries(desktop, only({ chord: "Ctrl+Alt+J+K" }));
+    expect(entry?.state).toBe("broken");
+    expect(entry?.reason).toBe('chord "Ctrl+Alt+J+K" is not one readable chord');
+  });
+
+  test("an action the adapter should register and does not is broken too", () => {
+    // Applies to Windows, the Windows adapter exists, and it carries no
+    // entry for it: a gap, not a platform limit.
+    const [entry] = keyEntries(windows, only({}));
+    expect(entry?.state).toBe("broken");
+    expect(entry?.reason).toContain("Windows Start Menu");
+  });
+
+  test("and a broken chord is reported even where the action does not apply", () => {
+    const [entry] = keyEntries(server, only({ chord: "" }));
+    expect(entry?.state).toBe("broken");
+  });
+});
+
+describe("searching", () => {
+  const entries = keyEntries(windows);
+
+  test("with nothing typed, everything is visible", () => {
+    expect(searchKeys(entries, "")).toHaveLength(ACTIONS.length);
+  });
+
+  test("matches the label, the id and the chord, in any case", () => {
+    expect(searchKeys(entries, "elevated").map((e) => e.id)).toEqual(["terminal.elevated"]);
+    expect(searchKeys(entries, "terminal.new").map((e) => e.id)).toEqual(["terminal.new"]);
+    expect(searchKeys(entries, "ctrl+alt+shift+t").map((e) => e.id)).toEqual([
+      "terminal.elevated",
+    ]);
+  });
+
+  test("every word has to match, in any order", () => {
+    expect(searchKeys(entries, "shift terminal").map((e) => e.id)).toEqual([
+      "terminal.elevated",
+    ]);
+    expect(searchKeys(entries, "terminal nonsense")).toEqual([]);
+  });
+
+  test("the state is searchable, so 'unbound work' is one query", () => {
+    expect(searchKeys(keyEntries(server), "unsupported")).toHaveLength(ACTIONS.length);
+    expect(searchKeys(entries, "unsupported")).toEqual([]);
+  });
+});
+
+describe("what Enter runs", () => {
+  test("selecting an entry dispatches that action, not the row above it", async () => {
+    // The whole point of the viewer being a launcher: type enough to
+    // isolate a row, press Enter, and the thing that starts is that
+    // row's action. A search and a selection indexing different lists
+    // would fail here by starting the terminal instead.
+    const entries = keyEntries(windows);
+    const state = typed(entries, "elev");
+    const step = viewerStep(entries, state, "", press({ return: true }));
+    expect(step.fire?.id).toBe("terminal.elevated");
+
+    const started: string[][] = [];
+    const outcome = await fireEntry(step.fire!, windows, (argv) => {
+      started.push(argv);
+      return 0;
+    }, nothing);
+
+    expect(outcome.fired).toBe(true);
+    expect(started).toHaveLength(1);
+    expect(started[0]?.join(" ")).toContain("Start-Process powershell -Verb RunAs");
+  });
+
+  test("the terminal action opens the same thing its shortcut points at", async () => {
+    const [terminal] = keyEntries(windows);
+    const started: string[][] = [];
+    await fireEntry(terminal!, windows, (argv) => started.push(argv), (cmd) =>
+      cmd === "alacritty.exe" ? "C:\\alacritty.exe" : null,
+    );
+    expect(started[0]).toEqual(["cmd.exe", "/c", "start", "", "alacritty.exe"]);
+
+    // Without Alacritty, WSL in the home directory — the fallback the
+    // Start Menu shortcut already uses.
+    const withoutIt: string[][] = [];
+    await fireEntry(terminal!, windows, (argv) => withoutIt.push(argv), nothing);
+    expect(withoutIt[0]).toEqual(["cmd.exe", "/c", "start", "", "wsl.exe", "--cd", "~"]);
+  });
+
+  test("an unbound action still runs — that is what the viewer is for", async () => {
+    // Ubuntu desktop binds no chord today. Someone who opened the viewer
+    // to reach the terminal gets the terminal, rather than a row telling
+    // them the chord they came here to find does not work.
+    const [terminal] = keyEntries(desktop);
+    expect(terminal?.state).toBe("unsupported");
+    const started: string[][] = [];
+    const outcome = await fireEntry(terminal!, desktop, (argv) => started.push(argv), anything);
+    expect(outcome.fired).toBe(true);
+    expect(started[0]).toEqual(["alacritty"]);
+  });
+
+  test("and a refusal is a sentence, not a process that fails elsewhere", async () => {
+    const elevated = keyEntries(desktop).find((e) => e.id === "terminal.elevated")!;
+    const started: string[][] = [];
+    const outcome = await fireEntry(elevated, desktop, (argv) => started.push(argv), anything);
+    expect(outcome.fired).toBe(false);
+    expect(outcome.detail).toContain("sudo");
+    expect(started).toEqual([]);
+  });
+
+  test("a machine with no terminal emulator says which ones were looked for", () => {
+    const plan = firePlan("terminal.new", desktop, nothing);
+    expect(plan.ok).toBe(false);
+    expect(plan.ok === false && plan.detail).toContain("alacritty");
+  });
+
+  test("an action nothing can run yet is named rather than shrugged at", () => {
+    const plan = firePlan("terminal.gone", windows, anything);
+    expect(plan.ok === false && plan.detail).toContain("terminal.gone");
+  });
+});
+
+describe("the keystrokes the viewer reads", () => {
+  const entries = keyEntries(windows);
+
+  test("letters are the search box, so j and k cannot be navigation", () => {
+    expect(typed(entries, "jk").query).toBe("jk");
+  });
+
+  test("backspace takes one back, and an empty box swallows it", () => {
+    const state = viewerStep(entries, typed(entries, "el"), "", press({ backspace: true })).state;
+    expect(state.query).toBe("e");
+    expect(viewerStep(entries, VIEWER_START, "", press({ backspace: true })).state.query).toBe("");
+  });
+
+  test("the arrows move within what is visible and stop at the ends", () => {
+    const down = viewerStep(entries, VIEWER_START, "", press({ downArrow: true })).state;
+    expect(down.index).toBe(1);
+    const further = viewerStep(entries, down, "", press({ downArrow: true })).state;
+    expect(further.index).toBe(entries.length - 1);
+    expect(viewerStep(entries, VIEWER_START, "", press({ upArrow: true })).state.index).toBe(0);
+  });
+
+  test("editing the query puts the cursor back on the first match", () => {
+    const moved = viewerStep(entries, VIEWER_START, "", press({ downArrow: true })).state;
+    expect(viewerStep(entries, moved, "t", press()).state.index).toBe(0);
+  });
+
+  test("escape clears a search before it closes the viewer", () => {
+    const searching = typed(entries, "zzz");
+    const cleared = viewerStep(entries, searching, "", press({ escape: true }));
+    expect(cleared.quit).toBeUndefined();
+    expect(cleared.state.query).toBe("");
+    expect(viewerStep(entries, VIEWER_START, "", press({ escape: true })).quit).toBe(true);
+  });
+
+  test("ctrl+c leaves, and no other ctrl chord types into the box", () => {
+    expect(viewerStep(entries, VIEWER_START, "c", press({ ctrl: true })).quit).toBe(true);
+    const state = viewerStep(entries, VIEWER_START, "a", press({ ctrl: true })).state;
+    expect(state.query).toBe("");
+  });
+
+  test("enter on a search that found nothing fires nothing", () => {
+    const empty = typed(entries, "zzz");
+    expect(viewerStep(entries, empty, "", press({ return: true })).fire).toBeUndefined();
+  });
+});

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -1,0 +1,449 @@
+/**
+ * `red-dev keys` — the registry, as something a person can search, read
+ * and press Enter on.
+ *
+ * The chords are decided once, in `src/actions/`, and registered by
+ * whichever adapter owns this target. Neither of those helps the person
+ * who knows red-dev binds *something* for the thing they want and cannot
+ * remember what. That is what this is: every semantic action, its chord,
+ * and whether this machine actually binds it — searchable, and a
+ * launcher, because a viewer that can only show you a chord you have
+ * forgotten leaves you to type it correctly on the first try.
+ *
+ * Two rules shape the list, both from ADR 0006.
+ *
+ * Nothing is hidden. An action with no chord on this target is listed
+ * *as unbound, with the reason*, because a viewer that quietly drops
+ * what it cannot bind is how "the same experience on every target"
+ * becomes untrue without anybody noticing. The reasons are two different
+ * kinds of news and are kept apart: `unsupported` is the machine saying
+ * "not here" — the action does not apply to this target, or red-dev has
+ * no adapter for it yet — and `broken` is the machine saying "here, and
+ * it should work, and it does not". The first is a fact to live with;
+ * the second is a bug someone has to fix, and merging them into one grey
+ * "unavailable" would bury it.
+ *
+ * Firing does not depend on binding. The Enter key runs the action even
+ * where nothing registers its chord, which is the case on GNOME today —
+ * an unbound action reachable from the viewer is the remedy the ADR
+ * promises, and refusing to run it would leave the target with neither
+ * the chord nor the fallback.
+ */
+
+import { ACTIONS, actionById, validateActions } from "./actions/index.ts";
+import type { SemanticAction } from "./actions/index.ts";
+import { WINDOWS_HOTKEYS } from "./hotkeys.ts";
+import type { Platform } from "./platform.ts";
+
+/**
+ * What this target does with an action's chord.
+ *
+ * Three answers rather than a boolean, because "not bound" is two
+ * different sentences — see the header. `bound` means an adapter on this
+ * target registers this chord.
+ */
+export type BindingState = "bound" | "unsupported" | "broken";
+
+export interface KeyEntry {
+  id: string;
+  label: string;
+  /**
+   * The chord in the registry's own spelling — `Ctrl+Alt+Shift+T`.
+   *
+   * Not the folded `CTRL+ALT+SHIFT+T` a comparison uses: that spelling
+   * exists so two chords can be told apart, and this one exists so a
+   * person reads the same thing in the viewer, in the source and in the
+   * README.
+   */
+  chord: string;
+  state: BindingState;
+  /** Empty when bound; one sentence, in plain words, when not. */
+  reason: string;
+}
+
+/**
+ * The thing that turns a chord into a registration on this target.
+ *
+ * One today: the Windows Start Menu `.lnk`, in src/hotkeys.ts. GNOME's
+ * is not written yet, and its absence is reported rather than hidden —
+ * that absence is precisely what someone reading the viewer on Ubuntu
+ * needs to be told.
+ */
+interface Adapter {
+  /** Named the way the reason sentence needs to read. */
+  name: string;
+  binds(id: string): boolean;
+}
+
+function adapterFor(p: Platform): Adapter | null {
+  if (p.env === "windows" || p.env === "wsl") {
+    return {
+      name: "Windows Start Menu",
+      binds: (id) => WINDOWS_HOTKEYS.some((h) => h.id === id && h.combo !== null),
+    };
+  }
+  return null;
+}
+
+/**
+ * Every action, in registry order, judged against this machine.
+ *
+ * Registry order rather than bound-first: the list is a map of what
+ * red-dev can do, and a map that reorders itself per machine is one
+ * nobody memorises. The actions are a parameter so a test can hold a
+ * broken one without the registry having to carry it.
+ */
+export function keyEntries(
+  p: Platform,
+  actions: readonly SemanticAction[] = ACTIONS,
+): KeyEntry[] {
+  // The validator's own sentences, so the viewer and `validateActions`
+  // never describe the same fault two different ways. First one per
+  // action: they are all about the same chord, and a list of five
+  // problems in a status line is a list nobody reads.
+  const faults = new Map<string, string>();
+  for (const problem of validateActions(actions)) {
+    if (!faults.has(problem.id)) faults.set(problem.id, problem.problem);
+  }
+
+  const adapter = adapterFor(p);
+
+  return actions.map((action): KeyEntry => {
+    const head = { id: action.id, label: action.label, chord: action.chord };
+
+    const fault = faults.get(action.id);
+    // Broken first, and deliberately before the platform check: an
+    // unreadable chord is wrong on every target, and reporting it as
+    // "not supported here" on the three targets it does not apply to
+    // would hide it on three machines out of four.
+    if (fault) return { ...head, state: "broken", reason: fault };
+
+    if (!action.platforms.includes(p.env)) {
+      return {
+        ...head,
+        state: "unsupported",
+        reason: `does not apply to ${p.env} — it applies to ${action.platforms.join(", ")}`,
+      };
+    }
+
+    if (!adapter) {
+      return {
+        ...head,
+        state: "unsupported",
+        reason: `red-dev has no bindings adapter for ${p.env} yet, so nothing registers the chord here`,
+      };
+    }
+
+    if (!adapter.binds(action.id)) {
+      return {
+        ...head,
+        state: "broken",
+        reason: `the ${adapter.name} adapter does not register it, though this target should`,
+      };
+    }
+
+    return { ...head, state: "bound", reason: "" };
+  });
+}
+
+/**
+ * The list, narrowed by what has been typed.
+ *
+ * Every word has to match somewhere, in any order and anywhere in the
+ * row: `alt t` finds the terminal, and so does `term`. Case is folded
+ * because nobody types `Ctrl+Alt+Shift+T` into a search box, and the
+ * state is part of the haystack so `broken` is a query that answers the
+ * question the word asks.
+ */
+export function searchKeys(
+  entries: readonly KeyEntry[],
+  query: string,
+): KeyEntry[] {
+  const words = query.trim().toLowerCase().split(/\s+/).filter(Boolean);
+  if (words.length === 0) return [...entries];
+  return entries.filter((entry) => {
+    const hay = `${entry.chord} ${entry.label} ${entry.id} ${entry.state}`.toLowerCase();
+    return words.every((word) => hay.includes(word));
+  });
+}
+
+export interface KeyColumns {
+  chord: number;
+  label: number;
+  id: number;
+}
+
+/** Wide enough for the widest of each, so the columns line up. */
+export function keyColumns(entries: readonly KeyEntry[]): KeyColumns {
+  const widest = (pick: (e: KeyEntry) => string): number =>
+    entries.reduce((max, e) => Math.max(max, pick(e).length), 0);
+  return {
+    chord: widest((e) => e.chord),
+    label: widest((e) => e.label),
+    id: widest((e) => e.id),
+  };
+}
+
+/**
+ * One row: the chord, what it does, the id, and whether it is bound.
+ *
+ * The id is on the row rather than behind a keypress because it is the
+ * name everything else stores — a bug report that says `terminal.new`
+ * is answerable and one that says "the terminal one" is not.
+ */
+export function keyRow(entry: KeyEntry, cols: KeyColumns): string {
+  return [
+    entry.chord.padEnd(cols.chord),
+    entry.label.padEnd(cols.label),
+    entry.id.padEnd(cols.id),
+    entry.state === "bound" ? "bound" : "unbound",
+  ].join("  ");
+}
+
+/**
+ * The whole list as text, for a terminal that cannot draw a viewer.
+ *
+ * The reason rides on the row here, because there is no panel to put it
+ * in and an unbound line with no reason is the thing this command exists
+ * not to print.
+ */
+export function keyLines(entries: readonly KeyEntry[]): string[] {
+  const cols = keyColumns(entries);
+  return entries.map((entry) => {
+    const row = keyRow(entry, cols);
+    return entry.state === "bound" ? row : `${row} — ${entry.reason}`;
+  });
+}
+
+/**
+ * What Enter runs, decided before anything is started.
+ *
+ * The same shape as `LaunchDecision` in src/agent-launch.ts and for the
+ * same reason: deciding and doing are separate so the deciding half can
+ * be read by a test, and so a refusal arrives as a sentence for the
+ * status line rather than as a process that failed somewhere off screen.
+ */
+export type FirePlan =
+  | { ok: true; id: string; argv: string[]; note: string }
+  | { ok: false; id: string; detail: string };
+
+/**
+ * The terminals a Linux desktop might have, best first.
+ *
+ * `x-terminal-emulator` is Debian's alternatives symlink — whatever the
+ * person actually chose — which is why it outranks naming GNOME's.
+ */
+const LINUX_TERMINALS = ["alacritty", "x-terminal-emulator", "gnome-terminal", "xterm"] as const;
+
+/** Windows is the host that registers chords, from either side of WSL. */
+function onWindowsHost(p: Platform): boolean {
+  return p.env === "windows" || p.env === "wsl";
+}
+
+export function firePlan(
+  id: string,
+  p: Platform,
+  locate: (cmd: string) => string | null,
+): FirePlan {
+  const action = actionById(id);
+  if (!action) return { ok: false, id, detail: `no action called ${id}` };
+
+  switch (id) {
+    case "terminal.new": {
+      if (onWindowsHost(p)) {
+        // Through `start`, not straight at the executable. This process
+        // is a console process on both sides of the WSL boundary, and
+        // spawning a terminal from it hands the new terminal the console
+        // red-dev is drawing in. `start` is the shell asking Windows for
+        // a window instead, and the empty argument after it is the title
+        // slot — without it `start` reads the program name as a title
+        // and opens an empty console.
+        //
+        // The targets are the ones the Start Menu shortcut already
+        // resolves to (src/hotkeys.ts): Alacritty when it is installed,
+        // otherwise WSL in the home directory.
+        const alacritty = locate("alacritty.exe") !== null;
+        const exe = alacritty ? "alacritty.exe" : "wsl.exe";
+        const argv = alacritty
+          ? ["cmd.exe", "/c", "start", "", exe]
+          : ["cmd.exe", "/c", "start", "", exe, "--cd", "~"];
+        return { ok: true, id, argv, note: `${exe} in a new window` };
+      }
+      const found = LINUX_TERMINALS.find((cmd) => locate(cmd) !== null);
+      if (!found) {
+        return {
+          ok: false,
+          id,
+          detail: `no terminal emulator on PATH — looked for ${LINUX_TERMINALS.join(", ")}`,
+        };
+      }
+      return { ok: true, id, argv: [found], note: found };
+    }
+
+    case "terminal.elevated": {
+      if (!onWindowsHost(p)) {
+        // Refused rather than approximated. `pkexec bash` in a window is
+        // not the act this action names, and inventing a local substitute
+        // is the exact thing ADR 0006 tells an adapter not to do.
+        return {
+          ok: false,
+          id,
+          detail:
+            "an elevated shell is the Windows act red-dev binds; on Linux, sudo in the terminal you already have does it",
+        };
+      }
+      // Start-Process -Verb RunAs is what raises the consent prompt; the
+      // .lnk does the same through byte 21 of the shortcut format.
+      return {
+        ok: true,
+        id,
+        argv: ["powershell.exe", "-NoProfile", "-Command", "Start-Process powershell -Verb RunAs"],
+        note: "PowerShell, once the consent prompt is answered",
+      };
+    }
+
+    default:
+      // An action in the registry that nothing can run yet. Named, not
+      // shrugged at: the registry is filled by slices that arrive one at
+      // a time, and "nothing happened" is the worst way to learn that
+      // this one has not landed.
+      return { ok: false, id, detail: `${action.label} has nothing to run from here yet` };
+  }
+}
+
+/** Started, or the reason it was not — either way, one line. */
+export interface FireOutcome {
+  fired: boolean;
+  detail: string;
+}
+
+export type Spawn = (argv: string[]) => Promise<number> | number;
+
+/**
+ * Start what the highlighted entry names.
+ *
+ * `spawn` and `locate` are injected for the reason resolveLaunch injects
+ * its own: PATH and process creation are not answerable in a test, and
+ * the thing worth pinning is that choosing an entry starts *that*
+ * action's command rather than its neighbour's.
+ */
+export async function fireEntry(
+  entry: KeyEntry,
+  p: Platform,
+  spawn: Spawn,
+  locate: (cmd: string) => string | null = (cmd) => Bun.which(cmd),
+): Promise<FireOutcome> {
+  const plan = firePlan(entry.id, p, locate);
+  if (!plan.ok) return { fired: false, detail: plan.detail };
+  try {
+    await spawn(plan.argv);
+  } catch (err) {
+    return { fired: false, detail: `${entry.label}: ${(err as Error).message}` };
+  }
+  return { fired: true, detail: `${entry.label} — ${plan.note}` };
+}
+
+/**
+ * Start it and let go.
+ *
+ * The three streams are ignored and the child is unref'd because what
+ * this starts is a window of its own: inheriting the streams would put
+ * a second program inside the frame red-dev is drawing, and keeping a
+ * reference would hold the viewer open until the terminal someone just
+ * opened is closed again.
+ */
+export function detach(argv: string[]): number {
+  const child = Bun.spawn(argv, { stdin: "ignore", stdout: "ignore", stderr: "ignore" });
+  child.unref();
+  return 0;
+}
+
+/** Where the search box and the cursor are, and nothing else. */
+export interface ViewerState {
+  query: string;
+  /** Into the filtered list, never into the whole one. */
+  index: number;
+}
+
+export const VIEWER_START: ViewerState = { query: "", index: 0 };
+
+/**
+ * The keys the viewer reads, structurally.
+ *
+ * tuiuiu's `Key` carries all of these, so the component hands its own
+ * object straight in; declaring only what is used keeps this module free
+ * of the renderer, which is what lets the whole interaction be tested
+ * without one.
+ */
+export interface ViewerKey {
+  upArrow: boolean;
+  downArrow: boolean;
+  return: boolean;
+  escape: boolean;
+  backspace: boolean;
+  delete: boolean;
+  ctrl: boolean;
+}
+
+export interface ViewerStep {
+  state: ViewerState;
+  /** The entry Enter chose, when it chose one. */
+  fire?: KeyEntry;
+  /** The viewer is finished. */
+  quit?: boolean;
+}
+
+/**
+ * One keystroke, as a decision rather than as a side effect.
+ *
+ * Every printable character is search, which is what makes this a
+ * searchable viewer rather than a list with a filter hidden behind a
+ * key: `j` and `k` cannot navigate here, because they are also the two
+ * letters in the middle of nothing anybody is trying to type. The arrows
+ * move.
+ *
+ * Escape clears the query before it closes the viewer. Someone with a
+ * search that found nothing is one keystroke from the whole list, and
+ * one more from leaving — rather than out of the program because their
+ * typo had no matches.
+ */
+export function viewerStep(
+  entries: readonly KeyEntry[],
+  state: ViewerState,
+  input: string,
+  key: ViewerKey,
+): ViewerStep {
+  const visible = searchKeys(entries, state.query);
+  const clamp = (i: number): number => Math.max(0, Math.min(visible.length - 1, i));
+
+  // Ctrl+C leaves, whatever is on screen. Every other Ctrl chord is
+  // swallowed rather than typed into the search box.
+  if (key.ctrl) return input === "c" ? { state, quit: true } : { state };
+
+  if (key.return) {
+    const chosen = visible[clamp(state.index)];
+    return chosen ? { state, fire: chosen } : { state };
+  }
+
+  if (key.escape) {
+    return state.query === "" ? { state, quit: true } : { state: VIEWER_START };
+  }
+
+  if (key.upArrow) return { state: { ...state, index: clamp(state.index - 1) } };
+  if (key.downArrow) return { state: { ...state, index: clamp(state.index + 1) } };
+
+  if (key.backspace || key.delete) {
+    return state.query === ""
+      ? { state }
+      : { state: { query: state.query.slice(0, -1), index: 0 } };
+  }
+
+  // Back to the top on every edit: the row under the cursor before the
+  // keystroke is rarely the row under it after, and leaving the index
+  // where it was highlights whatever happens to be in that position.
+  if (input.length === 1 && input >= " " && input !== "\u007f") {
+    return { state: { query: state.query + input, index: 0 } };
+  }
+
+  return { state };
+}

--- a/src/learn.test.ts
+++ b/src/learn.test.ts
@@ -1,0 +1,109 @@
+/**
+ * A link to a heading that no longer exists is a link to the top of a
+ * sixty-kilobyte page, and nothing anywhere reports it.
+ *
+ * That is the whole reason this file reads the README. The Learn section
+ * offers the documentation *by anchor*, which is only worth more than
+ * one "docs" link for as long as the anchors land; a heading renamed in
+ * a docs pass would leave six entries silently pointing at the front
+ * page. The README is in this repository, so the check is cheap and the
+ * rename fails here rather than on somebody's machine.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { anchor, browseArgv, LEARN, learnLines } from "./learn.ts";
+import type { Platform } from "./platform.ts";
+
+const readme = readFileSync("README.md", "utf8");
+
+/** Every anchor GitHub would generate for this README's own headings. */
+const headings = new Set(
+  readme
+    .split("\n")
+    .filter((line) => /^#{1,6} /.test(line))
+    .map((line) => anchor(line.replace(/^#+ /, ""))),
+);
+
+function machine(over: Partial<Platform>): Platform {
+  return {
+    os: "linux",
+    distro: "ubuntu",
+    version: "24.04",
+    codename: "noble",
+    env: "desktop",
+    arch: "x64",
+    caps: { apt: true, gui: true, systemd: true, winget: false, flatpak: true },
+    ...over,
+  };
+}
+
+describe("the README, by anchor", () => {
+  test("there are sections to check", () => {
+    expect(LEARN.filter((e) => e.key.startsWith("readme.")).length).toBeGreaterThan(3);
+  });
+
+  for (const entry of LEARN.filter((e) => e.key.startsWith("readme."))) {
+    test(`${entry.label} points at a heading the README still has`, () => {
+      const fragment = entry.url?.split("#")[1];
+      expect(fragment).toBeDefined();
+      expect(headings.has(fragment!)).toBe(true);
+    });
+  }
+
+  test("anchors are folded the way GitHub folds them", () => {
+    expect(anchor("Quick start")).toBe("quick-start");
+    expect(anchor("Under the hood")).toBe("under-the-hood");
+    expect(anchor("Themes & colour")).toBe("themes--colour");
+  });
+});
+
+describe("what else Learn carries", () => {
+  test("RedSkills, because it is the other half of what gets installed", () => {
+    const skills = LEARN.find((e) => e.key === "red-skills");
+    expect(skills?.url).toBe("https://github.com/reddb-io/red-skills");
+  });
+
+  test("and the keys viewer itself, which is a surface rather than a link", () => {
+    // The one entry that answers a question about *this* machine. A URL
+    // here would be the wrong answer to "which key does that".
+    const keys = LEARN.find((e) => e.key === "keys");
+    expect(keys).toBeDefined();
+    expect(keys?.url).toBeNull();
+    expect(learnLines([keys!])[0]).toContain("red-dev keys");
+  });
+
+  test("every entry is printable, with somewhere to go on the line", () => {
+    const lines = learnLines();
+    expect(lines).toHaveLength(LEARN.length);
+    for (const line of lines) expect(line).toMatch(/https:\/\/|red-dev keys/);
+  });
+});
+
+describe("opening a link", () => {
+  test("Windows and WSL both go through the shell launcher", () => {
+    for (const env of ["windows", "wsl"] as const) {
+      expect(browseArgv("https://example.com", machine({ env }), () => null)).toEqual([
+        "cmd.exe",
+        "/c",
+        "start",
+        "",
+        "https://example.com",
+      ]);
+    }
+  });
+
+  test("a desktop uses xdg-open when it has one", () => {
+    expect(browseArgv("https://example.com", machine({}), (cmd) => `/usr/bin/${cmd}`)).toEqual([
+      "xdg-open",
+      "https://example.com",
+    ]);
+    expect(browseArgv("https://example.com", machine({}), () => null)).toBeNull();
+  });
+
+  test("and a server has nothing to open it with, which is an answer", () => {
+    // Not a failure to report: printing the URL is what a headless
+    // machine can actually use.
+    expect(browseArgv("https://example.com", machine({ env: "server" }), () => "/usr/bin/x")).toBeNull();
+  });
+});

--- a/src/learn.ts
+++ b/src/learn.ts
@@ -1,0 +1,127 @@
+/**
+ * Learn — where the documentation is, from inside the program.
+ *
+ * The README is sixty kilobytes and answers almost everything, which is
+ * exactly the problem: nobody reads it from the top, and the person who
+ * needs the troubleshooting section is the person least likely to be
+ * looking at a browser. So the menu carries the README by anchor —
+ * named sections, each a link to that heading — rather than one "docs"
+ * entry pointing at the front of a long page.
+ *
+ * Three kinds of thing, and the third is the point. The README sections
+ * and RedSkills are elsewhere; the keys viewer is here, in this program,
+ * and listing it beside them is what makes Learn a place to find out how
+ * red-dev works rather than a bookmark folder. It is also the honest
+ * answer to "which key does X" — a link cannot answer that for the
+ * machine you are on, and the viewer can.
+ *
+ * Flat, deliberately. ADR 0006's neighbour decision was that the menu
+ * grows by sections rather than by Omarchy's tree, and a Learn submenu
+ * of submenus is the first place a tree would grow back.
+ */
+
+import type { Platform } from "./platform.ts";
+
+/** The repository, whose front page renders the README with its anchors. */
+const README = "https://github.com/reddb-io/red-dev";
+
+/**
+ * The heading text, exactly as the README spells it.
+ *
+ * Exactly, because the anchor is derived from it and a link to a
+ * heading that has been renamed is a link to the top of the page — a
+ * failure with no error, which is why learn.test.ts reads the README
+ * and checks that each of these is still a heading in it.
+ */
+const README_SECTIONS: readonly { key: string; heading: string; detail: string }[] = [
+  { key: "quick-start", heading: "Quick start", detail: "the one-liner, and what it does first" },
+  { key: "usage", heading: "Usage", detail: "every command, on one screen" },
+  {
+    key: "targets",
+    heading: "Using it on each target",
+    detail: "Ubuntu, WSL and Windows, and what differs",
+  },
+  { key: "themes", heading: "Themes", detail: "the palettes, and what they reach" },
+  { key: "troubleshooting", heading: "Troubleshooting", detail: "when the machine disagrees" },
+  { key: "under-the-hood", heading: "Under the hood", detail: "how a converge is put together" },
+];
+
+/**
+ * GitHub's anchor for a heading: folded, punctuation dropped, spaces
+ * hyphenated.
+ *
+ * Derived rather than written down beside each heading, so the two
+ * cannot drift apart while both look right.
+ */
+export function anchor(heading: string): string {
+  // Space by space rather than run by run: GitHub drops the punctuation
+  // and hyphenates what is left where it stands, so `Themes & colour`
+  // is `themes--colour` and a tidier collapse here would produce an
+  // anchor that looks right and matches nothing.
+  return heading
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9 -]/g, "")
+    .replace(/ /g, "-");
+}
+
+export interface LearnEntry {
+  /** Stable, because the menu stores it. */
+  key: string;
+  label: string;
+  /** One line, read after the label. */
+  detail: string;
+  /** Where it leads, or null when it opens a surface of red-dev's own. */
+  url: string | null;
+}
+
+export const LEARN: readonly LearnEntry[] = [
+  ...README_SECTIONS.map((section) => ({
+    key: `readme.${section.key}`,
+    label: `README — ${section.heading}`,
+    detail: section.detail,
+    url: `${README}#${anchor(section.heading)}`,
+  })),
+  {
+    key: "red-skills",
+    label: "RedSkills",
+    detail: "the skills red-dev wires into every agent host",
+    url: "https://github.com/reddb-io/red-skills",
+  },
+  {
+    // Last, and in the list rather than beside it: someone who came to
+    // Learn to find out how something works is one row away from the
+    // answer for the machine they are on.
+    key: "keys",
+    label: "Keys — the searchable viewer",
+    detail: "every action, its chord, and whether this machine binds it",
+    url: null,
+  },
+];
+
+/** The list as text, for a terminal with no interface to draw. */
+export function learnLines(entries: readonly LearnEntry[] = LEARN): string[] {
+  const width = entries.reduce((max, e) => Math.max(max, e.label.length), 0);
+  return entries.map(
+    (entry) => `${entry.label.padEnd(width)}  ${entry.url ?? "red-dev keys"}  — ${entry.detail}`,
+  );
+}
+
+/**
+ * How this target opens a link, or nothing when it cannot.
+ *
+ * Null is a real answer, not a failure: a headless server has no browser
+ * to hand a URL to, and printing the URL there is more useful than
+ * spawning something that will not work. The Windows idiom is the shell
+ * launcher for the same reason the terminal action uses it — it works
+ * identically from Windows and from inside WSL.
+ */
+export function browseArgv(
+  url: string,
+  p: Platform,
+  locate: (cmd: string) => string | null,
+): string[] | null {
+  if (p.env === "windows" || p.env === "wsl") return ["cmd.exe", "/c", "start", "", url];
+  if (p.env === "desktop" && locate("xdg-open") !== null) return ["xdg-open", url];
+  return null;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1071,6 +1071,67 @@ async function cmdApps(p: Platform, inv: Invocation): Promise<number> {
 }
 
 /**
+ * `red-dev keys` — every action, its chord, and whether this machine
+ * binds it.
+ *
+ * Two shapes, and the plain one is not a degraded mode. A terminal that
+ * cannot draw the viewer still gets the whole list with the reason on
+ * every unbound row, which is the form a bug report pastes and a script
+ * greps — and the form that proves nothing was hidden. The viewer adds
+ * the search and the Enter key, not the information.
+ */
+async function cmdKeys(p: Platform): Promise<number> {
+  const { keyEntries, keyLines } = await import("./keys.ts");
+  const entries = keyEntries(p);
+
+  if (!interactive()) {
+    for (const line of keyLines(entries)) log.plain(line);
+    return 0;
+  }
+
+  const { runKeysViewer } = await import("./keys-view.ts");
+  await runKeysViewer(p, entries);
+  return 0;
+}
+
+/**
+ * `red-dev learn` — the documentation, from inside the program.
+ *
+ * Picking a README section opens it at its heading where the machine
+ * has something to open a link with, and prints the URL where it does
+ * not: a headless server cannot browse, and a spawn that quietly fails
+ * there would be worse than the address it could have copied.
+ */
+async function cmdLearn(p: Platform): Promise<number> {
+  const { browseArgv, LEARN, learnLines } = await import("./learn.ts");
+
+  if (!interactive()) {
+    for (const line of learnLines()) log.plain(line);
+    return 0;
+  }
+
+  const labels = LEARN.map((entry) => `${entry.label} — ${entry.detail}`);
+  const picked = await select("Learn what?", labels as [string, ...string[]], labels[0]!);
+  const entry = LEARN[labels.indexOf(picked)];
+  if (!entry) return 0;
+
+  // The one entry that is a surface rather than a link, and the reason
+  // Learn is worth having beside the README: it answers "which key does
+  // that" for the machine in front of you.
+  if (entry.url === null) return await cmdKeys(p);
+
+  const argv = browseArgv(entry.url, p, (cmd) => Bun.which(cmd));
+  if (!argv) {
+    log.plain(entry.url);
+    return 0;
+  }
+  const { detach } = await import("./keys.ts");
+  detach(argv);
+  log.ok(entry.url);
+  return 0;
+}
+
+/**
  * Choose where a terminal lands on a machine that has both Windows and
  * WSL.
  *
@@ -1292,6 +1353,13 @@ async function cmdUi(p: Platform, inv: Invocation): Promise<number> {
       return await cmdDoctor(p, inv);
     case "apps":
       return await cmdApps(p, inv);
+    case "keys":
+      // Both of these draw their own interface, so they run after this
+      // one has released the screen — the same reason `apps` is here
+      // rather than in the actions handed into the render.
+      return await cmdKeys(p);
+    case "learn":
+      return await cmdLearn(p);
     default:
       return 0;
   }
@@ -1751,6 +1819,8 @@ async function cmdMenu(p: Platform, inv: Invocation, cliHelp: string): Promise<n
     plan: () => cmdPlan(p, inv),
     platform: () => cmdPlatform(p),
     apps: () => cmdApps(p, inv),
+    keys: () => cmdKeys(p),
+    learn: () => cmdLearn(p),
     lang: () => cmdLang(p, inv),
     shell: () => cmdShell(p, inv),
     uninstall: () => cmdUninstall(p),
@@ -1911,6 +1981,10 @@ async function main(): Promise<number> {
       return await cmdRedwall(p);
     case "apps":
       return await cmdApps(p, inv);
+    case "keys":
+      return await cmdKeys(p);
+    case "learn":
+      return await cmdLearn(p);
     case "agents":
       return await cmdAgents(p, inv);
     case "lang":

--- a/src/menu-sections.test.ts
+++ b/src/menu-sections.test.ts
@@ -1,0 +1,122 @@
+/**
+ * The menu is flat, and it carries Keys and Learn on both surfaces.
+ *
+ * Two things are pinned here, and the second is the one that rots. The
+ * first is the decision itself: the `red-dev` menu grows by flat
+ * sections rather than by Omarchy's tree, so Keys and Learn are entries
+ * at the top level and not leaves of a "More" branch.
+ *
+ * The second is that the interface has two menus. The fullscreen one in
+ * tui.ts is what almost everybody sees; the line-based one in menu.ts is
+ * what a terminal under sixty columns falls back to. They are separate
+ * lists, which means an entry added to one and forgotten in the other is
+ * invisible until somebody with a narrow window reports it missing.
+ *
+ * Read as data rather than through a render: this is a claim about what
+ * the product offers, and pinning it against a drawn frame would turn a
+ * layout change into a failure about sections.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { menuEntries } from "./menu.ts";
+import type { Platform } from "./platform.ts";
+import { SECTIONS } from "./tui.ts";
+
+function machine(over: Partial<Platform>): Platform {
+  return {
+    os: "linux",
+    distro: "ubuntu",
+    version: "24.04",
+    codename: "noble",
+    env: "desktop",
+    arch: "x64",
+    caps: { apt: true, gui: true, systemd: true, winget: false, flatpak: true },
+    ...over,
+  };
+}
+
+describe("the fullscreen menu", () => {
+  test("carries a Keys section and a Learn section", () => {
+    const keys = SECTIONS.find((s) => s.key === "keys");
+    const learn = SECTIONS.find((s) => s.key === "learn");
+    expect(keys?.label).toBe("Keys");
+    expect(learn?.label).toBe("Learn");
+  });
+
+  test("and both say what they are for while highlighted", () => {
+    // The right-hand panel is the only explanation a section gets; one
+    // with no notes is a word on a list.
+    for (const key of ["keys", "learn"]) {
+      expect(SECTIONS.find((s) => s.key === key)?.notes.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("with every section still one move from the top", () => {
+    // Flat, not a tree: a section whose label announces a submenu is
+    // the first step back toward the shape ADR 0006's neighbours
+    // decided against.
+    expect(new Set(SECTIONS.map((s) => s.key)).size).toBe(SECTIONS.length);
+    for (const section of SECTIONS) {
+      expect(section.label).not.toContain("…");
+      expect(section.label).not.toContain(">");
+    }
+  });
+});
+
+describe("choosing one opens something", () => {
+  // Structural, like tui-single-render.test.ts, and for the same
+  // reason: what happens after the interface releases the screen cannot
+  // be reached without a keystroke and a real console. A section whose
+  // key nothing answers falls through cmdUi's switch to `default`,
+  // which returns 0 — the interface closes and the person is back at a
+  // shell, having asked for a viewer. That is the failure this catches.
+  const cmdUi = (() => {
+    const main = readFileSync("src/main.ts", "utf8");
+    const from = main.indexOf("async function cmdUi");
+    return main.slice(from, main.indexOf("\nasync function", from + 1));
+  })();
+
+  for (const key of ["keys", "learn"]) {
+    test(`the ${key} section is answered after the render exits`, () => {
+      expect(cmdUi).toContain(`case "${key}":`);
+    });
+  }
+});
+
+describe("the narrow-terminal menu", () => {
+  for (const p of [machine({}), machine({ os: "windows", env: "windows" })]) {
+    test(`offers Keys and Learn on ${p.env} too`, () => {
+      const verbs = menuEntries(p).map((entry) => entry.split(" ")[0]);
+      expect(verbs).toContain("Keys");
+      expect(verbs).toContain("Learn");
+    });
+  }
+
+  test("and every entry it offers is one the loop can act on", () => {
+    // The loop switches on the first word. An entry whose verb nothing
+    // handles falls through to `default`, which quits the menu — a
+    // section that closes the program instead of opening.
+    const handled = new Set([
+      "Install",
+      "Theme",
+      "Wallpaper",
+      "Font",
+      "Redwall",
+      "Apps",
+      "Keys",
+      "Languages",
+      "Shell",
+      "Update",
+      "Plan",
+      "Doctor",
+      "Learn",
+      "Uninstall",
+      "Platform",
+      "Quit",
+    ]);
+    for (const entry of menuEntries(machine({ os: "windows", env: "windows" }))) {
+      expect(handled.has(entry.split(" ")[0] ?? "")).toBe(true);
+    }
+  });
+});

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -50,6 +50,8 @@ type Handlers = {
   plan: () => Promise<number>;
   platform: () => number;
   apps: () => Promise<number>;
+  keys: () => Promise<number>;
+  learn: () => Promise<number>;
   lang: () => Promise<number>;
   shell: () => Promise<number>;
   uninstall: () => Promise<number>;
@@ -238,6 +240,36 @@ async function redwallMenu(p: Platform): Promise<void> {
   }
 }
 
+/**
+ * The same flat list the fullscreen menu offers, in one line each.
+ *
+ * Held apart from the loop, and exported, because it is the narrow
+ * terminal's copy of a decision made in tui.ts: the menu grows by flat
+ * sections. Two copies that can silently disagree is how one surface
+ * ends up missing an entry for a release; a test reads both.
+ */
+export function menuEntries(p: Platform): [string, ...string[]] {
+  const wslish = p.env === "wsl" || p.os === "windows";
+  return [
+    "Install — converge this machine",
+    "Theme — colour scheme",
+    "Wallpaper — Red artwork",
+    "Font — family and size",
+    "Redwall — machine state on the wallpaper",
+    "Apps — optional tools",
+    "Keys — every action, its chord, and what is bound here",
+    "Languages — runtimes mise manages",
+    ...(wslish ? ["Shell — where a terminal lands"] : []),
+    "Update — upgrade, then converge",
+    "Plan — preview, change nothing",
+    "Doctor — report drift",
+    "Learn — the README, RedSkills, and the keys viewer",
+    "Uninstall — remove tools or config",
+    "Platform — what this machine is",
+    "Quit",
+  ];
+}
+
 export async function runMenu(
   p: Platform,
   inv: Invocation,
@@ -253,23 +285,7 @@ export async function runMenu(
   let last = 0;
 
   for (;;) {
-    const wslish = p.env === "wsl" || p.os === "windows";
-    const entries = [
-      "Install — converge this machine",
-      "Theme — colour scheme",
-      "Wallpaper — Red artwork",
-      "Font — family and size",
-      "Redwall — machine state on the wallpaper",
-      "Apps — optional tools",
-      "Languages — runtimes mise manages",
-      ...(wslish ? ["Shell — where a terminal lands"] : []),
-      "Update — upgrade, then converge",
-      "Plan — preview, change nothing",
-      "Doctor — report drift",
-      "Uninstall — remove tools or config",
-      "Platform — what this machine is",
-      "Quit",
-    ] as [string, ...string[]];
+    const entries = menuEntries(p);
 
     const picked = await select("What now?", entries, entries[0]);
     const verb = picked.split(" ")[0];
@@ -292,6 +308,12 @@ export async function runMenu(
         break;
       case "Apps":
         last = await h.apps();
+        break;
+      case "Keys":
+        last = await h.keys();
+        break;
+      case "Learn":
+        last = await h.learn();
         break;
       case "Languages":
         last = await h.lang();

--- a/src/single-prompt.test.ts
+++ b/src/single-prompt.test.ts
@@ -72,6 +72,13 @@ const EXEMPT: Record<string, string> = {
   "privileged.ts":
     "The shared batch. This is the one prompt: every declared privileged item of a " +
     "run is composed into a single script and elevated once, at the end.",
+  "keys.ts":
+    "The elevated-shell action, fired from the keys viewer. Here the prompt is the " +
+    "act rather than an interruption of one: somebody read `Elevated shell` on a " +
+    "list and pressed enter, and the consent they get is the same one the " +
+    "Ctrl+Alt+Shift+T shortcut raises through byte 21 of its .lnk. Nothing is being " +
+    "converged, so there is no batch to defer it into — deferring it would mean " +
+    "answering a request for a shell by scheduling one.",
   "wsl.ts":
     "The machine-wide font repair, which predates the guarantee and is the one " +
     "second prompt still in the tree. It fires only on a machine where the per-user " +

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -75,14 +75,27 @@ function Swatches(hexes: string[]) {
   );
 }
 
-interface MenuSection {
+export interface MenuSection {
   key: string;
   label: string;
   /** Shown in the right-hand panel while this section is highlighted. */
   notes: string[];
 }
 
-const SECTIONS: MenuSection[] = [
+/**
+ * The menu, as a flat list.
+ *
+ * Flat is a decision, not a stage it has not grown out of. Omarchy's
+ * menu is a tree, and a tree is how "open the network panel" becomes
+ * three keystrokes down a path you have to remember the shape of; every
+ * section here is one move from the top, and the ones that would be
+ * branches — Keys, Learn — are sections of their own instead.
+ *
+ * Exported so a test can read the list. It is a claim about the product
+ * rather than about a render, and pinning it through a screenshot would
+ * make it a claim about layout.
+ */
+export const SECTIONS: MenuSection[] = [
   {
     // First, and it is not filler. The right panel was empty until a
     // section was highlighted, which meant the landing screen of the
@@ -139,6 +152,28 @@ const SECTIONS: MenuSection[] = [
     notes: [
       "Optional tools, never installed by a",
       "plain converge. Chosen, not assumed.",
+    ],
+  },
+  {
+    key: "keys",
+    label: "Keys",
+    notes: [
+      "Every action red-dev knows, its chord,",
+      "and whether this machine binds it.",
+      "Search it, and press enter to run one —",
+      "including the ones nothing binds here,",
+      "which are listed with the reason rather",
+      "than left out.",
+    ],
+  },
+  {
+    key: "learn",
+    label: "Learn",
+    notes: [
+      "The README at the section you want,",
+      "RedSkills, and the keys viewer — the",
+      "one answer a link cannot give, because",
+      "it is about this machine.",
     ],
   },
 ];


### PR DESCRIPTION
Automated AFK landing for #140. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #140

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/166"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789437971&installation_model_id=20659&pr_number=166&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F166&signature=4e727bfbe53c3923a7b3fb0698ecc657721de041953fd4a1727e2245229141f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->