### PR TITLE
fix: #151 Hand a crash to the Default agent with the context assembled

### DIFF
--- a/src/crash-handoff.test.ts
+++ b/src/crash-handoff.test.ts
@@ -1,0 +1,337 @@
+/**
+ * A crash handed over, and the three ways that goes wrong.
+ *
+ * It goes wrong by arriving empty — an agent told "red-dev crashed" and
+ * left to ask the person for the stack, the run and the machine, which
+ * is the whole failure this exists to remove. It goes wrong by nagging:
+ * an offer that comes back after the person has already said no. And it
+ * goes wrong by assuming an agent — a machine with none must still
+ * capture the crash, because red-dev is usable with no agent at all and
+ * "install one" is not an answer to "it crashed".
+ *
+ * So the tests below pin the brief's contents rather than that a brief
+ * was produced, and pin the decline across a real preferences file
+ * rather than across one call.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import type { LaunchTarget } from "./agent-launch.ts";
+import { recordCrash, type CrashCapture } from "./crash.ts";
+import {
+  crashBrief,
+  crashHandoffDeclined,
+  offerCrashHandoff,
+  planCrashHandoff,
+  productSkillPointer,
+  type CrashEvidence,
+  type CrashHandoffDeps,
+} from "./crash-handoff.ts";
+import type { Platform } from "./platform.ts";
+import { summary } from "./platform.ts";
+import { readPreferences, writePreferences } from "./preferences.ts";
+import { PRODUCT_SKILL_NAME } from "./product-skill.ts";
+
+const LINUX: Platform = {
+  os: "linux",
+  distro: "ubuntu",
+  version: "24.04",
+  codename: "noble",
+  env: "desktop",
+  arch: "x64",
+  caps: { apt: true, gui: true, systemd: true, winget: false, flatpak: true },
+};
+
+/** A machine with no preferences on it, torn down with the test. */
+async function onFreshMachine<T>(run: (home: string) => Promise<T>): Promise<T> {
+  const previous = process.env["HOME"];
+  const home = mkdtempSync(`${tmpdir()}/red-dev-crash-handoff-`);
+  process.env["HOME"] = home;
+  try {
+    return await run(home);
+  } finally {
+    if (previous === undefined) delete process.env["HOME"];
+    else process.env["HOME"] = previous;
+    rmSync(home, { recursive: true, force: true });
+  }
+}
+
+function capture(over: Partial<CrashCapture> = {}): CrashCapture {
+  return {
+    path: "/home/someone/.local/state/red-dev/crash.log",
+    kind: "uncaughtException",
+    entry:
+      "\n=== 2026-08-16T01:00:00.000Z uncaughtException red-dev 1.0.26 linux ===\n" +
+      "TypeError: undefined is not a function\n" +
+      "    at applyProvider (src/providers.ts:120:9)\n",
+    ...over,
+  };
+}
+
+function evidence(over: Partial<CrashEvidence> = {}): CrashEvidence {
+  return {
+    version: "1.0.26",
+    capture: capture(),
+    transcript: "/home/someone/.local/state/red-dev/2026-08-16T01-00-00-install.log",
+    census: summary(LINUX),
+    skill: `/home/someone/.claude/skills/${PRODUCT_SKILL_NAME}/SKILL.md`,
+    ...over,
+  };
+}
+
+/** PATH with exactly the named commands on it. */
+function locate(...commands: string[]): (command: string) => string | null {
+  return (command) => (commands.includes(command) ? `/usr/bin/${command}` : null);
+}
+
+function deps(over: Partial<CrashHandoffDeps> = {}): CrashHandoffDeps {
+  return {
+    prefs: { defaultAgent: "claude-code", agents: ["claude-code", "codex"] },
+    locate: locate("claude"),
+    interactive: true,
+    ask: async () => false,
+    remember: async () => {},
+    start: async () => 0,
+    ...over,
+  };
+}
+
+describe("the brief", () => {
+  test("carries the crash, the run, the machine and the skill", () => {
+    const e = evidence();
+    const brief = crashBrief(e);
+
+    // The four pieces of evidence, each named where it actually is.
+    // An agent that has to ask for any of them is back to diagnosing
+    // from a re-description, which is the failure this removes.
+    expect(brief).toContain(e.capture.path);
+    expect(brief).toContain("TypeError: undefined is not a function");
+    expect(brief).toContain("at applyProvider (src/providers.ts:120:9)");
+    expect(brief).toContain(e.transcript!);
+    expect(brief).toContain("os=linux distro=ubuntu version=24.04 env=desktop arch=x64");
+    expect(brief).toContain("caps: apt=1 gui=1 systemd=1 winget=0 flatpak=1");
+    expect(brief).toContain(PRODUCT_SKILL_NAME);
+    expect(brief).toContain(e.skill!);
+
+    // And it says which build died, so a brief pasted anywhere still
+    // identifies itself.
+    expect(brief).toContain("red-dev 1.0.26 crashed");
+    expect(brief).toContain("uncaughtException");
+  });
+
+  test("says so rather than naming a file that is not there", () => {
+    const brief = crashBrief(evidence({ transcript: null, skill: null }));
+    expect(brief).toContain("No transcript was open");
+    expect(brief).toContain(`The \`${PRODUCT_SKILL_NAME}\` skill is not installed`);
+    // A pointer at a document the agent cannot open is worse than none.
+    expect(brief).not.toContain("SKILL.md");
+  });
+
+  test("carries the end of a deep stack and the path to the rest", () => {
+    const frames = Array.from({ length: 90 }, (_, i) => `    at frame${i} (src/x.ts:${i}:1)`);
+    const brief = crashBrief(
+      evidence({
+        capture: capture({ entry: `\n=== header ===\nError: deep\n${frames.join("\n")}\n` }),
+      }),
+    );
+
+    expect(brief).toContain("at frame89");
+    expect(brief).not.toContain("at frame0 ");
+    expect(brief).toContain("the full stack is in that file");
+  });
+
+  test("points at the skill home the skill is actually written to", () => {
+    expect(productSkillPointer("claude-code", "/home/someone")).toBe(
+      `/home/someone/.claude/skills/${PRODUCT_SKILL_NAME}/SKILL.md`,
+    );
+    expect(productSkillPointer("codex", "C:\\Users\\someone")).toBe(
+      `C:/Users/someone/.codex/skills/${PRODUCT_SKILL_NAME}/SKILL.md`,
+    );
+    // A host red-dev does not write the skill into, and a machine with
+    // no home to resolve against.
+    expect(productSkillPointer("gemini", "/home/someone")).toBeNull();
+    expect(productSkillPointer("claude-code", null)).toBeNull();
+  });
+});
+
+describe("declining", () => {
+  test("is recorded the moment it is answered", async () => {
+    const written: { crashHandoff: boolean }[] = [];
+    const outcome = await offerCrashHandoff(
+      evidence(),
+      deps({ ask: async () => false, remember: async (patch) => void written.push(patch) }),
+    );
+
+    expect(outcome.state).toBe("declined");
+    expect(written).toEqual([{ crashHandoff: false }]);
+  });
+
+  test("is honoured on the next run, and the host is never resolved", async () => {
+    await onFreshMachine(async () => {
+      // The first crash: asked, declined, and the answer written to the
+      // same preferences file every other choice lives in.
+      const first = await offerCrashHandoff(
+        evidence(),
+        deps({
+          ask: async () => false,
+          remember: (patch) => writePreferences(LINUX, patch),
+        }),
+      );
+      expect(first.state).toBe("declined");
+      expect((await readPreferences(LINUX)).crashHandoff).toBe(false);
+
+      // A converge between the two crashes rewrites the file. The
+      // decline has to survive that, or it is remembered for as long as
+      // nobody uses the tool.
+      await writePreferences(LINUX, { theme: "cobalt", defaultAgent: "claude-code" });
+
+      // The second crash: nothing asked, nothing started, and no host
+      // even looked for — a machine whose owner said no does not get
+      // its PATH searched at every crash.
+      let asked = 0;
+      let started = 0;
+      let located = 0;
+      const second = await offerCrashHandoff(
+        evidence(),
+        deps({
+          prefs: await readPreferences(LINUX),
+          locate: (command) => (located++, locate("claude")(command)),
+          ask: async () => (asked++, true),
+          start: async () => (started++, 0),
+        }),
+      );
+
+      expect(second).toEqual({
+        state: "silent",
+        reason: "the offer was declined once and is not made again",
+      });
+      expect([asked, started, located]).toEqual([0, 0, 0]);
+      expect(crashHandoffDeclined(await readPreferences(LINUX))).toBe(true);
+    });
+  });
+
+  test("is a decision, and a session nobody is watching is not", async () => {
+    const plan = planCrashHandoff("brief", { defaultAgent: "claude-code" }, {
+      locate: locate("claude"),
+      interactive: false,
+    });
+    expect(plan).toEqual({ state: "silent", reason: "nobody to ask on a non-interactive run" });
+
+    // Nothing is recorded for it either: a crash in CI must not answer
+    // on behalf of the person who owns the machine.
+    const written: unknown[] = [];
+    const outcome = await offerCrashHandoff(
+      evidence(),
+      deps({ interactive: false, remember: async (patch) => void written.push(patch) }),
+    );
+    expect(outcome.state).toBe("silent");
+    expect(written).toEqual([]);
+  });
+});
+
+describe("a machine with no Default agent", () => {
+  test("captures the crash and makes no offer", async () => {
+    const dir = mkdtempSync(`${tmpdir()}/red-dev-crash-`);
+    try {
+      const said: string[] = [];
+      const recorded = recordCrash("uncaughtException", new Error("boom"), {
+        dir,
+        version: "1.0.26",
+        platform: "linux",
+        at: new Date("2026-08-16T01:00:00.000Z"),
+        say: (text) => said.push(text),
+      });
+
+      // Captured: the file is on disk with the stack in it, exactly as
+      // it is on a machine that has every agent installed.
+      expect(recorded.path).toBe(`${dir}/crash.log`);
+      const written = readFileSync(recorded.path, "utf8");
+      expect(written).toContain("uncaughtException red-dev 1.0.26 linux");
+      expect(written).toContain("Error: boom");
+      expect(said.join()).toContain(`recorded to ${recorded.path}`);
+
+      // And no offer: nothing asked, nothing started, and the reason is
+      // the same sentence doctor prints for an unset Default agent.
+      let asked = 0;
+      let started = 0;
+      const outcome = await offerCrashHandoff(
+        evidence({ capture: recorded, skill: null }),
+        deps({
+          prefs: { agents: ["claude-code", "codex"] },
+          ask: async () => (asked++, true),
+          start: async () => (started++, 0),
+        }),
+      );
+
+      expect(outcome.state).toBe("silent");
+      expect(outcome).toMatchObject({ reason: expect.stringContaining("not chosen") });
+      expect([asked, started]).toEqual([0, 0]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("says nothing about agents when the recorded one is gone", async () => {
+    const outcome = await offerCrashHandoff(
+      evidence(),
+      deps({
+        prefs: { defaultAgent: "claude-code", agents: ["claude-code"] },
+        locate: locate(),
+      }),
+    );
+    expect(outcome).toEqual({
+      state: "silent",
+      reason: "Claude Code is recorded and no longer installed",
+    });
+  });
+});
+
+describe("handing it over", () => {
+  test("starts the recorded host with the brief and nothing of red-dev's", async () => {
+    const started: LaunchTarget[] = [];
+    const questions: string[] = [];
+    const outcome = await offerCrashHandoff(
+      evidence(),
+      deps({
+        ask: async (question) => (questions.push(question), true),
+        start: async (target) => (started.push(target), 0),
+      }),
+    );
+
+    expect(outcome).toEqual({ state: "handed", key: "claude-code", label: "Claude Code" });
+    expect(questions).toEqual(["Hand this crash to Claude Code to diagnose?"]);
+
+    const target = started[0]!;
+    // The brief is the prompt, and it is the only thing on the command
+    // line: what red-dev contributes stays empty, which is the promise
+    // agent-launch.ts guards.
+    expect(target.added).toEqual([]);
+    expect(target.argv[0]).toBe("/usr/bin/claude");
+    expect(target.argv).toHaveLength(2);
+    expect(target.argv[1]).toContain("crashed on this machine");
+    expect(target.argv[1]).toContain(PRODUCT_SKILL_NAME);
+  });
+
+  test("accepting one crash is not a standing answer for the next", async () => {
+    const written: unknown[] = [];
+    await offerCrashHandoff(
+      evidence(),
+      deps({ ask: async () => true, remember: async (patch) => void written.push(patch) }),
+    );
+    expect(written).toEqual([]);
+  });
+
+  test("a host that will not start is reported, not thrown", async () => {
+    const outcome = await offerCrashHandoff(
+      evidence(),
+      deps({
+        ask: async () => true,
+        start: async () => {
+          throw new Error("spawn claude ENOENT");
+        },
+      }),
+    );
+    expect(outcome).toEqual({ state: "failed", reason: "spawn claude ENOENT" });
+  });
+});

--- a/src/crash-handoff.ts
+++ b/src/crash-handoff.ts
@@ -1,0 +1,314 @@
+/**
+ * Handing a crash to the Default agent with the evidence already
+ * assembled.
+ *
+ * The alternative is the one everybody has lived through: red-dev dies,
+ * the person opens an agent, and the agent asks them what happened. So
+ * the diagnosis starts from a re-description — of a stack nobody read,
+ * of a run whose transcript is sitting on disk, on a machine the agent
+ * has no facts about. Every one of those four things is already written
+ * down at the moment of the crash, which is exactly when nobody has the
+ * patience to go and find them.
+ *
+ * So the brief carries all four: the crash entry and where the rest of
+ * them live, the transcript of the run that died, this machine's
+ * platform census, and a pointer at the Product skill — which is the
+ * document that tells the agent what the paths in the other three mean.
+ * See src/product-skill.ts and .red/contexts/agents/CONTEXT.md.
+ *
+ * ## Declining is a decision, not a postponement
+ *
+ * An offer that returns after every crash is a nag, and a nag is how a
+ * feature meant to help becomes the thing people work around. `no` is
+ * recorded in preferences and honoured from then on, and it is honoured
+ * before anything else here runs — a machine whose owner said no does
+ * not get its hosts resolved or its brief assembled.
+ *
+ * red-dev stays fully usable with no agent at all. A machine with no
+ * Default agent captures the crash exactly as before and says nothing
+ * about agents, because "install one" is not an answer to "it crashed".
+ */
+
+import { resolveLaunch, type LaunchTarget } from "./agent-launch.ts";
+import type { CrashCapture } from "./crash.ts";
+import type { Preferences } from "./preferences.ts";
+import { PRODUCT_SKILL_NAME, SKILL_HOMES } from "./product-skill.ts";
+
+/**
+ * How much of a crash entry the brief carries inline.
+ *
+ * The whole file is not the brief: crash.log accumulates every crash
+ * this machine has had, and the entry itself can be a deep stack. What
+ * goes inline is the end of this crash — the frames nearest the failure
+ * — and the path, so an agent that wants the rest reads it rather than
+ * being handed it.
+ */
+export const BRIEF_ENTRY_LINES = 40;
+
+/** Everything the brief is written from. Assembled by the caller. */
+export interface CrashEvidence {
+  /** The red-dev that died, so a brief identifies its own build. */
+  version: string;
+  capture: CrashCapture;
+  /** The run that crashed, when a transcript was open for it. */
+  transcript: string | null;
+  /** What `red-dev platform` says about this machine. */
+  census: string;
+  /** Where the host reads the Product skill, when it is installed. */
+  skill: string | null;
+}
+
+/**
+ * Where a host reads the Product skill from. PURE.
+ *
+ * Read off SKILL_HOMES rather than composed here, so the pointer in the
+ * brief cannot drift from the path the skill is actually written to. A
+ * host red-dev does not put the skill into gets null, and the brief says
+ * so instead of naming a file that is not there — a document an agent
+ * cannot open is worse than an admission that there is none.
+ */
+export function productSkillPointer(agent: string, home: string | null): string | null {
+  const skillHome = SKILL_HOMES.find((h) => h.agent === agent);
+  if (!skillHome || !home) return null;
+  return `${skillHome.dir(home.replace(/\\/g, "/"))}/${PRODUCT_SKILL_NAME}/SKILL.md`;
+}
+
+/** The end of a crash entry, which is the part nearest the failure. */
+function tail(entry: string, lines: number): string {
+  const all = entry.split("\n").filter((line) => line.trim().length > 0);
+  return all.slice(Math.max(0, all.length - lines)).join("\n");
+}
+
+/**
+ * The brief, as the agent receives it.
+ *
+ * Written as instructions rather than as a report, because it is a
+ * prompt: it says what happened, where the evidence is, and what to
+ * read first. It deliberately does not diagnose — a brief that guesses
+ * at the cause is a brief that anchors the agent on the guess.
+ */
+export function crashBrief(e: CrashEvidence): string {
+  const entry = tail(e.capture.entry, BRIEF_ENTRY_LINES);
+  const truncated = entry.split("\n").length < e.capture.entry.trim().split("\n").length;
+
+  return [
+    `red-dev ${e.version} crashed on this machine (${e.capture.kind}). Everything known`,
+    "about it is below — diagnose it from this evidence rather than asking me to",
+    "describe what happened.",
+    "",
+    "## The crash",
+    "",
+    `Every crash on this machine is appended to \`${e.capture.path}\`.`,
+    truncated
+      ? `The end of the entry this run wrote — the full stack is in that file:`
+      : "The entry this run wrote:",
+    "",
+    entry.replace(/^/gm, "    "),
+    "",
+    "## The run",
+    "",
+    e.transcript
+      ? [
+        `The transcript of the run that crashed is \`${e.transcript}\`. It opens with`,
+        "the version, the time and the platform, and its converge steps are",
+        "fixed-width rows — `grep failed` over it is the whole technique for",
+        "finding what went wrong before the stack did.",
+      ].join("\n")
+      : [
+        "No transcript was open for this run, so there is none to read. Read-only",
+        "commands do not write one on purpose; a mutating command would have.",
+      ].join("\n"),
+    "",
+    "## The machine",
+    "",
+    "What `red-dev platform` reports here:",
+    "",
+    e.census.replace(/^/gm, "    "),
+    "",
+    "## What red-dev is",
+    "",
+    e.skill
+      ? [
+        `Read the \`${PRODUCT_SKILL_NAME}\` skill first — \`${e.skill}\` — for where this`,
+        "machine keeps managed configuration and state, which commands report it,",
+        "and which acts need administrator. `red-dev doctor` is the first command",
+        "to run; it changes nothing.",
+      ].join("\n")
+      : [
+        `The \`${PRODUCT_SKILL_NAME}\` skill is not installed for this host, so the paths`,
+        "above are all there is to go on. `red-dev doctor` is the first command to",
+        "run; it changes nothing.",
+      ].join("\n"),
+    "",
+  ].join("\n");
+}
+
+export type CrashHandoffPlan =
+  /** There is a host to offer, and a command line ready for it. */
+  | { state: "offer"; target: LaunchTarget }
+  /** Nothing is offered, and the reason is always said. */
+  | { state: "silent"; reason: string };
+
+/** The preferences this reads. A narrow view, so a test can hold one. */
+export type CrashHandoffPreferences = Pick<
+  Preferences,
+  "defaultAgent" | "agents" | "crashHandoff"
+>;
+
+/**
+ * Whether the offer was declined for good.
+ *
+ * `=== false` rather than a truthy read, for the reason
+ * `resolveRedwall` gives: this is JSON a person can open, and a decline
+ * written as a string should not be read as one — nor should absent,
+ * which is a machine that has never been asked.
+ */
+export function crashHandoffDeclined(prefs: CrashHandoffPreferences): boolean {
+  return prefs.crashHandoff === false;
+}
+
+/**
+ * What to do about a captured crash, decided before anything is asked.
+ * PURE, given a PATH lookup.
+ *
+ * The order is the doctrine. A recorded decline wins over everything,
+ * including a perfectly good Default agent — that is what "honoured"
+ * means. Then a session nobody is watching, which is a reason to stay
+ * quiet and *not* a decline: a crash in CI must not silently answer a
+ * question on behalf of the person who owns the machine. Only then the
+ * host, resolved through resolveLaunch so this surface cannot name one
+ * red-dev has not been told to use.
+ */
+export function planCrashHandoff(
+  brief: string,
+  prefs: CrashHandoffPreferences,
+  deps: { locate: (command: string) => string | null; interactive: boolean },
+): CrashHandoffPlan {
+  if (crashHandoffDeclined(prefs)) {
+    return { state: "silent", reason: "the offer was declined once and is not made again" };
+  }
+  if (!deps.interactive) {
+    return { state: "silent", reason: "nobody to ask on a non-interactive run" };
+  }
+
+  // The brief travels in the passthrough slot — the one reserved for
+  // what the person typed after `--`. It is a prompt and never a flag,
+  // so what agent-launch.ts guards stays empty: red-dev adds no
+  // argument of its own to a host's command line, here least of all.
+  const decision = resolveLaunch(prefs, deps.locate, [brief]);
+  if (!decision.ok) return { state: "silent", reason: decision.detail };
+  return { state: "offer", target: decision.target };
+}
+
+export type CrashHandoffOutcome =
+  | { state: "handed"; key: string; label: string }
+  /** Asked and answered no. Recorded, so it is asked once. */
+  | { state: "declined" }
+  /** Never asked. The reason is what planCrashHandoff decided. */
+  | { state: "silent"; reason: string }
+  /** Asked, accepted, and the host did not start. */
+  | { state: "failed"; reason: string };
+
+/** Every side of the machine the offer touches, so a test can hold all of them. */
+export interface CrashHandoffDeps {
+  prefs: CrashHandoffPreferences;
+  locate: (command: string) => string | null;
+  interactive: boolean;
+  ask: (question: string) => Promise<boolean>;
+  /** Records the decline. Merged into preferences, never a rewrite. */
+  remember: (patch: { crashHandoff: boolean }) => Promise<void>;
+  /** Hands the terminal to the host. */
+  start: (target: LaunchTarget) => Promise<number>;
+  say?: (line: string) => void;
+}
+
+/**
+ * Offer the crash to the Default agent, and honour the answer.
+ *
+ * Only a `no` is written down. An accepted offer records nothing on
+ * purpose: saying yes to this crash is not a standing instruction to
+ * launch an agent at the next one, and a preference that appeared
+ * because someone accepted once would be a decision they never made.
+ */
+export async function offerCrashHandoff(
+  evidence: CrashEvidence,
+  deps: CrashHandoffDeps,
+): Promise<CrashHandoffOutcome> {
+  const brief = crashBrief(evidence);
+  const plan = planCrashHandoff(brief, deps.prefs, {
+    locate: deps.locate,
+    interactive: deps.interactive,
+  });
+  if (plan.state === "silent") return plan;
+
+  const { target } = plan;
+  if (!(await deps.ask(`Hand this crash to ${target.label} to diagnose?`))) {
+    // Written before anything else can fail, so the answer survives even
+    // if the rest of this run does not.
+    await deps.remember({ crashHandoff: false });
+    deps.say?.(
+      `not asked again — turn it back on by removing "crashHandoff" from red-dev.json`,
+    );
+    return { state: "declined" };
+  }
+
+  try {
+    await deps.start(target);
+    return { state: "handed", key: target.key, label: target.label };
+  } catch (err) {
+    // A host that would not start is reported and nothing more. The
+    // crash is already on disk, which was always the durable half.
+    return { state: "failed", reason: (err as Error).message };
+  }
+}
+
+/**
+ * The offer as this machine answers it.
+ *
+ * Every dependency resolved here rather than at the crash handler, and
+ * every module reached by dynamic import: this runs once a process is
+ * already dying, and nothing above it should pay for agent hosts,
+ * preferences and skills homes on a run that never crashes.
+ */
+export async function handOffCrash(capture: CrashCapture, version: string): Promise<
+  CrashHandoffOutcome
+> {
+  const [
+    { commandPath },
+    { runLaunchTarget },
+    { detect, summary },
+    { readPreferences, writePreferences },
+    { transcriptPath },
+    { confirm, interactive },
+  ] = await Promise.all([
+    import("./agents.ts"),
+    import("./agent-launch.ts"),
+    import("./platform.ts"),
+    import("./preferences.ts"),
+    import("./transcript.ts"),
+    import("./ui.ts"),
+  ]);
+
+  const p = detect();
+  const prefs = await readPreferences(p);
+  const home = process.env["HOME"] ?? process.env["USERPROFILE"] ?? null;
+
+  return await offerCrashHandoff(
+    {
+      version,
+      capture,
+      transcript: transcriptPath(),
+      census: summary(p),
+      skill: prefs.defaultAgent ? productSkillPointer(prefs.defaultAgent, home) : null,
+    },
+    {
+      prefs,
+      locate: commandPath,
+      interactive: interactive(),
+      ask: (question) => confirm(question, false),
+      remember: (patch) => writePreferences(p, patch),
+      start: runLaunchTarget,
+      say: (line) => process.stderr.write(`${line}\n`),
+    },
+  );
+}

--- a/src/crash.ts
+++ b/src/crash.ts
@@ -1,0 +1,89 @@
+/**
+ * Leave a trace when the process dies.
+ *
+ * A fullscreen app that crashes on Windows takes the console with it,
+ * so the stack scrolls past inside a window that is already closing and
+ * there is nothing left to report but "it crashed". Writing it to a file
+ * first turns that into something diagnosable — and the file is the only
+ * copy that survives the window.
+ *
+ * Deliberately synchronous: an async write loses the race with process
+ * death, which is the one case this exists for. It is also deliberately
+ * light — node:fs and the state directory, nothing else — because it is
+ * imported by main.ts on every run rather than behind the dynamic import
+ * every command body uses, and because the module that runs while the
+ * process is dying is the wrong place to discover a broken import.
+ *
+ * What is done with the capture afterwards lives in crash-handoff.ts,
+ * which is reached only once there is a crash to hand over.
+ */
+
+import { appendFileSync, mkdirSync } from "node:fs";
+import { transcriptDir } from "./transcript.ts";
+
+/** What was written down, so a caller can act on it without re-reading. */
+export interface CrashCapture {
+  /** Where every crash on this machine is appended. */
+  path: string;
+  /** This crash's entry, exactly as the file received it. */
+  entry: string;
+  /** `uncaughtException` or `unhandledRejection` — the header's first word. */
+  kind: string;
+}
+
+/** Every side of the machine this touches, so a test can hold all of them. */
+export interface CrashCaptureDeps {
+  /** Where the log goes. Defaults to this machine's state directory. */
+  dir?: string;
+  at?: Date;
+  version?: string;
+  platform?: string;
+  /** Writes the entry. Injected so a test never appends to a real log. */
+  append?: (path: string, entry: string) => void;
+  /**
+   * The copy for a terminal that survived, which is not the same
+   * medium as the file: it leaves the alternate screen first, because
+   * a crash inside a fullscreen view otherwise prints behind a frame
+   * nobody is drawing any more.
+   */
+  say?: (text: string) => void;
+}
+
+function defaultAppend(path: string, entry: string): void {
+  mkdirSync(path.replace(/\/[^/]+$/, ""), { recursive: true });
+  appendFileSync(path, entry);
+}
+
+/**
+ * Append one crash and hand back what was written.
+ *
+ * A failing write is swallowed on purpose: there is nothing useful to
+ * do about it while the process is dying, and the console copy below is
+ * the fallback. The capture is still returned, so what could not be
+ * written to a file can still be handed to an agent.
+ */
+export function recordCrash(
+  kind: string,
+  err: unknown,
+  deps: CrashCaptureDeps = {},
+): CrashCapture {
+  const detail = err instanceof Error ? (err.stack ?? err.message) : String(err);
+  const at = deps.at ?? new Date();
+  const version = deps.version ?? "";
+  const platform = deps.platform ?? process.platform;
+  const path = `${deps.dir ?? transcriptDir()}/crash.log`;
+  const entry = `\n=== ${at.toISOString()} ${kind} red-dev ${version} ${platform} ===\n${detail}\n`;
+
+  try {
+    (deps.append ?? defaultAppend)(path, entry);
+  } catch {
+    // Nothing useful to do if even this fails.
+  }
+
+  // stderr as well as the file: on a terminal that survives, the user
+  // should not have to know a log file exists.
+  const say = deps.say ?? ((text: string) => process.stderr.write(text));
+  say(`\x1b[?1049l${entry}\nrecorded to ${path}\n`);
+
+  return { path, entry, kind };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,10 +3,10 @@
  * red-dev — one dev environment across Ubuntu 24, Ubuntu 26, WSL and Windows.
  */
 
-import { appendFileSync, mkdirSync } from "node:fs";
 import { buildCli, parseArgs, VERSION, type Invocation } from "./cli.ts";
 import type { VerdictItem } from "./completion.ts";
 import type { StepOutcome } from "./converge.ts";
+import { recordCrash } from "./crash.ts";
 import { log } from "./log.ts";
 import {
   applicableScopes,
@@ -23,7 +23,6 @@ import { administratorNotice } from "./plan.ts";
 import { applyProvider, systemUpdate, type ApplyContext } from "./providers.ts";
 import { applyContextForEntry, type ApplyContextEntryPath } from "./preferences.ts";
 import { themeFor, themeNames } from "./themes.ts";
-import { transcriptDir } from "./transcript.ts";
 import { interactive, select, text } from "./ui.ts";
 import type { UpdateStage } from "./update-order.ts";
 
@@ -1876,42 +1875,37 @@ async function cmdMenu(p: Platform, inv: Invocation, cliHelp: string): Promise<n
 process.env.NODE_ENV = "production";
 
 /**
- * Leave a trace when the process dies.
+ * Write the crash down, then offer it to the Default agent.
  *
- * A fullscreen app that crashes on Windows takes the console with it,
- * so the stack scrolls past inside a window that is already closing and
- * there is nothing left to report but "it crashed". Writing it to a file
- * first turns that into something diagnosable — and the file is the only
- * copy that survives the window.
+ * The capture is synchronous and comes first, because it is the half
+ * that has to survive: an async write loses the race with process death
+ * on Windows, where the window closing is the whole reason the file
+ * exists. Everything after it is a courtesy — a machine with no Default
+ * agent, or one whose owner declined the offer, exits here exactly as
+ * it did before crash-handoff.ts existed.
  *
- * Deliberately synchronous: an async write loses the race with process
- * death, which is the one case this exists for.
+ * The exit is deferred until the offer settles, and only until then. A
+ * handed-off crash means the person is now inside the agent, and the
+ * process that crashed is waiting to release the terminal back to them.
  */
-function recordCrash(kind: string, err: unknown): void {
-  const detail = err instanceof Error ? (err.stack ?? err.message) : String(err);
-  const dir = transcriptDir();
-  const path = `${dir}/crash.log`;
-  const entry = `\n=== ${new Date().toISOString()} ${kind} red-dev ${VERSION} ${process.platform} ===\n${detail}\n`;
+async function endWithCrash(kind: string, err: unknown): Promise<never> {
+  const capture = recordCrash(kind, err, { version: VERSION });
   try {
-    mkdirSync(dir, { recursive: true });
-    appendFileSync(path, entry);
+    const { handOffCrash } = await import("./crash-handoff.ts");
+    await handOffCrash(capture, VERSION);
   } catch {
-    // Nothing useful to do if even this fails; the console copy below
-    // is the fallback.
+    // A failure while offering must not replace the crash that is
+    // already on disk with one about the offer.
   }
-  // stderr as well as the file: on a terminal that survives, the user
-  // should not have to know a log file exists.
-  process.stderr.write(`\x1b[?1049l${entry}\nrecorded to ${path}\n`);
+  process.exit(70);
 }
 
 if (process.argv[2] !== "statusline") {
   process.on("uncaughtException", (err) => {
-    recordCrash("uncaughtException", err);
-    process.exit(70);
+    void endWithCrash("uncaughtException", err);
   });
   process.on("unhandledRejection", (err) => {
-    recordCrash("unhandledRejection", err);
-    process.exit(70);
+    void endWithCrash("unhandledRejection", err);
   });
 }
 

--- a/src/preferences.ts
+++ b/src/preferences.ts
@@ -68,6 +68,17 @@ export interface Preferences {
    * is a state red-dev reports rather than fills in.
    */
   defaultAgent?: string;
+  /**
+   * Whether a captured crash may be offered to the Default agent — see
+   * src/crash-handoff.ts.
+   *
+   * Absent means the offer is made. Boolean false is the durable
+   * decline: an offer that came back after every crash would be a nag,
+   * so `no` is recorded here and honoured from then on. Nothing writes
+   * true — accepting one offer is not a standing instruction about the
+   * next crash.
+   */
+  crashHandoff?: boolean;
   /** mise runtime ids chosen for this workstation. */
   runtimes?: string[];
   /** Ids of one-off repairs already applied; see src/migrations.ts. */


### PR DESCRIPTION
Automated AFK landing for #151. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #151

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/167"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789438274&installation_model_id=20659&pr_number=167&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F167&signature=ff6582bf836a90bdf1e3279c273e0a25f6bc91b6d2b0a18e160bc0014e07d0b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->