### PR TITLE
fix: #142 The audio and power Panels, with a declared native fallback

### DIFF
--- a/src/actions/panels.ts
+++ b/src/actions/panels.ts
@@ -38,4 +38,27 @@ export const PANEL_ACTIONS: readonly SemanticAction[] = [
     // network panel to Super+Ctrl+W, which ADR 0006 leaves to the host.
     chord: "Ctrl+Alt+N",
   },
+  {
+    id: "panel.audio",
+    label: "Audio panel",
+    platforms: WITH_A_DISPLAY,
+    // Opening it lists what the machine plays and hears. Switching from
+    // inside it needs nothing on Ubuntu — the sound server belongs to
+    // the session — and on Windows it opens the host's own Sound page,
+    // because nothing Microsoft ships can set the default device.
+    mutates: false,
+    privileged: false,
+    // A for audio, and free in the family on both hosts.
+    chord: "Ctrl+Alt+A",
+  },
+  {
+    id: "panel.power",
+    label: "Power panel",
+    platforms: WITH_A_DISPLAY,
+    mutates: false,
+    privileged: false,
+    // P for power. Neither host claims it, and the one thing that might
+    // — GNOME's print-screen family — lives on Print, not on P.
+    chord: "Ctrl+Alt+P",
+  },
 ];

--- a/src/actions/registry.test.ts
+++ b/src/actions/registry.test.ts
@@ -47,6 +47,8 @@ describe("the registry itself", () => {
       "terminal.new",
       "terminal.elevated",
       "panel.network",
+      "panel.audio",
+      "panel.power",
     ]);
   });
 

--- a/src/keys.test.ts
+++ b/src/keys.test.ts
@@ -215,9 +215,13 @@ describe("searching", () => {
 
   test("the state is searchable, so 'unbound work' is one query", () => {
     expect(searchKeys(keyEntries(server), "unsupported")).toHaveLength(ACTIONS.length);
-    // On Windows the terminal pair is bound and the Panel is not, so the
-    // query answers with exactly what this machine does not register.
-    expect(searchKeys(entries, "unsupported").map((e) => e.id)).toEqual(["panel.network"]);
+    // On Windows the terminal pair is bound and the Panels are not, so
+    // the query answers with exactly what this machine does not register.
+    expect(searchKeys(entries, "unsupported").map((e) => e.id)).toEqual([
+      "panel.network",
+      "panel.audio",
+      "panel.power",
+    ]);
   });
 });
 
@@ -301,6 +305,28 @@ describe("what Enter runs", () => {
     ]);
   });
 
+  test("and every other Panel opens the same way, under the name on its id", () => {
+    // firePlan carries one case for all of them and takes the subsystem
+    // off the id. Three copies of that block is how the fourth Panel
+    // arrives with the gnome-terminal flag wrong, so this holds the
+    // shared path rather than the network Panel's copy of it.
+    for (const [id, name] of [["panel.audio", "audio"], ["panel.power", "power"]] as const) {
+      const onWindows = firePlan(id, windows, anything);
+      expect(onWindows.ok && onWindows.argv).toEqual([
+        "cmd.exe", "/c", "start", "", "red-dev.exe", "panel", name,
+      ]);
+
+      const onUbuntu = firePlan(id, desktop, anything);
+      expect(onUbuntu.ok && onUbuntu.argv).toEqual([
+        "alacritty", "-e", "red-dev", "panel", name,
+      ]);
+
+      const headless = firePlan(id, desktop, nothing);
+      expect(headless.ok).toBe(false);
+      expect(headless.ok === false && headless.detail).toContain(`red-dev panel ${name}`);
+    }
+  });
+
   test("and gnome-terminal is told with `--`, because its -e was deprecated years ago", () => {
     // A wrong flag here opens a terminal with a shell in it and no sign
     // that the command was dropped.
@@ -340,7 +366,13 @@ describe("the keystrokes the viewer reads", () => {
   test("the arrows move within what is visible and stop at the ends", () => {
     const down = viewerStep(entries, VIEWER_START, "", press({ downArrow: true })).state;
     expect(down.index).toBe(1);
-    const further = viewerStep(entries, down, "", press({ downArrow: true })).state;
+    // Pressed more times than there are rows, so what stops the cursor
+    // is the clamp rather than the arithmetic of this test — which is
+    // what used to stop it, back when the registry held three actions.
+    let further = down;
+    for (let i = 0; i <= entries.length; i++) {
+      further = viewerStep(entries, further, "", press({ downArrow: true })).state;
+    }
     expect(further.index).toBe(entries.length - 1);
     expect(viewerStep(entries, VIEWER_START, "", press({ upArrow: true })).state.index).toBe(0);
   });

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -347,11 +347,19 @@ export function firePlan(
       };
     }
 
-    case "panel.network": {
+    case "panel.network":
+    case "panel.audio":
+    case "panel.power": {
       // A Panel is a TUI, so firing one means giving it a terminal of
       // its own. The viewer is already drawing in this one, and running
       // the Panel inside it would put two full-screen surfaces on the
       // same frame.
+      //
+      // One case for all of them, and the subsystem taken off the id
+      // rather than written out per Panel: every Panel is opened exactly
+      // the same way, and three copies of this block is how the fourth
+      // one arrives with the gnome-terminal flag wrong.
+      const name = id.slice("panel.".length);
       if (onWindowsHost(p)) {
         // `start` with the empty title slot, exactly as terminal.new
         // uses it, and for the same reason: this process is a console
@@ -361,8 +369,8 @@ export function firePlan(
         return {
           ok: true,
           id,
-          argv: ["cmd.exe", "/c", "start", "", "red-dev.exe", "panel", "network"],
-          note: "the network panel in a new window",
+          argv: ["cmd.exe", "/c", "start", "", "red-dev.exe", "panel", name],
+          note: `the ${name} panel in a new window`,
         };
       }
       const found = LINUX_TERMINALS.find((cmd) => locate(cmd) !== null);
@@ -374,14 +382,14 @@ export function firePlan(
         return {
           ok: false,
           id,
-          detail: "no terminal emulator on PATH — run `red-dev panel network` here instead",
+          detail: `no terminal emulator on PATH — run \`red-dev panel ${name}\` here instead`,
         };
       }
       return {
         ok: true,
         id,
-        argv: [found, TERMINAL_EXEC[found] ?? "-e", "red-dev", "panel", "network"],
-        note: `the network panel in ${found}`,
+        argv: [found, TERMINAL_EXEC[found] ?? "-e", "red-dev", "panel", name],
+        note: `the ${name} panel in ${found}`,
       };
     }
 

--- a/src/panel-audio.test.ts
+++ b/src/panel-audio.test.ts
@@ -1,0 +1,524 @@
+/**
+ * What the audio Panel runs, what it never runs, and what it admits it
+ * cannot do.
+ *
+ * The argv is the artefact under test, for the reason the network
+ * Panel's tests give: the machine this process runs on has one sound
+ * stack, the Panel has to be right about two, and one of those two it
+ * will only ever meet through WSL interop. So every command is pinned
+ * word for word, per target, for the read and for the switch.
+ *
+ * The third claim is the one this Panel adds to the family. Windows
+ * ships no first-party command that sets the default audio device, and
+ * the decision (spec #134) is that the act opens the host's own page and
+ * says why, rather than red-dev drawing a switch that cannot switch. A
+ * reason nobody can print is a limit that has been hidden, so the test
+ * holds both halves: the argv opens `ms-settings:sound`, and the plan
+ * carries a sentence explaining it.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { applicableScopes } from "./manifest.ts";
+import {
+  applyAudio,
+  audioPlan,
+  endpointDirection,
+  observeArgv,
+  observeAudio,
+  observePlan,
+  panelLines,
+  parsePactlDefaults,
+  parsePactlDevices,
+  parseWindowsEndpoints,
+  WINDOWS_SOUND,
+  type AudioView,
+} from "./panel-audio.ts";
+import { listStep, raisesRights, type Captured, type PanelKey } from "./panel.ts";
+import type { Platform } from "./platform.ts";
+import { batchScript, privilegedItems } from "./privileged.ts";
+
+function machine(over: Partial<Platform>): Platform {
+  return {
+    os: "linux",
+    distro: "ubuntu",
+    version: "24.04",
+    codename: "noble",
+    env: "desktop",
+    arch: "x64",
+    caps: { apt: true, gui: true, systemd: true, winget: false, flatpak: true },
+    ...over,
+  };
+}
+
+const desktop = machine({});
+const wsl = machine({
+  env: "wsl",
+  caps: { apt: true, gui: false, systemd: false, winget: true, flatpak: false },
+});
+const windows = machine({ os: "windows", env: "windows", distro: null, version: null, codename: null });
+const mac = machine({ os: "darwin", env: "desktop", distro: null, version: null, codename: null });
+
+/** A laptop with its speakers and a plugged-in headset, as observed. */
+const onUbuntu: AudioView = {
+  target: "linux",
+  devices: [
+    {
+      id: "alsa_output.pci-0000_00_1f.3.analog-stereo",
+      name: "Built-in Audio Analog Stereo",
+      direction: "output",
+      current: true,
+    },
+    { id: "alsa_output.usb-Headset", name: "USB Headset", direction: "output", current: false },
+    {
+      id: "alsa_input.pci-0000_00_1f.3.analog-stereo",
+      name: "Built-in Audio Analog Stereo",
+      direction: "input",
+      current: true,
+    },
+  ],
+  native: null,
+};
+
+/** The same machine on Windows: endpoints listed, nothing marked current. */
+const onWindows: AudioView = {
+  target: "windows",
+  devices: [
+    {
+      id: "SWD\\MMDEVAPI\\{0.0.0.00000000}.{aaaa}",
+      name: "Speakers (Realtek Audio)",
+      direction: "output",
+      current: false,
+    },
+    {
+      id: "SWD\\MMDEVAPI\\{0.0.1.00000000}.{bbbb}",
+      name: "Microphone (Realtek Audio)",
+      direction: "input",
+      current: false,
+    },
+  ],
+  native: WINDOWS_SOUND,
+};
+
+/** No key pressed; each test turns on the one it means. */
+function press(over: Partial<PanelKey> = {}): PanelKey {
+  return {
+    upArrow: false,
+    downArrow: false,
+    return: false,
+    escape: false,
+    backspace: false,
+    delete: false,
+    ctrl: false,
+    ...over,
+  };
+}
+
+describe("observation, pinned per target", () => {
+  test("Ubuntu asks the sound server three questions, because it answers one at a time", () => {
+    // The defaults come from `info` and not from the lists: neither list
+    // marks its own default, and taking the first row instead is how a
+    // Panel ends up pointing at the HDMI output on every machine.
+    expect(observeArgv("linux")).toEqual([
+      ["pactl", "-f", "json", "info"],
+      ["pactl", "-f", "json", "list", "sinks"],
+      ["pactl", "-f", "json", "list", "sources"],
+    ]);
+  });
+
+  test("Windows asks once, and gets the endpoints back as JSON", () => {
+    // Pinned whole, because the script is the argv.
+    expect(observeArgv("windows")).toEqual([
+      [
+        "powershell.exe",
+        "-NoProfile",
+        "-Command",
+        "$ErrorActionPreference = 'SilentlyContinue'; " +
+          "$endpoints = @(Get-PnpDevice -Class AudioEndpoint | ForEach-Object { [pscustomobject]@{" +
+          " id = [string]$_.InstanceId; name = [string]$_.FriendlyName;" +
+          " status = [string]$_.Status } }); " +
+          "[pscustomobject]@{ endpoints = $endpoints } | ConvertTo-Json -Depth 4 -Compress",
+      ],
+    ]);
+  });
+
+  test("asks in JSON on both, rather than parsing prose meant for reading", () => {
+    // `pactl`'s human-readable output is indented paragraphs, and a
+    // parser walking them starts failing the day a device description
+    // contains a colon.
+    for (const step of observeArgv("linux")) expect(step).toContain("json");
+    expect(observeArgv("windows")[0]?.[3]).toContain("ConvertTo-Json");
+  });
+});
+
+describe("looking is never a privileged act", () => {
+  for (const target of ["linux", "windows"] as const) {
+    test(`on ${target}, no observation argv reaches for rights`, () => {
+      const plan = observePlan(target);
+      // Both halves. `gate` is the claim the code makes about itself and
+      // `raisesRights` reads the words that actually run, so a plan
+      // cannot say null while quietly carrying a sudo.
+      expect(plan.gate).toBeNull();
+      expect(plan.prime).toBeNull();
+      for (const step of plan.steps) expect(raisesRights(step)).toBe(false);
+    });
+
+    test(`on ${target}, every observation command is a read`, () => {
+      // Named rather than implied by raisesRights: a cmdlet that writes
+      // without elevating is still not something opening a Panel does.
+      for (const step of observePlan(target).steps) {
+        const words = step.join(" ");
+        expect(words).not.toContain("Set-");
+        expect(words).not.toContain("sudo");
+        expect(words).not.toContain("RunAs");
+        expect(words).not.toContain("set-default");
+      }
+    });
+  }
+});
+
+describe("switching, pinned per target", () => {
+  test("Ubuntu moves the sound server's default sink, and asks for nothing", () => {
+    // No sudo and no prime. This is the signed-in person's own session,
+    // and a password prompt for an act that never needed one teaches
+    // people that the prompt means nothing.
+    const plan = audioPlan(onUbuntu, "alsa_output.usb-Headset");
+    expect(plan.ok).toBe(true);
+    if (!plan.ok) return;
+    expect(plan.steps).toEqual([["pactl", "set-default-sink", "alsa_output.usb-Headset"]]);
+    expect(plan.prime).toBeNull();
+    expect(plan.gate).toBeNull();
+    expect(plan.native).toBeNull();
+    expect(raisesRights(plan.steps[0] ?? [])).toBe(false);
+  });
+
+  test("an input row moves the source instead, because they are two settings", () => {
+    const plan = audioPlan(onUbuntu, "alsa_input.pci-0000_00_1f.3.analog-stereo");
+    expect(plan.ok && plan.steps).toEqual([
+      ["pactl", "set-default-source", "alsa_input.pci-0000_00_1f.3.analog-stereo"],
+    ]);
+  });
+
+  test("Windows opens its own Sound page, and carries the reason it does", () => {
+    // The claim spec #134 makes about a subsystem with no first-party
+    // CLI: the act resolves to the host's surface, and the limit is
+    // stated rather than hidden.
+    const plan = audioPlan(onWindows, "SWD\\MMDEVAPI\\{0.0.0.00000000}.{aaaa}");
+    expect(plan.ok).toBe(true);
+    if (!plan.ok) return;
+    expect(plan.steps).toEqual([["cmd.exe", "/c", "start", "", "ms-settings:sound"]]);
+    expect(plan.native?.surface).toBe("Settings > System > Sound");
+    expect(plan.native?.reason).toContain("no first-party command");
+    expect(plan.note).toContain(WINDOWS_SOUND.reason);
+  });
+
+  test("and it does not reach for rights to open a page either", () => {
+    const plan = audioPlan(onWindows, "SWD\\MMDEVAPI\\{0.0.1.00000000}.{bbbb}");
+    expect(plan.ok && plan.gate).toBeNull();
+    expect(plan.ok && plan.prime).toBeNull();
+    for (const step of plan.ok ? plan.steps : []) expect(raisesRights(step)).toBe(false);
+  });
+
+  test("no target builds a switch that asks for a password", () => {
+    // The complement of the network Panel's rule, and the reason this
+    // one is worth pinning: changing DNS is system configuration and
+    // costs a prompt; moving your own session's default speaker is not,
+    // and must not grow one because the neighbouring Panel has it.
+    for (const view of [onUbuntu, onWindows]) {
+      for (const device of view.devices) {
+        const plan = audioPlan(view, device.id);
+        expect(plan.ok).toBe(true);
+        if (!plan.ok) continue;
+        expect(plan.gate).toBeNull();
+        expect(plan.steps.some((step) => raisesRights(step))).toBe(false);
+      }
+    }
+  });
+});
+
+describe("a switch the Panel cannot make", () => {
+  test("to a device this machine never reported, is refused rather than passed through", () => {
+    // `pactl` accepts the name of a sink that no longer exists and
+    // reports nothing, which is the quietest way for a Panel to be wrong.
+    const plan = audioPlan(onUbuntu, "alsa_output.usb-Gone");
+    expect(plan.ok).toBe(false);
+    expect(plan.ok || plan.detail).toContain("not a device this machine reported");
+  });
+
+  test("on a platform with no adapter, is refused by name", () => {
+    const plan = audioPlan({ ...onUbuntu, target: null }, "alsa_output.usb-Headset");
+    expect(plan.ok).toBe(false);
+    expect(plan.ok || plan.detail).toContain("no audio adapter");
+  });
+});
+
+describe("reading what Ubuntu said", () => {
+  const INFO = JSON.stringify({
+    default_sink_name: "alsa_output.pci-0000_00_1f.3.analog-stereo",
+    default_source_name: "alsa_input.pci-0000_00_1f.3.analog-stereo",
+  });
+
+  const SINKS = JSON.stringify([
+    {
+      index: 47,
+      name: "alsa_output.pci-0000_00_1f.3.analog-stereo",
+      description: "Built-in Audio Analog Stereo",
+    },
+    { index: 52, name: "alsa_output.usb-Headset", description: "USB Headset" },
+  ]);
+
+  const SOURCES = JSON.stringify([
+    {
+      index: 48,
+      name: "alsa_output.pci-0000_00_1f.3.analog-stereo.monitor",
+      description: "Monitor of Built-in Audio Analog Stereo",
+    },
+    {
+      index: 49,
+      name: "alsa_input.pci-0000_00_1f.3.analog-stereo",
+      description: "Built-in Audio Analog Stereo",
+    },
+  ]);
+
+  test("takes the current device from info, and the names from the lists", () => {
+    expect(parsePactlDefaults(INFO).sink).toBe("alsa_output.pci-0000_00_1f.3.analog-stereo");
+    expect(parsePactlDevices(SINKS, "output", parsePactlDefaults(INFO).sink)).toEqual([
+      {
+        id: "alsa_output.pci-0000_00_1f.3.analog-stereo",
+        name: "Built-in Audio Analog Stereo",
+        direction: "output",
+        current: true,
+      },
+      {
+        id: "alsa_output.usb-Headset",
+        name: "USB Headset",
+        direction: "output",
+        current: false,
+      },
+    ]);
+  });
+
+  test("never offers a monitor source as a microphone", () => {
+    // Every sink has one, it sits in the source list beside the real
+    // microphones, and choosing it records silence.
+    const inputs = parsePactlDevices(SOURCES, "input", null);
+    expect(inputs.map((d) => d.id)).toEqual(["alsa_input.pci-0000_00_1f.3.analog-stereo"]);
+  });
+
+  test("and puts the three answers together into one view", async () => {
+    const capture = async (cmd: readonly string[]): Promise<Captured> => {
+      if (cmd.includes("info")) return { out: INFO, code: 0 };
+      if (cmd.includes("sinks")) return { out: SINKS, code: 0 };
+      return { out: SOURCES, code: 0 };
+    };
+
+    const view = await observeAudio(desktop, capture);
+    expect(view.target).toBe("linux");
+    expect(view.native).toBeNull();
+    expect(view.devices.map((d) => d.name)).toEqual([
+      "Built-in Audio Analog Stereo",
+      "USB Headset",
+      "Built-in Audio Analog Stereo",
+    ]);
+    expect(view.devices.filter((d) => d.current).map((d) => d.direction)).toEqual([
+      "output",
+      "input",
+    ]);
+  });
+
+  test("a machine with no sound server reports nothing rather than inventing a device", async () => {
+    const capture = async (): Promise<Captured> => ({ out: "", code: 127 });
+    expect(await observeAudio(desktop, capture)).toEqual({
+      target: "linux",
+      devices: [],
+      native: null,
+    });
+  });
+
+  test("and a platform red-dev has no adapter for says so rather than guessing", async () => {
+    expect(await observeAudio(mac, async () => ({ out: "", code: 0 }))).toEqual({
+      target: null,
+      devices: [],
+      native: null,
+    });
+  });
+});
+
+describe("reading what Windows said", () => {
+  const JSON_OUT = JSON.stringify({
+    endpoints: [
+      {
+        id: "SWD\\MMDEVAPI\\{0.0.0.00000000}.{aaaa}",
+        name: "Speakers (Realtek Audio)",
+        status: "OK",
+      },
+      {
+        id: "SWD\\MMDEVAPI\\{0.0.1.00000000}.{bbbb}",
+        name: "Microphone (Realtek Audio)",
+        status: "OK",
+      },
+      {
+        id: "SWD\\MMDEVAPI\\{0.0.0.00000000}.{cccc}",
+        name: "Headphones (Old Headset)",
+        status: "Unknown",
+      },
+    ],
+  });
+
+  test("reads the direction off the endpoint id, which is where Windows keeps it", () => {
+    expect(endpointDirection("SWD\\MMDEVAPI\\{0.0.0.00000000}.{aaaa}")).toBe("output");
+    expect(endpointDirection("SWD\\MMDEVAPI\\{0.0.1.00000000}.{bbbb}")).toBe("input");
+    // Neither: dropped rather than guessed at, because a row in the
+    // wrong half is a person choosing a speaker as their microphone.
+    expect(endpointDirection("USB\\VID_1234")).toBeNull();
+  });
+
+  test("keeps the endpoints Windows has and drops the ones it merely remembers", () => {
+    expect(parseWindowsEndpoints(JSON_OUT)).toEqual([
+      {
+        id: "SWD\\MMDEVAPI\\{0.0.0.00000000}.{aaaa}",
+        name: "Speakers (Realtek Audio)",
+        direction: "output",
+        current: false,
+      },
+      {
+        id: "SWD\\MMDEVAPI\\{0.0.1.00000000}.{bbbb}",
+        name: "Microphone (Realtek Audio)",
+        direction: "input",
+        current: false,
+      },
+    ]);
+  });
+
+  test("marks nothing as current, because the PnP read never says which is", () => {
+    // Guessing — the first one, the enabled one — would be wrong on
+    // every machine with two speakers, and wrong silently.
+    expect(parseWindowsEndpoints(JSON_OUT).some((d) => d.current)).toBe(false);
+  });
+
+  test("PowerShell writing an error where the JSON belonged yields no devices", () => {
+    expect(parseWindowsEndpoints("Get-PnpDevice : not recognized")).toEqual([]);
+  });
+
+  test("a machine that could not answer still carries the limit, from WSL too", async () => {
+    // The reason does not depend on the read: Windows cannot switch
+    // whether or not it managed to list anything.
+    for (const p of [windows, wsl]) {
+      const view = await observeAudio(p, async () => ({ out: "", code: 1 }));
+      expect(view).toEqual({ target: "windows", devices: [], native: WINDOWS_SOUND });
+    }
+  });
+});
+
+describe("carrying a plan out", () => {
+  test("Ubuntu runs the one command and reports the change", async () => {
+    const ran: string[][] = [];
+    const outcome = await applyAudio(audioPlan(onUbuntu, "alsa_output.usb-Headset"), async (argv) => {
+      ran.push([...argv]);
+      return 0;
+    });
+    expect(ran).toEqual([["pactl", "set-default-sink", "alsa_output.usb-Headset"]]);
+    expect(outcome).toEqual({ changed: true, detail: "audio: USB Headset for output" });
+  });
+
+  test("opening the host's page is reported as what it is, and not as a switch", async () => {
+    // The window opens, the command exits zero, and the machine is
+    // playing through exactly what it was playing through. Calling that
+    // a change would be the Panel taking credit for a page it opened.
+    const outcome = await applyAudio(
+      audioPlan(onWindows, "SWD\\MMDEVAPI\\{0.0.0.00000000}.{aaaa}"),
+      async () => 0,
+    );
+    expect(outcome.changed).toBe(false);
+    expect(outcome.detail).toContain("Settings > System > Sound");
+  });
+
+  test("a command that failed names the exit code, not a rights problem", async () => {
+    // There is no gate here, so inventing one would send whoever reads
+    // the line looking for a password prompt that never existed.
+    const outcome = await applyAudio(audioPlan(onUbuntu, "alsa_output.usb-Headset"), async () => 3);
+    expect(outcome.changed).toBe(false);
+    expect(outcome.detail).toBe("pactl failed — exit 3");
+  });
+
+  test("a refusal runs nothing at all", async () => {
+    let calls = 0;
+    const outcome = await applyAudio(audioPlan(onUbuntu, "nothing.like.this"), async () => {
+      calls++;
+      return 0;
+    });
+    expect(calls).toBe(0);
+    expect(outcome.changed).toBe(false);
+  });
+});
+
+describe("no Panel act reaches the converge's privileged batch", () => {
+  // The same decision the network Panel's tests pin, read for this
+  // Panel's binaries: "make this machine correct" and "change this now"
+  // are different things, and an audio act in the batch would take
+  // effect at the end of somebody's next converge.
+  test("the composed batch script carries none of the Panel's commands", async () => {
+    for (const p of [desktop, wsl, windows]) {
+      const script = await batchScript(privilegedItems(p, applicableScopes(p)), "C:\\tmp\\r.txt");
+      expect(script).not.toContain("pactl");
+      expect(script).not.toContain("set-default-sink");
+      expect(script).not.toContain("ms-settings:sound");
+    }
+  });
+});
+
+describe("the Panel as text, for a terminal with none to draw", () => {
+  test("names what is playing and what is listening", () => {
+    expect(panelLines(onUbuntu)).toEqual([
+      "output   Built-in Audio Analog Stereo",
+      "input    Built-in Audio Analog Stereo",
+      "devices  2 out, 1 in",
+    ]);
+  });
+
+  test("and on Windows says where switching lives, so two blanks are not a broken probe", () => {
+    const lines = panelLines(onWindows);
+    expect(lines.slice(0, 3)).toEqual([
+      "output   not reported",
+      "input    not reported",
+      "devices  1 out, 1 in",
+    ]);
+    expect(lines[3]).toContain("Settings > System > Sound");
+    expect(lines[3]).toContain("no first-party command");
+  });
+});
+
+describe("the keyboard, shared by every Panel that is a list", () => {
+  test("the arrows move between the rows and stop at the ends", () => {
+    let state = listStep({ index: 0 }, 3, "", press({ upArrow: true })).state;
+    expect(state.index).toBe(0);
+    for (let i = 0; i < 9; i++) state = listStep(state, 3, "", press({ downArrow: true })).state;
+    expect(state.index).toBe(2);
+  });
+
+  test("enter asks for the highlighted row", () => {
+    expect(listStep({ index: 1 }, 3, "", press({ return: true })).apply).toBe(1);
+  });
+
+  test("a cursor left past the end by a device disappearing is clamped, not applied", () => {
+    // The rows come from the machine and change underneath the cursor: a
+    // headset unplugged between two observations leaves an index
+    // pointing at a device that is gone.
+    const step = listStep({ index: 7 }, 2, "", press({ return: true }));
+    expect(step.apply).toBe(1);
+    expect(step.state.index).toBe(1);
+  });
+
+  test("with no rows at all, enter asks for nothing", () => {
+    expect(listStep({ index: 0 }, 0, "", press({ return: true })).apply).toBeUndefined();
+  });
+
+  test("typing is swallowed, because this is a list and not a search box", () => {
+    expect(listStep({ index: 1 }, 3, "9", press())).toEqual({ state: { index: 1 } });
+  });
+
+  test("escape and ctrl+c leave, and every other ctrl chord is swallowed", () => {
+    expect(listStep({ index: 1 }, 3, "", press({ escape: true })).quit).toBe(true);
+    expect(listStep({ index: 1 }, 3, "c", press({ ctrl: true })).quit).toBe(true);
+    expect(listStep({ index: 1 }, 3, "a", press({ ctrl: true })).quit).toBeUndefined();
+  });
+});

--- a/src/panel-audio.ts
+++ b/src/panel-audio.ts
@@ -1,0 +1,444 @@
+/**
+ * The audio Panel: which speaker the machine plays through, which
+ * microphone it listens on, and what it takes to change either.
+ *
+ * The second Panel, built on the shape src/panel.ts holds and the
+ * network Panel established. The same rule decides what it drives: the
+ * platform's *first-party* CLI, never the files underneath it. `pactl`
+ * on Ubuntu is that CLI — it speaks to the sound server the desktop is
+ * already using, which under Ubuntu 24.04 is PipeWire wearing
+ * pipewire-pulse — and writing a default into `~/.config/pulse` behind
+ * its back would leave the running server and the Panel disagreeing
+ * until the next login.
+ *
+ * ## Nothing here asks for rights, and that is the honest answer
+ *
+ * Observation is a read, as it is in every Panel. The change is a read's
+ * neighbour: `pactl set-default-sink` moves the default of the sound
+ * server running in the signed-in person's own session, which is theirs
+ * to move. There is no sudo in this file at all, and adding one to match
+ * the network Panel's shape would be the same erosion from the other
+ * end — a password prompt for an act that never needed one teaches
+ * people that the prompt means nothing.
+ *
+ * ## Windows has no first-party command for this, and says so
+ *
+ * Windows can be *asked* what audio endpoints exist —
+ * `Get-PnpDevice -Class AudioEndpoint` is a shipped cmdlet and a read.
+ * What it cannot be told, by anything Microsoft ships, is which endpoint
+ * to make the default: the API behind its own Sound page (`IPolicyConfig`)
+ * is undocumented and reachable from no shipped CLI. The honest options
+ * were a Panel that lists devices and cannot switch between them, a
+ * dependency on somebody's third-party cmdlet module, or opening the
+ * page Windows already has and saying why. This Panel does the third —
+ * `NativeFallback` carries the surface and the reason, and the reason is
+ * printed rather than buried here (spec #134, `interaction/CONTEXT.md`).
+ *
+ * That is also why the fallback belongs to the *act* and not to the
+ * Panel. Observation works on both targets, so opening the Panel on
+ * Windows still answers "what does this machine have"; it is only the
+ * switch that crosses to the host's own surface.
+ */
+
+import { panelTarget, runPlan, spawnCapture, windowsSurface } from "./panel.ts";
+import type { Capture, NativeFallback, PanelPlan, PanelTarget, Run } from "./panel.ts";
+import type { Platform } from "./platform.ts";
+
+/** Which way the sound goes. */
+export type AudioDirection = "output" | "input";
+
+/** The two, in the order the Panel lists them. */
+export const AUDIO_DIRECTIONS: readonly AudioDirection[] = ["output", "input"];
+
+export interface AudioDevice {
+  /**
+   * What this platform's CLI takes back to make it the default.
+   *
+   * PulseAudio's sink or source name on Ubuntu — the long
+   * `alsa_output.pci-…` string, not the index, because indices are
+   * handed out afresh every time the server restarts and a Panel that
+   * remembered one across a suspend would switch to whatever now holds
+   * it. On Windows it is the endpoint's device instance id, which
+   * nothing switches with; it is the row's identity and no more.
+   */
+  id: string;
+  /** The name a person would recognise on the box in front of them. */
+  name: string;
+  direction: AudioDirection;
+  /**
+   * True when the machine is using it now.
+   *
+   * False for every Windows row, and not because they are all idle: the
+   * PnP read says which endpoints exist and never which is default. A
+   * Panel that guessed — the first one, the one that is enabled — would
+   * be wrong on every machine with two speakers, and it would be wrong
+   * silently.
+   */
+  current: boolean;
+}
+
+/** What the Panel shows, once the machine has been asked. */
+export interface AudioView {
+  target: PanelTarget | null;
+  /** Outputs first, then inputs, each in the order the CLI gave them. */
+  devices: AudioDevice[];
+  /**
+   * Null where this target can switch, and the reason it cannot where
+   * it cannot.
+   *
+   * Carried on the view rather than discovered when Enter is pressed, so
+   * the Panel can say what it will do before somebody asks it to do
+   * something else.
+   */
+  native: NativeFallback | null;
+}
+
+/**
+ * Windows' own Sound page, and why the Panel hands over to it.
+ *
+ * The surface is spelled the way Windows spells it, because a person
+ * reading the sentence is about to go looking for it.
+ */
+export const WINDOWS_SOUND: NativeFallback = {
+  surface: "Settings > System > Sound",
+  reason:
+    "Windows ships no first-party command that sets the default audio device, so red-dev opens the page that does rather than showing a switch that cannot switch",
+};
+
+const NOTHING: AudioView = { target: null, devices: [], native: null };
+
+// ------------------------------------------------------- the observation
+
+/**
+ * The reads. Three commands on Ubuntu, one round trip on Windows.
+ *
+ * Ubuntu is asked three times because `pactl` answers one question per
+ * invocation and the three answers do not correlate: a sink list, a
+ * source list, and the two names the server currently calls default.
+ * The defaults have to come from `info` — neither list marks its own
+ * default, and inferring one from the order is how a Panel ends up
+ * pointing at the HDMI output on every machine.
+ *
+ * `-f json` on all three. `pactl`'s human-readable form is indented
+ * prose meant for reading, and a parser that walks it starts failing the
+ * day a device description contains a colon.
+ */
+export function observeArgv(target: PanelTarget): readonly (readonly string[])[] {
+  if (target === "linux") {
+    return [
+      ["pactl", "-f", "json", "info"],
+      ["pactl", "-f", "json", "list", "sinks"],
+      ["pactl", "-f", "json", "list", "sources"],
+    ];
+  }
+  return [["powershell.exe", "-NoProfile", "-Command", WINDOWS_OBSERVE]];
+}
+
+/**
+ * Observation as a plan, so it can be held to the rule every Panel keeps.
+ *
+ * `gate: null` is the claim; `observeArgv` is the evidence. Keeping them
+ * in one object is what lets one test read both.
+ */
+export function observePlan(target: PanelTarget): PanelPlan {
+  return {
+    prime: null,
+    steps: observeArgv(target),
+    gate: null,
+    note: "reads this machine and changes nothing",
+  };
+}
+
+/**
+ * The whole Windows read, in one script.
+ *
+ * `Get-PnpDevice -Class AudioEndpoint` is the shipped way to enumerate
+ * what the Sound page lists, and it is a `Get-`, which is the whole
+ * reason opening this Panel needs nothing. Errors are silenced rather
+ * than thrown, exactly as the neighbouring probe in `lan-address.ts`
+ * does — a machine without the PnpDevice module produces an empty list,
+ * which the parser already reads as "no answer".
+ */
+const WINDOWS_OBSERVE = [
+  "$ErrorActionPreference = 'SilentlyContinue'",
+  "$endpoints = @(Get-PnpDevice -Class AudioEndpoint |" +
+    " ForEach-Object { [pscustomobject]@{ id = [string]$_.InstanceId;" +
+    " name = [string]$_.FriendlyName; status = [string]$_.Status } })",
+  "[pscustomobject]@{ endpoints = $endpoints } | ConvertTo-Json -Depth 4 -Compress",
+].join("; ");
+
+// -------------------------------------------------------------- ubuntu
+
+type Record_ = { [key: string]: unknown };
+
+function records(value: unknown): Record_[] {
+  const many = Array.isArray(value) ? value : [value];
+  return many.filter((v): v is Record_ => typeof v === "object" && v !== null);
+}
+
+function stringOf(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed === "" ? null : trimmed;
+}
+
+/** The two names `pactl -f json info` reports as current. */
+export function parsePactlDefaults(json: string): { sink: string | null; source: string | null } {
+  let payload: unknown;
+  try {
+    payload = JSON.parse(json);
+  } catch {
+    return { sink: null, source: null };
+  }
+  if (typeof payload !== "object" || payload === null) return { sink: null, source: null };
+  const root = payload as Record_;
+  return {
+    sink: stringOf(root["default_sink_name"]),
+    source: stringOf(root["default_source_name"]),
+  };
+}
+
+/**
+ * Read one `pactl -f json list` answer into rows.
+ *
+ * Monitor sources are dropped. Every sink has one — it is the loopback
+ * that lets a screen recorder capture what is playing — and it appears
+ * in the source list beside the real microphones. Offering them as
+ * inputs would put "Monitor of Built-in Audio" one keystroke away from
+ * being the machine's microphone, which records silence and sounds like
+ * a broken headset.
+ */
+export function parsePactlDevices(
+  json: string,
+  direction: AudioDirection,
+  current: string | null,
+): AudioDevice[] {
+  let payload: unknown;
+  try {
+    payload = JSON.parse(json);
+  } catch {
+    return [];
+  }
+
+  const devices: AudioDevice[] = [];
+  for (const entry of records(payload)) {
+    const id = stringOf(entry["name"]);
+    if (id === null || id.endsWith(".monitor")) continue;
+    devices.push({
+      id,
+      // The description is the human name — "Built-in Audio Analog
+      // Stereo" — and the name is the handle. A Panel that showed the
+      // handle would be a list of `alsa_output.pci-0000_00_1f.3` rows.
+      name: stringOf(entry["description"]) ?? id,
+      direction,
+      current: id === current,
+    });
+  }
+  return devices;
+}
+
+// ------------------------------------------------------------- windows
+
+/**
+ * Which way a Windows audio endpoint points, read off its instance id.
+ *
+ * MMDEVAPI endpoint ids carry the data flow in their first brace:
+ * `{0.0.0.00000000}` is render and `{0.0.1.00000000}` is capture. It is
+ * a convention rather than a documented field, which is why an id that
+ * matches neither is dropped rather than guessed at — a row in the wrong
+ * half of the list is a person choosing a speaker as their microphone.
+ */
+export function endpointDirection(id: string): AudioDirection | null {
+  if (id.includes("{0.0.0.00000000}")) return "output";
+  if (id.includes("{0.0.1.00000000}")) return "input";
+  return null;
+}
+
+/**
+ * Read what the Windows script printed.
+ *
+ * Only endpoints Windows reports as `OK` are kept. The others are
+ * devices it remembers rather than devices it has — a headset unplugged
+ * three weeks ago is still in the PnP tree — and the Sound page does not
+ * offer them either.
+ */
+export function parseWindowsEndpoints(json: string): AudioDevice[] {
+  let payload: unknown;
+  try {
+    payload = JSON.parse(json);
+  } catch {
+    // PowerShell writes its errors where the JSON was meant to go, and a
+    // machine that cannot answer is not a machine to guess about.
+    return [];
+  }
+  if (typeof payload !== "object" || payload === null) return [];
+
+  const devices: AudioDevice[] = [];
+  for (const entry of records((payload as Record_)["endpoints"])) {
+    const id = stringOf(entry["id"]);
+    if (id === null) continue;
+    if (stringOf(entry["status"]) !== "OK") continue;
+    const direction = endpointDirection(id);
+    if (direction === null) continue;
+    devices.push({ id, name: stringOf(entry["name"]) ?? id, direction, current: false });
+  }
+  // Outputs first, then inputs, so the flat list the Panel draws reads
+  // the way the two questions are asked.
+  return [
+    ...devices.filter((d) => d.direction === "output"),
+    ...devices.filter((d) => d.direction === "input"),
+  ];
+}
+
+// ------------------------------------------------------------- the seam
+
+async function observeLinux(capture: Capture): Promise<AudioView> {
+  const [info, sinks, sources] = observeArgv("linux");
+  // Not `?? []` on the argv: these three are pinned by a test, and a
+  // missing one is a programming error rather than a machine's answer.
+  const defaults = info ? await capture(info) : { out: "", code: 127 };
+  const outputs = sinks ? await capture(sinks) : { out: "", code: 127 };
+  const inputs = sources ? await capture(sources) : { out: "", code: 127 };
+
+  const current = defaults.code === 0
+    ? parsePactlDefaults(defaults.out)
+    : { sink: null, source: null };
+
+  return {
+    target: "linux",
+    devices: [
+      ...(outputs.code === 0 ? parsePactlDevices(outputs.out, "output", current.sink) : []),
+      ...(inputs.code === 0 ? parsePactlDevices(inputs.out, "input", current.source) : []),
+    ],
+    // Ubuntu switches with the same binary it was asked with, so there
+    // is nothing to hand over to.
+    native: null,
+  };
+}
+
+/** What this machine says about the sound it plays and hears. */
+export async function observeAudio(
+  p: Platform,
+  capture: Capture = spawnCapture,
+): Promise<AudioView> {
+  const target = panelTarget(p);
+  if (target === null) return NOTHING;
+  if (target === "linux") return await observeLinux(capture);
+
+  const [argv] = observeArgv("windows");
+  // The limit does not depend on the read: Windows cannot switch whether
+  // or not it managed to answer, so the reason is on the view either way.
+  if (!argv) return { target, devices: [], native: WINDOWS_SOUND };
+  const { out, code } = await capture(argv);
+  return {
+    target,
+    devices: code === 0 ? parseWindowsEndpoints(out) : [],
+    native: WINDOWS_SOUND,
+  };
+}
+
+// ---------------------------------------------------------------- acting
+
+/** Chosen, and the argv that carries it out — or the reason it cannot. */
+export type AudioPlan =
+  | ({ ok: true; device: AudioDevice; native: NativeFallback | null } & PanelPlan)
+  | { ok: false; detail: string };
+
+/**
+ * What making `id` the default costs, given what the Panel is showing.
+ *
+ * Built from the observed view rather than from a target and a name, for
+ * the reason `dnsPlan` gives: the id is what the platform's own CLI
+ * takes back, so the device this switches to is by construction a device
+ * on screen. A Panel that took an id from anywhere else could set the
+ * default to a sink that no longer exists, which `pactl` accepts.
+ */
+export function audioPlan(view: AudioView, id: string): AudioPlan {
+  if (view.target === null) {
+    return { ok: false, detail: "red-dev has no audio adapter for this platform" };
+  }
+
+  const device = view.devices.find((d) => d.id === id);
+  if (!device) {
+    // Refused rather than passed through. An id the machine did not
+    // report is either a device that has just been unplugged or a bug,
+    // and `pactl` says nothing useful about either.
+    return { ok: false, detail: `not a device this machine reported: ${id}` };
+  }
+
+  if (view.target === "linux") {
+    return {
+      ok: true,
+      device,
+      native: null,
+      prime: null,
+      // One act, and no elevation: this moves the default of the sound
+      // server in this session. Streams that follow the default follow
+      // it here; one an application has pinned to a device stays where
+      // it was put, which is the application's choice to have made and
+      // not something a default is allowed to override.
+      steps: [
+        ["pactl", device.direction === "output" ? "set-default-sink" : "set-default-source", device.id],
+      ],
+      gate: null,
+      note: `${device.name} for ${device.direction}`,
+    };
+  }
+
+  return {
+    ok: true,
+    device,
+    native: WINDOWS_SOUND,
+    prime: null,
+    steps: [windowsSurface("ms-settings:sound")],
+    gate: null,
+    note: `${WINDOWS_SOUND.surface} — ${WINDOWS_SOUND.reason}`,
+  };
+}
+
+/** Changed, or the reason it was not — either way, one line. */
+export interface AudioOutcome {
+  changed: boolean;
+  detail: string;
+}
+
+/**
+ * Carry a plan out, and be exact about what happened.
+ *
+ * Opening the host's own page is not a switch. The window opens, the
+ * command exits zero, and the machine is playing through exactly what it
+ * was playing through a moment ago — so `changed` stays false and the
+ * line says where the switch now lives. Reporting it as a change would
+ * be the Panel taking credit for a page it opened.
+ */
+export async function applyAudio(plan: AudioPlan, run: Run): Promise<AudioOutcome> {
+  if (!plan.ok) return { changed: false, detail: plan.detail };
+  const outcome = await runPlan(plan, run);
+  if (!outcome.done) return { changed: false, detail: outcome.detail };
+  return { changed: plan.native === null, detail: `audio: ${plan.note}` };
+}
+
+/**
+ * The view as text, for a terminal with no Panel to draw.
+ *
+ * Not a degraded mode: this is the form a bug report pastes and a script
+ * greps. The limit is a line of its own where there is one, because a
+ * Windows machine printing "not reported" twice with no explanation
+ * reads as a broken probe rather than as a stated boundary.
+ */
+export function panelLines(view: AudioView): string[] {
+  const current = (direction: AudioDirection): string =>
+    view.devices.find((d) => d.direction === direction && d.current)?.name ?? "not reported";
+  const count = (direction: AudioDirection): number =>
+    view.devices.filter((d) => d.direction === direction).length;
+
+  const lines = [
+    `output   ${current("output")}`,
+    `input    ${current("input")}`,
+    `devices  ${count("output")} out, ${count("input")} in`,
+  ];
+  if (view.native !== null) {
+    lines.push(`switch   ${view.native.surface} — ${view.native.reason}`);
+  }
+  return lines;
+}

--- a/src/panel-network.ts
+++ b/src/panel-network.ts
@@ -3,14 +3,15 @@
  * resolver answers for it, and the four things an operator can do about
  * that.
  *
- * The first Panel, and the shape the rest are meant to copy. A Panel is
- * a red-dev TUI over one host subsystem, and it earns that by driving
- * the platform's *first-party* CLI rather than writing the files
- * underneath it — `nmcli` and `resolvectl` on Ubuntu, the NetTCPIP and
- * DnsClient cmdlets on Windows. Editing `/etc/resolv.conf` by hand would
- * work for about one reboot on a machine NetworkManager owns, and would
- * leave the host's own tools disagreeing with the Panel about what the
- * machine is configured to do.
+ * The first Panel, and the shape the rest copy — the shape itself now
+ * lives in src/panel.ts, which is where the two rules every Panel keeps
+ * are written down. A Panel is a red-dev TUI over one host subsystem,
+ * and it earns that by driving the platform's *first-party* CLI rather
+ * than writing the files underneath it — `nmcli` and `resolvectl` on
+ * Ubuntu, the NetTCPIP and DnsClient cmdlets on Windows. Editing
+ * `/etc/resolv.conf` by hand would work for about one reboot on a
+ * machine NetworkManager owns, and would leave the host's own tools
+ * disagreeing with the Panel about what the machine is configured to do.
  *
  * ## Looking is never privileged
  *
@@ -35,6 +36,12 @@
  * takes effect at the end of the next converge. Those are different
  * things and they stay different.
  *
+ * This is also the Panel where an act genuinely needs rights, which is
+ * not true of the other two: `pactl` and `powerprofilesctl` change the
+ * signed-in person's own session and ask for nothing. Writing DNS onto a
+ * NetworkManager connection is system configuration, and that is the
+ * difference — not that this Panel came first.
+ *
  * ## WSL asks the Windows host
  *
  * The same crossing `lan-address.ts` and `ssh-server.ts` already make,
@@ -55,32 +62,20 @@
  * the Panel shows after a change is what the machine actually holds.
  */
 
+import { panelTarget, runPlan, spawnCapture } from "./panel.ts";
+import type { Capture, PanelKey, PanelPlan, PanelTarget, Run } from "./panel.ts";
 import type { Platform } from "./platform.ts";
-import type { Gate } from "./rights.ts";
 
 /**
- * The two adapters this Panel has.
+ * The Panel vocabulary, re-exported so this module reads as one Panel.
  *
- * Not one per `Env`: Ubuntu desktop and an Ubuntu server drive the same
- * two binaries, and WSL drives the Windows ones. Darwin and an unknown
- * OS are absent deliberately, failing closed as `providerFor` does and
- * as ADR 0001 requires.
+ * Everything a Panel shares now lives in src/panel.ts, and nothing that
+ * consumes the network Panel should have to know which half of it moved
+ * there — the split is about two Panels not writing "which CLI answers
+ * for this machine" twice, not about a second import path for callers.
  */
-export type PanelTarget = "linux" | "windows";
-
-/**
- * Which CLI answers for this machine, or nothing when none does.
- *
- * Windows first, and WSL with it, in the same order `hostNetState` asks
- * the question — a WSL distro is `os: "linux"`, so testing Linux first
- * would send it to `nmcli`, which is not installed and would not be
- * describing the right machine if it were.
- */
-export function panelTarget(p: Platform): PanelTarget | null {
-  if (p.os === "windows" || p.env === "wsl") return "windows";
-  if (p.os === "linux") return "linux";
-  return null;
-}
+export { panelTarget, raisesRights, spawnCapture } from "./panel.ts";
+export type { Capture, Captured, PanelKey, PanelPlan, PanelTarget, Run } from "./panel.ts";
 
 /** The four, in the order the Panel offers them. */
 export type DnsChoice = "dhcp" | "cloudflare" | "google" | "custom";
@@ -155,51 +150,6 @@ export function serversFor(choice: DnsChoice, custom = ""): readonly string[] | 
 }
 
 // ----------------------------------------------------------- the plans
-
-/**
- * What the Panel would run, decided before anything runs.
- *
- * The same split `firePlan` makes, for the same reason: a plan can be
- * read by a test, and a refusal arrives as a sentence for the status
- * line rather than as a process that failed off screen. It is also what
- * makes "observation is never privileged" a checkable claim instead of a
- * paragraph — `gate` says which gate the acts pass, and `raisesRights`
- * reads the argv itself, so a plan cannot claim `null` while quietly
- * carrying a `sudo`.
- */
-export interface PanelPlan {
-  /**
-   * The one visible ask that raises the rights, before the acts.
-   *
-   * `sudo -v` on Ubuntu, so the password is typed once, in the ordinary
-   * terminal, at the moment the operator asked — the same shape
-   * `primeSudoInteractive` uses before the installer takes the screen.
-   * Null on Windows, where consent is not a separate question: the UAC
-   * dialog is raised by the act itself and cannot be raised early.
-   */
-  prime: readonly string[] | null;
-  /** The acts, in order, each already carrying the rights it needs. */
-  steps: readonly (readonly string[])[];
-  /** Which gate those acts pass, or null when they pass none. */
-  gate: Gate | null;
-  /** One line, for the status line under the list. */
-  note: string;
-}
-
-/**
- * Does this argv ask the machine for rights?
- *
- * Read off the words rather than taken on trust, because the claim worth
- * pinning is about what runs. Both spellings of each gate are here: the
- * Linux elevators as argv[0], and Windows' consent verb as it appears
- * inside a `-Command` string, where no amount of looking at argv[0]
- * would find it.
- */
-export function raisesRights(argv: readonly string[]): boolean {
-  const head = argv[0]?.toLowerCase().replace(/\.exe$/, "") ?? "";
-  if (["sudo", "pkexec", "doas", "su", "runas"].includes(head)) return true;
-  return argv.some((word) => /-verb\s+runas/i.test(word));
-}
 
 /**
  * The reads. Two commands on Ubuntu, one round trip on Windows.
@@ -485,15 +435,6 @@ const NOTHING: NetworkView = {
   named: null,
 };
 
-/** Ran, and what it printed. Same shape as `lan-address.ts`'s. */
-export interface Captured {
-  out: string;
-  code: number;
-}
-
-/** The seam the tests replace: how a question reaches the machine. */
-export type Capture = (cmd: readonly string[]) => Promise<Captured>;
-
 /**
  * Whether the observed resolvers are one of the named choices.
  *
@@ -724,26 +665,6 @@ function windowsLinkState(status: string): LinkState {
 
 // ------------------------------------------------------------- the seam
 
-/**
- * Ask the machine, with the child's streams captured.
- *
- * The same shape `lan-address.ts` uses, including the UTF-16LE decode:
- * PowerShell reached through WSL interop writes UTF-16LE when its stdout
- * is redirected, which is not JSON until it is decoded.
- */
-export async function spawnCapture(cmd: readonly string[]): Promise<Captured> {
-  const { readWindowsOutput } = await import("./windows-output.ts");
-  try {
-    const proc = Bun.spawn([...cmd], { stdout: "pipe", stderr: "ignore", stdin: "ignore" });
-    const out = await readWindowsOutput(proc.stdout);
-    return { out, code: await proc.exited };
-  } catch {
-    // A binary that is not there is an answer, not an exception: this
-    // machine cannot be asked, so it reports nothing.
-    return { out: "", code: 127 };
-  }
-}
-
 /** What this machine says about the network it is on. */
 export async function observeNetwork(
   p: Platform,
@@ -788,22 +709,6 @@ export interface PanelState {
 }
 
 export const PANEL_START: PanelState = { index: 0, custom: "" };
-
-/**
- * The keys the Panel reads, structurally — the same declaration
- * `keys.ts` makes, and for the same reason: tuiuiu's `Key` carries all
- * of these, so the component hands its own object straight in, and
- * naming only what is used keeps this module free of the renderer.
- */
-export interface PanelKey {
-  upArrow: boolean;
-  downArrow: boolean;
-  return: boolean;
-  escape: boolean;
-  backspace: boolean;
-  delete: boolean;
-  ctrl: boolean;
-}
 
 export interface PanelStep {
   state: PanelState;
@@ -866,40 +771,24 @@ export interface DnsOutcome {
   detail: string;
 }
 
-/** Run one argv attached to the terminal, and say how it ended. */
-export type Run = (argv: readonly string[]) => Promise<number>;
-
 /**
  * Carry out a plan: the visible ask, then the acts, stopping at the
  * first one that fails.
  *
- * Stopping matters on Ubuntu, where the two acts are "record it" and
- * "make it take effect": running the second after the first failed would
- * bring the connection up with the DNS it already had and report that as
- * the change the operator asked for.
+ * `runPlan` is the stopping, shared with the other Panels — and stopping
+ * is what matters most here, where the two Ubuntu acts are "record it"
+ * and "make it take effect". Running the second after the first failed
+ * would bring the connection up with the DNS it already had and report
+ * that as the change the operator asked for.
+ *
+ * What stays here is the sentence: a Panel names its own subject, so
+ * this one says `dns:` and the audio one says which device it moved.
  */
 export async function applyDns(plan: DnsPlan, run: Run): Promise<DnsOutcome> {
   if (!plan.ok) return { changed: false, detail: plan.detail };
-
-  if (plan.prime) {
-    const code = await run(plan.prime);
-    if (code !== 0) {
-      const { missingRights } = await import("./rights.ts");
-      return { changed: false, detail: missingRights("sudo").cause };
-    }
-  }
-
-  for (const step of plan.steps) {
-    const code = await run(step);
-    if (code !== 0) {
-      const { missingRights } = await import("./rights.ts");
-      // A non-zero exit from an elevated Start-Process is what a
-      // declined UAC dialog looks like from here; there is no separate
-      // signal for it, and the remedy is the same either way.
-      const gate = plan.gate ?? "sudo";
-      return { changed: false, detail: `${step[0]} failed — ${missingRights(gate).cause}` };
-    }
-  }
-
-  return { changed: true, detail: `dns: ${plan.note}` };
+  const outcome = await runPlan(plan, run);
+  return {
+    changed: outcome.done,
+    detail: outcome.done ? `dns: ${plan.note}` : outcome.detail,
+  };
 }

--- a/src/panel-power.test.ts
+++ b/src/panel-power.test.ts
@@ -1,0 +1,442 @@
+/**
+ * What the power Panel runs, and what it never runs.
+ *
+ * The argv is the artefact under test, for the reason the network
+ * Panel's tests give: this process runs on one machine and the Panel has
+ * to be right about two, one of which it meets only through WSL
+ * interop. So every command is pinned word for word, per target, for the
+ * read and for each of the three profiles.
+ *
+ * Two claims are this Panel's own.
+ *
+ * The reads are unprivileged, which is a real claim here rather than a
+ * formality: most of `powercfg`'s switches need administrator, and
+ * `/list` is one of the ones that does not. So is the *change* — the
+ * host's own menu switches profiles in one click on both platforms — and
+ * a test pins that too, because the failure mode this Panel has is the
+ * opposite of the network Panel's. Growing a password prompt for an act
+ * that never needed one teaches people that prompts mean nothing just as
+ * effectively as a missing one does.
+ *
+ * And the Panel offers what the machine has, never what the platform is
+ * supposed to have. Windows 11 hides the classic schemes on most
+ * modern-standby machines; a laptop without power-profiles-daemon lists
+ * nothing at all. On those, a well-known GUID sent anyway is a command
+ * that fails, and the refusal that names what the machine does offer is
+ * the more useful answer.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { applicableScopes } from "./manifest.ts";
+import {
+  applyPower,
+  observeArgv,
+  observePlan,
+  observePower,
+  panelLines,
+  parsePowercfgSchemes,
+  parsePowerProfiles,
+  parseUpower,
+  parseWindowsBattery,
+  POWER_PROFILES,
+  powerPlan,
+  WINDOWS_SCHEMES,
+  type PowerView,
+} from "./panel-power.ts";
+import { raisesRights, type Captured } from "./panel.ts";
+import type { Platform } from "./platform.ts";
+import { batchScript, privilegedItems } from "./privileged.ts";
+
+function machine(over: Partial<Platform>): Platform {
+  return {
+    os: "linux",
+    distro: "ubuntu",
+    version: "24.04",
+    codename: "noble",
+    env: "desktop",
+    arch: "x64",
+    caps: { apt: true, gui: true, systemd: true, winget: false, flatpak: true },
+    ...over,
+  };
+}
+
+const desktop = machine({});
+const wsl = machine({
+  env: "wsl",
+  caps: { apt: true, gui: false, systemd: false, winget: true, flatpak: false },
+});
+const windows = machine({ os: "windows", env: "windows", distro: null, version: null, codename: null });
+const mac = machine({ os: "darwin", env: "desktop", distro: null, version: null, codename: null });
+
+/** A laptop with all three profiles, as observation would report it. */
+const onUbuntu: PowerView = {
+  target: "linux",
+  profile: "balanced",
+  offered: ["power-saver", "balanced", "performance"],
+  battery: { percent: 74, state: "discharging" },
+};
+
+const onWindows: PowerView = {
+  target: "windows",
+  profile: "balanced",
+  offered: ["power-saver", "balanced", "performance"],
+  battery: { percent: 91, state: "charging" },
+};
+
+describe("observation, pinned per target", () => {
+  test("Ubuntu asks the profiles daemon what it has, and upower how long is left", () => {
+    // `list` rather than `get`, because which profiles exist is the half
+    // that decides what the Panel is allowed to offer.
+    expect(observeArgv("linux")).toEqual([
+      ["powerprofilesctl", "list"],
+      ["upower", "-i", "/org/freedesktop/UPower/devices/DisplayDevice"],
+    ]);
+  });
+
+  test("Windows asks powercfg for its schemes, and WMI for the battery", () => {
+    expect(observeArgv("windows")).toEqual([
+      ["powercfg.exe", "/list"],
+      [
+        "powershell.exe",
+        "-NoProfile",
+        "-Command",
+        "$ErrorActionPreference = 'SilentlyContinue'; " +
+          "$battery = @(Get-CimInstance Win32_Battery | ForEach-Object { [pscustomobject]@{" +
+          " percent = [int]$_.EstimatedChargeRemaining; status = [int]$_.BatteryStatus } }); " +
+          "[pscustomobject]@{ battery = $battery } | ConvertTo-Json -Depth 4 -Compress",
+      ],
+    ]);
+  });
+
+  test("in two round trips on both, because the two answers cannot go stale on each other", () => {
+    // The network Panel folds its Windows reads into one script because
+    // an interface index joins them. A battery percentage and a list of
+    // schemes are independent, so there is nothing to synchronise.
+    for (const target of ["linux", "windows"] as const) {
+      expect(observeArgv(target)).toHaveLength(2);
+    }
+  });
+});
+
+describe("looking is never a privileged act", () => {
+  for (const target of ["linux", "windows"] as const) {
+    test(`on ${target}, no observation argv reaches for rights`, () => {
+      const plan = observePlan(target);
+      expect(plan.gate).toBeNull();
+      expect(plan.prime).toBeNull();
+      for (const step of plan.steps) expect(raisesRights(step)).toBe(false);
+    });
+
+    test(`on ${target}, every observation command is a read`, () => {
+      // powercfg is the one worth naming: most of its switches need
+      // administrator, and /list is not one of them. A read that had
+      // drifted to /setactive would still pass raisesRights.
+      for (const step of observePlan(target).steps) {
+        const words = step.join(" ");
+        expect(words).not.toContain("sudo");
+        expect(words).not.toContain("RunAs");
+        expect(words).not.toContain("/setactive");
+        expect(words).not.toContain("Set-");
+        expect(words).not.toMatch(/\bset\b/);
+      }
+    });
+  }
+});
+
+describe("each profile, pinned per target", () => {
+  test("Ubuntu hands the name straight to the daemon GNOME's own menu uses", () => {
+    const plan = powerPlan(onUbuntu, "performance");
+    expect(plan.ok).toBe(true);
+    if (!plan.ok) return;
+    expect(plan.steps).toEqual([["powerprofilesctl", "set", "performance"]]);
+    expect(plan.prime).toBeNull();
+    expect(plan.gate).toBeNull();
+  });
+
+  test("Windows activates the scheme by GUID, because the name is translated", () => {
+    const plan = powerPlan(onWindows, "performance");
+    expect(plan.ok && plan.steps).toEqual([
+      ["powercfg.exe", "/setactive", "8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c"],
+    ]);
+  });
+
+  test("and the other two carry the other two built-in GUIDs", () => {
+    expect(powerPlan(onWindows, "power-saver").ok && powerPlan(onWindows, "power-saver")).toMatchObject({
+      steps: [["powercfg.exe", "/setactive", "a1841308-3541-4fab-bc81-f71556f20b4a"]],
+    });
+    expect(powerPlan(onWindows, "balanced").ok && powerPlan(onWindows, "balanced")).toMatchObject({
+      steps: [["powercfg.exe", "/setactive", "381b4222-f694-41f0-9685-ff5bb260df2e"]],
+    });
+  });
+
+  test("the same three words drive both targets, which is the point of the Panel", () => {
+    // A person who learned "performance" on their laptop should not have
+    // to learn "High performance" again on the other machine.
+    for (const profile of POWER_PROFILES) {
+      expect(powerPlan(onUbuntu, profile).ok).toBe(true);
+      expect(powerPlan(onWindows, profile).ok).toBe(true);
+    }
+  });
+
+  test("no target builds a switch that asks for a password", () => {
+    // The inverse of the network Panel's rule, and the reason it is
+    // pinned: both hosts change this from their own menus without a
+    // prompt, so a Panel that grew one would be asking for consent it
+    // does not need — which is how consent stops meaning anything.
+    for (const view of [onUbuntu, onWindows]) {
+      for (const profile of POWER_PROFILES) {
+        const plan = powerPlan(view, profile);
+        expect(plan.ok).toBe(true);
+        if (!plan.ok) continue;
+        expect(plan.gate).toBeNull();
+        expect(plan.prime).toBeNull();
+        expect(plan.steps.some((step) => raisesRights(step))).toBe(false);
+      }
+    }
+  });
+});
+
+describe("a change the Panel cannot make", () => {
+  test("to a profile the machine does not have, names what it does have", () => {
+    // Windows 11 hides the classic schemes on most modern-standby
+    // machines. Sending the well-known GUID anyway is a command that
+    // fails; this is the more useful answer.
+    const plan = powerPlan({ ...onWindows, offered: ["balanced"] }, "performance");
+    expect(plan.ok).toBe(false);
+    expect(plan.ok || plan.detail).toBe("this machine has no Performance profile — it offers Balanced");
+  });
+
+  test("on a machine offering nothing at all, says so rather than listing an empty set", () => {
+    const plan = powerPlan({ ...onUbuntu, offered: [] }, "balanced");
+    expect(plan.ok || plan.detail).toContain("it offers none");
+  });
+
+  test("on a platform with no adapter, is refused by name", () => {
+    const plan = powerPlan({ ...onUbuntu, target: null }, "balanced");
+    expect(plan.ok).toBe(false);
+    expect(plan.ok || plan.detail).toContain("no power adapter");
+  });
+});
+
+describe("reading what Ubuntu said", () => {
+  const LIST = [
+    "* balanced:",
+    "    CpuDriver:  intel_pstate",
+    "    Degraded:   no",
+    "",
+    "  performance:",
+    "    CpuDriver:  intel_pstate",
+    "",
+    "  power-saver:",
+    "    CpuDriver:  intel_pstate",
+  ].join("\n");
+
+  const UPOWER = [
+    "Device: /org/freedesktop/UPower/devices/DisplayDevice",
+    "  power supply:         yes",
+    "  updated:              Sun 16 Aug 2026 03:00:00 (12 seconds ago)",
+    "  battery",
+    "    present:             yes",
+    "    state:               discharging",
+    "    warning-level:       none",
+    "    percentage:          74%",
+    "    icon-name:          'battery-good-symbolic'",
+  ].join("\n");
+
+  test("takes the marked profile as the active one, and lists them in the Panel's order", () => {
+    // The daemon prints the active one first; the Panel's order is
+    // saver to performance, and a list that reordered itself per machine
+    // would put a different row under the cursor on each.
+    expect(parsePowerProfiles(LIST)).toEqual({
+      offered: ["power-saver", "balanced", "performance"],
+      active: "balanced",
+    });
+  });
+
+  test("a daemon that is not there offers nothing, rather than the three by default", () => {
+    expect(parsePowerProfiles("")).toEqual({ offered: [], active: null });
+  });
+
+  test("reads the battery off the composite device", () => {
+    expect(parseUpower(UPOWER)).toEqual({ percent: 74, state: "discharging" });
+  });
+
+  test("a machine that says it has no battery is believed", () => {
+    // Printing "0% — unknown" on a workstation would be a fault report
+    // about a machine with nothing wrong with it.
+    const desktopOut = ["  battery", "    present:             no", "    state:               unknown"].join("\n");
+    expect(parseUpower(desktopOut)).toEqual({ percent: null, state: "none" });
+    expect(parseUpower("")).toEqual({ percent: null, state: "none" });
+  });
+
+  test("plugged in and not charging is its own answer, not charging", () => {
+    const pending = ["    present:             yes", "    state:               pending-charge", "    percentage:          80%"].join("\n");
+    expect(parseUpower(pending)).toEqual({ percent: 80, state: "mains" });
+  });
+
+  test("and puts the two answers together into one view", async () => {
+    const capture = async (cmd: readonly string[]): Promise<Captured> =>
+      cmd[0] === "powerprofilesctl" ? { out: LIST, code: 0 } : { out: UPOWER, code: 0 };
+
+    expect(await observePower(desktop, capture)).toEqual({
+      target: "linux",
+      profile: "balanced",
+      offered: ["power-saver", "balanced", "performance"],
+      battery: { percent: 74, state: "discharging" },
+    });
+  });
+
+  test("a battery probe that could not run is unknown, and not a machine without one", async () => {
+    const capture = async (cmd: readonly string[]): Promise<Captured> =>
+      cmd[0] === "powerprofilesctl" ? { out: LIST, code: 0 } : { out: "", code: 127 };
+    const view = await observePower(desktop, capture);
+    expect(view.battery).toEqual({ percent: null, state: "unknown" });
+  });
+
+  test("and a platform red-dev has no adapter for says so rather than guessing", async () => {
+    expect(await observePower(mac, async () => ({ out: "", code: 0 }))).toMatchObject({
+      target: null,
+      offered: [],
+    });
+  });
+});
+
+describe("reading what Windows said", () => {
+  /** A Portuguese install, to prove nothing is matched on the name. */
+  const SCHEMES = [
+    "",
+    "Esquemas de Energia Existentes (* Ativo)",
+    "-----------------------------------",
+    "GUID do Esquema de Energia: 381b4222-f694-41f0-9685-ff5bb260df2e  (Equilibrado) *",
+    "GUID do Esquema de Energia: a1841308-3541-4fab-bc81-f71556f20b4a  (Economia de energia)",
+    "GUID do Esquema de Energia: e9a42b02-d5df-448d-aa00-03f14749eb61  (Fabricante)",
+  ].join("\r\n");
+
+  test("matches the built-in schemes by GUID, and the active one by its asterisk", () => {
+    // The bracketed names are translated; the GUIDs are the same on
+    // every Windows since Vista, and the `*` is the only mark on the
+    // line that is not localised.
+    expect(parsePowercfgSchemes(SCHEMES)).toEqual({
+      offered: ["power-saver", "balanced"],
+      active: "balanced",
+    });
+  });
+
+  test("a machine on an OEM scheme is on none of the three, rather than on a guess", () => {
+    const oem = "GUID do Esquema de Energia: e9a42b02-d5df-448d-aa00-03f14749eb61  (Fabricante) *";
+    expect(parsePowercfgSchemes(oem)).toEqual({ offered: [], active: null });
+  });
+
+  test("every profile's GUID is one powercfg would recognise", () => {
+    for (const profile of POWER_PROFILES) {
+      expect(WINDOWS_SCHEMES[profile]).toMatch(/^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$/);
+    }
+  });
+
+  test("reads the battery, and the on-AC state WMI will not call charging", () => {
+    const charging = JSON.stringify({ battery: [{ percent: 91, status: 6 }] });
+    expect(parseWindowsBattery(charging)).toEqual({ percent: 91, state: "charging" });
+
+    // BatteryStatus 2 is documented as "the system has access to AC,
+    // however the battery is not necessarily charging".
+    const onMains = JSON.stringify({ battery: [{ percent: 100, status: 2 }] });
+    expect(parseWindowsBattery(onMains)).toEqual({ percent: 100, state: "mains" });
+  });
+
+  test("a desktop with no Win32_Battery has no battery, which is an answer", () => {
+    expect(parseWindowsBattery(JSON.stringify({ battery: [] }))).toEqual({
+      percent: null,
+      state: "none",
+    });
+  });
+
+  test("PowerShell writing an error where the JSON belonged is not a machine to guess about", () => {
+    expect(parseWindowsBattery("Get-CimInstance : not recognized")).toEqual({
+      percent: null,
+      state: "unknown",
+    });
+  });
+
+  test("and WSL is asked the Windows host's questions, because the battery is the host's", async () => {
+    const capture = async (cmd: readonly string[]): Promise<Captured> =>
+      cmd[0] === "powercfg.exe"
+        ? { out: SCHEMES, code: 0 }
+        : { out: JSON.stringify({ battery: [{ percent: 55, status: 1 }] }), code: 0 };
+
+    for (const p of [windows, wsl]) {
+      expect(await observePower(p, capture)).toEqual({
+        target: "windows",
+        profile: "balanced",
+        offered: ["power-saver", "balanced"],
+        battery: { percent: 55, state: "discharging" },
+      });
+    }
+  });
+});
+
+describe("carrying a plan out", () => {
+  test("runs the one command and reports the change", async () => {
+    const ran: string[][] = [];
+    const outcome = await applyPower(powerPlan(onUbuntu, "power-saver"), async (argv) => {
+      ran.push([...argv]);
+      return 0;
+    });
+    expect(ran).toEqual([["powerprofilesctl", "set", "power-saver"]]);
+    expect(outcome).toEqual({ changed: true, detail: "power: Power saver" });
+  });
+
+  test("a command that failed names the exit code, not a rights problem", async () => {
+    // There is no gate here. A machine whose scheme is locked by policy
+    // says so through powercfg; inventing "this needs administrator"
+    // would send whoever reads it looking for a prompt that never was.
+    const outcome = await applyPower(powerPlan(onWindows, "performance"), async () => 1);
+    expect(outcome.changed).toBe(false);
+    expect(outcome.detail).toBe("powercfg.exe failed — exit 1");
+  });
+
+  test("a refusal runs nothing at all", async () => {
+    let calls = 0;
+    const outcome = await applyPower(powerPlan({ ...onUbuntu, offered: [] }, "balanced"), async () => {
+      calls++;
+      return 0;
+    });
+    expect(calls).toBe(0);
+    expect(outcome.changed).toBe(false);
+  });
+});
+
+describe("no Panel act reaches the converge's privileged batch", () => {
+  test("the composed batch script carries none of the Panel's commands", async () => {
+    // The same decision the network Panel's tests pin, read for this
+    // Panel's binaries: a power act in the batch would take effect at
+    // the end of somebody's next converge instead of when it was asked
+    // for.
+    for (const p of [desktop, wsl, windows]) {
+      const script = await batchScript(privilegedItems(p, applicableScopes(p)), "C:\\tmp\\r.txt");
+      expect(script).not.toContain("powerprofilesctl");
+      expect(script).not.toContain("powercfg");
+      expect(script).not.toContain("upower");
+    }
+  });
+});
+
+describe("the Panel as text, for a terminal with none to draw", () => {
+  test("carries the profile, what else is on offer, and the battery", () => {
+    expect(panelLines(onUbuntu)).toEqual([
+      "profile  Balanced",
+      "offered  Power saver, Balanced, Performance",
+      "battery  74% — discharging",
+    ]);
+  });
+
+  test("says a machine is on none of the three rather than picking one", () => {
+    const lines = panelLines({ ...onWindows, profile: null, offered: ["balanced"] });
+    expect(lines[0]).toBe("profile  not one of the three");
+    expect(lines[1]).toBe("offered  Balanced");
+  });
+
+  test("and a machine with no battery says none, not a percentage it does not have", () => {
+    const lines = panelLines({ ...onUbuntu, battery: { percent: null, state: "none" } });
+    expect(lines[2]).toBe("battery  none");
+  });
+});

--- a/src/panel-power.ts
+++ b/src/panel-power.ts
@@ -1,0 +1,489 @@
+/**
+ * The power Panel: how hard this machine is allowed to work, and how
+ * long it has left.
+ *
+ * The third Panel, on the shape src/panel.ts holds. The first-party CLI
+ * rule picks what it drives on each side: `powerprofilesctl` on Ubuntu,
+ * which is the command GNOME's own power menu goes through, and
+ * `powercfg` on Windows, which has been the shipped tool for power
+ * schemes since Vista. Neither side is written to by hand — a profile
+ * poked into sysfs is one that power-profiles-daemon overwrites the next
+ * time anything asks it for anything.
+ *
+ * ## The same three words on both, which is the whole point
+ *
+ * Ubuntu names its profiles `power-saver`, `balanced` and `performance`.
+ * Windows ships three schemes meaning the same three things under
+ * different names and behind GUIDs. The Panel speaks the first set on
+ * both targets, because a person who learns "performance" on their
+ * laptop should not have to learn "High performance" again on the other
+ * machine — that is the same promise ADR 0006 makes about chords, kept
+ * one layer down.
+ *
+ * ## Nothing here asks for rights either
+ *
+ * Observation is a read on both sides. So, near enough, is the change:
+ * power-profiles-daemon lets the active session switch profiles without
+ * a polkit prompt, which is why GNOME's menu can do it in one click, and
+ * Windows lets the signed-in person pick their own scheme without a
+ * consent shield on its own Settings page. So this Panel raises nothing.
+ * If a machine's policy has locked the scheme, the command says so and
+ * `applyPower` reports the exit code rather than inventing a rights
+ * problem the person would then go looking for.
+ *
+ * ## What the machine offers is what the Panel offers
+ *
+ * Both plans are built from the observed view, so the Panel never sends
+ * a name the machine did not list. That is not defensiveness: a laptop
+ * without power-profiles-daemon lists nothing, and Windows 11 hides the
+ * classic schemes on most modern-standby machines and keeps the
+ * three-way choice in its battery flyout instead. On those, `powercfg`
+ * really has no High performance scheme to activate, and a Panel that
+ * sent the well-known GUID anyway would report a switch that the machine
+ * refused.
+ */
+
+import { panelTarget, runPlan, spawnCapture } from "./panel.ts";
+import type { Capture, PanelPlan, PanelTarget, Run } from "./panel.ts";
+import type { Platform } from "./platform.ts";
+
+/** The three, in the order the Panel offers them. */
+export type PowerProfile = "power-saver" | "balanced" | "performance";
+
+export const POWER_PROFILES: readonly PowerProfile[] = ["power-saver", "balanced", "performance"];
+
+/** What the Panel calls each one, and the sentence under it. */
+export const POWER_LABELS: Record<PowerProfile, { label: string; detail: string }> = {
+  "power-saver": { label: "Power saver", detail: "quieter and slower, longer on a charge" },
+  balanced: { label: "Balanced", detail: "what the machine ships on" },
+  performance: { label: "Performance", detail: "faster and hotter, shorter on a charge" },
+};
+
+/**
+ * The Windows scheme behind each profile, by GUID.
+ *
+ * By GUID and never by name, because the name is translated: the scheme
+ * called "Balanced" on this machine is "Equilibrado" on the next one,
+ * and a parser matching the word would work on English installs and
+ * quietly find nothing everywhere else. These three GUIDs are the
+ * built-in schemes and are the same on every Windows since Vista.
+ */
+export const WINDOWS_SCHEMES: Record<PowerProfile, string> = {
+  "power-saver": "a1841308-3541-4fab-bc81-f71556f20b4a",
+  balanced: "381b4222-f694-41f0-9685-ff5bb260df2e",
+  performance: "8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c",
+};
+
+/**
+ * What the battery is doing, in the words both sides can honestly
+ * produce.
+ *
+ * `mains` is its own answer rather than a synonym for charging, because
+ * both platforms report exactly that state and neither means charging by
+ * it: upower's `pending-charge` is a battery that is plugged in and not
+ * taking current, and WMI's BatteryStatus 2 is documented as "the system
+ * has access to AC, however the battery is not necessarily charging".
+ * Folding either into `charging` would be the Panel making a claim the
+ * machine declined to make.
+ */
+export type BatteryState = "charging" | "discharging" | "full" | "mains" | "none" | "unknown";
+
+export interface Battery {
+  /** Null when the machine has no battery, or would not say. */
+  percent: number | null;
+  state: BatteryState;
+}
+
+/** What the Panel shows, once the machine has been asked. */
+export interface PowerView {
+  target: PanelTarget | null;
+  /**
+   * The profile the machine is on, when it is one of the three.
+   *
+   * Null covers a machine running an OEM or hand-made scheme. Saying
+   * "Balanced" about it would be a guess, and the person looking at the
+   * Panel is the one who would have to discover it was wrong.
+   */
+  profile: PowerProfile | null;
+  /** The ones this machine actually has, in the Panel's own order. */
+  offered: PowerProfile[];
+  battery: Battery;
+}
+
+const NO_BATTERY: Battery = { percent: null, state: "none" };
+
+const NOTHING: PowerView = {
+  target: null,
+  profile: null,
+  offered: [],
+  battery: NO_BATTERY,
+};
+
+// ------------------------------------------------------- the observation
+
+/**
+ * The reads. Two commands per target, and two round trips on both.
+ *
+ * Two rather than one, unlike the network Panel, because nothing here
+ * correlates: a battery percentage and a list of power schemes are
+ * independent answers, and there is no index to go stale between them.
+ * The network Panel folds its Windows reads into one script precisely
+ * because its three answers are joined by an interface index that two
+ * adapters coming up mid-read would invalidate.
+ */
+export function observeArgv(target: PanelTarget): readonly (readonly string[])[] {
+  if (target === "linux") {
+    return [
+      // `list` rather than `get`: it answers both questions at once,
+      // marking the active profile with a `*` among the ones the daemon
+      // has — and which ones exist is the half that decides what the
+      // Panel may offer.
+      ["powerprofilesctl", "list"],
+      // The composite device, not a numbered one. UPower publishes
+      // DisplayDevice as the single battery a desktop would draw, which
+      // is the same thing this Panel wants and saves it choosing between
+      // BAT0 and BAT1 on a ThinkPad.
+      ["upower", "-i", "/org/freedesktop/UPower/devices/DisplayDevice"],
+    ];
+  }
+  return [
+    ["powercfg.exe", "/list"],
+    ["powershell.exe", "-NoProfile", "-Command", WINDOWS_BATTERY],
+  ];
+}
+
+/**
+ * Observation as a plan, so it can be held to the rule every Panel keeps.
+ *
+ * `gate: null` is the claim; `observeArgv` is the evidence. `powercfg`
+ * is the interesting one here — most of its switches need administrator
+ * and `/list` is not one of them, which is exactly why the read is
+ * pinned rather than assumed.
+ */
+export function observePlan(target: PanelTarget): PanelPlan {
+  return {
+    prime: null,
+    steps: observeArgv(target),
+    gate: null,
+    note: "reads this machine and changes nothing",
+  };
+}
+
+/**
+ * The Windows battery read.
+ *
+ * `Win32_Battery` is absent on a desktop rather than empty, which is the
+ * answer the Panel wants: no battery, said by the machine. Errors are
+ * silenced as the neighbouring probe in `lan-address.ts` does, so a
+ * machine without the CIM class produces an empty list instead of
+ * PowerShell's error text where the JSON belonged.
+ */
+const WINDOWS_BATTERY = [
+  "$ErrorActionPreference = 'SilentlyContinue'",
+  "$battery = @(Get-CimInstance Win32_Battery |" +
+    " ForEach-Object { [pscustomobject]@{ percent = [int]$_.EstimatedChargeRemaining;" +
+    " status = [int]$_.BatteryStatus } })",
+  "[pscustomobject]@{ battery = $battery } | ConvertTo-Json -Depth 4 -Compress",
+].join("; ");
+
+// -------------------------------------------------------------- ubuntu
+
+/**
+ * Parse `powerprofilesctl list` into what the daemon has and what it is
+ * on.
+ *
+ * The output is a block per profile, each headed by its name and the
+ * active one marked with a `*`. Only the three names the Panel knows are
+ * kept: a daemon that grows a fourth is reporting something this Panel
+ * has no word for, and listing it would offer a row whose meaning is
+ * unknown on the other target.
+ */
+export function parsePowerProfiles(out: string): { offered: PowerProfile[]; active: PowerProfile | null } {
+  const offered: PowerProfile[] = [];
+  let active: PowerProfile | null = null;
+
+  for (const line of out.split(/\r?\n/)) {
+    const m = /^(\*?)\s*([a-z][a-z-]*):\s*$/.exec(line.trim());
+    const name = m?.[2];
+    if (!name || !POWER_PROFILES.includes(name as PowerProfile)) continue;
+    const profile = name as PowerProfile;
+    if (!offered.includes(profile)) offered.push(profile);
+    if (m?.[1] === "*") active = profile;
+  }
+
+  // In the Panel's order, not the daemon's: the rows mean saver to
+  // performance, and a list that reordered itself between machines would
+  // put a different profile under the cursor on each one.
+  return { offered: POWER_PROFILES.filter((p) => offered.includes(p)), active };
+}
+
+/**
+ * upower's states, in the Panel's words.
+ *
+ * `empty` and `unknown` both land on `unknown`: a running machine whose
+ * battery reports empty is a machine whose battery is not being read
+ * properly, and there is nothing true to say about it in one word.
+ */
+const UPOWER_STATES: Record<string, BatteryState> = {
+  charging: "charging",
+  discharging: "discharging",
+  "fully-charged": "full",
+  "pending-charge": "mains",
+  "pending-discharge": "mains",
+};
+
+/**
+ * Parse `upower -i` on the composite battery device.
+ *
+ * `present: no` is the desktop answer and is taken at its word — a
+ * machine that says it has no battery is not a machine with an unknown
+ * one, and printing "0% — unknown" on a workstation would be a fault
+ * report about a machine with nothing wrong with it.
+ */
+export function parseUpower(out: string): Battery {
+  const field = (name: string): string | null => {
+    const m = new RegExp(`^\\s*${name}:\\s*(.+?)\\s*$`, "m").exec(out);
+    return m?.[1] ?? null;
+  };
+
+  if (field("present") === "no") return NO_BATTERY;
+
+  const state = field("state");
+  if (state === null) return NO_BATTERY;
+
+  const percentage = field("percentage");
+  const percent = percentage === null ? null : Number.parseInt(percentage, 10);
+
+  return {
+    percent: percent === null || Number.isNaN(percent) ? null : percent,
+    state: UPOWER_STATES[state] ?? "unknown",
+  };
+}
+
+// ------------------------------------------------------------- windows
+
+type Record_ = { [key: string]: unknown };
+
+function records(value: unknown): Record_[] {
+  const many = Array.isArray(value) ? value : [value];
+  return many.filter((v): v is Record_ => typeof v === "object" && v !== null);
+}
+
+/**
+ * Parse `powercfg /list` into the schemes this machine has.
+ *
+ * The GUID is found by its shape, anywhere on the line, because every
+ * word around it is translated — the label reads `Power Scheme GUID:` on
+ * an English install and `GUID do Esquema de Energia:` on a Portuguese
+ * one, and anchoring on either spelling finds nothing on the other. The
+ * GUID and the trailing `*` are the two things on the line that are the
+ * same on every machine.
+ *
+ * A scheme this build has no word for is skipped, and an active one that
+ * is skipped leaves `active` null, which is how a machine on an OEM
+ * scheme is reported as being on none of the three rather than on
+ * whichever GUID sorted first.
+ */
+export function parsePowercfgSchemes(out: string): {
+  offered: PowerProfile[];
+  active: PowerProfile | null;
+} {
+  const byGuid = new Map<string, PowerProfile>(
+    POWER_PROFILES.map((p) => [WINDOWS_SCHEMES[p].toLowerCase(), p]),
+  );
+
+  const offered: PowerProfile[] = [];
+  let active: PowerProfile | null = null;
+
+  for (const line of out.split(/\r?\n/)) {
+    const m = /([0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12})(.*)$/i.exec(line);
+    const guid = m?.[1]?.toLowerCase();
+    if (guid === undefined) continue;
+    const profile = byGuid.get(guid);
+    if (profile === undefined) continue;
+    if (!offered.includes(profile)) offered.push(profile);
+    // The trailing `*` is how powercfg marks the active scheme, and it
+    // is the only mark on the line that is not translated.
+    if ((m?.[2] ?? "").trimEnd().endsWith("*")) active = profile;
+  }
+
+  return { offered: POWER_PROFILES.filter((p) => offered.includes(p)), active };
+}
+
+/**
+ * WMI's BatteryStatus, in the Panel's words.
+ *
+ * 1 is the documented "Other", which every machine that reports it means
+ * discharging by; 4 and 5 are Low and Critical, which are discharging
+ * with an adjective. 2 is the on-AC-but-not-necessarily-charging state
+ * that `mains` exists for, and 11 (partially charged, on AC) is the
+ * same claim.
+ */
+const WMI_BATTERY_STATES: Record<number, BatteryState> = {
+  1: "discharging",
+  2: "mains",
+  3: "full",
+  4: "discharging",
+  5: "discharging",
+  6: "charging",
+  7: "charging",
+  8: "charging",
+  9: "charging",
+  11: "mains",
+};
+
+/** Read what the Windows battery script printed. */
+export function parseWindowsBattery(json: string): Battery {
+  let payload: unknown;
+  try {
+    payload = JSON.parse(json);
+  } catch {
+    // PowerShell writes its errors where the JSON was meant to go, and a
+    // machine that cannot answer is not a machine to guess about.
+    return { percent: null, state: "unknown" };
+  }
+  if (typeof payload !== "object" || payload === null) return { percent: null, state: "unknown" };
+
+  const [battery] = records((payload as Record_)["battery"]);
+  // No Win32_Battery at all is a desktop saying it has none, which is an
+  // answer rather than a silence.
+  if (!battery) return NO_BATTERY;
+
+  const percent = battery["percent"];
+  const status = battery["status"];
+  return {
+    percent: typeof percent === "number" && Number.isFinite(percent) ? percent : null,
+    state: typeof status === "number" ? (WMI_BATTERY_STATES[status] ?? "unknown") : "unknown",
+  };
+}
+
+// ------------------------------------------------------------- the seam
+
+async function observeOne(
+  capture: Capture,
+  argv: readonly string[] | undefined,
+): Promise<{ out: string; code: number }> {
+  // Not `?? []` on the argv: these are pinned by a test, and a missing
+  // one is a programming error rather than a machine's answer.
+  return argv ? await capture(argv) : { out: "", code: 127 };
+}
+
+/** What this machine says about how hard it may work, and for how long. */
+export async function observePower(
+  p: Platform,
+  capture: Capture = spawnCapture,
+): Promise<PowerView> {
+  const target = panelTarget(p);
+  if (target === null) return NOTHING;
+
+  const [profilesArgv, batteryArgv] = observeArgv(target);
+  const profiles = await observeOne(capture, profilesArgv);
+  const battery = await observeOne(capture, batteryArgv);
+
+  const read = profiles.code === 0
+    ? target === "linux"
+      ? parsePowerProfiles(profiles.out)
+      : parsePowercfgSchemes(profiles.out)
+    : { offered: [] as PowerProfile[], active: null };
+
+  return {
+    target,
+    profile: read.active,
+    offered: read.offered,
+    battery: battery.code !== 0
+      // A battery probe that could not run says nothing about whether
+      // there is a battery, so this is `unknown` and not `none`.
+      ? { percent: null, state: "unknown" }
+      : target === "linux"
+        ? parseUpower(battery.out)
+        : parseWindowsBattery(battery.out),
+  };
+}
+
+// ---------------------------------------------------------------- acting
+
+/** Chosen, and the argv that carries it out — or the reason it cannot. */
+export type PowerPlan =
+  | ({ ok: true; profile: PowerProfile } & PanelPlan)
+  | { ok: false; profile: PowerProfile; detail: string };
+
+/**
+ * What switching to `profile` costs, given what the Panel is showing.
+ *
+ * Built from the observed view for the reason `dnsPlan` gives, with one
+ * addition of its own: the view is also what says the profile exists
+ * here. Sending Windows the High performance GUID on a machine that
+ * lists only Balanced is a command that fails, and a refusal naming what
+ * the machine does offer is more use than that failure.
+ */
+export function powerPlan(view: PowerView, profile: PowerProfile): PowerPlan {
+  const target = view.target;
+
+  if (target === null) {
+    return { ok: false, profile, detail: "red-dev has no power adapter for this platform" };
+  }
+
+  if (!view.offered.includes(profile)) {
+    const has = view.offered.length === 0
+      ? "none"
+      : view.offered.map((p) => POWER_LABELS[p].label).join(", ");
+    return {
+      ok: false,
+      profile,
+      detail: `this machine has no ${POWER_LABELS[profile].label} profile — it offers ${has}`,
+    };
+  }
+
+  return {
+    ok: true,
+    profile,
+    // No prime and no gate on either target: the host's own menu makes
+    // this change in one click without a password or a consent shield,
+    // and a Panel that asked for one anyway would be teaching people to
+    // wave prompts through.
+    prime: null,
+    steps: [
+      target === "linux"
+        ? ["powerprofilesctl", "set", profile]
+        : ["powercfg.exe", "/setactive", WINDOWS_SCHEMES[profile]],
+    ],
+    gate: null,
+    note: POWER_LABELS[profile].label,
+  };
+}
+
+/** Changed, or the reason it was not — either way, one line. */
+export interface PowerOutcome {
+  changed: boolean;
+  detail: string;
+}
+
+/** Carry a plan out, and say how it ended. */
+export async function applyPower(plan: PowerPlan, run: Run): Promise<PowerOutcome> {
+  if (!plan.ok) return { changed: false, detail: plan.detail };
+  const outcome = await runPlan(plan, run);
+  return {
+    changed: outcome.done,
+    detail: outcome.done ? `power: ${plan.note}` : outcome.detail,
+  };
+}
+
+/**
+ * The view as text, for a terminal with no Panel to draw.
+ *
+ * Not a degraded mode: this is the form a bug report pastes and a script
+ * greps. `offered` is on it because the interesting fault on this Panel
+ * is a machine that offers one profile, and a view that printed only the
+ * active one would look identical to a machine with all three.
+ */
+export function panelLines(view: PowerView): string[] {
+  const offered = view.offered.length === 0
+    ? "none reported"
+    : view.offered.map((p) => POWER_LABELS[p].label).join(", ");
+  const percent = view.battery.percent === null ? "" : `${view.battery.percent}% — `;
+  return [
+    `profile  ${view.profile === null ? "not one of the three" : POWER_LABELS[view.profile].label}`,
+    `offered  ${offered}`,
+    `battery  ${view.battery.state === "none" ? "none" : `${percent}${view.battery.state}`}`,
+  ];
+}

--- a/src/panel.ts
+++ b/src/panel.ts
@@ -1,0 +1,316 @@
+/**
+ * What every Panel is made of, before any subsystem has been named.
+ *
+ * The network Panel arrived first and carried all of this inside itself,
+ * which was the right shape while there was one. There are three now —
+ * network, audio, power — and a second copy of "which CLI answers for
+ * this machine" is exactly how two Panels end up disagreeing about WSL.
+ * So the vocabulary lives here, and each Panel is what is left once the
+ * shape is taken out of it: the commands it builds, and what the answers
+ * to those commands mean.
+ *
+ * ## The two rules every Panel keeps
+ *
+ * Looking is never privileged. Not "usually is not" — never, checkably,
+ * by reading the words of every command observation builds. `PanelPlan`
+ * carries the claim as `gate` and `raisesRights` reads the argv that
+ * actually runs, so a plan cannot say `null` while quietly carrying a
+ * `sudo`. A Panel that raised a consent prompt to *show* something would
+ * teach people to dismiss consent prompts, and the next one is the one
+ * that changes the machine.
+ *
+ * And where an act does need rights, the Panel asks inline, at that
+ * moment — never by queueing the act into `red-dev privileged`, the
+ * converge's single-consent batch (decision of 2026-08-15,
+ * `interaction/CONTEXT.md`). The batch exists so that "make this machine
+ * correct" costs one prompt at the end of a long run. A Panel act
+ * belongs to neither that run nor that prompt.
+ *
+ * The corollary is the one that is easy to get wrong in the other
+ * direction: an act that does *not* need rights must not ask for them.
+ * Two of the three Panels turn out to need nothing — `pactl`,
+ * `powerprofilesctl` and `powercfg` all act on the signed-in person's
+ * own session — and a Panel that raised a password prompt anyway,
+ * because the first one did, would erode consent from the same end.
+ *
+ * ## And the limit that is declared rather than hidden
+ *
+ * Some subsystem has no first-party CLI on some target — audio devices
+ * and bluetooth on native Windows are the ones red-dev has met. There
+ * the act opens the host's own panel and says why, which is what
+ * `NativeFallback` is: a surface to open and a reason to print beside
+ * it. The alternative is a red-dev Panel with a list of devices in it
+ * and no way to switch between them, which is worse than the limit.
+ */
+
+import type { Platform } from "./platform.ts";
+import type { Gate } from "./rights.ts";
+
+/**
+ * The two adapters a Panel has.
+ *
+ * Not one per `Env`: Ubuntu desktop and an Ubuntu server drive the same
+ * binaries, and WSL drives the Windows ones. Darwin and an unknown OS
+ * are absent deliberately, failing closed as `providerFor` does and as
+ * ADR 0001 requires.
+ */
+export type PanelTarget = "linux" | "windows";
+
+/**
+ * Which CLI answers for this machine, or nothing when none does.
+ *
+ * Windows first, and WSL with it, in the same order `hostNetState` asks
+ * the question — a WSL distro is `os: "linux"`, so testing Linux first
+ * would send it to `nmcli`, which is not installed and would not be
+ * describing the right machine if it were.
+ *
+ * WSL folds into `windows` for every subsystem, for a different reason
+ * each time and the same reason underneath: the distro is not where the
+ * hardware is. It has no NetworkManager and its `/etc/resolv.conf` is
+ * generated from the host. Its audio reaches WSLg's PulseAudio bridge,
+ * so `pactl` does answer inside it — and switching WSLg's default sink
+ * would change nothing about which speaker plays, because the endpoint
+ * is chosen on the Windows side. And it has no battery at all.
+ */
+export function panelTarget(p: Platform): PanelTarget | null {
+  if (p.os === "windows" || p.env === "wsl") return "windows";
+  if (p.os === "linux") return "linux";
+  return null;
+}
+
+// ----------------------------------------------------------- the plans
+
+/**
+ * What a Panel would run, decided before anything runs.
+ *
+ * The same split `firePlan` makes, for the same reason: a plan can be
+ * read by a test, and a refusal arrives as a sentence for the status
+ * line rather than as a process that failed off screen.
+ */
+export interface PanelPlan {
+  /**
+   * The one visible ask that raises the rights, before the acts.
+   *
+   * `sudo -v` where a gate needs a password, so it is typed once, in the
+   * ordinary terminal, at the moment the operator asked — the same shape
+   * `primeSudoInteractive` uses before the installer takes the screen.
+   * Null on Windows, where consent is not a separate question: the UAC
+   * dialog is raised by the act itself and cannot be raised early. Null
+   * too for every act that passes no gate, which is most of them.
+   */
+  prime: readonly string[] | null;
+  /** The acts, in order, each already carrying the rights it needs. */
+  steps: readonly (readonly string[])[];
+  /** Which gate those acts pass, or null when they pass none. */
+  gate: Gate | null;
+  /** One line, for the status line under the list. */
+  note: string;
+}
+
+/**
+ * Does this argv ask the machine for rights?
+ *
+ * Read off the words rather than taken on trust, because the claim worth
+ * pinning is about what runs. Both spellings of each gate are here: the
+ * Linux elevators as argv[0], and Windows' consent verb as it appears
+ * inside a `-Command` string, where no amount of looking at argv[0]
+ * would find it.
+ *
+ * The list below is why src/single-prompt.test.ts exempts this module by
+ * name: these words are here to be *found* in somebody else's command,
+ * and nothing in this file runs one.
+ */
+export function raisesRights(argv: readonly string[]): boolean {
+  const head = argv[0]?.toLowerCase().replace(/\.exe$/, "") ?? "";
+  if (["sudo", "pkexec", "doas", "su", "runas"].includes(head)) return true;
+  return argv.some((word) => /-verb\s+runas/i.test(word));
+}
+
+/**
+ * The host's own panel, and why red-dev is opening it instead of doing
+ * the work itself.
+ *
+ * The reason is a field rather than a comment because it is shown. A
+ * person who pressed Enter on a device and got a Settings window instead
+ * of a switched device is owed the sentence explaining that, and a
+ * `reason` nobody can print is a limit that has been hidden rather than
+ * declared.
+ */
+export interface NativeFallback {
+  /** What the host calls it, spelled the way the host spells it. */
+  surface: string;
+  /** One sentence: what red-dev cannot do here, and why. */
+  reason: string;
+}
+
+/**
+ * Open one of Windows' own pages, by the URI Windows publishes for it.
+ *
+ * Through `cmd /c start` with the empty title slot, exactly as
+ * `terminal.new` opens a terminal and for the same two reasons. This
+ * process is a console process on both sides of the WSL boundary, so
+ * `start` is the shell asking Windows for a window rather than handing
+ * the child the console red-dev is drawing in; and without the empty
+ * argument `start` reads the first word as a window title.
+ *
+ * `explorer.exe ms-settings:…` opens the same page and is the form most
+ * often written down, but it exits non-zero often enough that a Panel
+ * using it would report a failure over a window that opened fine.
+ */
+export function windowsSurface(uri: string): string[] {
+  return ["cmd.exe", "/c", "start", "", uri];
+}
+
+// ------------------------------------------------------------- the seam
+
+/** Ran, and what it printed. Same shape as `lan-address.ts`'s. */
+export interface Captured {
+  out: string;
+  code: number;
+}
+
+/** The seam the tests replace: how a question reaches the machine. */
+export type Capture = (cmd: readonly string[]) => Promise<Captured>;
+
+/** Run one argv attached to the terminal, and say how it ended. */
+export type Run = (argv: readonly string[]) => Promise<number>;
+
+/**
+ * Ask the machine, with the child's streams captured.
+ *
+ * The same shape `lan-address.ts` uses, including the UTF-16LE decode:
+ * PowerShell reached through WSL interop writes UTF-16LE when its stdout
+ * is redirected, which is not JSON until it is decoded.
+ */
+export async function spawnCapture(cmd: readonly string[]): Promise<Captured> {
+  const { readWindowsOutput } = await import("./windows-output.ts");
+  try {
+    const proc = Bun.spawn([...cmd], { stdout: "pipe", stderr: "ignore", stdin: "ignore" });
+    const out = await readWindowsOutput(proc.stdout);
+    return { out, code: await proc.exited };
+  } catch {
+    // A binary that is not there is an answer, not an exception: this
+    // machine cannot be asked, so it reports nothing.
+    return { out: "", code: 127 };
+  }
+}
+
+// -------------------------------------------------------- carrying it out
+
+/** Done, or the reason it was not — either way, one line. */
+export interface PanelOutcome {
+  done: boolean;
+  detail: string;
+}
+
+/**
+ * Carry a plan out: the visible ask, then the acts, stopping at the
+ * first one that fails.
+ *
+ * Stopping matters wherever a plan has two acts and the second only
+ * makes sense after the first — "record the choice" then "make it take
+ * effect". Running the second after a failed first applies the setting
+ * the machine already had and reports that as the change somebody asked
+ * for, which is the quietest kind of wrong.
+ *
+ * A failure is described by the gate when there is one, because "sudo
+ * needs a password" is the whole remedy and a non-zero exit is not. With
+ * no gate the exit code is all there is, and inventing a rights problem
+ * for a `pactl` that could not find the device would send whoever reads
+ * it to the wrong place entirely.
+ */
+export async function runPlan(plan: PanelPlan, run: Run): Promise<PanelOutcome> {
+  if (plan.prime) {
+    const code = await run(plan.prime);
+    if (code !== 0) {
+      const { missingRights } = await import("./rights.ts");
+      return { done: false, detail: missingRights(plan.gate ?? "sudo").cause };
+    }
+  }
+
+  for (const step of plan.steps) {
+    const code = await run(step);
+    if (code === 0) continue;
+    if (plan.gate !== null) {
+      const { missingRights } = await import("./rights.ts");
+      // A non-zero exit from an elevated Start-Process is what a declined
+      // UAC dialog looks like from here; there is no separate signal for
+      // it, and the remedy is the same either way.
+      return { done: false, detail: `${step[0]} failed — ${missingRights(plan.gate).cause}` };
+    }
+    return { done: false, detail: `${step[0]} failed — exit ${code}` };
+  }
+
+  return { done: true, detail: plan.note };
+}
+
+// -------------------------------------------------------- the keyboard
+
+/**
+ * The keys a Panel reads, structurally — the same declaration `keys.ts`
+ * makes, and for the same reason: tuiuiu's `Key` carries all of these,
+ * so the component hands its own object straight in, and naming only
+ * what is used keeps this module free of the renderer.
+ */
+export interface PanelKey {
+  upArrow: boolean;
+  downArrow: boolean;
+  return: boolean;
+  escape: boolean;
+  backspace: boolean;
+  delete: boolean;
+  ctrl: boolean;
+}
+
+/** Where the cursor is in a Panel that is a list and nothing else. */
+export interface ListState {
+  index: number;
+}
+
+export interface ListStep {
+  state: ListState;
+  /** The row Enter asked for, when there was a row to ask for. */
+  apply?: number;
+  /** The Panel is finished. */
+  quit?: boolean;
+}
+
+/**
+ * One keystroke over a plain list, as a decision rather than as a side
+ * effect.
+ *
+ * Typing is swallowed: this is a list of things to choose between, not a
+ * search box, and a stray letter that did something invisible would be a
+ * change nobody asked for. The network Panel keeps a step function of
+ * its own because it has a field to type resolvers into; a Panel whose
+ * rows are the devices the machine reported has nothing to type.
+ *
+ * `count` is passed rather than stored because the rows come from the
+ * machine and change under the cursor — a headset unplugged between two
+ * observations leaves an index pointing past the end, and clamping on
+ * every keystroke is what stops Enter from applying a row that is no
+ * longer there.
+ */
+export function listStep(
+  state: ListState,
+  count: number,
+  input: string,
+  key: PanelKey,
+): ListStep {
+  const clamp = (i: number): number => Math.max(0, Math.min(count - 1, i));
+
+  // Ctrl+C leaves, whatever is on screen. Every other Ctrl chord is
+  // swallowed rather than read as a movement.
+  if (key.ctrl) return input === "c" ? { state, quit: true } : { state };
+
+  if (key.escape) return { state, quit: true };
+
+  if (key.return) {
+    return count === 0 ? { state } : { state: { index: clamp(state.index) }, apply: clamp(state.index) };
+  }
+
+  if (key.upArrow) return { state: { index: clamp(state.index - 1) } };
+  if (key.downArrow) return { state: { index: clamp(state.index + 1) } };
+
+  return { state };
+}

--- a/src/single-prompt.test.ts
+++ b/src/single-prompt.test.ts
@@ -79,6 +79,19 @@ const EXEMPT: Record<string, string> = {
     "Ctrl+Alt+Shift+T shortcut raises through byte 21 of its .lnk. Nothing is being " +
     "converged, so there is no batch to defer it into — deferring it would mean " +
     "answering a request for a shell by scheduling one.",
+  "panel-network.ts":
+    "The DNS switch inside the network Panel, and the same argument keys.ts makes: " +
+    "the prompt is the act. Somebody highlighted a resolver and pressed enter, asking " +
+    "for a change to this machine now, and the batch is deliberately the wrong place " +
+    "for it (decision of 2026-08-15) — deferring it would mean the DNS they chose " +
+    "takes effect at the end of their next converge. It is the only Panel that " +
+    "elevates: audio and power drive commands that ask for nothing.",
+  "panel.ts":
+    "Names the elevators rather than running one. `raisesRights` reads an argv and " +
+    "answers whether it asks the machine for rights, which is how every Panel's " +
+    "observation is held to being unprivileged — the spellings in it are there to be " +
+    "found in somebody else's command. This module spawns nothing but the reads its " +
+    "callers hand it.",
   "wsl.ts":
     "The machine-wide font repair, which predates the guarantee and is the one " +
     "second prompt still in the tree. It fires only on a machine where the per-user " +


### PR DESCRIPTION
Automated AFK landing for #142. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #142

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/170"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789456336&installation_model_id=20659&pr_number=170&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F170&signature=0d7dc5f75e0b0f4b9f1406d9a2c0f1eef569fc38a1f79e9eaf6d30b066bb5400"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->