### PR TITLE
fix: #145 The emoji picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,6 +466,7 @@ red-dev wallpaper [source]   # theme | Red artwork | absolute PNG path | HTTPS U
 red-dev redwall              # redraw the wallpaper carrying this machine's state
 red-dev apps                 # choose optional tools and web apps; untick one to remove it
 red-dev keys                 # search every action and its chord, and run one
+red-dev emoji                # search the bundled emoji table, copy one to the clipboard
 red-dev learn                # the README by anchor, RedSkills, and the keys viewer
 red-dev lang                 # choose runtimes for mise to manage
 red-dev lang node@24,bun@1.3 # unattended, independently selected versions

--- a/src/actions/registry.test.ts
+++ b/src/actions/registry.test.ts
@@ -46,6 +46,7 @@ describe("the registry itself", () => {
     expect(ACTIONS.map((a) => a.id)).toEqual([
       "terminal.new",
       "terminal.elevated",
+      "emoji.pick",
       "panel.network",
       "panel.audio",
       "panel.power",

--- a/src/actions/terminal-surfaces.ts
+++ b/src/actions/terminal-surfaces.ts
@@ -2,13 +2,48 @@
  * The surfaces red-dev draws in a terminal of its own — the menu, the
  * keys viewer, the emoji picker.
  *
- * Born empty, and that is the point. The registry is a directory with a
+ * Born empty, and that was the point. The registry is a directory with a
  * module per area from its first commit so that the slices which build
  * these surfaces add a line to their own file, rather than six slices
  * queueing behind one another over the same list. An empty area is a
- * declaration of where its actions will go.
+ * declaration of where its actions will go; this is the first one
+ * arriving.
  */
 
 import type { SemanticAction } from "./types.ts";
 
-export const TERMINAL_SURFACE_ACTIONS: readonly SemanticAction[] = [];
+/**
+ * Everywhere with a display, WSL included — the same set the terminal
+ * actions and the Panels claim, and for the same reason: this list is
+ * about a chord, and a chord needs somewhere to be pressed.
+ *
+ * `server` is absent from the list and not from the product. `red-dev
+ * emoji` is a command and it answers over SSH exactly as it does here —
+ * it draws the table, searches it, and says that this machine has no
+ * clipboard to put the answer on, which is a more useful thing to be
+ * told than nothing.
+ */
+const WITH_A_DISPLAY = ["desktop", "wsl", "windows"] as const;
+
+export const TERMINAL_SURFACE_ACTIONS: readonly SemanticAction[] = [
+  {
+    id: "emoji.pick",
+    label: "Emoji picker",
+    platforms: WITH_A_DISPLAY,
+    // Opening it reads a table compiled into the binary. Pressing Enter
+    // writes the clipboard, which belongs to the signed-in session and
+    // needs nothing from the machine — the same reason the Panels are
+    // both false.
+    mutates: false,
+    privileged: false,
+    // E for emoji. Free in the family on both hosts: GNOME spends its
+    // Ctrl+Alt on the workspaces, L, Tab, Esc, Delete and the virtual
+    // terminals, and Windows on Delete, Tab and the display drivers'
+    // arrows. Neither claims E — and the host pickers people may know,
+    // GNOME's Ctrl+. and Windows' Win+. , are left exactly where they
+    // are, because ADR 0006 keeps red-dev out of the Super family and
+    // taking Ctrl+. would fight GTK for a key it uses inside text
+    // fields.
+    chord: "Ctrl+Alt+E",
+  },
+];

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -191,6 +191,14 @@ export function buildCli(): CLI {
         // chord you cannot name yet.
         description: "search every action and its chord, and run one",
       },
+      emoji: {
+        // No positional and no flags, for the reason `keys` has none:
+        // the search is typed into the picker, not onto the command
+        // line, because the point of the thing is to find a character
+        // you cannot name yet. What it copies through comes from what
+        // this machine is.
+        description: "search the bundled emoji table and copy one to the clipboard",
+      },
       learn: {
         description: "the README by anchor, RedSkills, and the keys viewer",
       },

--- a/src/dotfiles.ts
+++ b/src/dotfiles.ts
@@ -325,15 +325,27 @@ const SHIPPED_ZELLIJ_CONFIGS = new Set([
  * iconv + clip.exe completes in tens of milliseconds. clip.exe accepts
  * redirected UTF-16LE without a BOM, preserving accents and supplementary
  * Unicode characters in the Windows clipboard.
+ *
+ * The argv is the primitive and the string is derived from it, not the
+ * other way round. zellij wants one line of shell; a red-dev surface that
+ * copies something — the Emoji picker is the first — wants a program and
+ * its arguments, and deriving the string means the second one cannot
+ * drift into a second bridge with its own encoding bug. `join(" ")`
+ * reproduces the exact line this function has always returned, which is
+ * what keeps the SHIPPED_ZELLIJ_CONFIGS upgrade path intact.
  */
+export function wslClipboardArgv(): readonly string[] {
+  return ["bash", `${home()}/.local/share/red-dev/config/bash/windows-clipboard.sh`];
+}
+
 export function wslClipboardCommand(): string {
-  return `bash ${home()}/.local/share/red-dev/config/bash/windows-clipboard.sh`;
+  return wslClipboardArgv().join(" ");
 }
 
 /** Native Windows fallback. WSL uses the faster helper above because Zellij
  * terminates commands after one second; PowerShell startup inside WSL can
  * exceed that deadline. */
-export function windowsClipboardCommand(): string {
+export function windowsClipboardArgv(): readonly string[] {
   const script =
     "$ProgressPreference='SilentlyContinue';" +
     "$s=[Console]::OpenStandardInput();" +
@@ -341,7 +353,40 @@ export function windowsClipboardCommand(): string {
     "$s.CopyTo($m);" +
     "Set-Clipboard -Value ([Text.Encoding]::UTF8.GetString($m.ToArray()))";
   const encoded = Buffer.from(script, "utf16le").toString("base64");
-  return `powershell.exe -NoProfile -EncodedCommand ${encoded}`;
+  return ["powershell.exe", "-NoProfile", "-EncodedCommand", encoded];
+}
+
+export function windowsClipboardCommand(): string {
+  return windowsClipboardArgv().join(" ");
+}
+
+/**
+ * The three routes, and the one target that has none.
+ *
+ * This is the whole clipboard layer of the product, in one function: the
+ * WSL bridge, the native Windows bridge, and `wl-copy` on a Linux
+ * desktop. A server gets null, because a copy_command naming a program
+ * that is not installed is the same silent failure as no clipboard at
+ * all, pointed the other way — and there is no display there to have a
+ * clipboard on.
+ *
+ * The order is not alphabetical and cannot be reordered. A WSL distro is
+ * `os: "linux"` and `env: "wsl"`, so asking about the OS first would send
+ * it to a `wl-copy` that is not there; and native Windows is `env:
+ * "windows"`, not `"desktop"`, so the desktop branch has to come last.
+ *
+ * Exported so every surface that copies asks the same question. zellij's
+ * `copy_command` was the first caller and the Emoji picker is the second;
+ * a third one that wrote its own ternary is how one target quietly gets a
+ * clipboard the others do not have.
+ */
+export function clipboardArgvFor(p: Platform): readonly string[] | null {
+  if (p.env === "wsl") return wslClipboardArgv();
+  if (p.os === "windows") return windowsClipboardArgv();
+  // wl-copy, not xclip: the desktop targets are Wayland sessions, and
+  // wl-copy takes UTF-8 on stdin with no encoding step in between.
+  if (p.env === "desktop") return ["wl-copy"];
+  return null;
 }
 
 /**
@@ -362,16 +407,9 @@ export function windowsClipboardCommand(): string {
  * other way.
  */
 export function zellijConfigFor(p: Platform): string {
-  const command =
-    p.env === "wsl"
-      ? wslClipboardCommand()
-      : p.os === "windows"
-        ? windowsClipboardCommand()
-        : p.env === "desktop"
-          ? "wl-copy"
-          : null;
-
-  if (!command) return zellijBase;
+  const argv = clipboardArgvFor(p);
+  if (!argv) return zellijBase;
+  const command = argv.join(" ");
 
   return `${zellijBase}
 // Generated for this target by red-dev.

--- a/src/emoji-table.ts
+++ b/src/emoji-table.ts
@@ -1,0 +1,450 @@
+/**
+ * The emoji table, shipped inside the binary.
+ *
+ * Not read from a system font, not fetched, not shelled out to. That is
+ * the whole reason this file exists rather than a lookup: the picker has
+ * to return the same rows on Ubuntu 24, Ubuntu 26, WSL, native Windows
+ * and a headless server, and every alternative source varies by target.
+ * A font query answers with what the machine happens to have installed,
+ * which is a different list on a fresh Windows than on an Ubuntu with
+ * Noto Color Emoji; a service answers differently on the day it is
+ * unreachable. A table compiled into the binary cannot do either.
+ *
+ * What is *drawn* still varies — a terminal with no emoji font shows
+ * boxes — and that is the terminal's business, not red-dev's. What goes
+ * on the clipboard is these code points, and those are identical
+ * everywhere.
+ *
+ * ## What is in it, and what is not
+ *
+ * A curated set rather than all ~3,800 of Unicode's. The picker exists
+ * to be typed into, and the rows that matter are the ones somebody
+ * reaches for: the faces, the hands, the check marks and crosses, the
+ * things a commit message or a chat reply is made of. The long tail —
+ * every flag, every skin-tone and gender variant, the full clock face
+ * series — makes the search noisier without making it more useful, and
+ * the variants in particular would bury their own base emoji.
+ *
+ * Skin-tone modifiers are deliberately absent for a second reason: a
+ * picker that offers six versions of every hand offers a choice about
+ * somebody's body that a tool converging a dev environment has no
+ * business putting in a list.
+ *
+ * ## The shape of a row
+ *
+ * `name` is the CLDR short name, lowercased — it is what a person half
+ * remembers, and it is what the search ranks on first. `keywords` are
+ * the words that are *not* in the name and that somebody would type
+ * anyway: `lol` for 😂, `deploy` for 🚀, `config` for ⚙️. Putting a word
+ * already in the name into the keywords does nothing, so none do.
+ */
+
+export interface Emoji {
+  /** The code points that go on the clipboard. */
+  char: string;
+  /** The CLDR short name, lowercased. */
+  name: string;
+  /** Which of the eight groups it belongs to. */
+  group: string;
+  /** Words a person would type that are not already in the name. */
+  keywords: readonly string[];
+}
+
+// Short local names, because the group is repeated on every row and a
+// literal per row is 200 chances to typo one of eight strings.
+const SMILEY = "Smileys & Emotion";
+const PEOPLE = "People & Body";
+const NATURE = "Animals & Nature";
+const FOOD = "Food & Drink";
+const TRAVEL = "Travel & Places";
+const ACTIVITY = "Activities";
+const OBJECT = "Objects";
+const SYMBOL = "Symbols";
+
+/**
+ * Every group, in the order the table lists them.
+ *
+ * Exported so a caller can say what the picker holds without walking the
+ * table, and so the ordering is one decision rather than an emergent
+ * property of where somebody pasted their new row.
+ */
+export const EMOJI_GROUPS: readonly string[] = [
+  SMILEY,
+  PEOPLE,
+  NATURE,
+  FOOD,
+  TRAVEL,
+  ACTIVITY,
+  OBJECT,
+  SYMBOL,
+];
+
+export const EMOJI: readonly Emoji[] = [
+  // ------------------------------------------------ Smileys & Emotion
+  { char: "😀", name: "grinning face", group: SMILEY, keywords: ["smile", "happy"] },
+  { char: "😃", name: "grinning face with big eyes", group: SMILEY, keywords: ["smile", "happy"] },
+  { char: "😄", name: "grinning face with smiling eyes", group: SMILEY, keywords: ["joy"] },
+  { char: "😁", name: "beaming face with smiling eyes", group: SMILEY, keywords: ["grin"] },
+  { char: "😆", name: "grinning squinting face", group: SMILEY, keywords: ["laugh", "haha"] },
+  { char: "😅", name: "grinning face with sweat", group: SMILEY, keywords: ["laugh", "relief"] },
+  { char: "🤣", name: "rolling on the floor laughing", group: SMILEY, keywords: ["rofl", "lol"] },
+  { char: "😂", name: "face with tears of joy", group: SMILEY, keywords: ["lol", "laugh", "cry"] },
+  { char: "🙂", name: "slightly smiling face", group: SMILEY, keywords: ["smile"] },
+  { char: "🙃", name: "upside-down face", group: SMILEY, keywords: ["irony", "sarcasm"] },
+  { char: "😉", name: "winking face", group: SMILEY, keywords: ["wink", "flirt"] },
+  { char: "😊", name: "smiling face with smiling eyes", group: SMILEY, keywords: ["blush", "happy"] },
+  { char: "😇", name: "smiling face with halo", group: SMILEY, keywords: ["angel", "innocent"] },
+  { char: "😍", name: "smiling face with heart-eyes", group: SMILEY, keywords: ["love", "crush"] },
+  { char: "🤩", name: "star-struck", group: SMILEY, keywords: ["wow", "amazed"] },
+  { char: "😘", name: "face blowing a kiss", group: SMILEY, keywords: ["love"] },
+  { char: "😋", name: "face savoring food", group: SMILEY, keywords: ["yum", "tasty"] },
+  { char: "😛", name: "face with tongue", group: SMILEY, keywords: ["cheeky"] },
+  { char: "🤪", name: "zany face", group: SMILEY, keywords: ["silly", "goofy"] },
+  { char: "🤨", name: "face with raised eyebrow", group: SMILEY, keywords: ["skeptical", "suspicious"] },
+  { char: "🧐", name: "face with monocle", group: SMILEY, keywords: ["inspect", "scrutiny"] },
+  { char: "🤓", name: "nerd face", group: SMILEY, keywords: ["geek", "glasses"] },
+  { char: "😎", name: "smiling face with sunglasses", group: SMILEY, keywords: ["cool"] },
+  { char: "🥳", name: "partying face", group: SMILEY, keywords: ["celebrate", "party"] },
+  { char: "😏", name: "smirking face", group: SMILEY, keywords: ["smug", "sly"] },
+  { char: "😒", name: "unamused face", group: SMILEY, keywords: ["meh", "unimpressed"] },
+  { char: "😔", name: "pensive face", group: SMILEY, keywords: ["sad", "thoughtful"] },
+  { char: "😕", name: "confused face", group: SMILEY, keywords: ["puzzled"] },
+  { char: "😣", name: "persevering face", group: SMILEY, keywords: ["struggle"] },
+  { char: "😫", name: "tired face", group: SMILEY, keywords: ["exhausted"] },
+  { char: "🥺", name: "pleading face", group: SMILEY, keywords: ["beg", "puppy eyes"] },
+  { char: "😢", name: "crying face", group: SMILEY, keywords: ["sad", "tear"] },
+  { char: "😭", name: "loudly crying face", group: SMILEY, keywords: ["sob", "bawl"] },
+  { char: "😤", name: "face with steam from nose", group: SMILEY, keywords: ["triumph", "frustrated"] },
+  { char: "😠", name: "angry face", group: SMILEY, keywords: ["mad"] },
+  { char: "😡", name: "enraged face", group: SMILEY, keywords: ["rage", "furious"] },
+  { char: "🤬", name: "face with symbols on mouth", group: SMILEY, keywords: ["swearing", "cursing"] },
+  { char: "🤯", name: "exploding head", group: SMILEY, keywords: ["mind blown", "shocked"] },
+  { char: "😳", name: "flushed face", group: SMILEY, keywords: ["embarrassed", "blush"] },
+  { char: "🥵", name: "hot face", group: SMILEY, keywords: ["heat", "sweating"] },
+  { char: "🥶", name: "cold face", group: SMILEY, keywords: ["freezing"] },
+  { char: "😱", name: "face screaming in fear", group: SMILEY, keywords: ["scream", "shock"] },
+  { char: "😨", name: "fearful face", group: SMILEY, keywords: ["scared"] },
+  { char: "😰", name: "anxious face with sweat", group: SMILEY, keywords: ["nervous"] },
+  { char: "🤗", name: "smiling face with open hands", group: SMILEY, keywords: ["hug"] },
+  { char: "🤔", name: "thinking face", group: SMILEY, keywords: ["think", "ponder", "hmm"] },
+  { char: "🤭", name: "face with hand over mouth", group: SMILEY, keywords: ["oops", "giggle"] },
+  { char: "🤫", name: "shushing face", group: SMILEY, keywords: ["quiet", "secret"] },
+  { char: "🤥", name: "lying face", group: SMILEY, keywords: ["pinocchio", "liar"] },
+  { char: "😶", name: "face without mouth", group: SMILEY, keywords: ["speechless"] },
+  { char: "😐", name: "neutral face", group: SMILEY, keywords: ["deadpan"] },
+  { char: "😑", name: "expressionless face", group: SMILEY, keywords: ["blank"] },
+  { char: "😬", name: "grimacing face", group: SMILEY, keywords: ["awkward", "cringe"] },
+  { char: "🙄", name: "face with rolling eyes", group: SMILEY, keywords: ["eyeroll", "annoyed"] },
+  { char: "😴", name: "sleeping face", group: SMILEY, keywords: ["zzz", "asleep"] },
+  { char: "😷", name: "face with medical mask", group: SMILEY, keywords: ["sick"] },
+  { char: "🤒", name: "face with thermometer", group: SMILEY, keywords: ["fever", "ill"] },
+  { char: "🤢", name: "nauseated face", group: SMILEY, keywords: ["sick", "gross"] },
+  { char: "🤮", name: "face vomiting", group: SMILEY, keywords: ["puke", "sick"] },
+  { char: "🥱", name: "yawning face", group: SMILEY, keywords: ["bored", "sleepy"] },
+  { char: "🤠", name: "cowboy hat face", group: SMILEY, keywords: ["yeehaw"] },
+  { char: "🥸", name: "disguised face", group: SMILEY, keywords: ["incognito"] },
+  { char: "😈", name: "smiling face with horns", group: SMILEY, keywords: ["devil", "mischief"] },
+  { char: "💀", name: "skull", group: SMILEY, keywords: ["dead", "danger"] },
+  { char: "☠️", name: "skull and crossbones", group: SMILEY, keywords: ["poison", "danger"] },
+  { char: "👻", name: "ghost", group: SMILEY, keywords: ["halloween", "boo"] },
+  { char: "👽", name: "alien", group: SMILEY, keywords: ["ufo", "extraterrestrial"] },
+  { char: "🤖", name: "robot", group: SMILEY, keywords: ["bot", "agent", "ai"] },
+  { char: "💩", name: "pile of poo", group: SMILEY, keywords: ["poop", "crap"] },
+  { char: "❤️", name: "red heart", group: SMILEY, keywords: ["love"] },
+  { char: "🧡", name: "orange heart", group: SMILEY, keywords: ["love"] },
+  { char: "💛", name: "yellow heart", group: SMILEY, keywords: ["love"] },
+  { char: "💚", name: "green heart", group: SMILEY, keywords: ["love"] },
+  { char: "💙", name: "blue heart", group: SMILEY, keywords: ["love"] },
+  { char: "💜", name: "purple heart", group: SMILEY, keywords: ["love"] },
+  { char: "🖤", name: "black heart", group: SMILEY, keywords: ["love"] },
+  { char: "💔", name: "broken heart", group: SMILEY, keywords: ["heartbreak"] },
+  { char: "💕", name: "two hearts", group: SMILEY, keywords: ["love"] },
+  { char: "💖", name: "sparkling heart", group: SMILEY, keywords: ["love"] },
+  { char: "💯", name: "hundred points", group: SMILEY, keywords: ["perfect", "score", "100"] },
+  { char: "💥", name: "collision", group: SMILEY, keywords: ["boom", "explosion"] },
+  { char: "💫", name: "dizzy", group: SMILEY, keywords: ["stars"] },
+  { char: "💦", name: "sweat droplets", group: SMILEY, keywords: ["water"] },
+  { char: "💤", name: "zzz", group: SMILEY, keywords: ["sleep", "snore"] },
+
+  // ---------------------------------------------------- People & Body
+  { char: "👋", name: "waving hand", group: PEOPLE, keywords: ["wave", "hello", "bye"] },
+  { char: "✋", name: "raised hand", group: PEOPLE, keywords: ["stop", "high five"] },
+  { char: "🖖", name: "vulcan salute", group: PEOPLE, keywords: ["spock", "star trek"] },
+  { char: "👌", name: "ok hand", group: PEOPLE, keywords: ["okay", "perfect"] },
+  { char: "🤏", name: "pinching hand", group: PEOPLE, keywords: ["small", "tiny"] },
+  { char: "✌️", name: "victory hand", group: PEOPLE, keywords: ["peace"] },
+  { char: "🤞", name: "crossed fingers", group: PEOPLE, keywords: ["luck", "hope"] },
+  { char: "🤟", name: "love-you gesture", group: PEOPLE, keywords: ["ily"] },
+  { char: "🤘", name: "sign of the horns", group: PEOPLE, keywords: ["rock"] },
+  { char: "🤙", name: "call me hand", group: PEOPLE, keywords: ["shaka", "hang loose"] },
+  { char: "👈", name: "backhand index pointing left", group: PEOPLE, keywords: ["point"] },
+  { char: "👉", name: "backhand index pointing right", group: PEOPLE, keywords: ["point"] },
+  { char: "👆", name: "backhand index pointing up", group: PEOPLE, keywords: ["point", "this"] },
+  { char: "👇", name: "backhand index pointing down", group: PEOPLE, keywords: ["point", "below"] },
+  { char: "👍", name: "thumbs up", group: PEOPLE, keywords: ["yes", "approve", "like", "lgtm"] },
+  { char: "👎", name: "thumbs down", group: PEOPLE, keywords: ["no", "disapprove", "dislike"] },
+  { char: "✊", name: "raised fist", group: PEOPLE, keywords: ["solidarity"] },
+  { char: "👊", name: "oncoming fist", group: PEOPLE, keywords: ["punch", "bump"] },
+  { char: "👏", name: "clapping hands", group: PEOPLE, keywords: ["applause", "bravo"] },
+  { char: "🙌", name: "raising hands", group: PEOPLE, keywords: ["celebrate", "praise"] },
+  { char: "🤝", name: "handshake", group: PEOPLE, keywords: ["deal", "agreement"] },
+  { char: "🙏", name: "folded hands", group: PEOPLE, keywords: ["please", "thanks", "pray"] },
+  { char: "✍️", name: "writing hand", group: PEOPLE, keywords: ["write", "sign"] },
+  { char: "💪", name: "flexed biceps", group: PEOPLE, keywords: ["strong", "muscle"] },
+  { char: "🧠", name: "brain", group: PEOPLE, keywords: ["mind", "smart", "think"] },
+  { char: "👀", name: "eyes", group: PEOPLE, keywords: ["look", "watching"] },
+  { char: "👁️", name: "eye", group: PEOPLE, keywords: ["see", "watch"] },
+  { char: "🫡", name: "saluting face", group: PEOPLE, keywords: ["salute", "yes sir"] },
+  { char: "🧑‍💻", name: "technologist", group: PEOPLE, keywords: ["developer", "coder", "programmer"] },
+  { char: "🕵️", name: "detective", group: PEOPLE, keywords: ["investigate", "spy", "debug"] },
+  { char: "🦸", name: "superhero", group: PEOPLE, keywords: ["hero"] },
+  { char: "🧙", name: "mage", group: PEOPLE, keywords: ["wizard", "magic"] },
+  { char: "🧑‍🚀", name: "astronaut", group: PEOPLE, keywords: ["space"] },
+
+  // -------------------------------------------------- Animals & Nature
+  { char: "🐶", name: "dog face", group: NATURE, keywords: ["puppy"] },
+  { char: "🐱", name: "cat face", group: NATURE, keywords: ["kitten"] },
+  { char: "🐭", name: "mouse face", group: NATURE, keywords: [] },
+  { char: "🐰", name: "rabbit face", group: NATURE, keywords: ["bunny"] },
+  { char: "🦊", name: "fox", group: NATURE, keywords: ["firefox"] },
+  { char: "🐻", name: "bear", group: NATURE, keywords: [] },
+  { char: "🐼", name: "panda", group: NATURE, keywords: [] },
+  { char: "🐨", name: "koala", group: NATURE, keywords: [] },
+  { char: "🐯", name: "tiger face", group: NATURE, keywords: [] },
+  { char: "🦁", name: "lion", group: NATURE, keywords: [] },
+  { char: "🐷", name: "pig face", group: NATURE, keywords: [] },
+  { char: "🐸", name: "frog", group: NATURE, keywords: [] },
+  { char: "🐵", name: "monkey face", group: NATURE, keywords: [] },
+  { char: "🙈", name: "see-no-evil monkey", group: NATURE, keywords: ["oops"] },
+  { char: "🐧", name: "penguin", group: NATURE, keywords: ["linux", "tux"] },
+  { char: "🦉", name: "owl", group: NATURE, keywords: ["night"] },
+  { char: "🐝", name: "honeybee", group: NATURE, keywords: ["bee"] },
+  { char: "🐛", name: "bug", group: NATURE, keywords: ["insect", "defect", "issue"] },
+  { char: "🦋", name: "butterfly", group: NATURE, keywords: [] },
+  { char: "🐌", name: "snail", group: NATURE, keywords: ["slow"] },
+  { char: "🐢", name: "turtle", group: NATURE, keywords: ["slow"] },
+  { char: "🐍", name: "snake", group: NATURE, keywords: ["python"] },
+  { char: "🐙", name: "octopus", group: NATURE, keywords: ["github"] },
+  { char: "🐳", name: "spouting whale", group: NATURE, keywords: ["docker"] },
+  { char: "🐬", name: "dolphin", group: NATURE, keywords: [] },
+  { char: "🦈", name: "shark", group: NATURE, keywords: [] },
+  { char: "🦄", name: "unicorn", group: NATURE, keywords: ["magic", "rare"] },
+  { char: "🐴", name: "horse face", group: NATURE, keywords: [] },
+  { char: "🌵", name: "cactus", group: NATURE, keywords: ["desert"] },
+  { char: "🌲", name: "evergreen tree", group: NATURE, keywords: ["forest", "pine"] },
+  { char: "🌴", name: "palm tree", group: NATURE, keywords: ["beach", "holiday"] },
+  { char: "🍀", name: "four leaf clover", group: NATURE, keywords: ["luck"] },
+  { char: "🍁", name: "maple leaf", group: NATURE, keywords: ["autumn", "canada"] },
+  { char: "🌸", name: "cherry blossom", group: NATURE, keywords: ["sakura", "spring"] },
+  { char: "🌻", name: "sunflower", group: NATURE, keywords: [] },
+  { char: "🌹", name: "rose", group: NATURE, keywords: ["flower"] },
+  { char: "🌈", name: "rainbow", group: NATURE, keywords: ["pride"] },
+  { char: "⭐", name: "star", group: NATURE, keywords: ["favourite", "favorite"] },
+  { char: "🌟", name: "glowing star", group: NATURE, keywords: ["sparkle", "shine"] },
+  { char: "✨", name: "sparkles", group: NATURE, keywords: ["magic", "shiny", "new"] },
+  { char: "⚡", name: "high voltage", group: NATURE, keywords: ["lightning", "fast", "power"] },
+  { char: "🔥", name: "fire", group: NATURE, keywords: ["hot", "lit", "flame", "burn"] },
+  { char: "💧", name: "droplet", group: NATURE, keywords: ["water"] },
+  { char: "🌊", name: "water wave", group: NATURE, keywords: ["ocean", "sea"] },
+  { char: "❄️", name: "snowflake", group: NATURE, keywords: ["cold", "snow", "winter"] },
+  { char: "☀️", name: "sun", group: NATURE, keywords: ["sunny", "clear"] },
+  { char: "🌙", name: "crescent moon", group: NATURE, keywords: ["night"] },
+  { char: "☁️", name: "cloud", group: NATURE, keywords: ["overcast"] },
+  { char: "🌧️", name: "cloud with rain", group: NATURE, keywords: ["wet"] },
+  { char: "🌍", name: "globe showing europe-africa", group: NATURE, keywords: ["earth", "world"] },
+
+  // -------------------------------------------------------- Food & Drink
+  { char: "🍎", name: "red apple", group: FOOD, keywords: ["fruit"] },
+  { char: "🍌", name: "banana", group: FOOD, keywords: ["fruit"] },
+  { char: "🍇", name: "grapes", group: FOOD, keywords: ["fruit"] },
+  { char: "🍓", name: "strawberry", group: FOOD, keywords: ["fruit"] },
+  { char: "🍉", name: "watermelon", group: FOOD, keywords: ["fruit"] },
+  { char: "🍒", name: "cherries", group: FOOD, keywords: ["fruit"] },
+  { char: "🥑", name: "avocado", group: FOOD, keywords: [] },
+  { char: "🍅", name: "tomato", group: FOOD, keywords: [] },
+  { char: "🥕", name: "carrot", group: FOOD, keywords: [] },
+  { char: "🌶️", name: "hot pepper", group: FOOD, keywords: ["spicy", "chilli"] },
+  { char: "🍞", name: "bread", group: FOOD, keywords: ["loaf"] },
+  { char: "🧀", name: "cheese wedge", group: FOOD, keywords: [] },
+  { char: "🥐", name: "croissant", group: FOOD, keywords: ["bakery"] },
+  { char: "🍕", name: "pizza", group: FOOD, keywords: ["slice"] },
+  { char: "🍔", name: "hamburger", group: FOOD, keywords: ["burger"] },
+  { char: "🌮", name: "taco", group: FOOD, keywords: ["mexican"] },
+  { char: "🍟", name: "french fries", group: FOOD, keywords: ["chips"] },
+  { char: "🍣", name: "sushi", group: FOOD, keywords: ["japanese"] },
+  { char: "🍜", name: "steaming bowl", group: FOOD, keywords: ["ramen", "noodles"] },
+  { char: "🍩", name: "doughnut", group: FOOD, keywords: ["donut"] },
+  { char: "🍪", name: "cookie", group: FOOD, keywords: ["biscuit"] },
+  { char: "🎂", name: "birthday cake", group: FOOD, keywords: [] },
+  { char: "🍰", name: "shortcake", group: FOOD, keywords: ["cake", "slice"] },
+  { char: "🍫", name: "chocolate bar", group: FOOD, keywords: [] },
+  { char: "🍿", name: "popcorn", group: FOOD, keywords: ["cinema", "drama"] },
+  { char: "☕", name: "hot beverage", group: FOOD, keywords: ["coffee", "tea", "espresso"] },
+  { char: "🍵", name: "teacup without handle", group: FOOD, keywords: ["tea", "matcha"] },
+  { char: "🍺", name: "beer mug", group: FOOD, keywords: ["pint"] },
+  { char: "🍻", name: "clinking beer mugs", group: FOOD, keywords: ["cheers"] },
+  { char: "🥂", name: "clinking glasses", group: FOOD, keywords: ["cheers", "champagne", "toast"] },
+  { char: "🍷", name: "wine glass", group: FOOD, keywords: [] },
+  { char: "🧉", name: "mate", group: FOOD, keywords: ["chimarrão", "erva"] },
+  { char: "🍽️", name: "fork and knife with plate", group: FOOD, keywords: ["dinner", "eat", "meal"] },
+
+  // ------------------------------------------------------ Travel & Places
+  { char: "🚗", name: "automobile", group: TRAVEL, keywords: ["car", "drive"] },
+  { char: "🚕", name: "taxi", group: TRAVEL, keywords: ["cab"] },
+  { char: "🚌", name: "bus", group: TRAVEL, keywords: [] },
+  { char: "🚑", name: "ambulance", group: TRAVEL, keywords: ["emergency"] },
+  { char: "🚓", name: "police car", group: TRAVEL, keywords: [] },
+  { char: "🚲", name: "bicycle", group: TRAVEL, keywords: ["bike", "cycle"] },
+  { char: "🏍️", name: "motorcycle", group: TRAVEL, keywords: ["motorbike"] },
+  { char: "✈️", name: "airplane", group: TRAVEL, keywords: ["flight", "travel", "plane"] },
+  { char: "🚀", name: "rocket", group: TRAVEL, keywords: ["launch", "ship", "deploy", "release"] },
+  { char: "🛸", name: "flying saucer", group: TRAVEL, keywords: ["ufo"] },
+  { char: "🚁", name: "helicopter", group: TRAVEL, keywords: [] },
+  { char: "🚂", name: "locomotive", group: TRAVEL, keywords: ["train", "steam"] },
+  { char: "🚢", name: "ship", group: TRAVEL, keywords: ["boat", "cargo"] },
+  { char: "⛵", name: "sailboat", group: TRAVEL, keywords: ["sailing"] },
+  { char: "🏠", name: "house", group: TRAVEL, keywords: ["home"] },
+  { char: "🏢", name: "office building", group: TRAVEL, keywords: ["work", "company"] },
+  { char: "🏥", name: "hospital", group: TRAVEL, keywords: ["clinic"] },
+  { char: "🏦", name: "bank", group: TRAVEL, keywords: ["money"] },
+  { char: "🗽", name: "statue of liberty", group: TRAVEL, keywords: ["new york", "usa"] },
+  { char: "🏔️", name: "snow-capped mountain", group: TRAVEL, keywords: ["peak", "alps"] },
+  { char: "🏝️", name: "desert island", group: TRAVEL, keywords: ["beach", "holiday"] },
+  { char: "🏕️", name: "camping", group: TRAVEL, keywords: ["tent", "outdoors"] },
+  { char: "🌆", name: "cityscape at dusk", group: TRAVEL, keywords: ["city", "skyline"] },
+
+  // ----------------------------------------------------------- Activities
+  { char: "⚽", name: "soccer ball", group: ACTIVITY, keywords: ["football"] },
+  { char: "🏀", name: "basketball", group: ACTIVITY, keywords: [] },
+  { char: "🏈", name: "american football", group: ACTIVITY, keywords: ["nfl"] },
+  { char: "⚾", name: "baseball", group: ACTIVITY, keywords: [] },
+  { char: "🎾", name: "tennis", group: ACTIVITY, keywords: [] },
+  { char: "🏐", name: "volleyball", group: ACTIVITY, keywords: [] },
+  { char: "🏓", name: "ping pong", group: ACTIVITY, keywords: ["table tennis"] },
+  { char: "🎯", name: "bullseye", group: ACTIVITY, keywords: ["target", "goal", "dart", "aim"] },
+  { char: "🎮", name: "video game", group: ACTIVITY, keywords: ["gaming", "controller"] },
+  { char: "🕹️", name: "joystick", group: ACTIVITY, keywords: ["arcade", "retro"] },
+  { char: "🎲", name: "game die", group: ACTIVITY, keywords: ["dice", "random", "chance"] },
+  { char: "🧩", name: "puzzle piece", group: ACTIVITY, keywords: ["plugin", "fit"] },
+  { char: "🎨", name: "artist palette", group: ACTIVITY, keywords: ["art", "paint", "design", "theme"] },
+  { char: "🎬", name: "clapper board", group: ACTIVITY, keywords: ["film", "movie", "action"] },
+  { char: "🎤", name: "microphone", group: ACTIVITY, keywords: ["mic", "sing", "podcast"] },
+  { char: "🎧", name: "headphone", group: ACTIVITY, keywords: ["music", "listen", "audio"] },
+  { char: "🎸", name: "guitar", group: ACTIVITY, keywords: ["rock", "music"] },
+  { char: "🎹", name: "musical keyboard", group: ACTIVITY, keywords: ["piano", "music"] },
+  { char: "🥁", name: "drum", group: ACTIVITY, keywords: ["music", "beat"] },
+  { char: "🏆", name: "trophy", group: ACTIVITY, keywords: ["win", "champion", "award"] },
+  { char: "🥇", name: "1st place medal", group: ACTIVITY, keywords: ["gold", "first", "winner"] },
+  { char: "🎉", name: "party popper", group: ACTIVITY, keywords: ["celebrate", "congrats", "tada"] },
+  { char: "🎊", name: "confetti ball", group: ACTIVITY, keywords: ["celebrate", "party"] },
+  { char: "🎁", name: "wrapped gift", group: ACTIVITY, keywords: ["present", "birthday"] },
+  { char: "🎈", name: "balloon", group: ACTIVITY, keywords: ["party"] },
+  { char: "🎃", name: "jack-o-lantern", group: ACTIVITY, keywords: ["halloween", "pumpkin"] },
+
+  // -------------------------------------------------------------- Objects
+  { char: "💻", name: "laptop", group: OBJECT, keywords: ["computer", "machine", "dev"] },
+  { char: "🖥️", name: "desktop computer", group: OBJECT, keywords: ["monitor", "screen"] },
+  { char: "⌨️", name: "keyboard", group: OBJECT, keywords: ["typing", "keys", "chord"] },
+  { char: "🖱️", name: "computer mouse", group: OBJECT, keywords: ["pointer"] },
+  { char: "🖨️", name: "printer", group: OBJECT, keywords: ["print"] },
+  { char: "💾", name: "floppy disk", group: OBJECT, keywords: ["save"] },
+  { char: "💿", name: "optical disk", group: OBJECT, keywords: ["cd", "iso"] },
+  { char: "🔌", name: "electric plug", group: OBJECT, keywords: ["power", "socket"] },
+  { char: "🔋", name: "battery", group: OBJECT, keywords: ["charge", "power"] },
+  { char: "📱", name: "mobile phone", group: OBJECT, keywords: ["smartphone"] },
+  { char: "📞", name: "telephone receiver", group: OBJECT, keywords: ["call", "ring"] },
+  { char: "📷", name: "camera", group: OBJECT, keywords: ["photo", "picture"] },
+  { char: "📺", name: "television", group: OBJECT, keywords: ["tv", "screen"] },
+  { char: "⏰", name: "alarm clock", group: OBJECT, keywords: ["time", "wake", "schedule"] },
+  { char: "⌛", name: "hourglass done", group: OBJECT, keywords: ["time", "wait", "timeout"] },
+  { char: "⏱️", name: "stopwatch", group: OBJECT, keywords: ["timer", "benchmark", "elapsed"] },
+  { char: "📅", name: "calendar", group: OBJECT, keywords: ["date", "schedule"] },
+  { char: "📌", name: "pushpin", group: OBJECT, keywords: ["pin", "location"] },
+  { char: "📎", name: "paperclip", group: OBJECT, keywords: ["attach", "attachment"] },
+  { char: "✂️", name: "scissors", group: OBJECT, keywords: ["cut", "snip"] },
+  { char: "📏", name: "straight ruler", group: OBJECT, keywords: ["measure", "size"] },
+  { char: "🔍", name: "magnifying glass tilted left", group: OBJECT, keywords: ["search", "find", "zoom", "inspect"] },
+  { char: "🔒", name: "locked", group: OBJECT, keywords: ["lock", "secure", "private"] },
+  { char: "🔓", name: "unlocked", group: OBJECT, keywords: ["unlock", "open", "public"] },
+  { char: "🔑", name: "key", group: OBJECT, keywords: ["password", "access", "secret"] },
+  { char: "🔨", name: "hammer", group: OBJECT, keywords: ["build", "fix", "nail"] },
+  { char: "🔧", name: "wrench", group: OBJECT, keywords: ["tool", "fix", "spanner"] },
+  { char: "⚙️", name: "gear", group: OBJECT, keywords: ["settings", "config", "cog", "options"] },
+  { char: "🛠️", name: "hammer and wrench", group: OBJECT, keywords: ["tools", "build", "maintenance"] },
+  { char: "🧰", name: "toolbox", group: OBJECT, keywords: ["tools", "kit"] },
+  { char: "🧲", name: "magnet", group: OBJECT, keywords: ["attract"] },
+  { char: "🧪", name: "test tube", group: OBJECT, keywords: ["lab", "experiment"] },
+  { char: "🔬", name: "microscope", group: OBJECT, keywords: ["science", "research", "detail"] },
+  { char: "🔭", name: "telescope", group: OBJECT, keywords: ["observe", "astronomy", "far"] },
+  { char: "💡", name: "light bulb", group: OBJECT, keywords: ["idea", "insight", "tip"] },
+  { char: "🔦", name: "flashlight", group: OBJECT, keywords: ["torch", "light"] },
+  { char: "🕯️", name: "candle", group: OBJECT, keywords: ["light", "wax"] },
+  { char: "📦", name: "package", group: OBJECT, keywords: ["box", "shipping", "release", "npm"] },
+  { char: "✉️", name: "envelope", group: OBJECT, keywords: ["email", "mail", "letter"] },
+  { char: "📝", name: "memo", group: OBJECT, keywords: ["note", "write", "edit", "changelog"] },
+  { char: "📄", name: "page facing up", group: OBJECT, keywords: ["document", "file"] },
+  { char: "📁", name: "file folder", group: OBJECT, keywords: ["directory"] },
+  { char: "📊", name: "bar chart", group: OBJECT, keywords: ["stats", "metrics"] },
+  { char: "📈", name: "chart increasing", group: OBJECT, keywords: ["growth", "up", "trending"] },
+  { char: "📉", name: "chart decreasing", group: OBJECT, keywords: ["loss", "down", "regression"] },
+  { char: "📋", name: "clipboard", group: OBJECT, keywords: ["copy", "paste", "list"] },
+  { char: "📚", name: "books", group: OBJECT, keywords: ["library", "docs", "reading"] },
+  { char: "📖", name: "open book", group: OBJECT, keywords: ["read", "docs", "manual"] },
+  { char: "🔖", name: "bookmark", group: OBJECT, keywords: ["save", "mark"] },
+  { char: "🏷️", name: "label", group: OBJECT, keywords: ["tag", "version"] },
+  { char: "💰", name: "money bag", group: OBJECT, keywords: ["cost", "budget"] },
+  { char: "💳", name: "credit card", group: OBJECT, keywords: ["payment", "billing"] },
+  { char: "🛒", name: "shopping cart", group: OBJECT, keywords: ["buy", "checkout"] },
+  { char: "💊", name: "pill", group: OBJECT, keywords: ["medicine", "drug"] },
+  { char: "🩹", name: "adhesive bandage", group: OBJECT, keywords: ["bandaid", "patch", "hotfix"] },
+  { char: "🧹", name: "broom", group: OBJECT, keywords: ["clean", "sweep", "cleanup"] },
+  { char: "🗑️", name: "wastebasket", group: OBJECT, keywords: ["trash", "delete", "bin", "remove"] },
+  { char: "🛡️", name: "shield", group: OBJECT, keywords: ["security", "protect", "defend"] },
+  { char: "⚔️", name: "crossed swords", group: OBJECT, keywords: ["battle", "fight", "conflict"] },
+  { char: "🪄", name: "magic wand", group: OBJECT, keywords: ["auto"] },
+  { char: "🧭", name: "compass", group: OBJECT, keywords: ["navigate", "direction", "north"] },
+  { char: "🗺️", name: "world map", group: OBJECT, keywords: ["atlas"] },
+  { char: "🚩", name: "triangular flag", group: OBJECT, keywords: ["marker", "feature flag"] },
+  { char: "🏁", name: "chequered flag", group: OBJECT, keywords: ["finish", "race", "done"] },
+
+  // -------------------------------------------------------------- Symbols
+  { char: "✅", name: "check mark button", group: SYMBOL, keywords: ["done", "yes", "pass", "ok"] },
+  { char: "☑️", name: "check box with check", group: SYMBOL, keywords: ["ticked", "todo", "selected"] },
+  { char: "✔️", name: "check mark", group: SYMBOL, keywords: ["tick", "done"] },
+  { char: "❌", name: "cross mark", group: SYMBOL, keywords: ["no", "fail", "wrong", "error"] },
+  { char: "⭕", name: "hollow red circle", group: SYMBOL, keywords: ["ring"] },
+  { char: "🚫", name: "prohibited", group: SYMBOL, keywords: ["forbidden", "banned", "no", "denied"] },
+  { char: "⚠️", name: "warning", group: SYMBOL, keywords: ["caution", "alert", "careful"] },
+  { char: "🛑", name: "stop sign", group: SYMBOL, keywords: ["halt"] },
+  { char: "❗", name: "exclamation mark", group: SYMBOL, keywords: ["important", "attention"] },
+  { char: "❓", name: "question mark", group: SYMBOL, keywords: ["help", "unknown"] },
+  { char: "💬", name: "speech balloon", group: SYMBOL, keywords: ["comment", "chat", "message"] },
+  { char: "💭", name: "thought balloon", group: SYMBOL, keywords: ["thinking", "idea"] },
+  { char: "🔔", name: "bell", group: SYMBOL, keywords: ["notification", "alert", "ring"] },
+  { char: "🔕", name: "bell with slash", group: SYMBOL, keywords: ["mute", "silent", "snooze"] },
+  { char: "🔊", name: "speaker high volume", group: SYMBOL, keywords: ["loud", "sound", "audio"] },
+  { char: "🔇", name: "muted speaker", group: SYMBOL, keywords: ["mute", "silence"] },
+  { char: "📢", name: "loudspeaker", group: SYMBOL, keywords: ["announce", "broadcast"] },
+  { char: "♻️", name: "recycling symbol", group: SYMBOL, keywords: ["recycle", "reuse", "refactor"] },
+  { char: "🔄", name: "counterclockwise arrows button", group: SYMBOL, keywords: ["refresh", "retry", "sync", "reload"] },
+  { char: "🔁", name: "repeat button", group: SYMBOL, keywords: ["loop", "again"] },
+  { char: "▶️", name: "play button", group: SYMBOL, keywords: ["start", "run"] },
+  { char: "⏸️", name: "pause button", group: SYMBOL, keywords: ["hold"] },
+  { char: "⏭️", name: "next track button", group: SYMBOL, keywords: ["skip", "forward"] },
+  { char: "⬆️", name: "up arrow", group: SYMBOL, keywords: ["increase"] },
+  { char: "⬇️", name: "down arrow", group: SYMBOL, keywords: ["decrease"] },
+  { char: "➡️", name: "right arrow", group: SYMBOL, keywords: ["next", "forward"] },
+  { char: "⬅️", name: "left arrow", group: SYMBOL, keywords: ["back", "previous"] },
+  { char: "↩️", name: "right arrow curving left", group: SYMBOL, keywords: ["reply", "return", "undo"] },
+  { char: "🔗", name: "link", group: SYMBOL, keywords: ["url", "chain", "href"] },
+  { char: "➕", name: "plus", group: SYMBOL, keywords: ["add", "more", "new"] },
+  { char: "➖", name: "minus", group: SYMBOL, keywords: ["remove", "subtract", "less"] },
+  { char: "♾️", name: "infinity", group: SYMBOL, keywords: ["endless", "forever"] },
+  { char: "🆕", name: "new button", group: SYMBOL, keywords: ["fresh"] },
+  { char: "🔴", name: "red circle", group: SYMBOL, keywords: ["record", "stop", "failing"] },
+  { char: "🟢", name: "green circle", group: SYMBOL, keywords: ["go", "healthy", "passing"] },
+  { char: "🟡", name: "yellow circle", group: SYMBOL, keywords: ["warning", "pending"] },
+  { char: "🔵", name: "blue circle", group: SYMBOL, keywords: ["info"] },
+  { char: "⚫", name: "black circle", group: SYMBOL, keywords: ["dot"] },
+  { char: "⚪", name: "white circle", group: SYMBOL, keywords: ["empty", "unset"] },
+];

--- a/src/emoji-view.ts
+++ b/src/emoji-view.ts
@@ -1,0 +1,179 @@
+/**
+ * The emoji picker, drawn.
+ *
+ * Everything this reacts to is decided in src/emoji.ts — which rows are
+ * visible, where the cursor is, what a keystroke means, what Enter
+ * copies and through which bridge. What is left here is the part a test
+ * cannot read anyway: a frame, a list, and a status line. The same split
+ * keys-view.ts makes with src/keys.ts, and for the same reason: a picker
+ * whose behaviour only exists inside a render is a picker nothing can
+ * pin.
+ *
+ * One render, like everywhere else in this codebase. The command starts
+ * it, the person leaves it, and the clipboard write is a bounded child
+ * process rather than anything drawn in here.
+ */
+
+import {
+  Box,
+  ListItem,
+  Text,
+  render,
+  useApp,
+  useInput,
+  useState,
+  useTerminalSize,
+} from "tuiuiu.js";
+import { VERSION } from "./cli.ts";
+import {
+  clipboardRoute,
+  copyEmoji,
+  emojiColumns,
+  emojiRow,
+  searchEmoji,
+  EMOJI,
+  PICKER_START,
+  pickerStep,
+  type CopyOutcome,
+  type Emoji,
+  type PickerState,
+} from "./emoji.ts";
+import type { Platform } from "./platform.ts";
+import { CenteredScreen, centeredFrame, Header, StatusLine, Surface } from "./tui-chrome.ts";
+import { muted, subtle, text } from "./tui-theme.ts";
+import { withConsoleSelectionSuspended } from "./windows-console-mode.ts";
+
+/** The slice of the table that fits, kept around the cursor. */
+function windowOf(items: readonly Emoji[], index: number, rows: number): Emoji[] {
+  if (items.length <= rows) return [...items];
+  const from = Math.max(0, Math.min(items.length - rows, index - Math.floor(rows / 2)));
+  return items.slice(from, from + rows);
+}
+
+/**
+ * The terminal to draw on, when it is not this process's own. Only a
+ * test passes these — the same seam the keys viewer opens, for the same
+ * reason.
+ */
+export interface PickerIo {
+  stdin: NodeJS.ReadStream;
+  stdout: NodeJS.WriteStream;
+}
+
+/**
+ * Draw it, and return when the person leaves.
+ *
+ * `copy` is a parameter for the same reason the keys viewer's `fire` is:
+ * it is the one thing in here that starts a process, and a caller that
+ * wants the picker without touching the clipboard — a screenshot, a
+ * smoke test — should not have to overwrite what somebody had copied.
+ */
+export async function runEmojiPicker(
+  p: Platform,
+  table: readonly Emoji[] = EMOJI,
+  copy: (emoji: Emoji) => Promise<CopyOutcome> = (emoji) => copyEmoji(p, emoji),
+  io?: PickerIo,
+): Promise<void> {
+  // Read once, outside the component: it is a property of the machine,
+  // not of the frame, and asking per render would put a platform check
+  // in the draw path.
+  const route = clipboardRoute(p);
+  const cols = emojiColumns(table);
+
+  function App() {
+    // exit() from useApp rather than process.exit, so waitUntilExit
+    // resolves and the caller gets its terminal back.
+    const { exit } = useApp();
+    const size = useTerminalSize();
+    const [state, setState] = useState<PickerState>(PICKER_START);
+    const [status, setStatus] = useState("");
+
+    useInput((input, key) => {
+      const step = pickerStep(state(), input, key, table);
+      setState(step.state);
+      if (step.quit) {
+        exit();
+        return;
+      }
+      const chosen = step.copy;
+      if (!chosen) return;
+      // Said before it is done: the WSL bridge crosses into Windows and
+      // takes a moment, and a picker that shows nothing in that moment
+      // reads as an Enter that did not register.
+      setStatus(`copying ${chosen.char}…`);
+      void copy(chosen)
+        .then((outcome) => setStatus(outcome.detail))
+        .catch((err: unknown) => setStatus(`failed: ${(err as Error).message}`));
+    });
+
+    const width = Math.max(size.columns ?? 80, 60);
+    const height = Math.max(size.rows ?? 24, 16);
+    const frame = centeredFrame(width, height, 112, 34);
+    const rows = Math.max(4, frame.height - 12);
+
+    const query = state().query;
+    const visible = searchEmoji(query, table);
+    // Clamped for drawing only. The model clamps what it stores; a
+    // filter that shrank the list under a cursor still holds an index
+    // one frame too large.
+    const index = Math.min(state().index, Math.max(0, visible.length - 1));
+    const shown = windowOf(visible, index, rows);
+    const chosen = visible[index];
+
+    return CenteredScreen(
+      width,
+      height,
+      112,
+      34,
+
+      Header("red-dev emoji", `${visible.length}/${table.length}`),
+      Text({}, ""),
+
+      // The search box, always visible and never modal: this is a picker
+      // you type into, so the query is part of the frame rather than a
+      // prompt that has to be opened first.
+      Text(
+        { color: query === "" ? subtle : text },
+        query === "" ? "search: type to filter" : `search: ${query}`,
+      ),
+      Text({}, ""),
+
+      Box(
+        {},
+        Surface(
+          frame.width,
+          rows + 2,
+          ...(shown.length === 0
+            ? [Text({ color: muted }, `nothing matches ${query}`)]
+            : shown.map((emoji) =>
+                ListItem({
+                  primary: emojiRow(emoji, cols),
+                  selected: emoji.char === chosen?.char,
+                }),
+              )),
+        ),
+      ),
+
+      Text({}, ""),
+      // Where Enter would put it, stated before it is pressed. A picker
+      // that only mentions the clipboard once it has failed to reach one
+      // is a picker somebody uses twice before finding out.
+      Text(
+        { color: route ? text : muted },
+        route ? `enter copies through ${route.note}` : `no clipboard on ${p.env} — enter says so`,
+      ),
+      // The outcome of the last Enter, kept on screen until the next one.
+      Text({ color: muted }, status()),
+
+      StatusLine(
+        "type to search · up/down move · enter copy · esc clear, then quit",
+        `red-dev ${VERSION}`,
+      ),
+    );
+  }
+
+  await withConsoleSelectionSuspended(async () => {
+    const { waitUntilExit } = render(App, { fullHeight: true, ...io });
+    await waitUntilExit();
+  });
+}

--- a/src/emoji.test.ts
+++ b/src/emoji.test.ts
@@ -1,0 +1,501 @@
+/**
+ * The picker's two promises, held against machines it cannot be run on.
+ *
+ * The first is that the answer does not depend on the machine. The table
+ * ships inside the binary, so the same query returns the same rows in
+ * the same order on Ubuntu 24, Ubuntu 26, WSL, native Windows and a
+ * headless server — and a search that reordered itself per target would
+ * be a picker nobody builds muscle memory for.
+ *
+ * The second is that copying goes through the clipboard the terminal
+ * layer already has, not through a second one this feature invented. The
+ * WSL route is the one that earns the paranoia: `clip.exe` alone decodes
+ * redirected stdin with the Windows OEM code page and turned UTF-8 into
+ * mojibake, then a PowerShell bridge decoded correctly and exceeded
+ * zellij's one-second deadline, and only iconv-to-BOM-less-UTF-16LE is
+ * both correct and fast. A picker whose whole job is putting a
+ * supplementary-plane character on the Windows clipboard is exactly the
+ * surface that would have written that bug for a third time.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { chmodSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { ACTIONS } from "./actions/index.ts";
+import { zellijConfigFor } from "./dotfiles.ts";
+import {
+  clipboardRoute,
+  copyEmoji,
+  copyPlan,
+  EMOJI,
+  emojiColumns,
+  emojiLines,
+  emojiRow,
+  PICKER_START,
+  pickerStep,
+  searchEmoji,
+  writeClipboard,
+  type Emoji,
+  type PickerKey,
+  type PickerState,
+} from "./emoji.ts";
+import { firePlan } from "./keys.ts";
+import type { Platform } from "./platform.ts";
+
+function machine(over: Partial<Platform>): Platform {
+  return {
+    os: "linux",
+    distro: "ubuntu",
+    version: "24.04",
+    codename: "noble",
+    env: "desktop",
+    arch: "x64",
+    caps: { apt: true, gui: true, systemd: true, winget: false, flatpak: true },
+    ...over,
+  };
+}
+
+/**
+ * The five targets, named the way the product names them.
+ *
+ * Ubuntu 24 and Ubuntu 26 are two of the five and share one `Env`, which
+ * is the point rather than a redundancy: "identical on every target" is
+ * a claim about the machines, and the two releases are two machines.
+ */
+const noble = machine({ version: "24.04", codename: "noble" });
+const resolute = machine({ version: "26.04", codename: "resolute" });
+const wsl = machine({ env: "wsl", caps: { apt: true, gui: false, systemd: true, winget: true, flatpak: false } });
+const windows = machine({ os: "windows", env: "windows", distro: null, version: null, codename: null });
+const server = machine({ env: "server", caps: { apt: true, gui: false, systemd: true, winget: false, flatpak: false } });
+
+const FIVE_TARGETS = [noble, resolute, wsl, windows, server];
+
+/** No key pressed; each test turns on the one it means. */
+function press(over: Partial<PickerKey> = {}): PickerKey {
+  return {
+    upArrow: false,
+    downArrow: false,
+    return: false,
+    escape: false,
+    backspace: false,
+    delete: false,
+    ctrl: false,
+    ...over,
+  };
+}
+
+/** Type a string into the picker, one keystroke at a time. */
+function typed(text: string): PickerState {
+  let state = PICKER_START;
+  for (const ch of text) state = pickerStep(state, ch, press()).state;
+  return state;
+}
+
+/** The characters a query returns, which is the whole observable result. */
+function found(query: string): string[] {
+  return searchEmoji(query).map((e) => e.char);
+}
+
+describe("the table that ships with the binary", () => {
+  test("is not read from the machine — the same rows on all five targets", () => {
+    // Nothing in the search takes a Platform, and that is the design
+    // rather than an omission: a table sourced from installed fonts or
+    // from a service would need one, and would answer differently on
+    // each of these.
+    const once = found("rocket");
+    for (const p of FIVE_TARGETS) {
+      void p;
+      expect(found("rocket")).toEqual(once);
+    }
+  });
+
+  test("has a unique character on every row", () => {
+    // Two rows carrying one character is a duplicate in the list and an
+    // ambiguous selection under the cursor, which draws as a second row
+    // highlighting itself.
+    expect(new Set(EMOJI.map((e) => e.char)).size).toBe(EMOJI.length);
+  });
+
+  test("and a unique name, because the name is what the search ranks on", () => {
+    expect(new Set(EMOJI.map((e) => e.name)).size).toBe(EMOJI.length);
+  });
+
+  test("names are lowercase, so a query never has to guess the case", () => {
+    expect(EMOJI.filter((e) => e.name !== e.name.toLowerCase())).toEqual([]);
+    expect(EMOJI.filter((e) => e.keywords.some((k) => k !== k.toLowerCase()))).toEqual([]);
+  });
+
+  test("no keyword repeats a word already in its own name", () => {
+    // It would do nothing — the name is in the haystack already — and a
+    // keyword that does nothing reads as a search term that exists.
+    const wasted = EMOJI.filter((e) =>
+      e.keywords.some((k) => e.name.split(/[\s-]+/).includes(k)),
+    );
+    expect(wasted.map((e) => e.name)).toEqual([]);
+  });
+
+  test("is big enough to be worth a picker", () => {
+    expect(EMOJI.length).toBeGreaterThan(150);
+  });
+});
+
+describe("searching, pinned against a fixture query", () => {
+  test("`check` puts the check marks first, in one fixed order", () => {
+    // The whole result, not a containment: what this pins is the order,
+    // and an assertion that merely found ✅ somewhere would pass for a
+    // ranking that put it fourth.
+    //
+    // 🛒 is in the list because `checkout` is one of its keywords, and it
+    // is last because it is the only row whose name does not begin with
+    // the query. That is the ranking doing its job rather than noise to
+    // be filtered out: someone typing `check` at a shopping cart is not
+    // wrong, they are just less likely than the three above it.
+    expect(found("check")).toEqual(["✅", "☑️", "✔️", "🛒"]);
+  });
+
+  test("a name that is the query outranks every row that merely mentions it", () => {
+    // 🔥 is named "fire". 🦊 carries "firefox" as a keyword and would
+    // come first on a plain filter in table order, because Animals &
+    // Nature lists the fox above the flame.
+    expect(found("fire")[0]).toBe("🔥");
+    expect(found("fire")).toContain("🦊");
+  });
+
+  test("a keyword finds what the name never says", () => {
+    // Nothing in "rocket" is the word somebody types when they are
+    // shipping something.
+    expect(found("deploy")).toEqual(["🚀"]);
+    expect(found("lgtm")).toEqual(["👍"]);
+  });
+
+  test("every word has to match, in any order", () => {
+    expect(found("green circle")).toEqual(["🟢"]);
+    expect(found("circle green")).toEqual(["🟢"]);
+    expect(found("rocket nonsense")).toEqual([]);
+  });
+
+  test("the group is part of the haystack, so `food` is a query", () => {
+    const food = searchEmoji("food");
+    expect(food.length).toBeGreaterThan(20);
+    expect(food.every((e) => e.group === "Food & Drink" || e.name.includes("food"))).toBe(true);
+  });
+
+  test("case is folded, because nobody types a name the way it is stored", () => {
+    expect(found("ROCKET")).toEqual(found("rocket"));
+    expect(found("  Rocket  ")).toEqual(found("rocket"));
+  });
+
+  test("with nothing typed, the whole table is visible in declared order", () => {
+    expect(searchEmoji("")).toHaveLength(EMOJI.length);
+    expect(searchEmoji("   ")[0]?.char).toBe(EMOJI[0]?.char);
+  });
+
+  test("and a query that matches nothing returns nothing rather than everything", () => {
+    expect(found("zzzznope")).toEqual([]);
+  });
+});
+
+describe("which clipboard each target copies through", () => {
+  test("the route per target, all five pinned at once", () => {
+    expect(clipboardRoute(noble)?.target).toBe("wayland");
+    expect(clipboardRoute(resolute)?.target).toBe("wayland");
+    expect(clipboardRoute(wsl)?.target).toBe("wsl");
+    expect(clipboardRoute(windows)?.target).toBe("windows");
+    // Not a fourth route. A server has no display, so it has no
+    // clipboard, and naming a program that is not installed would be the
+    // same silent failure pointed the other way.
+    expect(clipboardRoute(server)).toBeNull();
+  });
+
+  test("and each one is the command zellij is given on the same machine", () => {
+    // The claim that matters: three routes, shared with the terminal
+    // layer rather than reimplemented beside it. A copy path that drifted
+    // from zellij's would mean selecting text and picking an emoji put
+    // different bytes on the same clipboard.
+    for (const p of [noble, resolute, wsl, windows]) {
+      const route = clipboardRoute(p);
+      expect(route).not.toBeNull();
+      expect(zellijConfigFor(p)).toContain(`copy_command "${route!.argv.join(" ")}"`);
+    }
+  });
+
+  test("the WSL route is the existing Unicode-safe bridge, not a new one", () => {
+    const route = clipboardRoute(wsl)!;
+    expect(route.argv[0]).toBe("bash");
+    expect(route.argv[1]).toContain("config/bash/windows-clipboard.sh");
+    // Never powershell.exe from inside WSL: correct on encoding and too
+    // slow to start, which is the mistake this path already made once.
+    expect(route.argv.join(" ")).not.toContain("powershell.exe");
+    expect(route.argv.join(" ")).not.toContain("clip.exe");
+  });
+
+  test("native Windows takes the PowerShell bridge, which decodes UTF-8 explicitly", () => {
+    const route = clipboardRoute(windows)!;
+    expect(route.argv[0]).toBe("powershell.exe");
+    expect(route.argv).toContain("-EncodedCommand");
+    const decoded = Buffer.from(route.argv[3] ?? "", "base64").toString("utf16le");
+    expect(decoded).toContain("Set-Clipboard");
+    expect(decoded).toContain("Text.Encoding]::UTF8.GetString");
+  });
+
+  test("a Linux desktop takes wl-copy, which needs no encoding step at all", () => {
+    expect(clipboardRoute(noble)?.argv).toEqual(["wl-copy"]);
+  });
+});
+
+/**
+ * The encoding itself, run rather than asserted about.
+ *
+ * The three tests above pin which program the picker reaches for. This
+ * one pins what comes out of it, because "the same argv" would still be
+ * true of a bridge that had been quietly broken — and the failure this
+ * whole path exists to prevent is invisible until the bytes are read
+ * back: an emoji that arrives on the Windows clipboard as `??`.
+ *
+ * The emoji is deliberately outside the Basic Multilingual Plane, so it
+ * is a surrogate pair in UTF-16 and two different mistakes could mangle
+ * it. The accented text beside it is what caught the OEM code page.
+ */
+describe("what the WSL route actually puts on the clipboard", () => {
+  test("the picker's own plan converts to BOM-less UTF-16LE within the deadline", async () => {
+    const dir = mkdtempSync(`${tmpdir()}/red-emoji-`);
+    const capture = `${dir}/clipboard.bin`;
+    const fakeClip = `${dir}/clip.exe`;
+    writeFileSync(fakeClip, '#!/bin/sh\nexec tee "$CLIP_CAPTURE" >/dev/null\n');
+    chmodSync(fakeClip, 0o755);
+
+    const rocket = EMOJI.find((e) => e.name === "rocket")!;
+    const plan = copyPlan(wsl, rocket);
+    expect(plan.ok).toBe(true);
+    if (!plan.ok) return;
+
+    // The script is read from the checkout rather than from ~/.local,
+    // which is where a converged machine deploys it: this test is about
+    // the bytes the bridge produces, not about whether a converge has
+    // run here. The rest of the argv is the plan's own.
+    const argv = ["bash", "config/bash/windows-clipboard.sh", ...plan.argv.slice(2)];
+    expect(plan.argv[0]).toBe(argv[0]);
+
+    const started = performance.now();
+    const proc = Bun.spawn(argv, {
+      env: { ...process.env, PATH: `${dir}:${process.env["PATH"] ?? ""}`, CLIP_CAPTURE: capture },
+      stdin: "pipe",
+      stdout: "ignore",
+      stderr: "pipe",
+    });
+    proc.stdin.write(plan.char);
+    proc.stdin.end();
+
+    expect(await proc.exited).toBe(0);
+    expect(performance.now() - started).toBeLessThan(1_000);
+
+    const bytes = readFileSync(capture);
+    expect(bytes.toString("utf16le")).toBe("🚀");
+    // A BOM would arrive in the Windows clipboard as a literal U+FEFF at
+    // the front of every paste.
+    expect(bytes[0]).not.toBe(0xff);
+    // And a surrogate pair is four bytes, which is what proves nothing
+    // dropped it to a replacement character on the way through.
+    expect(bytes.length).toBe(4);
+  });
+});
+
+describe("what Enter copies", () => {
+  test("the chosen row's character reaches this target's bridge, and nothing else does", async () => {
+    const state = typed("rocket");
+    const step = pickerStep(state, "", press({ return: true }));
+    expect(step.copy?.char).toBe("🚀");
+
+    const handed: { argv: readonly string[]; text: string }[] = [];
+    const outcome = await copyEmoji(wsl, step.copy!, async (argv, text) => {
+      handed.push({ argv, text });
+      return 0;
+    });
+
+    expect(outcome.copied).toBe(true);
+    expect(handed).toHaveLength(1);
+    expect(handed[0]?.text).toBe("🚀");
+    expect(handed[0]?.argv[1]).toContain("windows-clipboard.sh");
+  });
+
+  test("each target is handed the same character through its own route", async () => {
+    const rocket = EMOJI.find((e) => e.name === "rocket")!;
+    const reached: string[] = [];
+    for (const p of [noble, wsl, windows]) {
+      await copyEmoji(p, rocket, async (argv, text) => {
+        expect(text).toBe("🚀");
+        reached.push(argv[0] ?? "");
+        return 0;
+      });
+    }
+    expect(reached).toEqual(["wl-copy", "bash", "powershell.exe"]);
+  });
+
+  test("a machine with no clipboard says so, and hands over the character anyway", async () => {
+    const rocket = EMOJI.find((e) => e.name === "rocket")!;
+    const started: unknown[] = [];
+    const outcome = await copyEmoji(server, rocket, async (argv) => {
+      started.push(argv);
+      return 0;
+    });
+    expect(outcome.copied).toBe(false);
+    expect(outcome.detail).toContain("no clipboard on server");
+    expect(outcome.detail).toContain("🚀");
+    // Nothing was run. A refusal that still spawned would be a `wl-copy`
+    // that is not installed, failing one layer further down.
+    expect(started).toEqual([]);
+  });
+
+  test("a bridge that fails is reported rather than counted as copied", async () => {
+    const rocket = EMOJI.find((e) => e.name === "rocket")!;
+    const outcome = await copyEmoji(wsl, rocket, async () => 127);
+    expect(outcome.copied).toBe(false);
+    expect(outcome.detail).toContain("127");
+  });
+
+  test("and a bridge that throws becomes a sentence, not an unhandled rejection", async () => {
+    const rocket = EMOJI.find((e) => e.name === "rocket")!;
+    const outcome = await copyEmoji(wsl, rocket, async () => {
+      throw new Error("interop is disabled");
+    });
+    expect(outcome.copied).toBe(false);
+    expect(outcome.detail).toContain("interop is disabled");
+  });
+
+  test("the real write reports a non-zero exit rather than swallowing it", async () => {
+    // Through runBounded, against a program certain to exist and certain
+    // to fail. The seam above is where the routes are pinned; this is the
+    // one line of it that talks to a real process.
+    expect(await writeClipboard(["false"], "🚀")).not.toBe(0);
+    expect(await writeClipboard(["cat"], "🚀")).toBe(0);
+  });
+});
+
+describe("the keystrokes the picker reads", () => {
+  test("letters are the search box, so j and k cannot be navigation", () => {
+    expect(typed("jk").query).toBe("jk");
+  });
+
+  test("backspace takes one back, and an empty box swallows it", () => {
+    expect(pickerStep(typed("fire"), "", press({ backspace: true })).state.query).toBe("fir");
+    expect(pickerStep(PICKER_START, "", press({ backspace: true })).state.query).toBe("");
+  });
+
+  test("the arrows move within what is visible and stop at the ends", () => {
+    const narrow = typed("check");
+    const visible = searchEmoji(narrow.query).length;
+    let state = narrow;
+    for (let i = 0; i <= visible + 2; i++) {
+      state = pickerStep(state, "", press({ downArrow: true })).state;
+    }
+    expect(state.index).toBe(visible - 1);
+    expect(pickerStep(PICKER_START, "", press({ upArrow: true })).state.index).toBe(0);
+  });
+
+  test("editing the query puts the cursor back on the first match", () => {
+    const moved = pickerStep(PICKER_START, "", press({ downArrow: true })).state;
+    expect(pickerStep(moved, "f", press()).state.index).toBe(0);
+  });
+
+  test("escape clears a search before it closes the picker", () => {
+    const cleared = pickerStep(typed("zzzznope"), "", press({ escape: true }));
+    expect(cleared.quit).toBeUndefined();
+    expect(cleared.state.query).toBe("");
+    expect(pickerStep(PICKER_START, "", press({ escape: true })).quit).toBe(true);
+  });
+
+  test("ctrl+c leaves, and no other ctrl chord types into the box", () => {
+    expect(pickerStep(PICKER_START, "c", press({ ctrl: true })).quit).toBe(true);
+    expect(pickerStep(PICKER_START, "a", press({ ctrl: true })).state.query).toBe("");
+  });
+
+  test("enter on a search that found nothing copies nothing", () => {
+    expect(pickerStep(typed("zzzznope"), "", press({ return: true })).copy).toBeUndefined();
+  });
+
+  test("and a copy leaves the list where it was, because people want three", () => {
+    // A picker that closed on the first Enter would make somebody
+    // assembling a commit message press the chord again.
+    const state = { query: "check", index: 1 };
+    const step = pickerStep(state, "", press({ return: true }));
+    expect(step.copy?.char).toBe("☑️");
+    expect(step.quit).toBeUndefined();
+    expect(step.state).toEqual(state);
+  });
+});
+
+describe("the plain list, for a terminal that cannot draw the picker", () => {
+  test("carries every row, with its keywords, so nothing is hidden", () => {
+    const lines = emojiLines();
+    expect(lines).toHaveLength(EMOJI.length);
+    const rocket = lines.find((l) => l.includes("rocket"));
+    expect(rocket).toContain("🚀");
+    expect(rocket).toContain("Travel & Places");
+    expect(rocket).toContain("deploy");
+  });
+
+  test("and the columns line up on the widest of each", () => {
+    const table: readonly Emoji[] = [
+      { char: "🚀", name: "rocket", group: "Travel & Places", keywords: [] },
+      { char: "✅", name: "check mark button", group: "Symbols", keywords: [] },
+    ];
+    const cols = emojiColumns(table);
+    expect(cols.name).toBe("check mark button".length);
+    expect(cols.group).toBe("Travel & Places".length);
+    // Same offset for the group column on both rows, measured after the
+    // character. It is not padded and cannot be: 🚀 is a surrogate pair
+    // and ✅ is one unit, while a terminal draws both two cells wide, so
+    // a column computed from string length would misalign exactly the
+    // rows it was meant to align. What red-dev controls is the fixed gap
+    // after the character and everything to the right of it.
+    const rows = table.map((e) => emojiRow(e, cols).slice(e.char.length));
+    expect(rows[0]?.indexOf("Travel")).toBe(rows[1]?.indexOf("Symbols"));
+    expect(rows[0]?.startsWith("  ")).toBe(true);
+  });
+
+  test("a row with no keywords ends after its group rather than in a stray gap", () => {
+    const row = emojiRow(
+      { char: "🐼", name: "panda", group: "Animals & Nature", keywords: [] },
+      { name: 5, group: 16 },
+    );
+    expect(row).toBe(row.trimEnd());
+  });
+});
+
+describe("how the picker is reached", () => {
+  test("it is a semantic action, with one chord in the Ctrl+Alt family", () => {
+    const action = ACTIONS.find((a) => a.id === "emoji.pick");
+    expect(action?.label).toBe("Emoji picker");
+    expect(action?.chord).toBe("Ctrl+Alt+E");
+    // Opening it reads a table and writes nothing; the clipboard belongs
+    // to the signed-in session.
+    expect(action?.mutates).toBe(false);
+    expect(action?.privileged).toBe(false);
+  });
+
+  test("firing it opens a terminal of its own, not a second surface on this frame", () => {
+    const anything = (cmd: string): string => `/usr/bin/${cmd}`;
+
+    const onWindows = firePlan("emoji.pick", windows, anything);
+    expect(onWindows.ok && onWindows.argv).toEqual([
+      "cmd.exe", "/c", "start", "", "red-dev.exe", "emoji",
+    ]);
+
+    const onUbuntu = firePlan("emoji.pick", noble, anything);
+    expect(onUbuntu.ok && onUbuntu.argv).toEqual(["alacritty", "-e", "red-dev", "emoji"]);
+
+    // And gnome-terminal is told with `--`, whose -e was deprecated
+    // years ago: the wrong flag opens a terminal with a shell in it and
+    // no sign that the command was dropped.
+    const gnome = firePlan("emoji.pick", noble, (cmd) =>
+      cmd === "gnome-terminal" ? "/usr/bin/gnome-terminal" : null,
+    );
+    expect(gnome.ok && gnome.argv).toEqual(["gnome-terminal", "--", "red-dev", "emoji"]);
+  });
+
+  test("and a machine with no terminal emulator is told the command to run instead", () => {
+    const plan = firePlan("emoji.pick", noble, () => null);
+    expect(plan.ok).toBe(false);
+    expect(plan.ok === false && plan.detail).toContain("red-dev emoji");
+  });
+});

--- a/src/emoji.ts
+++ b/src/emoji.ts
@@ -1,0 +1,359 @@
+/**
+ * `red-dev emoji` — the bundled table, as something a person can search
+ * and press Enter on.
+ *
+ * There is no emoji picker on three of the five targets this project
+ * supports. GNOME has one behind Ctrl+. in GTK applications and nowhere
+ * else; Windows has Win+. , which ADR 0006 leaves to the host and which
+ * does not exist inside WSL at all; a headless server has neither. So
+ * the picker is red-dev's, drawn in a terminal, and it is the same
+ * picker in all five places — which is the only reason it is worth
+ * shipping a table rather than pointing at the host's.
+ *
+ * ## Deciding, then doing
+ *
+ * The same split `firePlan` and `PanelPlan` make, and for the same
+ * reason. `copyPlan` says which program would be run and with what on
+ * its stdin; `copyEmoji` runs it. A refusal — a server with no clipboard
+ * — arrives as a sentence for the status line rather than as a process
+ * that failed somewhere off screen, and the choice of route is readable
+ * by a test on all five targets from whichever one the test runs on.
+ *
+ * ## And the route is not this module's invention
+ *
+ * `clipboardArgvFor` is the terminal layer's own, the one zellij's
+ * `copy_command` is built from. That is deliberate to the point of being
+ * the design: the WSL route in particular took three attempts to get
+ * right — `clip.exe` alone mangled UTF-8 through the OEM code page, then
+ * a PowerShell bridge decoded correctly and exceeded zellij's one-second
+ * deadline, and only `iconv` to BOM-less UTF-16LE is both. A picker whose
+ * whole job is putting a supplementary-plane character on the Windows
+ * clipboard is exactly the surface that would have reinvented that bug,
+ * so it does not get to choose.
+ */
+
+import { clipboardArgvFor } from "./dotfiles.ts";
+import { EMOJI, type Emoji } from "./emoji-table.ts";
+import type { Platform } from "./platform.ts";
+
+export type { Emoji } from "./emoji-table.ts";
+export { EMOJI, EMOJI_GROUPS } from "./emoji-table.ts";
+
+/**
+ * Which of the three bridges this machine copies through.
+ *
+ * Named rather than inferred from the argv, because the name is what a
+ * person reads in the status line and what a test asserts on. "wl-copy
+ * succeeded" is a sentence; `["wl-copy"]` is an implementation detail
+ * that happens to be one word long today.
+ */
+export type ClipboardTarget = "wayland" | "wsl" | "windows";
+
+export interface ClipboardRoute {
+  target: ClipboardTarget;
+  /**
+   * The program and its arguments, taking the text on stdin.
+   *
+   * `argv.join(" ")` is the `copy_command` zellij is given on the same
+   * machine — not a similar one, the same one.
+   */
+  argv: readonly string[];
+  /** One line naming the bridge, for the status line. */
+  note: string;
+}
+
+/**
+ * How each route is described once it has worked.
+ *
+ * The WSL line names the encoding on purpose. Someone who copies an
+ * emoji under WSL and pastes a `?` into Teams needs to know which of the
+ * two sides to look at, and "through iconv to UTF-16LE" points at the
+ * one that has been wrong before.
+ */
+const NOTES: Record<ClipboardTarget, string> = {
+  wayland: "wl-copy",
+  wsl: "the Windows clipboard, through iconv to BOM-less UTF-16LE",
+  windows: "the Windows clipboard, through PowerShell",
+};
+
+/**
+ * The route for this machine, or nothing where there is no clipboard.
+ *
+ * The target is read off the platform rather than off the argv so that
+ * the two cannot disagree: `clipboardArgvFor` decides *what runs*, this
+ * decides *what it is called*, and both answer the same question in the
+ * same order.
+ */
+export function clipboardRoute(p: Platform): ClipboardRoute | null {
+  const argv = clipboardArgvFor(p);
+  if (!argv) return null;
+  const target: ClipboardTarget =
+    p.env === "wsl" ? "wsl" : p.os === "windows" ? "windows" : "wayland";
+  return { target, argv, note: NOTES[target] };
+}
+
+export type CopyPlan =
+  | { ok: true; char: string; argv: readonly string[]; note: string }
+  | { ok: false; char: string; detail: string };
+
+/**
+ * What copying this emoji would run, decided before anything runs.
+ *
+ * The refusal carries the character itself. A person on a server asked
+ * for an emoji and the honest answer is "this machine has no clipboard,
+ * and here it is anyway" — which they can select with the mouse. An
+ * empty "unavailable" would be the picker refusing to do the one part it
+ * can still do.
+ */
+export function copyPlan(p: Platform, emoji: Emoji): CopyPlan {
+  const route = clipboardRoute(p);
+  if (!route) {
+    return {
+      ok: false,
+      char: emoji.char,
+      detail: `no clipboard on ${p.env} — ${emoji.char} is ${emoji.name}, copy it by hand`,
+    };
+  }
+  return { ok: true, char: emoji.char, argv: route.argv, note: `${emoji.char} → ${route.note}` };
+}
+
+/** Copied, or the reason it was not — either way, one line. */
+export interface CopyOutcome {
+  copied: boolean;
+  detail: string;
+}
+
+/**
+ * The seam a test replaces: hand this text to that program's stdin, and
+ * say how it ended.
+ */
+export type ClipboardWrite = (argv: readonly string[], text: string) => Promise<number>;
+
+/**
+ * The real one, bounded.
+ *
+ * Through `runBounded` rather than a bare spawn because every route ends
+ * in a program that can hang: `clip.exe` when WSL interop is wedged,
+ * PowerShell while it starts, `wl-copy` when it is holding a selection
+ * for a compositor that has gone away. A picker that stopped responding
+ * to the keyboard because a copy never returned would be a worse failure
+ * than the copy failing.
+ *
+ * Three seconds rather than zellij's one: zellij's deadline is zellij's,
+ * imposed on a command it kills mid-selection, and a person who pressed
+ * Enter can afford to wait a moment longer than a mouse drag can.
+ */
+export async function writeClipboard(argv: readonly string[], text: string): Promise<number> {
+  const { runBounded } = await import("./bounded-command.ts");
+  const result = await runBounded([...argv], { stdin: text, timeoutMs: 3_000 });
+  // A timeout has no exit code and must not read as success. `?? 1` would
+  // be a lie in the other direction only if the program had exited well,
+  // which is precisely the case that carries a code.
+  return result.timedOut ? 1 : (result.exitCode ?? 1);
+}
+
+/**
+ * Put the chosen emoji on this machine's clipboard.
+ *
+ * `write` is injected for the reason `fireEntry` injects its spawn: the
+ * clipboard is not answerable in a test, and the thing worth pinning is
+ * that choosing a row hands *that* character to *this target's* bridge.
+ */
+export async function copyEmoji(
+  p: Platform,
+  emoji: Emoji,
+  write: ClipboardWrite = writeClipboard,
+): Promise<CopyOutcome> {
+  const plan = copyPlan(p, emoji);
+  if (!plan.ok) return { copied: false, detail: plan.detail };
+  try {
+    const code = await write(plan.argv, plan.char);
+    if (code !== 0) {
+      return { copied: false, detail: `${plan.argv[0]} exited ${code} — nothing was copied` };
+    }
+  } catch (err) {
+    return { copied: false, detail: `${emoji.name}: ${(err as Error).message}` };
+  }
+  return { copied: true, detail: `copied ${plan.note}` };
+}
+
+// ----------------------------------------------------------- searching
+
+/**
+ * How well one row answers a query, lower being better.
+ *
+ * A plain filter is not enough here and the difference is visible on the
+ * first keystroke. Typing `fire` into a filtered list of 300 rows puts
+ * 🔥 somewhere among "firefox", "fireworks" and every row whose group or
+ * keywords mention it, in table order — so the emoji the word *is* sits
+ * below three that merely mention it, and the person keeps typing a word
+ * that was already right.
+ *
+ * Four ranks, and the boundaries are the ones a person would draw: the
+ * name *is* the query, the name *starts with* it, a keyword *is* it,
+ * anything else that matches at all.
+ */
+function rank(emoji: Emoji, query: string): number {
+  if (emoji.name === query) return 0;
+  if (emoji.name.startsWith(query)) return 1;
+  if (emoji.keywords.includes(query)) return 2;
+  return 3;
+}
+
+/**
+ * The table, narrowed by what has been typed and then ordered.
+ *
+ * Every word has to match somewhere, in any order and anywhere in the
+ * row — the same rule `searchKeys` uses, so the two surfaces of this
+ * product behave the same way under the same fingers. The group is part
+ * of the haystack, which is what makes `food` and `symbols` queries that
+ * work; the ranking above is what stops that from burying the row a
+ * one-word query actually named.
+ *
+ * The sort is stable and the tiebreak is table order, so a query with no
+ * ranking signal at all returns the groups in the order the table
+ * declares them rather than in whatever order the engine felt like.
+ */
+export function searchEmoji(query: string, table: readonly Emoji[] = EMOJI): Emoji[] {
+  const folded = query.trim().toLowerCase();
+  const words = folded.split(/\s+/).filter(Boolean);
+  if (words.length === 0) return [...table];
+
+  const matches = table.filter((emoji) => {
+    const hay = `${emoji.name} ${emoji.keywords.join(" ")} ${emoji.group}`.toLowerCase();
+    return words.every((word) => hay.includes(word));
+  });
+
+  return matches
+    .map((emoji, i) => ({ emoji, i, rank: rank(emoji, folded) }))
+    .sort((a, b) => a.rank - b.rank || a.i - b.i)
+    .map((entry) => entry.emoji);
+}
+
+/** Wide enough for the widest of each, so the columns line up. */
+export interface EmojiColumns {
+  name: number;
+  group: number;
+}
+
+export function emojiColumns(table: readonly Emoji[]): EmojiColumns {
+  const widest = (pick: (e: Emoji) => string): number =>
+    table.reduce((max, e) => Math.max(max, pick(e).length), 0);
+  return { name: widest((e) => e.name), group: widest((e) => e.group) };
+}
+
+/**
+ * One row: the character, its name, its group, and the words that find
+ * it.
+ *
+ * The keywords are on the row rather than hidden because they are the
+ * half of the search nobody can guess. Someone who typed `deploy` and got
+ * 🚀 learns why; someone who typed it and got nothing needs to see which
+ * words exist before they can add the one that does not.
+ *
+ * The character is not padded. Terminals disagree about how wide an
+ * emoji is — two cells usually, one for the older symbols, and the ZWJ
+ * sequences are anyone's guess — so a column computed from string length
+ * would misalign on the rows it was meant to align. The name column
+ * starts after a fixed gap and the ragged left edge is the honest cost.
+ */
+export function emojiRow(emoji: Emoji, cols: EmojiColumns): string {
+  const words = emoji.keywords.length === 0 ? "" : `  ${emoji.keywords.join(", ")}`;
+  return `${emoji.char}  ${emoji.name.padEnd(cols.name)}  ${emoji.group.padEnd(cols.group)}${words}`;
+}
+
+/** The whole table as text, for a terminal that cannot draw a picker. */
+export function emojiLines(table: readonly Emoji[] = EMOJI): string[] {
+  const cols = emojiColumns(table);
+  return table.map((emoji) => emojiRow(emoji, cols));
+}
+
+// ---------------------------------------------------------- the keyboard
+
+/** Where the search box and the cursor are, and nothing else. */
+export interface PickerState {
+  query: string;
+  /** Into the filtered list, never into the whole table. */
+  index: number;
+}
+
+export const PICKER_START: PickerState = { query: "", index: 0 };
+
+/**
+ * The keys the picker reads, structurally — the same declaration
+ * `keys.ts` and `panel.ts` both make, and for the same reason: tuiuiu's
+ * `Key` carries all of these, so the component hands its own object
+ * straight in, and naming only what is used keeps this module free of
+ * the renderer.
+ */
+export interface PickerKey {
+  upArrow: boolean;
+  downArrow: boolean;
+  return: boolean;
+  escape: boolean;
+  backspace: boolean;
+  delete: boolean;
+  ctrl: boolean;
+}
+
+export interface PickerStep {
+  state: PickerState;
+  /** The emoji Enter chose, when it chose one. */
+  copy?: Emoji;
+  /** The picker is finished. */
+  quit?: boolean;
+}
+
+/**
+ * One keystroke, as a decision rather than as a side effect.
+ *
+ * Deliberately the same interaction as the keys viewer, down to escape
+ * clearing the query before it closes: two surfaces of one product that
+ * are both "type to filter, arrows to move, enter to act" must not
+ * disagree about what escape does, and the only way to be sure of that
+ * is to write the same rules twice and pin both.
+ *
+ * The picker does not close after a copy. Somebody assembling a commit
+ * message wants three of these, and a picker that exited on the first
+ * would make them press the chord again — so the copy is reported in the
+ * status line and the list stays where it is, cursor included.
+ */
+export function pickerStep(
+  state: PickerState,
+  input: string,
+  key: PickerKey,
+  table: readonly Emoji[] = EMOJI,
+): PickerStep {
+  const visible = searchEmoji(state.query, table);
+  const clamp = (i: number): number => Math.max(0, Math.min(visible.length - 1, i));
+
+  // Ctrl+C leaves, whatever is on screen. Every other Ctrl chord is
+  // swallowed rather than typed into the search box.
+  if (key.ctrl) return input === "c" ? { state, quit: true } : { state };
+
+  if (key.return) {
+    const chosen = visible[clamp(state.index)];
+    return chosen ? { state, copy: chosen } : { state };
+  }
+
+  if (key.escape) {
+    return state.query === "" ? { state, quit: true } : { state: PICKER_START };
+  }
+
+  if (key.upArrow) return { state: { ...state, index: clamp(state.index - 1) } };
+  if (key.downArrow) return { state: { ...state, index: clamp(state.index + 1) } };
+
+  if (key.backspace || key.delete) {
+    return state.query === ""
+      ? { state }
+      : { state: { query: state.query.slice(0, -1), index: 0 } };
+  }
+
+  // Back to the top on every edit: the row under the cursor before the
+  // keystroke is rarely the row under it after.
+  if (input.length === 1 && input >= " " && input !== "\u007f") {
+    return { state: { query: state.query + input, index: 0 } };
+  }
+
+  return { state };
+}

--- a/src/keys.test.ts
+++ b/src/keys.test.ts
@@ -215,9 +215,11 @@ describe("searching", () => {
 
   test("the state is searchable, so 'unbound work' is one query", () => {
     expect(searchKeys(keyEntries(server), "unsupported")).toHaveLength(ACTIONS.length);
-    // On Windows the terminal pair is bound and the Panels are not, so
-    // the query answers with exactly what this machine does not register.
+    // On Windows the terminal pair is bound and the other surfaces are
+    // not, so the query answers with exactly what this machine does not
+    // register.
     expect(searchKeys(entries, "unsupported").map((e) => e.id)).toEqual([
+      "emoji.pick",
       "panel.network",
       "panel.audio",
       "panel.power",

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -347,6 +347,31 @@ export function firePlan(
       };
     }
 
+    case "emoji.pick": {
+      // A terminal of its own, exactly as a Panel gets one and for the
+      // same reason: the viewer is already drawing in this one, and two
+      // full-screen surfaces on one frame is what firing it in place
+      // would produce.
+      if (onWindowsHost(p)) {
+        return {
+          ok: true,
+          id,
+          argv: ["cmd.exe", "/c", "start", "", "red-dev.exe", "emoji"],
+          note: "the emoji picker in a new window",
+        };
+      }
+      const found = LINUX_TERMINALS.find((cmd) => locate(cmd) !== null);
+      if (!found) {
+        return { ok: false, id, detail: "no terminal emulator on PATH — run `red-dev emoji` here instead" };
+      }
+      return {
+        ok: true,
+        id,
+        argv: [found, TERMINAL_EXEC[found] ?? "-e", "red-dev", "emoji"],
+        note: `the emoji picker in ${found}`,
+      };
+    }
+
     case "panel.network":
     case "panel.audio":
     case "panel.power": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1230,6 +1230,30 @@ async function cmdKeys(p: Platform): Promise<number> {
 }
 
 /**
+ * `red-dev emoji` — the bundled table, searchable, with Enter on the
+ * clipboard.
+ *
+ * Two shapes, and the plain one is not a degraded mode — the same rule
+ * `red-dev keys` follows. A terminal that cannot draw the picker still
+ * gets the whole table with the name, the group and the keywords on
+ * every row, which is the form a script greps and the form that proves
+ * the table ships with the binary rather than coming from the machine.
+ * The picker adds the search and the copy, not the information.
+ */
+async function cmdEmoji(p: Platform): Promise<number> {
+  const { emojiLines } = await import("./emoji.ts");
+
+  if (!interactive()) {
+    for (const line of emojiLines()) log.plain(line);
+    return 0;
+  }
+
+  const { runEmojiPicker } = await import("./emoji-view.ts");
+  await runEmojiPicker(p);
+  return 0;
+}
+
+/**
  * `red-dev ssh [github-user]` — the way in that is not a first run.
  *
  * The interview asks this once, on a machine that is new. Everything
@@ -1536,10 +1560,12 @@ async function cmdUi(p: Platform, inv: Invocation): Promise<number> {
     case "apps":
       return await cmdApps(p, inv);
     case "keys":
-      // Both of these draw their own interface, so they run after this
-      // one has released the screen — the same reason `apps` is here
-      // rather than in the actions handed into the render.
+      // All three of these draw their own interface, so they run after
+      // this one has released the screen — the same reason `apps` is
+      // here rather than in the actions handed into the render.
       return await cmdKeys(p);
+    case "emoji":
+      return await cmdEmoji(p);
     case "learn":
       return await cmdLearn(p);
     default:
@@ -2002,6 +2028,7 @@ async function cmdMenu(p: Platform, inv: Invocation, cliHelp: string): Promise<n
     platform: () => cmdPlatform(p),
     apps: () => cmdApps(p, inv),
     keys: () => cmdKeys(p),
+    emoji: () => cmdEmoji(p),
     learn: () => cmdLearn(p),
     lang: () => cmdLang(p, inv),
     shell: () => cmdShell(p, inv),
@@ -2160,6 +2187,8 @@ async function main(): Promise<number> {
       return await cmdApps(p, inv);
     case "keys":
       return await cmdKeys(p);
+    case "emoji":
+      return await cmdEmoji(p);
     case "ssh":
       return await cmdSsh(p, inv);
     case "learn":

--- a/src/menu-sections.test.ts
+++ b/src/menu-sections.test.ts
@@ -37,17 +37,19 @@ function machine(over: Partial<Platform>): Platform {
 }
 
 describe("the fullscreen menu", () => {
-  test("carries a Keys section and a Learn section", () => {
+  test("carries a Keys section, an Emoji section and a Learn section", () => {
     const keys = SECTIONS.find((s) => s.key === "keys");
+    const emoji = SECTIONS.find((s) => s.key === "emoji");
     const learn = SECTIONS.find((s) => s.key === "learn");
     expect(keys?.label).toBe("Keys");
+    expect(emoji?.label).toBe("Emoji");
     expect(learn?.label).toBe("Learn");
   });
 
-  test("and both say what they are for while highlighted", () => {
+  test("and each says what it is for while highlighted", () => {
     // The right-hand panel is the only explanation a section gets; one
     // with no notes is a word on a list.
-    for (const key of ["keys", "learn"]) {
+    for (const key of ["keys", "emoji", "learn"]) {
       expect(SECTIONS.find((s) => s.key === key)?.notes.length).toBeGreaterThan(0);
     }
   });
@@ -77,7 +79,7 @@ describe("choosing one opens something", () => {
     return main.slice(from, main.indexOf("\nasync function", from + 1));
   })();
 
-  for (const key of ["keys", "learn"]) {
+  for (const key of ["keys", "emoji", "learn"]) {
     test(`the ${key} section is answered after the render exits`, () => {
       expect(cmdUi).toContain(`case "${key}":`);
     });
@@ -86,9 +88,10 @@ describe("choosing one opens something", () => {
 
 describe("the narrow-terminal menu", () => {
   for (const p of [machine({}), machine({ os: "windows", env: "windows" })]) {
-    test(`offers Keys and Learn on ${p.env} too`, () => {
+    test(`offers Keys, Emoji and Learn on ${p.env} too`, () => {
       const verbs = menuEntries(p).map((entry) => entry.split(" ")[0]);
       expect(verbs).toContain("Keys");
+      expect(verbs).toContain("Emoji");
       expect(verbs).toContain("Learn");
     });
   }
@@ -105,6 +108,7 @@ describe("the narrow-terminal menu", () => {
       "Redwall",
       "Apps",
       "Keys",
+      "Emoji",
       "Languages",
       "Shell",
       "Update",

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -51,6 +51,7 @@ type Handlers = {
   platform: () => number;
   apps: () => Promise<number>;
   keys: () => Promise<number>;
+  emoji: () => Promise<number>;
   learn: () => Promise<number>;
   lang: () => Promise<number>;
   shell: () => Promise<number>;
@@ -258,6 +259,7 @@ export function menuEntries(p: Platform): [string, ...string[]] {
     "Redwall — machine state on the wallpaper",
     "Apps — optional tools and web apps",
     "Keys — every action, its chord, and what is bound here",
+    "Emoji — search the bundled table, copy one to the clipboard",
     "Languages — runtimes mise manages",
     ...(wslish ? ["Shell — where a terminal lands"] : []),
     "Update — upgrade, then converge",
@@ -311,6 +313,9 @@ export async function runMenu(
         break;
       case "Keys":
         last = await h.keys();
+        break;
+      case "Emoji":
+        last = await h.emoji();
         break;
       case "Learn":
         last = await h.learn();

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -170,6 +170,18 @@ export const SECTIONS: MenuSection[] = [
     ],
   },
   {
+    key: "emoji",
+    label: "Emoji",
+    notes: [
+      "A table that ships inside this binary,",
+      "not one read from the fonts installed",
+      "here — so the same search finds the",
+      "same character on every target. Enter",
+      "copies it through the clipboard the",
+      "terminal layer already uses.",
+    ],
+  },
+  {
     key: "learn",
     label: "Learn",
     notes: [


### PR DESCRIPTION
Automated AFK landing for #145. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #145

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/173"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789459484&installation_model_id=20659&pr_number=173&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F173&signature=4c1267245589d4e6dfec17f75be50000c968d56b14b8411892439fb2176b9c7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->