### PR TITLE
fix: #143 Web apps wired into the Catalogue, and web2app retired

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,7 +370,16 @@ Ctrl+Shift+V remains text paste. Plain Shift+V cannot be used because it is the
 ordinary uppercase `V`. Every config merge is non-destructive: malformed JSON
 and explicit conflicting bindings are left alone, and re-running is a no-op.
 
-**Web apps** — a page in its own window, its own icon and its own alt-tab entry, the way omakub's `web2app` does it. Desktop sessions only: a `.desktop` file needs a menu to appear in.
+**Web apps** — a page in its own window, its own icon and its own alt-tab entry,
+the way omakub's `web2app` does it, offered by `red-dev apps` alongside the
+optional tools. ChatGPT, Claude and GitHub arrive ticked; Google Photos, Google
+Contacts and Tailscale are one space bar away in the same list, and any URL can
+be typed in. Ticking installs, unticking an installed one removes it — the
+launcher and the icon it fetched. On a Linux desktop that is a `.desktop` entry
+launching whichever Chromium-family browser is installed with `--app=`; on
+native Windows it is a Start Menu shortcut carrying the same argument. Under WSL
+it is skipped and says why: there is no freedesktop menu there for the entry to
+appear in, so install those from the Windows side.
 
 **Optional**, never installed by a plain converge — `red-dev apps` offers them,
 and so does the interview: `just` · `duf` · `dust` · `hyperfine` · `glow` ·
@@ -432,13 +441,15 @@ with no error from either. `red-dev doctor` reports which daemon answers.
 | `atuin`, `carapace`, `direnv` | binaries nothing is bound to |
 
 `ble.sh` — autosuggestions and syntax highlighting, the two things people most
-often miss from zsh — is installed but **not enabled**. It replaces bash's line
-editor rather than sitting beside it, and atuin, fzf and carapace all bind into
-what it replaces. Whether they survive is an empirical question that needs a
-real terminal, so turning it on is deliberate:
+often miss from zsh — is installed and **enabled by default**. It shipped off,
+because it replaces bash's line editor rather than sitting beside it and atuin,
+fzf and carapace all bind into what it replaces; whether they survived was an
+empirical question that needed a real terminal. The trial answered it: atuin's
+Ctrl-R opens its TUI under an attached ble.sh, and carapace needed its
+`bash-ble` integration selected, which it now is. Opting out is one variable:
 
 ```bash
-export RED_BLE=1
+export RED_BLE=0
 ```
 
 ## Usage
@@ -453,7 +464,7 @@ red-dev update               # package managers, RedSkills, mise's tools, the ag
 red-dev theme [name]         # dark | light | obsidian | marble | cobalt | flare
 red-dev wallpaper [source]   # theme | Red artwork | absolute PNG path | HTTPS URL
 red-dev redwall              # redraw the wallpaper carrying this machine's state
-red-dev apps                 # choose optional tools
+red-dev apps                 # choose optional tools and web apps; untick one to remove it
 red-dev keys                 # search every action and its chord, and run one
 red-dev learn                # the README by anchor, RedSkills, and the keys viewer
 red-dev lang                 # choose runtimes for mise to manage
@@ -544,7 +555,7 @@ deliberately:
 | `red-dev` | the fullscreen interface, then whatever you pick — a line-based menu below 60 columns, and `--help` with no terminal at all |
 | `red-dev theme` | which theme, when given no name |
 | `red-dev wallpaper` | which bundled Red artwork, a custom PNG path/HTTPS URL, or whether to follow the theme |
-| `red-dev apps` | which optional tools — all ticked; untick to opt out |
+| `red-dev apps` | which optional tools — all ticked; untick to opt out — and which web apps, where ChatGPT, Claude and GitHub arrive ticked, unticking an installed one removes it, and the last line takes a URL |
 | `red-dev lang` | which runtimes mise should manage, then recommended or latest versions — Java, Ruby and Go start off; the rest are opt-out |
 | `red-dev shell` | whether a terminal lands in WSL or Git Bash |
 | `red-dev agents` | which coding agents — all ticked; untick to opt out, then offers red-skills |

--- a/config/bash/functions.sh
+++ b/config/bash/functions.sh
@@ -1,10 +1,10 @@
 # Shell functions.
 #
 # Omakub keeps these in defaults/bash/functions, written for a GNOME
-# desktop. Roughly half of them only make sense there: web2app builds a
-# .desktop launcher, app2folder pokes gsettings, iso2sd writes to a
-# block device. Sourcing those unconditionally under WSL or on a server
-# puts commands in your shell that cannot work, so they are guarded.
+# desktop. Roughly half of them only make sense there: app2folder pokes
+# gsettings, iso2sd writes to a block device. Sourcing those
+# unconditionally under WSL or on a server puts commands in your shell
+# that cannot work, so they are guarded.
 
 # ------------------------------------------------------ everywhere
 
@@ -66,42 +66,22 @@ if [ "${RED_ENV:-}" = "desktop" ]; then
       sudo eject "$2"
     fi
   }
-
-  # Create a desktop launcher that opens a URL as its own windowed app.
-  web2app() {
-    if [ "$#" -ne 3 ]; then
-      echo "Usage: web2app <AppName> <AppURL> <IconURL>   (icon must be PNG)"
-      return 1
-    fi
-    local APP_NAME="$1" APP_URL="$2" ICON_URL="$3"
-    local ICON_DIR="$HOME/.local/share/applications/icons"
-    local DESKTOP_FILE="$HOME/.local/share/applications/${APP_NAME}.desktop"
-    local ICON_PATH="${ICON_DIR}/${APP_NAME}.png"
-
-    mkdir -p "$ICON_DIR"
-    curl -sL -o "$ICON_PATH" "$ICON_URL" || { echo "icon download failed"; return 1; }
-
-    cat >"$DESKTOP_FILE" <<EOF
-[Desktop Entry]
-Version=1.0
-Name=$APP_NAME
-Comment=$APP_NAME
-Exec=google-chrome --app="$APP_URL" --name="$APP_NAME" --class="$APP_NAME"
-Terminal=false
-Type=Application
-Icon=$ICON_PATH
-Categories=GTK;
-StartupNotify=true
-EOF
-    chmod +x "$DESKTOP_FILE"
-  }
-
-  web2app-remove() {
-    [ "$#" -eq 1 ] || { echo "Usage: web2app-remove <AppName>"; return 1; }
-    rm -f "$HOME/.local/share/applications/${1}.desktop"
-    rm -f "$HOME/.local/share/applications/icons/${1}.png"
-  }
 fi
+
+# web2app and web2app-remove used to live here, ported from omakub.
+#
+# They are gone rather than kept beside the real thing. The function
+# hard-coded google-chrome, so on a machine with chromium and nothing
+# else it wrote a launcher that opens nothing; it existed only under
+# RED_ENV=desktop, so the same page could not be asked for on the
+# Windows half of the same setup; and its remove derived the icon path
+# from the app name a second time, which took the wrong file whenever
+# the two spellings disagreed.
+#
+# `red-dev apps` offers the same pages and any URL you type, resolves
+# whichever Chromium-family browser is actually installed, writes a
+# Start Menu shortcut on native Windows, and states the reason under
+# WSL instead of writing a .desktop file nothing there reads.
 
 # --------------------------------------------------------- wsl only
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -180,7 +180,7 @@ export function buildCli(): CLI {
         description: "regenerate the wallpaper that carries this machine's state",
       },
       apps: {
-        description: "choose optional tools to install",
+        description: "choose optional tools and web apps; untick an installed web app to remove it",
       },
       keys: {
         // No positional and no flags. What it lists comes from the

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,6 +25,7 @@ import { applyContextForEntry, type ApplyContextEntryPath } from "./preferences.
 import { themeFor, themeNames } from "./themes.ts";
 import { interactive, select, text } from "./ui.ts";
 import type { UpdateStage } from "./update-order.ts";
+import type { WebApp } from "./webapps.ts";
 
 function resolveScopes(p: Platform, arg?: string): Scope[] {
   return arg ? [arg as Scope] : applicableScopes(p);
@@ -1018,66 +1019,222 @@ async function cmdRedwall(p: Platform): Promise<number> {
   return 0;
 }
 
+/** What one line of the Catalogue stands for, once a label comes back. */
+type CatalogueRow =
+  | { kind: "tool"; name: string }
+  | { kind: "web"; app: WebApp; installed: boolean }
+  | { kind: "add" };
+
+const ADD_A_WEB_APP = "+ Add a web app by URL…";
+
 /**
- * Choose optional tools.
+ * The Catalogue — the list a person ticks rather than receives.
+ *
+ * Optional tools and web apps in one list, because they are the same
+ * kind of thing to the person looking at it: something none of them gets
+ * by converging, and all of them get by asking. A web app is the one
+ * half whose entry can also be typed, so the list ends with a line that
+ * asks for a URL.
  *
  * `install` stays silent on purpose — it runs in CI and in scripts,
  * where a prompt is a hang. Everything that wants an answer lives
  * behind a command you invoke deliberately, which is also why this can
  * be re-run whenever the answer changes.
+ *
+ * Unticking is what makes this a list rather than a form. An installed
+ * web app arrives ticked, so leaving the list alone changes nothing, and
+ * taking the tick off one is how it goes — after being named, because
+ * the one thing a checkbox must never do is delete something quietly.
+ * Optional tools do not remove from here yet; `red-dev uninstall` is
+ * still their way out, and the list says so rather than implying
+ * otherwise.
  */
 async function cmdApps(p: Platform, inv: Invocation): Promise<number> {
-  const { checkbox } = await import("./ui.ts");
+  const { checkbox, confirm } = await import("./ui.ts");
+  const {
+    installedWebApps,
+    installWebApp,
+    removeWebApp,
+    validateWebApp,
+    webAppCatalogue,
+    webAppSupport,
+  } = await import("./webapps.ts");
+
   const available = toolsInScope("optional").filter(
     (t) => providerFor(t, p).kind !== "skip",
   );
 
-  if (available.length === 0) {
-    log.skip("no optional tools apply to this target");
+  // A page is offered only where a launcher has something to live in.
+  // Under WSL that is nothing, and the reason is printed rather than the
+  // section silently disappearing.
+  const support = webAppSupport(p);
+  const webRows = support.ok ? webAppCatalogue(installedWebApps(p)) : [];
+  if (!support.ok) log.skip(`web apps: ${support.reason}`);
+
+  if (available.length === 0 && webRows.length === 0) {
+    log.skip("nothing on this target is optional");
     return 0;
   }
 
   const already = available.filter(isInstalled).map((t) => t.name);
-  const labels = available.map((t) =>
-    `${t.name}${t.about ? ` — ${t.about}` : ""}${already.includes(t.name) ? "  (installed)" : ""}`,
-  );
+  const rows = new Map<string, CatalogueRow>();
+  const labels: string[] = [];
+  const ticked: string[] = [];
+
+  for (const t of available) {
+    const label = `${t.name}${t.about ? ` — ${t.about}` : ""}${already.includes(t.name) ? "  (installed)" : ""}`;
+    rows.set(label, { kind: "tool", name: t.name });
+    labels.push(label);
+    // Every tool starts on: a curated list is an opt-out, and unticking
+    // a tool here does not remove it, so a tick left alone is harmless.
+    ticked.push(label);
+  }
+
+  // Kept rather than rebuilt: the label is the identity a checkbox
+  // answers with, and a second construction of it that drifts by one
+  // space is a removal that silently never happens.
+  const webLabels = new Map<string, string>();
+  for (const row of webRows) {
+    const label = `${row.app.name} — ${row.app.url || "web app"}${row.installed ? "  (installed)" : ""}`;
+    rows.set(label, { kind: "web", app: row.app, installed: row.installed });
+    webLabels.set(row.app.name, label);
+    labels.push(label);
+    if (row.ticked) ticked.push(label);
+  }
+
+  if (support.ok) {
+    rows.set(ADD_A_WEB_APP, { kind: "add" });
+    labels.push(ADD_A_WEB_APP);
+  }
 
   // Every install choice is opt-out, but a fallback must never install
   // the whole catalog when there is no terminal to show that choice.
   if (!interactive()) {
-    log.err("choosing optional tools needs a terminal");
+    log.err("choosing what to install needs a terminal");
     log.plain("     Run `red-dev apps` interactively and untick what you do not want.");
     return 1;
   }
 
-  const picked = await checkbox("Which optional tools?", labels as [string, ...string[]], labels);
-  if (picked.length === 0) {
-    log.skip("nothing selected");
-    return 0;
-  }
+  const picked = await checkbox(
+    "What should this machine have?",
+    labels as [string, ...string[]],
+    ticked,
+  );
+  const chosen = new Set(picked);
 
-  // Map the decorated labels back to tool names.
-  const names = picked.map((l) => l.split(" ")[0]!.trim());
-  const ctx = await contextFor(p, inv, "install");
+  // Named first and taken out first, so the list a person confirms is
+  // the list they were looking at rather than one an install has already
+  // changed underneath them.
+  const going = webRows.filter(
+    (row) => row.installed && !chosen.has(webLabels.get(row.app.name) ?? ""),
+  );
   let failures = 0;
 
-  for (const name of names) {
-    const tool = available.find((t) => t.name === name);
-    if (!tool) continue;
-    if (isInstalled(tool) && !tool.managed) {
-      log.skip(`${name} already present`);
+  if (going.length > 0) {
+    log.plain("     Unticked, so these go:");
+    for (const row of going) log.plain(`       ${row.app.name} — its launcher and its icon`);
+    if (await confirm("Remove them?", true)) {
+      for (const row of going) {
+        try {
+          const removed = removeWebApp(p, row.app.name);
+          log.ok(`${row.app.name} removed (${removed.length} file(s))`);
+        } catch (err) {
+          log.err(`${row.app.name}: ${(err as Error).message}`);
+          failures++;
+        }
+      }
+    } else {
+      log.skip("nothing removed");
+    }
+  }
+
+  if (picked.length === 0) {
+    if (going.length === 0) log.skip("nothing selected");
+    return failures > 0 ? 1 : 0;
+  }
+
+  // Built on demand: an apply context prepares things a run of nothing
+  // but web apps has no use for, and a person who ticked one page should
+  // not pay for the install path they did not take.
+  let context: ApplyContext | null = null;
+  const installContext = async (): Promise<ApplyContext> =>
+    (context ??= await contextFor(p, inv, "install"));
+
+  for (const label of picked) {
+    const row = rows.get(label);
+    if (!row) continue;
+
+    if (row.kind === "tool") {
+      const tool = available.find((t) => t.name === row.name);
+      if (!tool) continue;
+      if (isInstalled(tool) && !tool.managed) {
+        log.skip(`${tool.name} already present`);
+        continue;
+      }
+      try {
+        await applyProvider(providerFor(tool, p), await installContext());
+        log.ok(tool.name);
+      } catch (err) {
+        log.err(`${tool.name}: ${(err as Error).message}`);
+        failures++;
+      }
+      continue;
+    }
+
+    if (row.kind === "web") {
+      // A URL added on Windows comes back from the Start Menu without
+      // one, because a .lnk cannot say. Re-installing it would need a
+      // URL we do not have, and it is already there.
+      if (row.installed && row.app.url === "") continue;
+      try {
+        log.ok(`${row.app.name} — ${await installWebApp(p, row.app)}`);
+      } catch (err) {
+        log.err(`${row.app.name}: ${(err as Error).message}`);
+        failures++;
+      }
+      continue;
+    }
+
+    const app = await askForWebApp(validateWebApp);
+    if (!app) {
+      log.skip("no URL given");
       continue;
     }
     try {
-      await applyProvider(providerFor(tool, p), ctx);
-      log.ok(name);
+      log.ok(`${app.name} — ${await installWebApp(p, app)}`);
     } catch (err) {
-      log.err(`${name}: ${(err as Error).message}`);
+      log.err(`${app.name}: ${(err as Error).message}`);
       failures++;
     }
   }
 
   return failures > 0 ? 1 : 0;
+}
+
+/**
+ * The typed half of the web-app catalogue.
+ *
+ * Validated here rather than at the writer, so a typo is a question
+ * asked again instead of a stack trace — and the icon is optional
+ * because an internal page usually has no PNG anybody can name, and a
+ * launcher wearing the generic icon still works.
+ */
+async function askForWebApp(
+  check: (app: WebApp) => string | null,
+): Promise<WebApp | null> {
+  const url = (await text("URL? (https://…)")).trim();
+  if (url === "") return null;
+  const name = (await text("Name it?")).trim();
+  if (name === "") return null;
+  const iconUrl = (await text("PNG icon URL? (blank for none)")).trim();
+
+  const app: WebApp = iconUrl === "" ? { name, url } : { name, url, icon: iconUrl };
+  const problem = check(app);
+  if (problem) {
+    log.err(problem);
+    return null;
+  }
+  return app;
 }
 
 /**

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -256,7 +256,7 @@ export function menuEntries(p: Platform): [string, ...string[]] {
     "Wallpaper — Red artwork",
     "Font — family and size",
     "Redwall — machine state on the wallpaper",
-    "Apps — optional tools",
+    "Apps — optional tools and web apps",
     "Keys — every action, its chord, and what is bound here",
     "Languages — runtimes mise manages",
     ...(wslish ? ["Shell — where a terminal lands"] : []),

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -150,8 +150,10 @@ export const SECTIONS: MenuSection[] = [
     key: "apps",
     label: "Apps",
     notes: [
-      "Optional tools, never installed by a",
-      "plain converge. Chosen, not assumed.",
+      "Optional tools and web apps, never",
+      "installed by a plain converge. Chosen,",
+      "not assumed — and unticking an",
+      "installed web app takes it back off.",
     ],
   },
   {

--- a/src/webapps.test.ts
+++ b/src/webapps.test.ts
@@ -1,0 +1,413 @@
+/**
+ * What a web app writes, where, and what unticking it takes back.
+ *
+ * The artefact is pinned rather than described, on both targets, for the
+ * reason the Panel tests give: this process runs on one machine and the
+ * module has to be right about two. A `.desktop` file with a wrong Exec
+ * line and a shortcut with wrong arguments both fail the same way — a
+ * launcher that opens something, so nothing looks broken until you look
+ * at the window and it has a tab strip.
+ *
+ * The third target is the interesting one. WSL is not unsupported by
+ * omission here; it is refused, with the reason, because that is the
+ * target where writing the file would look like it worked.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import type { Platform } from "./platform.ts";
+import {
+  desktopEntry,
+  installedWebApps,
+  installWebApp,
+  RECOMMENDED_WEB_APPS,
+  removeWebApp,
+  validateWebApp,
+  WEB_APPS,
+  webAppCatalogue,
+  webAppDirs,
+  webAppFiles,
+  webAppSlug,
+  webAppSupport,
+  windowsShortcutArgs,
+  windowsShortcutScript,
+} from "./webapps.ts";
+
+function machine(over: Partial<Platform>): Platform {
+  return {
+    os: "linux",
+    distro: "ubuntu",
+    version: "24.04",
+    codename: "noble",
+    env: "desktop",
+    arch: "x64",
+    caps: { apt: true, gui: true, systemd: true, winget: false, flatpak: true },
+    ...over,
+  };
+}
+
+const DESKTOP = machine({});
+const WSL = machine({ env: "wsl", caps: { apt: true, gui: false, systemd: false, winget: true, flatpak: false } });
+const WINDOWS = machine({
+  os: "windows",
+  distro: null,
+  version: null,
+  codename: null,
+  env: "windows",
+  caps: { apt: false, gui: true, systemd: false, winget: true, flatpak: false },
+});
+const SERVER = machine({ env: "server", caps: { apt: true, gui: false, systemd: true, winget: false, flatpak: false } });
+
+/** Every Chromium-family name resolves; nothing else does. */
+const hasChrome = { which: (cmd: string) => cmd === "google-chrome" };
+
+function scratch(): string {
+  return mkdtempSync(`${tmpdir()}/red-webapps-`);
+}
+
+const CHATGPT = WEB_APPS.find((a) => a.name === "ChatGPT")!;
+
+describe("the Linux entry", () => {
+  test("is pinned, line for line", () => {
+    const entry = desktopEntry(CHATGPT, "google-chrome", "/home/x/.local/share/applications/icons/chatgpt.png");
+
+    expect(entry).toBe(
+      [
+        "[Desktop Entry]",
+        "Version=1.0",
+        "Type=Application",
+        "Name=ChatGPT",
+        "Comment=ChatGPT, in its own window",
+        'Exec=google-chrome --app="https://chatgpt.com/" --name="ChatGPT" --class="ChatGPT"',
+        "Icon=/home/x/.local/share/applications/icons/chatgpt.png",
+        "Terminal=false",
+        "StartupNotify=true",
+        "StartupWMClass=ChatGPT",
+        "Categories=Network;",
+        "MimeType=text/html;text/xml;application/xhtml_xml;",
+        "X-RedDev-WebApp=https://chatgpt.com/",
+        "",
+      ].join("\n"),
+    );
+  });
+
+  test("uses the browser it was given, not a hard-coded one", () => {
+    // The whole reason the shell function is retired: it wrote
+    // google-chrome onto machines that have chromium and nothing else.
+    expect(desktopEntry(CHATGPT, "brave-browser", null)).toContain(
+      'Exec=brave-browser --app="https://chatgpt.com/"',
+    );
+  });
+
+  test("omits Icon rather than pointing at a file it never fetched", () => {
+    const entry = desktopEntry({ name: "Intranet", url: "https://intranet.example/" }, "chromium", null);
+    expect(entry).not.toContain("Icon=");
+    // Still a launcher, still ours, still removable.
+    expect(entry).toContain("X-RedDev-WebApp=https://intranet.example/");
+  });
+
+  test("marks every entry as ours, which is what makes a typed URL removable", () => {
+    expect(desktopEntry(CHATGPT, "google-chrome", null)).toContain("X-RedDev-WebApp=");
+  });
+});
+
+describe("the Windows shortcut", () => {
+  test("carries --app and nothing else", () => {
+    // The two X11 switches the Exec line carries mean nothing here, and
+    // an argument list that names a WM_CLASS on Windows is cargo.
+    expect(windowsShortcutArgs(CHATGPT)).toBe('--app="https://chatgpt.com/"');
+  });
+
+  test("is written by PowerShell, against a browser the Windows side resolves", () => {
+    const script = windowsShortcutScript(CHATGPT, "C:/Users/x/AppData/Roaming/red-dev/Web Apps");
+
+    expect(script).toContain("$s.Arguments = '--app=\"https://chatgpt.com/\"'");
+    expect(script).toContain("CreateShortcut((Join-Path $dir 'ChatGPT.lnk'))");
+    expect(script).toContain("$s.TargetPath = $browser");
+    expect(script).toContain("$s.Save()");
+    // Resolved there rather than here: under WSL this process is Linux
+    // and cannot stat C:\Program Files.
+    expect(script).toContain('"$env:ProgramFiles\\Google\\Chrome\\Application\\chrome.exe"');
+    // Edge ships with Windows, so the fallback is always present.
+    expect(script).toContain("Microsoft\\Edge\\Application\\msedge.exe");
+    expect(script).toContain("if (-not $browser) { throw");
+    expect(script).toContain("$dir = 'C:\\Users\\x\\AppData\\Roaming\\red-dev\\Web Apps'");
+  });
+
+  test("survives an account name with an apostrophe in it", () => {
+    const script = windowsShortcutScript(CHATGPT, "C:/Users/O'Brien/AppData/Roaming/red-dev");
+    // Doubled, which is how a single-quoted PowerShell string carries
+    // one. Left alone it would end the string and run the rest.
+    expect(script).toContain("$dir = 'C:\\Users\\O''Brien\\AppData\\Roaming\\red-dev'");
+  });
+
+  test("goes in its own Start Menu folder, which is how Windows marks it as ours", () => {
+    const dirs = webAppDirs(WINDOWS, { appData: "C:/Users/x/AppData/Roaming" });
+    expect(dirs.entries).toBe(
+      "C:/Users/x/AppData/Roaming/Microsoft/Windows/Start Menu/Programs/red-dev/Web Apps",
+    );
+    expect(webAppFiles(WINDOWS, "Google Photos", { appData: "C:/Users/x/AppData/Roaming" }).entry)
+      .toEndWith("/red-dev/Web Apps/Google Photos.lnk");
+  });
+});
+
+describe("where a web app is offered", () => {
+  test("WSL is skipped, and the reason is WSL's rather than the generic one", () => {
+    const support = webAppSupport(WSL, hasChrome);
+
+    expect(support.ok).toBe(false);
+    // The failure this sentence exists to prevent: "no desktop session"
+    // is true under WSL and sends the reader off to install a display
+    // they will never have. The launcher belongs on the Windows side.
+    expect(support.reason).toContain("read by nothing");
+    expect(support.reason).toContain("Windows side");
+    expect(support.reason).not.toContain("no desktop session");
+  });
+
+  test("a Linux desktop with a Chromium-family browser is supported", () => {
+    expect(webAppSupport(DESKTOP, hasChrome)).toEqual({ ok: true, reason: "" });
+  });
+
+  test("native Windows is supported, because a shortcut is the equivalent", () => {
+    expect(webAppSupport(WINDOWS, { which: () => false }).ok).toBe(true);
+  });
+
+  test("a headless server is skipped", () => {
+    expect(webAppSupport(SERVER, hasChrome).reason).toContain("no desktop session");
+  });
+
+  test("Firefox alone is a refusal, not a broken launcher", () => {
+    const support = webAppSupport(DESKTOP, { which: (cmd) => cmd === "firefox" });
+    expect(support.ok).toBe(false);
+    expect(support.reason).toContain("Firefox");
+  });
+});
+
+describe("the pre-ticked set", () => {
+  test("is ChatGPT, Claude and GitHub", () => {
+    expect([...RECOMMENDED_WEB_APPS]).toEqual(["ChatGPT", "Claude", "GitHub"]);
+  });
+
+  test("every recommendation is a catalogue entry", () => {
+    // A recommendation naming something that is not on the list would
+    // pre-tick nothing, silently.
+    for (const name of RECOMMENDED_WEB_APPS) {
+      expect(WEB_APPS.map((a) => a.name)).toContain(name);
+    }
+  });
+
+  test("the rest stay in the catalogue rather than being dropped", () => {
+    const rest = WEB_APPS.map((a) => a.name).filter((n) => !RECOMMENDED_WEB_APPS.includes(n));
+    expect(rest).toEqual(["Google Photos", "Google Contacts", "Tailscale"]);
+  });
+
+  test("is what a fresh machine's Catalogue opens with", () => {
+    const rows = webAppCatalogue([]);
+
+    expect(rows.filter((r) => r.ticked).map((r) => r.app.name)).toEqual([
+      "ChatGPT",
+      "Claude",
+      "GitHub",
+    ]);
+    // Offered, and only that. The point of a recommendation is that the
+    // rest are one space bar away in the same list.
+    expect(rows.map((r) => r.app.name)).toEqual(WEB_APPS.map((a) => a.name));
+    expect(rows.every((r) => !r.installed)).toBe(true);
+  });
+});
+
+describe("the Catalogue's rows", () => {
+  test("tick everything already installed, so leaving the list alone changes nothing", () => {
+    const rows = webAppCatalogue([{ name: "Tailscale", url: "https://login.tailscale.com/admin/" }]);
+
+    const tailscale = rows.find((r) => r.app.name === "Tailscale");
+    expect(tailscale?.installed).toBe(true);
+    expect(tailscale?.ticked).toBe(true);
+    // Which makes the untick the only way out — and that is the whole
+    // contract: removal is a deliberate act, never a default.
+    expect(rows.filter((r) => r.ticked).map((r) => r.app.name)).toEqual([
+      "ChatGPT",
+      "Claude",
+      "GitHub",
+      "Tailscale",
+    ]);
+  });
+
+  test("list a typed URL after the catalogue, so it can be taken back out", () => {
+    const rows = webAppCatalogue([{ name: "Intranet", url: "https://intranet.example/" }]);
+
+    const last = rows[rows.length - 1];
+    expect(last?.app.name).toBe("Intranet");
+    expect(last?.installed).toBe(true);
+    expect(last?.ticked).toBe(true);
+  });
+
+  test("do not list a catalogue entry twice when it is installed", () => {
+    const rows = webAppCatalogue([{ name: "ChatGPT", url: "https://chatgpt.com/" }]);
+    expect(rows.filter((r) => r.app.name === "ChatGPT")).toHaveLength(1);
+  });
+});
+
+describe("install and its inverse, on a real directory", () => {
+  test("writes the entry and fetches the icon once", async () => {
+    const home = scratch();
+    try {
+      let downloads = 0;
+      const env = {
+        home,
+        ...hasChrome,
+        download: async () => {
+          downloads++;
+          return new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+        },
+      };
+
+      const path = await installWebApp(DESKTOP, CHATGPT, env);
+      expect(path).toBe(`${home}/.local/share/applications/chatgpt.desktop`);
+      expect(existsSync(`${home}/.local/share/applications/icons/chatgpt.png`)).toBe(true);
+      expect(downloads).toBe(1);
+
+      // Re-ticking something already installed costs a file write, not a
+      // download.
+      await installWebApp(DESKTOP, CHATGPT, env);
+      expect(downloads).toBe(1);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  test("removal deletes both the entry and its icon", async () => {
+    const home = scratch();
+    try {
+      const env = { home, ...hasChrome, download: async () => new Uint8Array([1]) };
+      await installWebApp(DESKTOP, CHATGPT, env);
+
+      const files = webAppFiles(DESKTOP, "ChatGPT", { home });
+      const removed = removeWebApp(DESKTOP, "ChatGPT", { home });
+
+      // Both, and reported as both: an icon left behind is the bug the
+      // shell function's remove had every time an app name and its icon
+      // name disagreed.
+      expect(removed).toEqual([files.entry, files.icon]);
+      expect(existsSync(files.entry)).toBe(false);
+      expect(existsSync(files.icon)).toBe(false);
+      // And nothing else in the directory it shares with every other
+      // launcher on the machine.
+      expect(readdirSync(`${home}/.local/share/applications`)).toEqual(["icons"]);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  test("removing something that was never installed is not an error", () => {
+    const home = scratch();
+    try {
+      expect(removeWebApp(DESKTOP, "Tailscale", { home })).toEqual([]);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  test("lists what red-dev wrote, and leaves every other launcher alone", async () => {
+    const home = scratch();
+    try {
+      const env = { home, ...hasChrome, download: async () => new Uint8Array([1]) };
+      await installWebApp(DESKTOP, CHATGPT, env);
+      await installWebApp(DESKTOP, { name: "Intranet", url: "https://intranet.example/" }, env);
+
+      // Somebody else's entry, in the same directory.
+      writeFileSync(
+        `${home}/.local/share/applications/firefox.desktop`,
+        "[Desktop Entry]\nName=Firefox\nExec=firefox\n",
+      );
+
+      const installed = installedWebApps(DESKTOP, { home });
+      expect(installed.map((a) => a.name)).toEqual(["ChatGPT", "Intranet"]);
+      // The typed URL comes back with its URL, which is what makes it
+      // offerable — and untickable — next time.
+      expect(installed.find((a) => a.name === "Intranet")?.url).toBe("https://intranet.example/");
+      expect(installed.map((a) => a.name)).not.toContain("Firefox");
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  test("on Windows, everything in the folder is one of ours", () => {
+    const appData = scratch();
+    try {
+      const dir = webAppDirs(WINDOWS, { appData }).entries;
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(`${dir}/ChatGPT.lnk`, "");
+      writeFileSync(`${dir}/Standup.lnk`, "");
+
+      const installed = installedWebApps(WINDOWS, { appData });
+      expect(installed.map((a) => a.name)).toEqual(["ChatGPT", "Standup"]);
+      // The catalogue fills in what the .lnk cannot say; a typed one
+      // reports its name and no URL, which is all removal needs.
+      expect(installed.find((a) => a.name === "ChatGPT")?.url).toBe("https://chatgpt.com/");
+      expect(installed.find((a) => a.name === "Standup")?.url).toBe("");
+    } finally {
+      rmSync(appData, { recursive: true, force: true });
+    }
+  });
+
+  test("an unsupported target has nothing installed rather than throwing", () => {
+    expect(installedWebApps(DESKTOP, { home: `${tmpdir()}/red-dev-nonexistent-home` })).toEqual([]);
+  });
+});
+
+describe("a URL somebody typed", () => {
+  test("is accepted when it is a URL", () => {
+    expect(validateWebApp({ name: "Intranet", url: "https://intranet.example/wiki" })).toBeNull();
+  });
+
+  test("is refused when a quote would break out of the launcher", () => {
+    // Both writers quote the URL — the Exec line and $s.Arguments — so a
+    // quote in it does not escape into a different value, it ends the
+    // quoting and turns the rest into something else.
+    expect(validateWebApp({ name: "X", url: 'https://x/" --load-extension=/tmp/e "' })).toContain(
+      "cannot contain quotes",
+    );
+    expect(validateWebApp({ name: 'A" --x', url: "https://x/" })).toContain("cannot contain quotes");
+    expect(validateWebApp({ name: "A'; rm", url: "https://x/" })).toContain("cannot contain quotes");
+  });
+
+  test("is refused when it is not something a browser window opens", () => {
+    expect(validateWebApp({ name: "X", url: "file:///etc/passwd" })).toContain("only http and https");
+    expect(validateWebApp({ name: "X", url: "not a url" })).toBeTruthy();
+  });
+
+  test("needs a name a file can be called", () => {
+    expect(validateWebApp({ name: "", url: "https://x/" })).toContain("needs a name");
+    expect(validateWebApp({ name: "...", url: "https://x/" })).toContain("at least one letter");
+  });
+
+  test("refuses to install rather than writing half a launcher", async () => {
+    const home = scratch();
+    try {
+      await expect(
+        installWebApp(DESKTOP, { name: "X", url: "file:///etc/passwd" }, { home }),
+      ).rejects.toThrow("only http and https");
+      expect(existsSync(`${home}/.local/share/applications`)).toBe(false);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("slugs", () => {
+  test("are the file name, and survive a two-word app", () => {
+    expect(webAppSlug("Google Photos")).toBe("google-photos");
+    expect(webAppSlug("ChatGPT")).toBe("chatgpt");
+  });
+
+  test("every catalogue entry has a distinct one, so no two share a file", () => {
+    const slugs = WEB_APPS.map((a) => webAppSlug(a.name));
+    expect(new Set(slugs).size).toBe(WEB_APPS.length);
+  });
+
+  test("every catalogue entry is one this module would accept", () => {
+    for (const app of WEB_APPS) expect(validateWebApp(app)).toBeNull();
+  });
+});

--- a/src/webapps.ts
+++ b/src/webapps.ts
@@ -3,33 +3,49 @@
  *
  * omakub's `web2app` writes a .desktop entry launching Chromium with
  * `--app=<url>`, which drops the tab strip and address bar and gives the
- * page its own window, icon and alt-tab entry. Same idea here.
+ * page its own window, icon and alt-tab entry. Same idea here, with the
+ * shell function's two limits removed: it is Linux-only, and it
+ * hard-codes `google-chrome` on a machine that may not have it.
  *
- * Desktop-only by construction rather than by omission. A .desktop file
- * needs a freedesktop menu to appear in, so under WSL it would write a
- * file nothing reads, and on native Windows the equivalent is a
- * different mechanism entirely (a shortcut with its own arguments).
- * Both are reported as skips with the reason rather than silently doing
- * nothing.
+ * ## Three targets, two mechanisms, one skip
+ *
+ * A Linux desktop gets the freedesktop entry, with the icon fetched once
+ * into the user's icon directory. Native Windows has no such thing: the
+ * equivalent is a Start Menu shortcut whose arguments carry the same
+ * `--app=` the entry's Exec line does. WSL gets neither — it has no
+ * freedesktop menu of its own, and a .desktop file written there is read
+ * by nothing, so it is reported as a skip with that reason rather than
+ * written and silently ignored.
+ *
+ * ## What the entry says about itself
+ *
+ * Every entry we write carries `X-RedDev-WebApp=<url>`. That is how the
+ * Catalogue knows which launchers are ours, which is what makes a URL
+ * somebody typed removable later: the catalogue below is a starting
+ * list, not the set of things that can exist. On Windows the marker has
+ * nowhere to live — a .lnk is a binary format read through COM — so a
+ * shortcut there is identified by the folder it is in, and a custom one
+ * reports its name without its URL. That is enough to offer its removal,
+ * which is all the Catalogue asks.
  */
 
-import { existsSync, mkdirSync } from "node:fs";
-import { log, RedError } from "./log.ts";
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import { RedError } from "./log.ts";
 import type { Platform } from "./platform.ts";
 
 export interface WebApp {
   name: string;
   url: string;
   /** PNG icon, fetched once into the user's icon directory. */
-  icon: string;
+  icon?: string;
 }
 
 /**
  * Kept short on purpose. omakub offers four; a list of thirty would be
  * a directory, and the point is a handful of pages you actually keep
- * open all day.
+ * open all day. Anything else is a URL the person types.
  */
-export const WEB_APPS: WebApp[] = [
+export const WEB_APPS: readonly WebApp[] = [
   {
     name: "ChatGPT",
     url: "https://chatgpt.com/",
@@ -39,6 +55,11 @@ export const WEB_APPS: WebApp[] = [
     name: "Claude",
     url: "https://claude.ai/",
     icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/anthropic.png",
+  },
+  {
+    name: "GitHub",
+    url: "https://github.com/",
+    icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/github.png",
   },
   {
     name: "Google Photos",
@@ -55,96 +76,423 @@ export const WEB_APPS: WebApp[] = [
     url: "https://login.tailscale.com/admin/",
     icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/tailscale-light.png",
   },
-  {
-    name: "GitHub",
-    url: "https://github.com/",
-    icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/github.png",
-  },
 ];
+
+/**
+ * The three that arrive ticked.
+ *
+ * Not a ranking of the six. These are the pages this project's own work
+ * happens in — two agent hosts and the place the code lives — so they
+ * are the ones a fresh machine is most likely to want a window for. The
+ * rest stay one space bar away in the same list, which is the whole
+ * difference between a recommendation and a decision.
+ */
+export const RECOMMENDED_WEB_APPS: readonly string[] = ["ChatGPT", "Claude", "GitHub"];
+
+/** One row of the Catalogue's web-app section. */
+export interface WebAppRow {
+  app: WebApp;
+  installed: boolean;
+  /** Whether the list opens with this one ticked. */
+  ticked: boolean;
+}
+
+/**
+ * The rows the Catalogue offers, and which of them arrive ticked.
+ *
+ * Two rules, and the second is the one that makes unticking mean
+ * something: a page already on this machine is always ticked, so leaving
+ * the list alone changes nothing and the only way to remove something is
+ * to deliberately take the tick off it. The recommendations are ticked
+ * on top of that, which is what makes a fresh machine's list a
+ * suggestion rather than an empty form.
+ *
+ * Anything installed that is not in the catalogue — a URL somebody typed
+ * — is listed after it, because the alternative is a page you can
+ * install and then never see again.
+ */
+export function webAppCatalogue(installed: readonly WebApp[] = []): WebAppRow[] {
+  const isInstalled = (name: string): boolean => installed.some((a) => a.name === name);
+  const rows: WebAppRow[] = WEB_APPS.map((app) => ({
+    app,
+    installed: isInstalled(app.name),
+    ticked: isInstalled(app.name) || RECOMMENDED_WEB_APPS.includes(app.name),
+  }));
+  for (const app of installed) {
+    if (WEB_APPS.some((a) => a.name === app.name)) continue;
+    rows.push({ app, installed: true, ticked: true });
+  }
+  return rows;
+}
+
+/** The file-name stem for an app, on both targets. */
+export function webAppSlug(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+}
+
+/**
+ * Seams. Every one of these is answered by the machine in production and
+ * by the test otherwise, so nothing here needs a desktop to be pinned.
+ */
+export interface WebAppEnv {
+  home?: string;
+  appData?: string;
+  /** Resolve a command on PATH — the Chromium-family probe. */
+  which?: (cmd: string) => boolean;
+  /** Fetch the icon bytes. */
+  download?: (url: string) => Promise<Uint8Array>;
+  /** Run the PowerShell that writes a .lnk, on the Windows side. */
+  powershell?: (script: string) => Promise<{ ok: boolean; out: string }>;
+}
 
 /**
  * A Chromium-family browser, which is what `--app=` requires. Firefox
  * has no equivalent that produces a chromeless window, so a machine
  * with only Firefox gets a clear refusal rather than a broken launcher.
  */
-function findBrowser(): string | null {
-  for (const bin of ["google-chrome", "chromium", "chromium-browser", "brave-browser", "microsoft-edge"]) {
-    if (Bun.which(bin)) return bin;
-  }
-  return null;
-}
+export const CHROMIUM_BINARIES: readonly string[] = [
+  "google-chrome",
+  "chromium",
+  "chromium-browser",
+  "brave-browser",
+  "microsoft-edge",
+];
 
-function home(): string {
-  const h = process.env["HOME"] ?? process.env["USERPROFILE"];
+/**
+ * The same list on Windows, as paths rather than names.
+ *
+ * Edge is last and is the reason the Windows side never reports "no
+ * browser": it ships with the OS, so the fallback is always present.
+ * PowerShell resolves these because only the Windows side can — under a
+ * converge driven from WSL, `C:\Program Files` is not a path this
+ * process can stat.
+ */
+export const WINDOWS_BROWSERS: readonly string[] = [
+  "$env:ProgramFiles\\Google\\Chrome\\Application\\chrome.exe",
+  "${env:ProgramFiles(x86)}\\Google\\Chrome\\Application\\chrome.exe",
+  "$env:LOCALAPPDATA\\Google\\Chrome\\Application\\chrome.exe",
+  "$env:ProgramFiles\\BraveSoftware\\Brave-Browser\\Application\\brave.exe",
+  "${env:ProgramFiles(x86)}\\Microsoft\\Edge\\Application\\msedge.exe",
+  "$env:ProgramFiles\\Microsoft\\Edge\\Application\\msedge.exe",
+];
+
+function home(env: WebAppEnv): string {
+  const h = env.home ?? process.env["HOME"] ?? process.env["USERPROFILE"];
   if (!h) throw new RedError("neither HOME nor USERPROFILE is set");
   return h;
 }
 
-export function webAppsSupported(p: Platform): { ok: boolean; reason: string } {
-  if (p.os === "windows") {
-    return { ok: false, reason: "native Windows uses shortcuts, not .desktop entries" };
+export function findBrowser(env: WebAppEnv = {}): string | null {
+  const which = env.which ?? ((cmd: string) => Bun.which(cmd) !== null);
+  for (const bin of CHROMIUM_BINARIES) if (which(bin)) return bin;
+  return null;
+}
+
+/**
+ * Whether this machine can hold a web app at all, and why not when it
+ * cannot.
+ *
+ * WSL is answered first and on its own terms. Its `caps.gui` is false
+ * and the generic "no desktop session" sentence would be technically
+ * true there, but it sends the reader looking for a display they are
+ * never going to install — the actual fact is that the desktop belongs
+ * to the Windows host, which is where the shortcut goes.
+ */
+export function webAppSupport(p: Platform, env: WebAppEnv = {}): { ok: boolean; reason: string } {
+  if (p.env === "wsl") {
+    return {
+      ok: false,
+      reason:
+        "WSL has no freedesktop menu of its own — a .desktop entry here is read by " +
+        "nothing; install web apps from the Windows side",
+    };
   }
-  if (!p.caps.gui) {
-    return { ok: false, reason: "no desktop session to show a launcher in" };
-  }
-  if (!findBrowser()) {
+  if (p.os === "windows") return { ok: true, reason: "" };
+  if (!p.caps.gui) return { ok: false, reason: "no desktop session to show a launcher in" };
+  if (!findBrowser(env)) {
     return { ok: false, reason: "no Chromium-family browser; --app= has no Firefox equivalent" };
   }
   return { ok: true, reason: "" };
 }
 
-export async function installWebApp(app: WebApp): Promise<void> {
-  const browser = findBrowser();
+export interface WebAppDirs {
+  /** Where the launcher itself is written. */
+  entries: string;
+  /** Where its icon is fetched to. */
+  icons: string;
+}
+
+export function webAppDirs(p: Platform, env: WebAppEnv = {}): WebAppDirs {
+  if (p.os === "windows") {
+    const appData = env.appData ?? process.env["APPDATA"] ?? `${home(env)}/AppData/Roaming`;
+    // Its own folder under the Start Menu, because on Windows the folder
+    // is the marker: everything in it is a web app red-dev wrote.
+    const dir = `${appData}/Microsoft/Windows/Start Menu/Programs/red-dev/Web Apps`;
+    return { entries: dir, icons: `${dir}/icons` };
+  }
+  const dir = `${home(env)}/.local/share/applications`;
+  return { entries: dir, icons: `${dir}/icons` };
+}
+
+/** The two paths one app owns, which are also the two removal deletes. */
+export function webAppFiles(
+  p: Platform,
+  name: string,
+  env: WebAppEnv = {},
+): { entry: string; icon: string } {
+  const dirs = webAppDirs(p, env);
+  const slug = webAppSlug(name);
+  return {
+    entry: p.os === "windows" ? `${dirs.entries}/${name}.lnk` : `${dirs.entries}/${slug}.desktop`,
+    icon: `${dirs.icons}/${slug}.png`,
+  };
+}
+
+/**
+ * A name and a URL we are willing to write into a launcher.
+ *
+ * The catalogue above is trusted; a URL somebody typed is not, and both
+ * reach the same two code paths — a shell-free `Bun.write` on Linux and
+ * a PowerShell string on Windows. A quote in either field would end the
+ * quoting in the Exec line or in `$s.Arguments` and turn the rest into
+ * something else, so both are refused before either path is built rather
+ * than escaped differently per target.
+ */
+export function validateWebApp(app: WebApp): string | null {
+  if (app.name.trim() === "") return "a web app needs a name";
+  if (/["'`\\\n\r]/.test(app.name)) return `${app.name}: a name cannot contain quotes or backslashes`;
+  if (webAppSlug(app.name) === "") return `${app.name}: a name needs at least one letter or digit`;
+  if (/["'`\\\s]/.test(app.url)) return `${app.url}: a URL cannot contain quotes or spaces`;
+  let parsed: URL;
+  try {
+    parsed = new URL(app.url);
+  } catch {
+    return `${app.url}: not a URL`;
+  }
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+    return `${app.url}: only http and https open in a browser window`;
+  }
+  if (app.icon !== undefined && /["'`\\\s]/.test(app.icon)) {
+    return `${app.icon}: an icon URL cannot contain quotes or spaces`;
+  }
+  return null;
+}
+
+function assertValid(app: WebApp): void {
+  const problem = validateWebApp(app);
+  if (problem) throw new RedError(problem);
+}
+
+/** The marker key every entry we write carries, and nothing else does. */
+export const WEB_APP_MARKER = "X-RedDev-WebApp";
+
+/**
+ * The freedesktop entry, byte for byte.
+ *
+ * `--app=` is what removes the tab strip; `--class` makes the window
+ * group under its own icon rather than under the browser's, which is the
+ * difference between an alt-tab entry that says ChatGPT and one that
+ * says Google Chrome. `Categories=Network;` is a registered main
+ * category — omakub writes `GTK;`, which is not one, and a desktop file
+ * validator says so.
+ */
+export function desktopEntry(app: WebApp, browser: string, iconPath: string | null): string {
+  assertValid(app);
+  const lines = [
+    "[Desktop Entry]",
+    "Version=1.0",
+    "Type=Application",
+    `Name=${app.name}`,
+    `Comment=${app.name}, in its own window`,
+    `Exec=${browser} --app="${app.url}" --name="${app.name}" --class="${app.name}"`,
+  ];
+  // Omitted rather than pointed at a file that is not there: a URL added
+  // without an icon still gets a working launcher, wearing the desktop's
+  // generic application icon.
+  if (iconPath) lines.push(`Icon=${iconPath}`);
+  lines.push(
+    "Terminal=false",
+    "StartupNotify=true",
+    `StartupWMClass=${app.name}`,
+    "Categories=Network;",
+    "MimeType=text/html;text/xml;application/xhtml_xml;",
+    `${WEB_APP_MARKER}=${app.url}`,
+    "",
+  );
+  return lines.join("\n");
+}
+
+/**
+ * What the Windows shortcut passes to the browser.
+ *
+ * Only `--app=`. The two X11 switches the Linux Exec line carries have
+ * no meaning here — Windows has no WM_CLASS — and Chrome gives an
+ * `--app` window the site's own favicon and its own taskbar button
+ * without being asked.
+ */
+export function windowsShortcutArgs(app: WebApp): string {
+  assertValid(app);
+  return `--app="${app.url}"`;
+}
+
+/**
+ * The PowerShell that writes one .lnk.
+ *
+ * The browser is resolved on the Windows side, for the reason
+ * src/hotkeys.ts gives about the same crossing: under WSL this process
+ * is Linux and cannot stat `C:\Program Files`. The shortcut's icon is
+ * the browser's, because a .lnk's IconLocation wants an .ico and the
+ * catalogue's icons are PNG — the window itself still wears the site's
+ * favicon.
+ */
+export function windowsShortcutScript(app: WebApp, dir: string): string {
+  assertValid(app);
+  const candidates = WINDOWS_BROWSERS.map((path) => `  "${path}"`).join(",\n");
+  // The directory is the one path here we did not choose — it comes from
+  // %APPDATA%, and a Windows account named O'Brien puts an apostrophe in
+  // it. Doubling is how a single-quoted PowerShell string carries one.
+  const quoted = dir.replace(/\//g, "\\").replace(/'/g, "''");
+  return `
+$ErrorActionPreference = 'Stop'
+$dir = '${quoted}'
+New-Item -ItemType Directory -Force -Path $dir | Out-Null
+$browser = @(
+${candidates}
+) | Where-Object { Test-Path $_ } | Select-Object -First 1
+if (-not $browser) { throw 'no Chromium-family browser on this machine' }
+$s = (New-Object -ComObject WScript.Shell).CreateShortcut((Join-Path $dir '${app.name}.lnk'))
+$s.TargetPath = $browser
+$s.Arguments = '${windowsShortcutArgs(app)}'
+$s.Description = '${app.name}, in its own window'
+$s.Save()
+"${app.name} -> $browser"
+`.trim();
+}
+
+async function fetchIcon(url: string, env: WebAppEnv): Promise<Uint8Array> {
+  if (env.download) return await env.download(url);
+  const res = await fetch(url);
+  if (!res.ok) throw new RedError(`icon download failed ${res.status}: ${url}`);
+  return new Uint8Array(await res.arrayBuffer());
+}
+
+async function runPowershell(
+  script: string,
+  env: WebAppEnv,
+): Promise<{ ok: boolean; out: string }> {
+  if (env.powershell) return await env.powershell(script);
+  const proc = Bun.spawn(["powershell.exe", "-NoProfile", "-Command", script], {
+    stdout: "pipe",
+    stderr: "pipe",
+    stdin: "ignore",
+  });
+  const out = (await new Response(proc.stdout).text()).trim();
+  const err = (await new Response(proc.stderr).text()).trim();
+  const code = await proc.exited;
+  return { ok: code === 0, out: code === 0 ? out : err };
+}
+
+/**
+ * Install one, and answer with the path that now exists — which is what
+ * the caller reports and what a person checks when a menu does not show
+ * what they just ticked.
+ */
+export async function installWebApp(
+  p: Platform,
+  app: WebApp,
+  env: WebAppEnv = {},
+): Promise<string> {
+  assertValid(app);
+  const files = webAppFiles(p, app.name, env);
+
+  if (p.os === "windows") {
+    const dirs = webAppDirs(p, env);
+    const result = await runPowershell(windowsShortcutScript(app, dirs.entries), env);
+    if (!result.ok) {
+      throw new RedError(`${app.name}: ${result.out.split("\n")[0] ?? "could not write the shortcut"}`);
+    }
+    return files.entry;
+  }
+
+  const browser = findBrowser(env);
   if (!browser) throw new RedError("no Chromium-family browser found");
 
-  const iconDir = `${home()}/.local/share/applications/icons`;
-  const appDir = `${home()}/.local/share/applications`;
-  mkdirSync(iconDir, { recursive: true });
-  mkdirSync(appDir, { recursive: true });
+  const dirs = webAppDirs(p, env);
+  mkdirSync(dirs.entries, { recursive: true });
 
-  const slug = app.name.toLowerCase().replace(/[^a-z0-9]+/g, "-");
-  const iconPath = `${iconDir}/${slug}.png`;
-
-  if (!existsSync(iconPath)) {
-    const res = await fetch(app.icon);
-    if (!res.ok) throw new RedError(`icon download failed ${res.status}: ${app.icon}`);
-    await Bun.write(iconPath, res);
+  let iconPath: string | null = null;
+  if (app.icon) {
+    mkdirSync(dirs.icons, { recursive: true });
+    // Fetched once. A re-tick of something already installed should cost
+    // a file write, not a download.
+    if (!existsSync(files.icon)) await Bun.write(files.icon, await fetchIcon(app.icon, env));
+    iconPath = files.icon;
   }
 
-  // --app= is what removes the tab strip; the class makes the window
-  // group under its own icon rather than the browser's.
-  const entry = `[Desktop Entry]
-Version=1.0
-Name=${app.name}
-Comment=${app.name}
-Exec=${browser} --app="${app.url}" --name="${app.name}" --class="${app.name}"
-Terminal=false
-Type=Application
-Icon=${iconPath}
-Categories=GTK;WebApps;
-MimeType=text/html;text/xml;application/xhtml_xml;
-StartupWMClass=${app.name}
-StartupNotify=true
-`;
-
-  await Bun.write(`${appDir}/${slug}.desktop`, entry);
-  log.ok(`${app.name} — ${app.url}`);
+  await Bun.write(files.entry, desktopEntry(app, browser, iconPath));
+  return files.entry;
 }
 
-export function installedWebApps(): string[] {
-  const appDir = `${home()}/.local/share/applications`;
-  if (!existsSync(appDir)) return [];
-  return WEB_APPS.filter((a) =>
-    existsSync(`${appDir}/${a.name.toLowerCase().replace(/[^a-z0-9]+/g, "-")}.desktop`),
-  ).map((a) => a.name);
-}
+/**
+ * Everything red-dev put on this machine, catalogue or not.
+ *
+ * Read from the launchers themselves rather than from a list we keep
+ * beside them: a state file and a menu directory disagree the first time
+ * somebody deletes an entry by hand, and the directory is the one the
+ * desktop actually reads.
+ */
+export function installedWebApps(p: Platform, env: WebAppEnv = {}): WebApp[] {
+  const dirs = webAppDirs(p, env);
+  if (!existsSync(dirs.entries)) return [];
 
-export async function removeWebApp(name: string): Promise<void> {
-  const slug = name.toLowerCase().replace(/[^a-z0-9]+/g, "-");
-  const appDir = `${home()}/.local/share/applications`;
-  for (const path of [`${appDir}/${slug}.desktop`, `${appDir}/icons/${slug}.png`]) {
-    if (existsSync(path)) {
-      await Bun.spawn(["rm", "-f", path], { stdout: "ignore", stderr: "ignore" }).exited;
+  if (p.os === "windows") {
+    return readdirSync(dirs.entries)
+      .filter((f) => f.endsWith(".lnk"))
+      .map((f) => {
+        const name = f.slice(0, -".lnk".length);
+        // A .lnk cannot be read back without COM, so the URL comes from
+        // the catalogue when the name is in it, and is left unknown when
+        // it is not. Removal needs only the name.
+        const known = WEB_APPS.find((a) => a.name === name);
+        return { name, url: known?.url ?? "", icon: known?.icon };
+      })
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  const out: WebApp[] = [];
+  for (const file of readdirSync(dirs.entries).sort()) {
+    if (!file.endsWith(".desktop")) continue;
+    let body: string;
+    try {
+      body = readFileSync(`${dirs.entries}/${file}`, "utf8");
+    } catch {
+      continue;
     }
+    const url = /^X-RedDev-WebApp=(.*)$/m.exec(body)?.[1]?.trim();
+    if (url === undefined) continue;
+    const name = /^Name=(.*)$/m.exec(body)?.[1]?.trim();
+    if (!name) continue;
+    const icon = /^Icon=(.*)$/m.exec(body)?.[1]?.trim();
+    out.push(icon ? { name, url, icon } : { name, url });
   }
+  return out;
+}
+
+/**
+ * The exact inverse of an install: the launcher and the icon it fetched,
+ * and the paths that were really deleted so the caller can name them.
+ *
+ * Node's own remove rather than a spawned `rm -f`, which the previous
+ * version used and which does not exist on the one target where the
+ * entry is a .lnk.
+ */
+export function removeWebApp(p: Platform, name: string, env: WebAppEnv = {}): string[] {
+  const files = webAppFiles(p, name, env);
+  const removed: string[] = [];
+  for (const path of [files.entry, files.icon]) {
+    if (!existsSync(path)) continue;
+    rmSync(path, { force: true });
+    removed.push(path);
+  }
+  return removed;
 }


### PR DESCRIPTION
Automated AFK landing for #143. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #143

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/171"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789457351&installation_model_id=20659&pr_number=171&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F171&signature=3fd9c0db3015d05b433b5014b70f4c0db9b699edd8b76612b81dd42d083142d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->