### PR TITLE
fix: #176 The four semantic actions the chord decision named and the drain never added

### DIFF
--- a/src/actions/agents.ts
+++ b/src/actions/agents.ts
@@ -6,8 +6,62 @@
  * being absent: the multiplexer is not installed on every machine, and
  * an adapter reports such an action unbound rather than dropping it, so
  * the keys viewer can say "not installed here" instead of going quiet.
+ *
+ * Neither entry names a host. `agent.launch` starts whichever host was
+ * recorded as the Default agent, resolved at the moment it fires by
+ * src/agent-launch.ts, because a chord that reached for `claude`
+ * because it is usually there would be right on most machines and
+ * wrong, silently, on exactly the machines where somebody bothered to
+ * choose. `agent.multiplex` names herdr, which is not an agent but the
+ * thing agents run inside.
  */
 
 import type { SemanticAction } from "./types.ts";
 
-export const AGENT_ACTIONS: readonly SemanticAction[] = [];
+/**
+ * Everywhere with a display, WSL included — the same set the terminal
+ * actions, the Panels and the terminal surfaces claim.
+ *
+ * `server` is absent from the list and not from the product: `red-dev
+ * agents run` is a command and it hands the terminal over an SSH
+ * connection exactly as it does here. What is missing on a server is
+ * somewhere to press a key, which is all this list is about.
+ */
+const WITH_A_DISPLAY = ["desktop", "wsl", "windows"] as const;
+
+export const AGENT_ACTIONS: readonly SemanticAction[] = [
+  {
+    id: "agent.launch",
+    label: "Default agent",
+    platforms: WITH_A_DISPLAY,
+    // Starting a host opens a session; what the person then asks it to
+    // do is theirs, and the host asks for each of those itself. That
+    // last clause is the whole of ADR 0001's amendment of 2026-08-15:
+    // red-dev never starts a host in bypass mode, so `mutates` here
+    // would be describing a permission red-dev deliberately does not
+    // hand over.
+    mutates: false,
+    privileged: false,
+    // G for agent — A is the audio Panel and the letter this act is
+    // named after is therefore already spent. Free in the family on
+    // both hosts: GNOME's Ctrl+Alt takes the arrows, L, Tab, Esc,
+    // Delete and the virtual terminals, Windows takes Delete, Tab and
+    // the display drivers' arrows, and neither claims G.
+    chord: "Ctrl+Alt+Shift+G",
+  },
+  {
+    id: "agent.multiplex",
+    label: "Agent multiplexer",
+    platforms: ["desktop", "wsl"],
+    mutates: false,
+    privileged: false,
+    // H for herdr, and free in the family on both hosts. `windows` is
+    // absent from the platforms above for the reason the manifest gives
+    // for skipping its RedSkills plugin there: herdr has no stable
+    // Windows build. It runs inside WSL on that machine, and the `wsl`
+    // entry is what says so — the action is not deleted from the list
+    // on a Windows host, it is reported as not applying there, which is
+    // ADR 0006's rule for exactly this case.
+    chord: "Ctrl+Alt+Shift+H",
+  },
+];

--- a/src/actions/registry.test.ts
+++ b/src/actions/registry.test.ts
@@ -42,14 +42,24 @@ describe("the registry itself", () => {
 
   test("carries the actions the areas have so far", () => {
     // Empty areas are aggregated too, so this is the whole list and not
-    // just the module that happens to be filled.
+    // just the module that happens to be filled — `apps` and `capture`
+    // are still empty and still imported, which is the arrangement that
+    // let this slice add four actions to two modules without touching
+    // the aggregate at all.
+    //
+    // Ten is the count the 2026-08-15 chord decision named, and it is
+    // the number `red-dev keys` prints.
     expect(ACTIONS.map((a) => a.id)).toEqual([
       "terminal.new",
       "terminal.elevated",
+      "menu.open",
+      "keys.viewer",
       "emoji.pick",
       "panel.network",
       "panel.audio",
       "panel.power",
+      "agent.launch",
+      "agent.multiplex",
     ]);
   });
 
@@ -67,10 +77,14 @@ describe("the registry itself", () => {
     expect(Object.fromEntries(ACTIONS.map((a) => [a.id, a.chord]))).toEqual({
       "terminal.new": "Ctrl+Alt+T",
       "terminal.elevated": "Ctrl+Alt+Shift+T",
+      "menu.open": "Ctrl+Alt+Shift+M",
+      "keys.viewer": "Ctrl+Alt+Shift+K",
       "emoji.pick": "Ctrl+Alt+Shift+E",
       "panel.network": "Ctrl+Alt+Shift+N",
       "panel.audio": "Ctrl+Alt+Shift+A",
       "panel.power": "Ctrl+Alt+Shift+P",
+      "agent.launch": "Ctrl+Alt+Shift+G",
+      "agent.multiplex": "Ctrl+Alt+Shift+H",
     });
   });
 

--- a/src/actions/terminal-surfaces.ts
+++ b/src/actions/terminal-surfaces.ts
@@ -8,6 +8,12 @@
  * queueing behind one another over the same list. An empty area is a
  * declaration of where its actions will go; this is the first one
  * arriving.
+ *
+ * All three are the same act with a different subcommand behind it —
+ * red-dev drawing one of its own full-screen surfaces — which is why
+ * `firePlan` opens them through one shared path rather than three.
+ * Listed in the order the header names them, so the module reads the
+ * way its own first sentence does.
  */
 
 import type { SemanticAction } from "./types.ts";
@@ -26,6 +32,36 @@ import type { SemanticAction } from "./types.ts";
 const WITH_A_DISPLAY = ["desktop", "wsl", "windows"] as const;
 
 export const TERMINAL_SURFACE_ACTIONS: readonly SemanticAction[] = [
+  {
+    id: "menu.open",
+    label: "red-dev menu",
+    platforms: WITH_A_DISPLAY,
+    // The menu is a way in, not a change: everything it can go on to do
+    // — converge, install, set a Default agent — asks for itself at the
+    // moment it is chosen. The same reading the Panels are given.
+    mutates: false,
+    privileged: false,
+    // M for menu. Free in the family on both hosts: GNOME's Ctrl+Alt
+    // spends the arrows on workspaces and takes L, Tab, Esc, Delete and
+    // the virtual terminals, and Windows takes Delete, Tab and the
+    // display drivers' arrows. Neither claims M.
+    chord: "Ctrl+Alt+Shift+M",
+  },
+  {
+    id: "keys.viewer",
+    label: "Keys viewer",
+    platforms: WITH_A_DISPLAY,
+    // It reads the registry and this machine's bindings. Enter inside it
+    // starts things, and each of those answers for itself.
+    mutates: false,
+    privileged: false,
+    // K for keys, and free in the family on both hosts. Worth saying
+    // plainly: this is the one chord whose whole job is to rescue the
+    // others — ADR 0006 calls the viewer the remedy for a chord nobody
+    // can remember, and a remedy reachable only by remembering where
+    // `red-dev keys` lives is half a remedy.
+    chord: "Ctrl+Alt+Shift+K",
+  },
   {
     id: "emoji.pick",
     label: "Emoji picker",

--- a/src/agent-launch.test.ts
+++ b/src/agent-launch.test.ts
@@ -12,9 +12,17 @@
  * The second half pins the other way this goes wrong: launching the
  * host that happens to be installed rather than the host that was
  * chosen. The recorded answer decides, or nothing launches.
+ *
+ * Between them sits the path a *chord* takes, which is the one the
+ * enumeration used not to reach. `agent.launch` is a semantic action
+ * with a key on it, and an action that assembled a host command line of
+ * its own would be a second launcher — outside the guard, outside the
+ * record, and pressed far more often than `red-dev agents run` is
+ * typed.
  */
 
 import { describe, expect, test } from "bun:test";
+import { ACTIONS } from "./actions/index.ts";
 import { AGENTS, type AgentSpec } from "./agents.ts";
 import {
   hostLaunchArgv,
@@ -23,6 +31,8 @@ import {
   resolveLaunch,
 } from "./agent-launch.ts";
 import { isDefaultAgentCandidate } from "./default-agent.ts";
+import { firePlan } from "./keys.ts";
+import type { Platform } from "./platform.ts";
 
 /** Every host red-dev can hand work to, and therefore can start. */
 const LAUNCHABLE = AGENTS.filter(isDefaultAgentCandidate);
@@ -88,6 +98,86 @@ describe("the launch argv of every agent host", () => {
     // This catches the same entry on the machine of whoever ships it
     // anyway, which is the difference between a test and a guard.
     expect(() => launchTarget(BYPASSING_HOST, "/usr/bin/fixture")).toThrow(/--yolo/);
+  });
+});
+
+/** A target for a fire plan, since a chord needs a machine to be pressed on. */
+function machine(over: Partial<Platform>): Platform {
+  return {
+    os: "linux",
+    distro: "ubuntu",
+    version: "24.04",
+    codename: "noble",
+    env: "desktop",
+    arch: "x64",
+    caps: { apt: true, gui: true, systemd: true, winget: false, flatpak: true },
+    ...over,
+  };
+}
+
+/** Every target a chord can be pressed on, plus the one that has no keyboard. */
+const TARGETS: readonly Platform[] = [
+  machine({}),
+  machine({ env: "wsl" }),
+  machine({ os: "windows", env: "windows", distro: null, version: null, codename: null }),
+  machine({ env: "server", caps: { apt: true, gui: false, systemd: true, winget: false, flatpak: false } }),
+];
+
+/** Everything is on PATH, so a plan is refused for its own reasons and not for PATH's. */
+const anything = (command: string): string => `/usr/bin/${command}`;
+
+describe("the chord that starts the Default agent", () => {
+  test("fires `red-dev agents run`, and names no host of its own", () => {
+    // The whole reason the action delegates. `red-dev agents run` is the
+    // single place that reads the recorded choice — resolveLaunch, in
+    // the describe below — and the single place launchTarget's guard
+    // stands. An action that assembled `claude …` here would be right
+    // on most machines, silently wrong on the ones where somebody
+    // chose, and outside both.
+    const plan = firePlan("agent.launch", machine({}), anything);
+    expect(plan.ok && plan.argv).toEqual(["alacritty", "-e", "red-dev", "agents", "run"]);
+
+    const argv = plan.ok ? plan.argv : [];
+    const named = AGENTS.filter((host) => host.cmd !== "" && argv.includes(host.cmd));
+    expect(named.map((host) => host.key)).toEqual([]);
+  });
+
+  test("and what that command then starts is the recorded host, plainly", () => {
+    // The far end of the same path, so the chord's promise is pinned end
+    // to end rather than at the handover: the person's recorded answer
+    // decides, and red-dev contributes nothing to the command line.
+    const decision = resolveLaunch(
+      { agents: ["claude-code", "codex"], defaultAgent: "codex" },
+      found("claude", "codex"),
+    );
+    expect(decision.ok).toBe(true);
+    if (!decision.ok) return;
+    expect(decision.target.key).toBe("codex");
+    expect(decision.target.added).toEqual([]);
+    expect(permissionBypassFlags(decision.target.argv)).toEqual([]);
+  });
+
+  test("and no action's fire plan carries a bypass flag, on any target", () => {
+    // The enumeration, widened from the host catalog to the action path.
+    // A chord is a command line red-dev assembles, which is exactly the
+    // thing ADR 0001's amendment is about, and until this ran the guard
+    // could only see the half of it that a person types.
+    const checked: string[] = [];
+    const offenders: string[] = [];
+    for (const p of TARGETS) {
+      for (const action of ACTIONS) {
+        const plan = firePlan(action.id, p, anything);
+        if (!plan.ok) continue;
+        checked.push(`${action.id} on ${p.env}`);
+        if (permissionBypassFlags(plan.argv).length > 0) {
+          offenders.push(`${action.id} on ${p.env}`);
+        }
+      }
+    }
+    // Guards against the enumeration passing because it enumerated
+    // nothing — the same way the host enumeration above guards itself.
+    expect(checked.length).toBeGreaterThan(ACTIONS.length);
+    expect(offenders).toEqual([]);
   });
 });
 

--- a/src/keys.test.ts
+++ b/src/keys.test.ts
@@ -219,10 +219,17 @@ describe("searching", () => {
     // not, so the query answers with exactly what this machine does not
     // register.
     expect(searchKeys(entries, "unsupported").map((e) => e.id)).toEqual([
+      "menu.open",
+      "keys.viewer",
       "emoji.pick",
       "panel.network",
       "panel.audio",
       "panel.power",
+      "agent.launch",
+      // Unsupported here for the other of the two reasons the word
+      // covers: herdr has no Windows build, so this row's sentence is
+      // about the platform rather than about a missing shortcut.
+      "agent.multiplex",
     ]);
   });
 });
@@ -349,6 +356,97 @@ describe("what Enter runs", () => {
   test("an action nothing can run yet is named rather than shrugged at", () => {
     const plan = firePlan("terminal.gone", windows, anything);
     expect(plan.ok === false && plan.detail).toContain("terminal.gone");
+  });
+});
+
+describe("the four actions the chord decision named", () => {
+  test("`red-dev keys` lists ten of them, on every target", () => {
+    // Ten is the count the 2026-08-15 decision named, and this holds it
+    // on the plain output rather than on the registry: that is the form
+    // a bug report pastes, and the form that would shrink first if a
+    // target ever started dropping what it cannot bind.
+    for (const p of [desktop, server, windows]) {
+      expect(keyLines(keyEntries(p))).toHaveLength(10);
+    }
+  });
+
+  test("the menu and the keys viewer open in a terminal of their own", () => {
+    // The same rule the emoji picker and the Panels follow, and the
+    // reason all five share one path now: the viewer is already drawing
+    // in this terminal, so firing one of them in place would put two
+    // full-screen surfaces on the same frame.
+    expect(firePlan("menu.open", desktop, anything)).toMatchObject({
+      argv: ["alacritty", "-e", "red-dev", "menu"],
+    });
+    expect(firePlan("keys.viewer", desktop, anything)).toMatchObject({
+      argv: ["alacritty", "-e", "red-dev", "keys"],
+    });
+    expect(firePlan("menu.open", windows, anything)).toMatchObject({
+      argv: ["cmd.exe", "/c", "start", "", "red-dev.exe", "menu"],
+    });
+    expect(firePlan("keys.viewer", windows, anything)).toMatchObject({
+      argv: ["cmd.exe", "/c", "start", "", "red-dev.exe", "keys"],
+    });
+  });
+
+  test("and a machine with no terminal emulator is told the command instead", () => {
+    for (const [id, command] of [["menu.open", "red-dev menu"], ["keys.viewer", "red-dev keys"], ["agent.launch", "red-dev agents run"]] as const) {
+      const plan = firePlan(id, desktop, nothing);
+      expect(plan.ok).toBe(false);
+      expect(plan.ok === false && plan.detail).toContain(command);
+    }
+  });
+
+  test("the Default agent is started through `red-dev agents run`, never a host by name", () => {
+    // Which host that resolves to is decided by the recorded choice, in
+    // src/agent-launch.ts, and pinned end to end in
+    // src/agent-launch.test.ts — including that the argv this builds
+    // carries no bypass flag, on any target.
+    expect(firePlan("agent.launch", desktop, anything)).toMatchObject({
+      argv: ["alacritty", "-e", "red-dev", "agents", "run"],
+    });
+    expect(firePlan("agent.launch", windows, anything)).toMatchObject({
+      argv: ["cmd.exe", "/c", "start", "", "red-dev.exe", "agents", "run"],
+    });
+  });
+
+  test("the multiplexer reports itself absent, with a reason, where herdr is not installed", () => {
+    const plan = firePlan("agent.multiplex", desktop, nothing);
+    expect(plan.ok).toBe(false);
+    expect(plan.ok === false && plan.detail).toContain("herdr is not installed");
+    // And the sentence is about herdr rather than about the terminal
+    // emulator this fixture machine is also missing. Nothing is on PATH
+    // here, so a check in the other order would answer a question
+    // nobody asked and send somebody to install Alacritty.
+    expect(plan.ok === false && plan.detail).not.toContain("terminal emulator");
+  });
+
+  test("and starts it where it is installed", () => {
+    const plan = firePlan("agent.multiplex", desktop, (cmd) =>
+      cmd === "herdr" || cmd === "alacritty" ? `/usr/bin/${cmd}` : null,
+    );
+    expect(plan.ok && plan.argv).toEqual(["alacritty", "-e", "herdr"]);
+  });
+
+  test("inside WSL it starts the distro's herdr, in a window belonging to the host", () => {
+    // red-dev is inside the distro here, so the herdr it found on PATH
+    // is the one wsl.exe will start — and the window it needs is the
+    // Windows host's, exactly as terminal.new's fallback opens one.
+    const wsl = machine({ env: "wsl" });
+    expect(firePlan("agent.multiplex", wsl, anything)).toMatchObject({
+      argv: ["cmd.exe", "/c", "start", "", "wsl.exe", "--", "herdr"],
+    });
+  });
+
+  test("and on a Windows host it is refused by name, without leaving the list", () => {
+    const plan = firePlan("agent.multiplex", windows, anything);
+    expect(plan.ok).toBe(false);
+    expect(plan.ok === false && plan.detail).toContain("no stable Windows build");
+    // Still listed there, which is ADR 0006's rule for a target that
+    // cannot honour an action: report it, do not delete it.
+    const entry = keyEntries(windows).find((e) => e.id === "agent.multiplex");
+    expect(entry?.state).toBe("unsupported");
+    expect(entry?.reason).toContain("does not apply to windows");
   });
 });
 

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -285,6 +285,58 @@ function onWindowsHost(p: Platform): boolean {
   return p.env === "windows" || p.env === "wsl";
 }
 
+/**
+ * One of red-dev's own surfaces, in a terminal of its own.
+ *
+ * The menu, the keys viewer, the emoji picker, every Panel and the
+ * Default agent are the same act with a different subcommand behind it,
+ * and all of them need a terminal that is not this one: the viewer is
+ * already drawing here, and running any of them in place would put two
+ * full-screen surfaces on the same frame. One helper rather than a
+ * block per action, because six copies of it is how the seventh arrives
+ * with the gnome-terminal flag wrong — the failure the Panels' shared
+ * case was already written to avoid.
+ *
+ * `tail` is the red-dev command line, and it doubles as the remedy
+ * printed on a machine with no terminal emulator: somebody working over
+ * SSH can run it where they already are, and being told so is more use
+ * than a window that could not be opened.
+ */
+function ownSurface(
+  id: string,
+  p: Platform,
+  locate: (cmd: string) => string | null,
+  tail: readonly string[],
+  description: string,
+): FirePlan {
+  if (onWindowsHost(p)) {
+    // `start` with the empty title slot, exactly as terminal.new uses
+    // it and for the same reason: this process is a console process, and
+    // spawning from it would hand the new surface the console red-dev is
+    // drawing in. red-dev.exe is on the PATH both installers write.
+    return {
+      ok: true,
+      id,
+      argv: ["cmd.exe", "/c", "start", "", "red-dev.exe", ...tail],
+      note: `${description} in a new window`,
+    };
+  }
+  const found = LINUX_TERMINALS.find((cmd) => locate(cmd) !== null);
+  if (!found) {
+    return {
+      ok: false,
+      id,
+      detail: `no terminal emulator on PATH — run \`red-dev ${tail.join(" ")}\` here instead`,
+    };
+  }
+  return {
+    ok: true,
+    id,
+    argv: [found, TERMINAL_EXEC[found] ?? "-e", "red-dev", ...tail],
+    note: `${description} in ${found}`,
+  };
+}
+
 export function firePlan(
   id: string,
   p: Platform,
@@ -347,74 +399,87 @@ export function firePlan(
       };
     }
 
-    case "emoji.pick": {
-      // A terminal of its own, exactly as a Panel gets one and for the
-      // same reason: the viewer is already drawing in this one, and two
-      // full-screen surfaces on one frame is what firing it in place
-      // would produce.
-      if (onWindowsHost(p)) {
-        return {
-          ok: true,
-          id,
-          argv: ["cmd.exe", "/c", "start", "", "red-dev.exe", "emoji"],
-          note: "the emoji picker in a new window",
-        };
-      }
-      const found = LINUX_TERMINALS.find((cmd) => locate(cmd) !== null);
-      if (!found) {
-        return { ok: false, id, detail: "no terminal emulator on PATH — run `red-dev emoji` here instead" };
-      }
-      return {
-        ok: true,
-        id,
-        argv: [found, TERMINAL_EXEC[found] ?? "-e", "red-dev", "emoji"],
-        note: `the emoji picker in ${found}`,
-      };
-    }
+    case "menu.open":
+      return ownSurface(id, p, locate, ["menu"], "the red-dev menu");
+
+    case "keys.viewer":
+      // The viewer opening the viewer is not a loop worth refusing: the
+      // chord exists so it can be pressed anywhere, and firing the row
+      // from inside the viewer is the least likely way anybody reaches
+      // it. What it must not do is draw a second one on this frame,
+      // which is exactly what the shared path prevents.
+      return ownSurface(id, p, locate, ["keys"], "the keys viewer");
+
+    case "emoji.pick":
+      return ownSurface(id, p, locate, ["emoji"], "the emoji picker");
 
     case "panel.network":
     case "panel.audio":
     case "panel.power": {
-      // A Panel is a TUI, so firing one means giving it a terminal of
-      // its own. The viewer is already drawing in this one, and running
-      // the Panel inside it would put two full-screen surfaces on the
-      // same frame.
-      //
-      // One case for all of them, and the subsystem taken off the id
-      // rather than written out per Panel: every Panel is opened exactly
-      // the same way, and three copies of this block is how the fourth
-      // one arrives with the gnome-terminal flag wrong.
+      // The subsystem is taken off the id rather than written out per
+      // Panel: every Panel is opened exactly the same way, and a copy
+      // each is how the next one arrives spelled differently.
       const name = id.slice("panel.".length);
+      return ownSurface(id, p, locate, ["panel", name], `the ${name} panel`);
+    }
+
+    case "agent.launch":
+      // `red-dev agents run`, never a host's own executable. That
+      // command is the single place that reads the recorded Default
+      // agent — `resolveLaunch` in src/agent-launch.ts — and the single
+      // place the bypass guard stands, so a plan that named `claude`
+      // here would walk around both: it would be right on most machines
+      // and silently wrong on the ones where somebody chose, and it
+      // would put red-dev in the business of assembling a host's command
+      // line from a surface that never reads the ADR.
+      return ownSurface(id, p, locate, ["agents", "run"], "the Default agent");
+
+    case "agent.multiplex": {
+      if (p.env === "windows") {
+        // Refused rather than approximated, the same way terminal.new's
+        // elevated sibling is refused on Linux. The action is still on
+        // the list here — ADR 0006 does not let a target delete what it
+        // cannot honour — and this is the sentence that says why.
+        return {
+          ok: false,
+          id,
+          detail:
+            "herdr has no stable Windows build — it runs inside WSL, which is where this chord starts it",
+        };
+      }
+      // Absence is answered before anything else is looked at, so a
+      // machine without herdr says so rather than reporting whichever
+      // other thing is also missing. That ordering is the acceptance
+      // criterion: "reported absent where it is not installed" is worth
+      // nothing if the sentence that comes back is about terminals.
+      if (locate("herdr") === null) {
+        return {
+          ok: false,
+          id,
+          detail:
+            "herdr is not installed here — it multiplexes several agents into one terminal, and lives at herdr.dev",
+        };
+      }
       if (onWindowsHost(p)) {
-        // `start` with the empty title slot, exactly as terminal.new
-        // uses it, and for the same reason: this process is a console
-        // process, and spawning from it would hand the Panel the console
-        // red-dev is drawing in. red-dev.exe is on the PATH both
-        // installers write.
+        // `env` is `wsl` by elimination: this red-dev is inside the
+        // distro, so the herdr just found on PATH is the one wsl.exe
+        // will start, and the window it needs belongs to the host.
         return {
           ok: true,
           id,
-          argv: ["cmd.exe", "/c", "start", "", "red-dev.exe", "panel", name],
-          note: `the ${name} panel in a new window`,
+          argv: ["cmd.exe", "/c", "start", "", "wsl.exe", "--", "herdr"],
+          note: "herdr in a new window",
         };
       }
       const found = LINUX_TERMINALS.find((cmd) => locate(cmd) !== null);
       if (!found) {
-        // The refusal names the command, because that is the whole
-        // remedy: a person on a headless machine can run it where they
-        // already are, and telling them so is more use than a terminal
-        // that could not be opened.
-        return {
-          ok: false,
-          id,
-          detail: `no terminal emulator on PATH — run \`red-dev panel ${name}\` here instead`,
-        };
+        return { ok: false, id, detail: "no terminal emulator on PATH — run `herdr` here instead" };
       }
       return {
         ok: true,
         id,
-        argv: [found, TERMINAL_EXEC[found] ?? "-e", "red-dev", "panel", name],
-        note: `the ${name} panel in ${found}`,
+        argv: [found, TERMINAL_EXEC[found] ?? "-e", "herdr"],
+        note: `herdr in ${found}`,
       };
     }
 


### PR DESCRIPTION
Automated AFK landing for #176. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #176

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/180"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789472814&installation_model_id=20659&pr_number=180&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F180&signature=65ca4728e058a2ca39376aaa606fba2ef57c11c3c853a406486d5b2cf65f6998"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->