### PR TITLE
fix: #144 Catalogue symmetry: unticking an installed item removes it

### DIFF
--- a/src/catalogue.test.ts
+++ b/src/catalogue.test.ts
@@ -1,0 +1,273 @@
+/**
+ * What an untick means, and what it is never allowed to mean.
+ *
+ * The Catalogue is the one list in this project where a checkbox runs a
+ * destructive act, so the three things worth pinning are the three ways
+ * that goes wrong: an untick that removes nothing (a checkbox that lies),
+ * an untick that reaches a scope nobody offered (the identical layer
+ * dismantled by a space bar), and an untick that removes something
+ * without saying what (the one thing a checkbox must never do).
+ *
+ * Every removal here is a fake that records rather than runs, which is
+ * the point: the module under test must be provably unable to touch the
+ * machine before it has asked, and a test that only checked the happy
+ * path would prove that by not noticing.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  ADD_A_WEB_APP,
+  catalogueLines,
+  catalogueRemovals,
+  CATALOGUE_SCOPE,
+  catalogueTools,
+  removalNotice,
+  removeUnticked,
+  type CatalogueTool,
+  type Going,
+} from "./catalogue.ts";
+import { toolsInScope, type Scope, type Tool } from "./manifest.ts";
+import type { Platform } from "./platform.ts";
+import type { WebAppRow } from "./webapps.ts";
+
+/**
+ * Every scope that is not the Catalogue's. Spelled out rather than
+ * derived, the way uninstall.ts spells its own list out: this is the
+ * thing being asserted, and a list computed from the code under test
+ * would agree with it no matter what the code did.
+ */
+const MACHINE_SCOPES = ["core", "desktop", "wsl"] as const satisfies readonly Scope[];
+
+function machine(over: Partial<Platform>): Platform {
+  return {
+    os: "linux",
+    distro: "ubuntu",
+    version: "24.04",
+    codename: "noble",
+    env: "desktop",
+    arch: "x64",
+    caps: { apt: true, gui: true, systemd: true, winget: false, flatpak: true },
+    ...over,
+  };
+}
+
+const DESKTOP = machine({});
+const WINDOWS = machine({
+  os: "windows",
+  distro: null,
+  version: null,
+  codename: null,
+  env: "windows",
+  caps: { apt: false, gui: true, systemd: false, winget: true, flatpak: false },
+});
+
+/**
+ * A tool row built by hand rather than probed.
+ *
+ * `catalogueTools` asks the machine running the test whether `just` is on
+ * PATH, and the answer differs between a laptop and CI. What the removal
+ * half has to be right about is the shape, so the shape is supplied.
+ */
+function toolRow(over: Partial<CatalogueTool> & { name: string }): CatalogueTool {
+  const tool: Tool = {
+    name: over.name,
+    about: "a command runner",
+    scope: "optional",
+    u24: { kind: "apt", pkg: over.name },
+    win: { kind: "skip", reason: "not offered here" },
+  };
+  return {
+    tool,
+    installed: true,
+    present: true,
+    removal: {
+      tool: over.name,
+      how: `apt remove ${over.name}`,
+      run: async () => {},
+    },
+    ...over,
+  };
+}
+
+function webRow(name: string, installed: boolean): WebAppRow {
+  return { app: { name, url: `https://${name.toLowerCase()}.example/` }, installed, ticked: installed };
+}
+
+/** A remover that records the names it was handed and touches nothing. */
+function recorder(): { calls: string[]; removeWeb: (name: string) => string[] } {
+  const calls: string[] = [];
+  return { calls, removeWeb: (name) => (calls.push(name), [`${name}.desktop`]) };
+}
+
+describe("unticking an installed item", () => {
+  test("names the tool it will remove, and how", async () => {
+    const lines = catalogueLines({
+      tools: [toolRow({ name: "just" })],
+      webApps: [],
+      canAdd: false,
+    });
+    const going = catalogueRemovals(lines, new Set(), recorder());
+
+    expect(going.map((g) => g.name)).toEqual(["just"]);
+    expect(removalNotice(going)).toEqual(["just — apt remove just"]);
+  });
+
+  test("names the web app it will remove, and what goes with it", () => {
+    const lines = catalogueLines({
+      tools: [],
+      webApps: [webRow("ChatGPT", true)],
+      canAdd: false,
+    });
+    const going = catalogueRemovals(lines, new Set(), recorder());
+
+    expect(removalNotice(going)).toEqual(["ChatGPT — its launcher and its icon"]);
+  });
+
+  test("removes both halves of the list in one act", async () => {
+    const lines = catalogueLines({
+      tools: [toolRow({ name: "duf" })],
+      webApps: [webRow("ChatGPT", true)],
+      canAdd: false,
+    });
+    const io = recorder();
+    const going = catalogueRemovals(lines, new Set(), io);
+    const outcome = await removeUnticked(going, async () => true);
+
+    expect(outcome.confirmed).toBe(true);
+    expect(outcome.failed).toEqual([]);
+    expect(outcome.done).toEqual([
+      "duf removed (apt remove duf)",
+      "ChatGPT removed (1 file(s))",
+    ]);
+    expect(io.calls).toEqual(["ChatGPT"]);
+  });
+
+  test("a tick left alone removes nothing", () => {
+    const lines = catalogueLines({
+      tools: [toolRow({ name: "just" })],
+      webApps: [webRow("ChatGPT", true)],
+      canAdd: true,
+    });
+    const chosen = new Set(lines.map((l) => l.label));
+
+    expect(catalogueRemovals(lines, chosen, recorder())).toEqual([]);
+    // And the list opens with every installed thing ticked, which is what
+    // makes the sentence above true in practice rather than only here.
+    expect(lines.filter((l) => l.label !== ADD_A_WEB_APP).every((l) => l.ticked)).toBe(true);
+  });
+
+  test("unticking something that is not there removes nothing", () => {
+    const lines = catalogueLines({
+      tools: [toolRow({ name: "gitui", installed: false, present: false, removal: null })],
+      webApps: [webRow("Tailscale", false)],
+      canAdd: false,
+    });
+
+    expect(catalogueRemovals(lines, new Set(), recorder())).toEqual([]);
+  });
+
+  test("an installed tool this project cannot undo says so instead of pretending", () => {
+    const lines = catalogueLines({
+      tools: [toolRow({ name: "blender", removal: null })],
+      webApps: [],
+      canAdd: false,
+    });
+
+    expect(lines[0]?.label).toContain("`red-dev uninstall`");
+    expect(catalogueRemovals(lines, new Set(), recorder())).toEqual([]);
+  });
+});
+
+describe("the scopes an untick can reach", () => {
+  test("is exactly one, and it is optional", () => {
+    expect(CATALOGUE_SCOPE).toBe("optional");
+  });
+
+  test("no core, desktop or wsl tool is ever offered", () => {
+    for (const p of [DESKTOP, WINDOWS]) {
+      const offered = new Set(catalogueTools(p).map((t) => t.tool.name));
+      expect(offered.size).toBeGreaterThan(0);
+
+      for (const scope of MACHINE_SCOPES) {
+        for (const tool of toolsInScope(scope)) {
+          expect(offered.has(tool.name)).toBe(false);
+        }
+      }
+    }
+  });
+
+  test("every row it does offer declares the optional scope", () => {
+    for (const p of [DESKTOP, WINDOWS]) {
+      for (const row of catalogueTools(p)) expect(row.tool.scope).toBe("optional");
+    }
+  });
+
+  test("a scope the target cannot use is not offered either", () => {
+    // PowerToys is optional and real, and its Linux provider is a skip.
+    // Filtering on the scope alone would put a row on a machine where
+    // ticking it does nothing and unticking it names a removal that
+    // cannot run.
+    expect(catalogueTools(DESKTOP).map((t) => t.tool.name)).not.toContain("powertoys");
+    expect(catalogueTools(WINDOWS).map((t) => t.tool.name)).toContain("powertoys");
+  });
+});
+
+describe("the naming step", () => {
+  /** A removal that records the order it was asked in, and never runs. */
+  function watched(name: string, order: string[]): Going {
+    return {
+      name,
+      what: `apt remove ${name}`,
+      run: async () => (order.push(`run:${name}`), "gone"),
+    };
+  }
+
+  test("a refusal removes nothing", async () => {
+    const order: string[] = [];
+    const going = [watched("just", order), watched("duf", order)];
+    const outcome = await removeUnticked(going, async () => (order.push("asked"), false));
+
+    expect(order).toEqual(["asked"]);
+    expect(outcome).toEqual({ confirmed: false, done: [], failed: [] });
+  });
+
+  test("the question comes before the first removal, not between them", async () => {
+    const order: string[] = [];
+    const going = [watched("just", order), watched("duf", order)];
+    await removeUnticked(going, async () => (order.push("asked"), true));
+
+    expect(order).toEqual(["asked", "run:just", "run:duf"]);
+  });
+
+  test("nothing unticked asks nothing", async () => {
+    let asked = 0;
+    const outcome = await removeUnticked([], async () => (asked++, true));
+
+    expect(asked).toBe(0);
+    expect(outcome).toEqual({ confirmed: false, done: [], failed: [] });
+  });
+
+  test("the question counts what it is about to do", async () => {
+    const questions: string[] = [];
+    const ask = async (q: string): Promise<boolean> => (questions.push(q), false);
+    const order: string[] = [];
+
+    await removeUnticked([watched("just", order)], ask);
+    await removeUnticked([watched("just", order), watched("duf", order)], ask);
+
+    expect(questions).toEqual(["Remove it?", "Remove all 2?"]);
+  });
+
+  test("one failure does not stop the rest, and is reported", async () => {
+    const order: string[] = [];
+    const going: Going[] = [
+      { name: "just", what: "apt remove just", run: async () => { throw new Error("apt is locked"); } },
+      watched("duf", order),
+    ];
+    const outcome = await removeUnticked(going, async () => true);
+
+    expect(outcome.confirmed).toBe(true);
+    expect(outcome.done).toEqual(["duf removed (gone)"]);
+    expect(outcome.failed).toEqual([{ name: "just", reason: "apt is locked" }]);
+  });
+});

--- a/src/catalogue.ts
+++ b/src/catalogue.ts
@@ -1,0 +1,274 @@
+/**
+ * The Catalogue, and the fact that it reads in both directions.
+ *
+ * A list of things you can have is half a feature. omakub answers "how
+ * do I remove this?" with a second script per application, somewhere
+ * else, named after the thing — which means the list you are looking at
+ * is not the place you take anything out of, and the only way to know
+ * what removing something would do is to read the script. So the tick
+ * goes on and stays on, because nothing in the list ever suggested it
+ * could come off.
+ *
+ * Here the untick is the removal. The list a person is already reading
+ * is where something leaves from, which makes it a list rather than an
+ * install form with a submit button.
+ *
+ * Two rules hold that up, and both are structural rather than advisory:
+ *
+ *  - Only `optional` is ever offered. `core`, `desktop` and `wsl` are
+ *    the identical-experience layer — the part of the machine nobody
+ *    chose and nobody should be able to dismantle with a space bar. They
+ *    are not in this file's reach at all, so an untick cannot name one
+ *    even by accident, and whole-product removal stays the separate,
+ *    explicit act it is (`red-dev uninstall`).
+ *  - Nothing goes without being named first. `catalogueRemovals` builds
+ *    the list and runs none of it; `removeUnticked` asks once, before
+ *    the first removal rather than between them, and returns having done
+ *    nothing at all if the answer was no.
+ *
+ * The removals themselves are not written here. A tool's is the inverse
+ * of its provider, which uninstall.ts already derives once for the whole
+ * manifest; a web app's is webapps.ts deleting the two files it wrote.
+ * This file is the part that decides *which*, and says so out loud.
+ */
+
+import { isInstalled, isPresent, providerFor, toolsInScope, type Tool } from "./manifest.ts";
+import type { Platform } from "./platform.ts";
+import { removalFor, type Removal } from "./uninstall.ts";
+import type { WebApp, WebAppRow } from "./webapps.ts";
+
+/**
+ * The one scope the Catalogue may offer, exported so a test can say so.
+ *
+ * A constant rather than a literal spelled at each use: the guarantee is
+ * that there is exactly one, and three copies of the same string are
+ * three places for a fourth to appear.
+ */
+export const CATALOGUE_SCOPE = "optional" as const;
+
+/** The line a person types to remove what this list will not. */
+const THE_OTHER_WAY_OUT = "`red-dev uninstall`";
+
+export interface CatalogueTool {
+  tool: Tool;
+  /** Usable at the version this machine has — what the install side asks. */
+  installed: boolean;
+  /**
+   * On disk at whatever version — what removal asks, and deliberately
+   * not the same question. A tool below its version floor is still the
+   * user's to take out; asking `isInstalled` would hide it from the list
+   * while leaving it on the machine.
+   */
+  present: boolean;
+  /** How it comes out, or null when nothing here may take it out. */
+  removal: Removal | null;
+}
+
+/**
+ * The optional tools this target can actually have.
+ *
+ * The scope filter is the guarantee; the provider filter is the honesty.
+ * PowerToys is optional everywhere and installable only on Windows, so
+ * on Ubuntu it would be a row that does nothing when ticked and names a
+ * removal that cannot run when unticked.
+ */
+export function catalogueTools(p: Platform): CatalogueTool[] {
+  const out: CatalogueTool[] = [];
+  for (const tool of toolsInScope(CATALOGUE_SCOPE)) {
+    if (providerFor(tool, p).kind === "skip") continue;
+    // `managed` means the provider owns the layout and nothing probes for
+    // it, so `present` is already false — the guard is here to say why
+    // rather than to leave the reason to a reader of installState.
+    const present = !tool.managed && isPresent(tool);
+    out.push({
+      tool,
+      installed: isInstalled(tool),
+      present,
+      removal: present ? removalFor(tool, p) : null,
+    });
+  }
+  return out;
+}
+
+/** What one line of the Catalogue stands for, once a label comes back. */
+export type CatalogueRow =
+  | { kind: "tool"; tool: CatalogueTool }
+  | { kind: "web"; app: WebApp; installed: boolean }
+  | { kind: "add" };
+
+export interface CatalogueLine {
+  /**
+   * The line the checkbox shows — and the identity it answers with,
+   * which is why it is built once and kept. A second construction that
+   * drifts by one space is a removal that silently never happens.
+   */
+  label: string;
+  row: CatalogueRow;
+  /** Whether the list opens with this one ticked. */
+  ticked: boolean;
+}
+
+export const ADD_A_WEB_APP = "+ Add a web app by URL…";
+
+/**
+ * The whole list, in the order it is drawn.
+ *
+ * Everything already on the machine opens ticked, in both halves. That
+ * is what makes "leaving the list alone changes nothing" true, and it is
+ * the precondition for treating an untick as an instruction rather than
+ * as the absence of one.
+ */
+export function catalogueLines(opts: {
+  tools: readonly CatalogueTool[];
+  webApps: readonly WebAppRow[];
+  /** Whether this target has somewhere for a typed-in launcher to live. */
+  canAdd: boolean;
+}): CatalogueLine[] {
+  const lines: CatalogueLine[] = [];
+
+  for (const t of opts.tools) {
+    // Every tool opens ticked: a curated list is an opt-out, and the
+    // ones that are not installed cost nothing by being on.
+    lines.push({ label: toolLabel(t), row: { kind: "tool", tool: t }, ticked: true });
+  }
+
+  for (const row of opts.webApps) {
+    lines.push({
+      label: webAppLabel(row),
+      row: { kind: "web", app: row.app, installed: row.installed },
+      ticked: row.ticked,
+    });
+  }
+
+  if (opts.canAdd) {
+    lines.push({ label: ADD_A_WEB_APP, row: { kind: "add" }, ticked: false });
+  }
+
+  return lines;
+}
+
+/**
+ * An installed tool this project cannot undo says so on its own row.
+ *
+ * A vendor script owns its own layout, so `removalFor` refuses to guess
+ * which files it wrote — the right answer, and one the list has to
+ * repeat, because a row that reads "(installed)" next to five rows an
+ * untick removes is a checkbox promising something it will not do.
+ */
+function toolLabel(t: CatalogueTool): string {
+  const about = t.tool.about ? ` — ${t.tool.about}` : "";
+  if (!t.present) return `${t.tool.name}${about}`;
+  if (!t.removal) return `${t.tool.name}${about}  (installed — ${THE_OTHER_WAY_OUT} removes it)`;
+  return `${t.tool.name}${about}  (installed)`;
+}
+
+function webAppLabel(row: WebAppRow): string {
+  return `${row.app.name} — ${row.app.url || "web app"}${row.installed ? "  (installed)" : ""}`;
+}
+
+/** One thing an untick will take out, named the way a person reads it. */
+export interface Going {
+  name: string;
+  /** What goes with it, in the words the confirmation prints. */
+  what: string;
+  /** Do it. Resolves to what to print once it has. */
+  run: () => Promise<string>;
+}
+
+/**
+ * Everything the answer left unticked that is actually there to remove.
+ *
+ * Builds closures and calls none of them, so this can be handed to the
+ * naming step and thrown away unread if the answer is no.
+ */
+export function catalogueRemovals(
+  lines: readonly CatalogueLine[],
+  chosen: ReadonlySet<string>,
+  io: { removeWeb: (name: string) => string[] },
+): Going[] {
+  const going: Going[] = [];
+
+  for (const line of lines) {
+    if (chosen.has(line.label)) continue;
+    const row = line.row;
+
+    if (row.kind === "tool") {
+      // Non-null only for something present that this project knows how
+      // to undo, so "installed" and "removable" are one check.
+      const removal = row.tool.removal;
+      if (!removal) continue;
+      going.push({
+        name: row.tool.tool.name,
+        what: removal.how,
+        run: async () => {
+          await removal.run();
+          return removal.how;
+        },
+      });
+      continue;
+    }
+
+    if (row.kind === "web") {
+      if (!row.installed) continue;
+      going.push({
+        name: row.app.name,
+        what: "its launcher and its icon",
+        run: async () => `${io.removeWeb(row.app.name).length} file(s)`,
+      });
+    }
+  }
+
+  return going;
+}
+
+/**
+ * The naming step, as lines rather than as printing.
+ *
+ * Separate from `removeUnticked` on purpose: what a person is told is
+ * the thing being promised, so it is a value a test can read rather than
+ * a side effect it would have to capture.
+ */
+export function removalNotice(going: readonly Going[]): string[] {
+  return going.map((g) => `${g.name} — ${g.what}`);
+}
+
+export interface RemovalOutcome {
+  /** Whether the question was answered yes. Nothing ran when it was not. */
+  confirmed: boolean;
+  /** One line per removal that happened. */
+  done: string[];
+  failed: { name: string; reason: string }[];
+}
+
+/**
+ * Ask once, then remove.
+ *
+ * The question is asked before the first removal rather than per item:
+ * a person who has just read the whole list should not be interrogated
+ * item by item, and a prompt that appears after two things are already
+ * gone is not a confirmation of anything.
+ *
+ * A failure does not stop the rest. Removing four tools and hitting a
+ * held apt lock on the second should not leave two of the four behind
+ * with nothing said about them.
+ */
+export async function removeUnticked(
+  going: readonly Going[],
+  confirm: (question: string, fallback: boolean) => Promise<boolean>,
+): Promise<RemovalOutcome> {
+  if (going.length === 0) return { confirmed: false, done: [], failed: [] };
+
+  const question = going.length === 1 ? "Remove it?" : `Remove all ${going.length}?`;
+  if (!(await confirm(question, true))) return { confirmed: false, done: [], failed: [] };
+
+  const done: string[] = [];
+  const failed: { name: string; reason: string }[] = [];
+  for (const g of going) {
+    try {
+      done.push(`${g.name} removed (${await g.run()})`);
+    } catch (err) {
+      failed.push({ name: g.name, reason: (err as Error).message });
+    }
+  }
+  return { confirmed: true, done, failed };
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -180,7 +180,7 @@ export function buildCli(): CLI {
         description: "regenerate the wallpaper that carries this machine's state",
       },
       apps: {
-        description: "choose optional tools and web apps; untick an installed web app to remove it",
+        description: "choose optional tools and web apps; untick an installed one to remove it",
       },
       keys: {
         // No positional and no flags. What it lists comes from the

--- a/src/main.ts
+++ b/src/main.ts
@@ -1019,14 +1019,6 @@ async function cmdRedwall(p: Platform): Promise<number> {
   return 0;
 }
 
-/** What one line of the Catalogue stands for, once a label comes back. */
-type CatalogueRow =
-  | { kind: "tool"; name: string }
-  | { kind: "web"; app: WebApp; installed: boolean }
-  | { kind: "add" };
-
-const ADD_A_WEB_APP = "+ Add a web app by URL…";
-
 /**
  * The Catalogue — the list a person ticks rather than receives.
  *
@@ -1041,13 +1033,15 @@ const ADD_A_WEB_APP = "+ Add a web app by URL…";
  * behind a command you invoke deliberately, which is also why this can
  * be re-run whenever the answer changes.
  *
- * Unticking is what makes this a list rather than a form. An installed
- * web app arrives ticked, so leaving the list alone changes nothing, and
- * taking the tick off one is how it goes — after being named, because
- * the one thing a checkbox must never do is delete something quietly.
- * Optional tools do not remove from here yet; `red-dev uninstall` is
- * still their way out, and the list says so rather than implying
- * otherwise.
+ * Unticking is what makes this a list rather than a form, and it now
+ * means the same thing in both halves: anything installed arrives
+ * ticked, so leaving the list alone changes nothing, and taking the tick
+ * off something is how it goes — after being named, because the one
+ * thing a checkbox must never do is delete something quietly.
+ *
+ * Which rows can be unticked into a removal, and which scopes are never
+ * on this list at all, is src/catalogue.ts. This function is the
+ * terminal around it: it asks, prints, and applies.
  */
 async function cmdApps(p: Platform, inv: Invocation): Promise<number> {
   const { checkbox, confirm } = await import("./ui.ts");
@@ -1059,56 +1053,37 @@ async function cmdApps(p: Platform, inv: Invocation): Promise<number> {
     webAppCatalogue,
     webAppSupport,
   } = await import("./webapps.ts");
+  const {
+    catalogueLines,
+    catalogueRemovals,
+    catalogueTools,
+    removalNotice,
+    removeUnticked,
+  } = await import("./catalogue.ts");
 
-  const available = toolsInScope("optional").filter(
-    (t) => providerFor(t, p).kind !== "skip",
-  );
+  const tools = catalogueTools(p);
 
   // A page is offered only where a launcher has something to live in.
   // Under WSL that is nothing, and the reason is printed rather than the
   // section silently disappearing.
   const support = webAppSupport(p);
-  const webRows = support.ok ? webAppCatalogue(installedWebApps(p)) : [];
+  const webApps = support.ok ? webAppCatalogue(installedWebApps(p)) : [];
   if (!support.ok) log.skip(`web apps: ${support.reason}`);
 
-  if (available.length === 0 && webRows.length === 0) {
+  if (tools.length === 0 && webApps.length === 0) {
     log.skip("nothing on this target is optional");
     return 0;
   }
 
-  const already = available.filter(isInstalled).map((t) => t.name);
-  const rows = new Map<string, CatalogueRow>();
-  const labels: string[] = [];
-  const ticked: string[] = [];
-
-  for (const t of available) {
-    const label = `${t.name}${t.about ? ` — ${t.about}` : ""}${already.includes(t.name) ? "  (installed)" : ""}`;
-    rows.set(label, { kind: "tool", name: t.name });
-    labels.push(label);
-    // Every tool starts on: a curated list is an opt-out, and unticking
-    // a tool here does not remove it, so a tick left alone is harmless.
-    ticked.push(label);
-  }
-
-  // Kept rather than rebuilt: the label is the identity a checkbox
-  // answers with, and a second construction of it that drifts by one
-  // space is a removal that silently never happens.
-  const webLabels = new Map<string, string>();
-  for (const row of webRows) {
-    const label = `${row.app.name} — ${row.app.url || "web app"}${row.installed ? "  (installed)" : ""}`;
-    rows.set(label, { kind: "web", app: row.app, installed: row.installed });
-    webLabels.set(row.app.name, label);
-    labels.push(label);
-    if (row.ticked) ticked.push(label);
-  }
-
-  if (support.ok) {
-    rows.set(ADD_A_WEB_APP, { kind: "add" });
-    labels.push(ADD_A_WEB_APP);
-  }
+  const lines = catalogueLines({ tools, webApps, canAdd: support.ok });
+  const byLabel = new Map(lines.map((line) => [line.label, line]));
+  const labels = lines.map((line) => line.label);
+  const ticked = lines.filter((line) => line.ticked).map((line) => line.label);
 
   // Every install choice is opt-out, but a fallback must never install
-  // the whole catalog when there is no terminal to show that choice.
+  // the whole catalog when there is no terminal to show that choice —
+  // and with removal on this list, a fallback answer is also an untick
+  // nobody typed.
   if (!interactive()) {
     log.err("choosing what to install needs a terminal");
     log.plain("     Run `red-dev apps` interactively and untick what you do not want.");
@@ -1125,26 +1100,20 @@ async function cmdApps(p: Platform, inv: Invocation): Promise<number> {
   // Named first and taken out first, so the list a person confirms is
   // the list they were looking at rather than one an install has already
   // changed underneath them.
-  const going = webRows.filter(
-    (row) => row.installed && !chosen.has(webLabels.get(row.app.name) ?? ""),
-  );
+  const going = catalogueRemovals(lines, chosen, {
+    removeWeb: (name) => removeWebApp(p, name),
+  });
   let failures = 0;
 
   if (going.length > 0) {
     log.plain("     Unticked, so these go:");
-    for (const row of going) log.plain(`       ${row.app.name} — its launcher and its icon`);
-    if (await confirm("Remove them?", true)) {
-      for (const row of going) {
-        try {
-          const removed = removeWebApp(p, row.app.name);
-          log.ok(`${row.app.name} removed (${removed.length} file(s))`);
-        } catch (err) {
-          log.err(`${row.app.name}: ${(err as Error).message}`);
-          failures++;
-        }
-      }
-    } else {
-      log.skip("nothing removed");
+    for (const line of removalNotice(going)) log.plain(`       ${line}`);
+    const outcome = await removeUnticked(going, confirm);
+    if (!outcome.confirmed) log.skip("nothing removed");
+    for (const line of outcome.done) log.ok(line);
+    for (const failure of outcome.failed) {
+      log.err(`${failure.name}: ${failure.reason}`);
+      failures++;
     }
   }
 
@@ -1161,13 +1130,12 @@ async function cmdApps(p: Platform, inv: Invocation): Promise<number> {
     (context ??= await contextFor(p, inv, "install"));
 
   for (const label of picked) {
-    const row = rows.get(label);
+    const row = byLabel.get(label)?.row;
     if (!row) continue;
 
     if (row.kind === "tool") {
-      const tool = available.find((t) => t.name === row.name);
-      if (!tool) continue;
-      if (isInstalled(tool) && !tool.managed) {
+      const { tool, installed } = row.tool;
+      if (installed && !tool.managed) {
         log.skip(`${tool.name} already present`);
         continue;
       }

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -153,7 +153,8 @@ export const SECTIONS: MenuSection[] = [
       "Optional tools and web apps, never",
       "installed by a plain converge. Chosen,",
       "not assumed — and unticking an",
-      "installed web app takes it back off.",
+      "installed one takes it back off, after",
+      "naming exactly what goes.",
     ],
   },
   {


### PR DESCRIPTION
Automated AFK landing for #144. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #144

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/172"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789458194&installation_model_id=20659&pr_number=172&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F172&signature=518b3ffbe1d112011fde77689ce7cae6922e5c0ec629c6907211d4d58d5f8a9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->