### PR TITLE
Put the new chords in the half the chord decision reserved

### DIFF
--- a/src/actions/panels.ts
+++ b/src/actions/panels.ts
@@ -36,7 +36,7 @@ export const PANEL_ACTIONS: readonly SemanticAction[] = [
     // the arrows on workspaces and takes L, Tab, Esc and Delete;
     // Windows takes Delete, Tab and the arrows. Omarchy binds its
     // network panel to Super+Ctrl+W, which ADR 0006 leaves to the host.
-    chord: "Ctrl+Alt+N",
+    chord: "Ctrl+Alt+Shift+N",
   },
   {
     id: "panel.audio",
@@ -49,7 +49,7 @@ export const PANEL_ACTIONS: readonly SemanticAction[] = [
     mutates: false,
     privileged: false,
     // A for audio, and free in the family on both hosts.
-    chord: "Ctrl+Alt+A",
+    chord: "Ctrl+Alt+Shift+A",
   },
   {
     id: "panel.power",
@@ -59,6 +59,6 @@ export const PANEL_ACTIONS: readonly SemanticAction[] = [
     privileged: false,
     // P for power. Neither host claims it, and the one thing that might
     // — GNOME's print-screen family — lives on Print, not on P.
-    chord: "Ctrl+Alt+P",
+    chord: "Ctrl+Alt+Shift+P",
   },
 ];

--- a/src/actions/registry.test.ts
+++ b/src/actions/registry.test.ts
@@ -53,6 +53,43 @@ describe("the registry itself", () => {
     ]);
   });
 
+  test("carries the exact chord the maintainer chose for each action", () => {
+    // Pinned per id rather than as a family property, because a family
+    // assertion is what let this drift in the first place: `Ctrl+Alt+N`
+    // and `Ctrl+Alt+Shift+N` both satisfy "ctrl and alt and not win",
+    // so the four panel and emoji chords shipped in the half the
+    // maintainer had explicitly rejected and every test stayed green.
+    //
+    // The decision is #138: everything red-dev adds lives in the
+    // Ctrl+Alt+Shift half, leaving plain Ctrl+Alt+<letter> to editors —
+    // JetBrains spends it on refactorings and a global hotkey wins over
+    // the focused application. The two terminal chords predate it.
+    expect(Object.fromEntries(ACTIONS.map((a) => [a.id, a.chord]))).toEqual({
+      "terminal.new": "Ctrl+Alt+T",
+      "terminal.elevated": "Ctrl+Alt+Shift+T",
+      "emoji.pick": "Ctrl+Alt+Shift+E",
+      "panel.network": "Ctrl+Alt+Shift+N",
+      "panel.audio": "Ctrl+Alt+Shift+A",
+      "panel.power": "Ctrl+Alt+Shift+P",
+    });
+  });
+
+  test("leaves the plain Ctrl+Alt half to editors, except where it predates the decision", () => {
+    const predating = new Set(["terminal.new"]);
+    for (const action of ACTIONS) {
+      if (predating.has(action.id)) continue;
+      expect(parseChord(action.chord)?.shift).toBe(true);
+    }
+  });
+
+  test("refuses a chord GNOME answers to in the Shift half", () => {
+    // Added with the decision: the guard carried Ctrl+Alt+Tab and
+    // Ctrl+Alt+Esc but not their Shift variants, which are
+    // switch-panels-backward and cycle-panels-backward.
+    expect(problems(fixture({ chord: "Ctrl+Alt+Shift+Tab" }))).not.toEqual([]);
+    expect(problems(fixture({ chord: "Ctrl+Alt+Shift+Esc" }))).not.toEqual([]);
+  });
+
   test("gives every action exactly one chord, in the Ctrl+Alt family", () => {
     for (const action of ACTIONS) {
       const chord = parseChord(action.chord);

--- a/src/actions/reserved.ts
+++ b/src/actions/reserved.ts
@@ -46,6 +46,13 @@ export const GNOME_RESERVED: ReadonlySet<string> = new Set([
   "CTRL+ALT+SHIFT+RIGHT",
   "CTRL+ALT+SHIFT+UP",
   "CTRL+ALT+SHIFT+DOWN",
+  // cycle-panels-backward and switch-panels-backward, measured from the
+  // GNOME schemas. They were harmless while nothing red-dev owned lived
+  // in the Shift half; the 2026-08-15 chord decision put every new
+  // action there, so a guard missing them would now pass a chord GNOME
+  // already answers to.
+  "CTRL+ALT+SHIFT+ESC",
+  "CTRL+ALT+SHIFT+TAB",
   "CTRL+ALT+DELETE",
   "CTRL+ALT+L",
   "CTRL+ALT+TAB",

--- a/src/actions/terminal-surfaces.ts
+++ b/src/actions/terminal-surfaces.ts
@@ -44,6 +44,6 @@ export const TERMINAL_SURFACE_ACTIONS: readonly SemanticAction[] = [
     // are, because ADR 0006 keeps red-dev out of the Super family and
     // taking Ctrl+. would fight GTK for a key it uses inside text
     // fields.
-    chord: "Ctrl+Alt+E",
+    chord: "Ctrl+Alt+Shift+E",
   },
 ];

--- a/src/emoji.test.ts
+++ b/src/emoji.test.ts
@@ -463,10 +463,12 @@ describe("the plain list, for a terminal that cannot draw the picker", () => {
 });
 
 describe("how the picker is reached", () => {
-  test("it is a semantic action, with one chord in the Ctrl+Alt family", () => {
+  test("it is a semantic action, in the half the chord decision reserved", () => {
     const action = ACTIONS.find((a) => a.id === "emoji.pick");
     expect(action?.label).toBe("Emoji picker");
-    expect(action?.chord).toBe("Ctrl+Alt+E");
+    // Ctrl+Alt+E until the #138 decision was applied, which is the bug
+    // this assertion now guards: plain Ctrl+Alt is left to editors.
+    expect(action?.chord).toBe("Ctrl+Alt+Shift+E");
     // Opening it reads a table and writes nothing; the clipboard belongs
     // to the signed-in session.
     expect(action?.mutates).toBe(false);


### PR DESCRIPTION
Four chords shipped in the family the maintainer explicitly rejected, and every test stayed green.

#138 decided: everything red-dev adds lives in `Ctrl+Alt+Shift+<letter>`, leaving plain `Ctrl+Alt+<letter>` to editors — JetBrains spends it on refactorings (`Ctrl+Alt+N` inline, `Ctrl+Alt+P` extract parameter, …) and a global hotkey wins over the focused application.

What actually landed:

| Action | Shipped | Decided |
| --- | --- | --- |
| `panel.network` | `Ctrl+Alt+N` | `Ctrl+Alt+Shift+N` |
| `panel.audio` | `Ctrl+Alt+A` | `Ctrl+Alt+Shift+A` |
| `panel.power` | `Ctrl+Alt+P` | `Ctrl+Alt+Shift+P` |
| `emoji.pick` | `Ctrl+Alt+E` | `Ctrl+Alt+Shift+E` |

## Why nothing caught it

The guard asserted a *family property* — "ctrl and alt and not win" — which `Ctrl+Alt+N` and `Ctrl+Alt+Shift+N` both satisfy. So the decision was unenforceable by construction.

This pins the chord per action id instead, and adds the complementary assertion that everything except the pre-existing `terminal.new` sits in the Shift half. Verified to bite: reverting one chord fails both.

## Also closes the gap #138 named

`GNOME_RESERVED` carried `CTRL+ALT+TAB` and `CTRL+ALT+ESC` but not their Shift variants — `switch-panels-backward` and `cycle-panels-backward`, measured from the GNOME schemas. Harmless while nothing lived in the Shift half; load-bearing the moment every new action moved there. Added, with a test that a fixture carrying either one fails validation.

## How it surfaced

Running the shipped binary — `red-dev keys` printed the real chords. CI was green on all of it.

`bun run typecheck` clean, **1742 tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/174"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789471450&installation_model_id=20659&pr_number=174&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F174&signature=7922ea27aa776a275b90d237fe1a47b33b69c3bef11b71b7b4a6a99f57a8c1bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->