### PR TITLE
fix: #177 The Windows adapter carries every applicable action, not the two it was migrated with

### DIFF
--- a/README.md
+++ b/README.md
@@ -931,15 +931,32 @@ either way.
 
 #### Global hotkeys
 
-Two keys, both anchored on Alt, written as Start Menu shortcuts — which is where
-they have to be for the key to fire. No AutoHotkey, no PowerToys: a `.lnk`
-carries a hotkey natively, and byte 21 of the file format carries the elevation
-flag.
+Every action that applies to Windows, anchored on Alt and written as Start Menu
+shortcuts — which is where they have to be for the key to fire. No AutoHotkey,
+no PowerToys: a `.lnk` carries a hotkey natively, and byte 21 of the file format
+carries the elevation flag.
 
 | Key | Opens |
 | --- | --- |
 | `Ctrl+Alt+T` | the terminal — bash inside WSL, through Alacritty when it is installed |
 | `Ctrl+Alt+Shift+T` | PowerShell, elevated — it will prompt for consent |
+| `Ctrl+Alt+Shift+M` | the red-dev menu |
+| `Ctrl+Alt+Shift+K` | the keys viewer — this table, searchable, and a launcher |
+| `Ctrl+Alt+Shift+E` | the emoji picker |
+| `Ctrl+Alt+Shift+N` | the network panel |
+| `Ctrl+Alt+Shift+A` | the audio panel |
+| `Ctrl+Alt+Shift+P` | the power panel |
+| `Ctrl+Alt+Shift+G` | the Default agent |
+
+The chords are decided once, in the action registry, and identical on every
+target — the adapter owns how a chord is registered, never which chord it is
+(ADR 0006). The seven below the terminal pair open `red-dev` itself, so they are
+written only where the binary can be found: `%LOCALAPPDATA%\red-dev\bin` or
+`RED_DEV_BIN_DIR`, and from inside WSL the distro's own through `wsl.exe`.
+
+`Ctrl+Alt+Shift+H` — the agent multiplexer — is the one action with no shortcut
+here. herdr has no stable Windows build, so `red-dev keys` reports it unbound
+rather than binding a key that opens nothing.
 
 `Ctrl+Shift+T` is deliberately not among them. It is reopen-closed-tab in every
 browser, in VS Code and in Windows Terminal itself, and a global hotkey beats the
@@ -1310,7 +1327,8 @@ Then, in order:
    already running, and this is the single most common "it did not install".
 2. `red-dev` — the interface. **Install** asks its questions first; nothing
    converges until you answer.
-3. Try `Ctrl+Alt+T` and `Ctrl+Alt+Shift+T`.
+3. Try `Ctrl+Alt+T` and `Ctrl+Alt+Shift+K`; the second is the viewer, and it
+   lists the rest.
 4. `red-dev theme flare`, then look at a title bar. Windows applies the accent
    to windows opened *after* the switch.
 5. `red-dev doctor` — it should report no drift.

--- a/src/hotkeys.test.ts
+++ b/src/hotkeys.test.ts
@@ -7,19 +7,37 @@
  * browser, in VS Code and in Windows Terminal itself, and installing
  * red-dev quietly removed that from the whole machine.
  *
- * Two combos, both anchored on Alt, which nothing else in a terminal
+ * Every combo is anchored on Alt, which nothing else in a terminal
  * workflow wants.
+ *
+ * The adapter carries every action that applies to Windows. It was
+ * migrated with two, and the seven the chord decision added read in
+ * `red-dev keys` as chords a person could press to no effect — which is
+ * the failure the tests below are written against, in both directions:
+ * the claimed set has to be complete, and the one action deliberately
+ * left out of it has to stay recognisable as never-claimed rather than
+ * as a shortcut that broke.
  */
 
 import { describe, expect, test } from "bun:test";
-import { actionById } from "./actions/index.ts";
-import { resolveScript, WINDOWS_HOTKEYS } from "./hotkeys.ts";
+import { ACTIONS, actionById, chordText, parseChord } from "./actions/index.ts";
+import { resolveScript, START_MENU_ACTIONS, WINDOWS_HOTKEYS } from "./hotkeys.ts";
 
 const claimed = WINDOWS_HOTKEYS.filter((h) => h.combo !== null).map((h) => h.combo);
 
 describe("the keys taken from the machine", () => {
-  test("are exactly the two that were agreed", () => {
-    expect(claimed).toEqual(["CTRL+ALT+T", "CTRL+ALT+SHIFT+T"]);
+  test("are exactly the ones the registry gives this target", () => {
+    expect(claimed).toEqual([
+      "CTRL+ALT+T",
+      "CTRL+ALT+SHIFT+T",
+      "CTRL+ALT+SHIFT+M",
+      "CTRL+ALT+SHIFT+K",
+      "CTRL+ALT+SHIFT+E",
+      "CTRL+ALT+SHIFT+N",
+      "CTRL+ALT+SHIFT+A",
+      "CTRL+ALT+SHIFT+P",
+      "CTRL+ALT+SHIFT+G",
+    ]);
   });
 
   test("Ctrl+Alt+T is the terminal and Ctrl+Alt+Shift+T is the elevated one", () => {
@@ -48,10 +66,12 @@ describe("the keys taken from the machine", () => {
 });
 
 describe("the shortcuts written", () => {
-  test("are two, and no more", () => {
+  test("are nine, and no more", () => {
     // Every global binding is taken from the whole machine, so the list
-    // growing is a decision rather than a detail.
-    expect(WINDOWS_HOTKEYS).toHaveLength(2);
+    // growing is a decision rather than a detail. Nine is what the
+    // 2026-08-15 chord decision named minus herdr, which has no Windows
+    // build to bind a key to.
+    expect(WINDOWS_HOTKEYS).toHaveLength(9);
   });
 
   test("all of them carry a key", () => {
@@ -61,13 +81,45 @@ describe("the shortcuts written", () => {
   });
 });
 
-describe("the two keys come from the action registry", () => {
+describe("the adapter carries every action that applies to Windows", () => {
+  /** What the registry says belongs on this target. */
+  const applicable = ACTIONS.filter((a) => a.platforms.includes("windows")).map((a) => a.id);
+
+  test("so nothing applicable is left without a Start Menu entry", () => {
+    // The criterion in one line, and derived from the registry rather
+    // than from a list repeated here: an action added to `src/actions/`
+    // with `windows` among its platforms fails this until somebody
+    // decides, out loud, what its shortcut opens.
+    expect([...START_MENU_ACTIONS].sort()).toEqual([...applicable].sort());
+  });
+
+  test("and the one action deliberately left out is one that does not apply here", () => {
+    // The boundary this widening must not blur. herdr has no stable
+    // Windows build, so `agent.multiplex` never claimed `windows` — and
+    // the adapter writing it a key anyway would put a chord in the Start
+    // Menu that opens nothing on a native Windows host.
+    expect(START_MENU_ACTIONS).not.toContain("agent.multiplex");
+    expect(actionById("agent.multiplex")?.platforms).not.toContain("windows");
+  });
+});
+
+describe("the keys come from the action registry", () => {
   // The migration this pins: the combos used to be literals in
   // hotkeys.ts and are now read from the registry. Behaviour is
   // unchanged, which is exactly the thing worth pinning — the values
   // above are what shipped, and they have to survive the move.
   test("each Start Menu entry names the action it registers", () => {
-    expect(WINDOWS_HOTKEYS.map((h) => h.id)).toEqual(["terminal.new", "terminal.elevated"]);
+    expect(WINDOWS_HOTKEYS.map((h) => h.id)).toEqual([
+      "terminal.new",
+      "terminal.elevated",
+      "menu.open",
+      "keys.viewer",
+      "emoji.pick",
+      "panel.network",
+      "panel.audio",
+      "panel.power",
+      "agent.launch",
+    ]);
   });
 
   test("and carries that action's chord, spelled the way Windows is given it", () => {
@@ -78,12 +130,36 @@ describe("the two keys come from the action registry", () => {
     expect(by("terminal.elevated")).toBe("CTRL+ALT+SHIFT+T");
   });
 
+  test("every entry does, and none of them keeps a second copy of the chord", () => {
+    // The generalisation of the test above, now that there are nine:
+    // whatever the registry says is what the .lnk gets, folded to the
+    // one spelling Windows is given. A hard-coded combo anywhere in this
+    // adapter fails here the moment the registry changes underneath it.
+    for (const hotkey of WINDOWS_HOTKEYS) {
+      const chord = actionById(hotkey.id)?.chord;
+      expect(chord).toBeDefined();
+      expect(hotkey.combo).toBe(chordText(parseChord(chord as string) as never));
+    }
+  });
+
   test("the .lnk names stay Windows' own, because machines already have them", () => {
     // The registry calls the elevated one "Elevated shell"; renaming the
     // shortcut would leave the old .lnk — and its key — behind.
     expect(actionById("terminal.elevated")?.label).toBe("Elevated shell");
     expect(WINDOWS_HOTKEYS.find((h) => h.id === "terminal.elevated")?.label)
       .toBe("PowerShell (Administrator)");
+  });
+
+  test("and every name nobody's machine carries yet is the registry's own", () => {
+    // The other half of the rule above. A Windows name is worth keeping
+    // when Windows already has one; inventing a second name for a .lnk
+    // this adapter is the first to write would just be a third spelling
+    // of the same act for the keys viewer to disagree with.
+    const windowsOwns = new Set(["terminal.new", "terminal.elevated"]);
+    for (const hotkey of WINDOWS_HOTKEYS) {
+      if (windowsOwns.has(hotkey.id)) continue;
+      expect(hotkey.label).toBe(actionById(hotkey.id)?.label as string);
+    }
   });
 
   test("and the written script carries those chords, not its own copy", () => {
@@ -93,6 +169,68 @@ describe("the two keys come from the action registry", () => {
     // The post-write probe asks about the terminal chord: MOD_CONTROL |
     // MOD_ALT is 3, and 0x54 is T.
     expect(script).toContain("RegisterHotKey([IntPtr]::Zero, 9004, 3, 0x54)");
+  });
+});
+
+describe("the shortcut written for each surface red-dev draws itself", () => {
+  const script = resolveScript(null);
+
+  test("names the .lnk, its hotkey and the subcommand it opens", () => {
+    // The whole line per shortcut, hotkey field included, because that
+    // field is the only part of a .lnk anybody presses: a shortcut
+    // written with the right target and the wrong HotKey is a Start Menu
+    // entry nobody will ever find, and one written with the right HotKey
+    // and the wrong subcommand opens the neighbouring surface.
+    for (const [label, combo, argv] of [
+      ["red-dev menu", "CTRL+ALT+SHIFT+M", "menu"],
+      ["Keys viewer", "CTRL+ALT+SHIFT+K", "keys"],
+      ["Emoji picker", "CTRL+ALT+SHIFT+E", "emoji"],
+      ["Network panel", "CTRL+ALT+SHIFT+N", "panel network"],
+      ["Audio panel", "CTRL+ALT+SHIFT+A", "panel audio"],
+      ["Power panel", "CTRL+ALT+SHIFT+P", "panel power"],
+      ["Default agent", "CTRL+ALT+SHIFT+G", "agents run"],
+    ]) {
+      expect(script).toContain(
+        `New-Hot '${label}' '${combo}' $surface ($surfaceArgs + '${argv}') $false`,
+      );
+    }
+  });
+
+  test("and none of them is written as the elevated one", () => {
+    // Byte 21 is the elevation flag, and the fifth argument is what sets
+    // it. Exactly one shortcut asks for consent; a copy-paste that
+    // spread `$true` across the surfaces would put a UAC prompt in front
+    // of the emoji picker.
+    const elevated = script.split("\n").filter((l) => l.includes("New-Hot") && l.includes("$true"));
+    expect(elevated).toHaveLength(1);
+    expect(elevated[0]).toContain("PowerShell (Administrator)");
+  });
+
+  test("through one binary, resolved on the Windows side like everything else", () => {
+    // Under WSL this process is Linux: it cannot stat %LOCALAPPDATA%,
+    // which is the mistake that once failed the whole step with "APPDATA
+    // is not set". PowerShell answers where red-dev lives, honouring the
+    // same RED_DEV_BIN_DIR both installers read.
+    expect(script).toContain("$env:RED_DEV_BIN_DIR");
+    expect(script).toContain("Join-Path $env:LOCALAPPDATA 'red-dev\\bin'");
+    expect(script).toContain("Get-Command 'red-dev.exe'");
+  });
+
+  test("and is skipped, out loud, when there is no red-dev.exe to name", () => {
+    // A .lnk with an empty target is a key that fails silently on a
+    // machine somebody was told it works on.
+    expect(script).toContain("if ($surface) {");
+    expect(script).toContain("(skipped) no red-dev.exe on this host");
+  });
+
+  test("reached through the distro when the host has no red-dev of its own", () => {
+    // Only from inside WSL, where there is a distro to name. On a native
+    // Windows host `wsl.exe -- red-dev` would be a guess at a distro
+    // nobody chose, so the fallback is not written at all.
+    expect(resolveScript("Ubuntu-24.04")).toContain(
+      "$surfaceArgs = '-d Ubuntu-24.04 -- red-dev '",
+    );
+    expect(script).not.toContain("-- red-dev ");
   });
 });
 

--- a/src/hotkeys.ts
+++ b/src/hotkeys.ts
@@ -12,7 +12,7 @@
  * The shortcut has to live in the Start Menu for the key to fire, which
  * is why that is where these go.
  *
- * Two keys, both anchored on Alt, which nothing in a terminal workflow
+ * Every chord is anchored on Alt, which nothing in a terminal workflow
  * competes for. Ctrl+Shift+T is deliberately not among them: it is
  * reopen-closed-tab in every browser, in VS Code and in Windows Terminal
  * itself, and a global hotkey wins over the focused application — so
@@ -23,11 +23,15 @@
  * verified on Windows — which is what lets a converge correct a machine
  * that still carries an old one.
  *
- * Which two keys they are is no longer decided here. This module is the
- * Windows adapter for two entries in the semantic action registry: it
- * owns how a chord is registered — a .lnk in the Start Menu, byte 21 for
- * elevation — and reads which chord it is from the registry, per ADR
- * 0006. The keys are the same ones it always wrote.
+ * Which keys they are is not decided here. This module is the Windows
+ * adapter for the semantic action registry: it owns how a chord is
+ * registered — a .lnk in the Start Menu, byte 21 for elevation — and
+ * reads which chord it is from the registry, per ADR 0006.
+ *
+ * It carries every action that applies to Windows. It started with the
+ * two it was migrated with, and the other seven read as chords a person
+ * could see in `red-dev keys` and press to no effect — which is worse
+ * than no chord, because the viewer had already promised them one.
  */
 
 import { actionById, chordText, parseChord } from "./actions/index.ts";
@@ -36,11 +40,12 @@ import { log, RedError } from "./log.ts";
 import type { Platform } from "./platform.ts";
 
 /**
- * The two, and what each one launches.
+ * One shortcut, and what it launches.
  *
  * Kept as data so the README and the tests can name them without
- * parsing PowerShell. The resolution — which terminal, which shell —
- * happens on the Windows side; this is the contract.
+ * parsing PowerShell. The resolution — which terminal, which shell,
+ * where red-dev itself lives — happens on the Windows side; this is the
+ * contract.
  */
 export interface Hotkey {
   /** The semantic action this shortcut registers. */
@@ -49,21 +54,59 @@ export interface Hotkey {
   /** null for a Start Menu entry that deliberately has no key. */
   combo: string | null;
   note: string;
+  /**
+   * The `red-dev` argv this shortcut runs, for the surfaces red-dev
+   * draws itself. Null for the two whose target is a host program.
+   */
+  command: readonly string[] | null;
+}
+
+interface StartMenuEntry {
+  id: string;
+  /**
+   * The .lnk name, when Windows already has one that is not the
+   * registry's label. Left off for every shortcut this adapter is the
+   * first to write.
+   */
+  name?: string;
+  note: string;
+  /** `red-dev <argv>`, for a surface red-dev draws itself. */
+  command?: readonly string[];
 }
 
 /**
- * The Windows half of two registry actions.
+ * The Windows half of the registry — every action that applies here.
  *
- * What the entry is called belongs to Windows and stays here:
+ * What an entry is *called* belongs to Windows and stays here:
  * `PowerShell (Administrator)` is the name of a .lnk that already exists
  * on people's machines, not the name of the act — the registry calls
- * that one "Elevated shell". Which key it carries belongs to the
- * registry, and is read from it rather than repeated here. That is the
- * migration: the values are identical, the source of truth moved.
+ * that one "Elevated shell", and renaming the file would strand the old
+ * one, and its key, on every machine that has it. Nobody has the other
+ * seven yet, so those take the registry's own label and name themselves
+ * once, in the list that decided the chord.
+ *
+ * Which key an entry carries belongs to the registry either way, and is
+ * read from it rather than repeated here.
+ *
+ * `agent.multiplex` is deliberately absent, and is the one action that
+ * applies to a machine this adapter serves and gets no shortcut. herdr
+ * has no stable Windows build — the registry says so by leaving
+ * `windows` off its platforms — and it runs inside WSL, where the .lnk
+ * this module writes cannot follow it: the same file is written on
+ * native Windows hosts, which have no distro to reach into. A key that
+ * opens nothing on half the machines it lands on is worse than the
+ * viewer saying no shortcut was written, so none is.
  */
-const START_MENU: readonly { id: string; label: string; note: string }[] = [
-  { id: "terminal.new", label: "Terminal", note: "bash inside WSL, through Alacritty when it is there" },
-  { id: "terminal.elevated", label: "PowerShell (Administrator)", note: "elevated" },
+const START_MENU: readonly StartMenuEntry[] = [
+  { id: "terminal.new", name: "Terminal", note: "bash inside WSL, through Alacritty when it is there" },
+  { id: "terminal.elevated", name: "PowerShell (Administrator)", note: "elevated" },
+  { id: "menu.open", note: "red-dev's own menu, in a console of its own", command: ["menu"] },
+  { id: "keys.viewer", note: "this list, searchable — the remedy ADR 0006 promises", command: ["keys"] },
+  { id: "emoji.pick", note: "the picker, which writes the clipboard", command: ["emoji"] },
+  { id: "panel.network", note: "network and DNS", command: ["panel", "network"] },
+  { id: "panel.audio", note: "what the machine plays and hears", command: ["panel", "audio"] },
+  { id: "panel.power", note: "battery, and what drains it", command: ["panel", "power"] },
+  { id: "agent.launch", note: "whichever host is the recorded Default agent", command: ["agents", "run"] },
 ];
 
 /**
@@ -80,22 +123,23 @@ const START_MENU: readonly { id: string; label: string; note: string }[] = [
  */
 export const START_MENU_ACTIONS: readonly string[] = START_MENU.map((entry) => entry.id);
 
-/** An action's chord, spelled the way Windows has always been given it. */
-function comboFromRegistry(id: string): string | null {
-  const action = actionById(id);
-  if (!action) return null;
-  const chord = parseChord(action.chord);
-  return chord ? chordText(chord) : null;
-}
-
 export const WINDOWS_HOTKEYS: Hotkey[] = START_MENU.flatMap((entry) => {
-  const combo = comboFromRegistry(entry.id);
+  const action = actionById(entry.id);
+  const chord = action ? parseChord(action.chord) : null;
   // A Start Menu entry written with no key *clears* the binding on
   // every machine that already had one, so an action that went missing
   // from the registry drops its shortcut rather than unbinding it. The
   // registry test is what keeps that unreachable; this is what it would
   // cost if it ever were not.
-  return combo === null ? [] : [{ id: entry.id, label: entry.label, combo, note: entry.note }];
+  if (!action || !chord) return [];
+  return [{
+    id: entry.id,
+    label: entry.name ?? action.label,
+    // Spelled the way Windows has always been given it.
+    combo: chordText(chord),
+    note: entry.note,
+    command: entry.command ?? null,
+  }];
 });
 
 /** The entry for an action, or a loud failure rather than a silent unbind. */
@@ -173,6 +217,29 @@ export function resolveScript(distro: string | null): string {
   // change if the chord ever did.
   const probe = hotkeyArgs(terminal.combo);
   if (!probe) throw new RedError(`${terminal.combo} is not a chord Windows can register`);
+
+  // One New-Hot per surface rather than a block each: they are one
+  // program with a different subcommand behind it, which is the same
+  // reading `firePlan` gives them, and nine hand-written copies is how
+  // the tenth arrives pointing at the wrong executable.
+  const surfaces = WINDOWS_HOTKEYS.filter((h) => h.command && h.combo)
+    .map((h) => `  New-Hot '${h.label}' '${h.combo}' $surface ($surfaceArgs + '${h.command?.join(" ")}') $false`)
+    .join("\n");
+
+  // The distro is the only fallback there is, and it exists only when
+  // this converge is running inside one. On a native Windows host with
+  // no red-dev.exe to be found, `wsl.exe -- red-dev` would be a guess at
+  // a distro nobody named, so the shortcuts are skipped — and said to be
+  // skipped — rather than written to point at nothing.
+  const throughWsl = distro
+    ? `
+if (-not $surface) {
+  $surface = (Join-Path $env:SystemRoot 'System32\\wsl.exe')
+  $surfaceArgs = '${d}-- red-dev '
+}
+`
+    : "";
+
   return `
 $ErrorActionPreference = 'Stop'
 $dir = Join-Path $env:APPDATA 'Microsoft\\Windows\\Start Menu\\Programs\\red-dev'
@@ -184,6 +251,19 @@ $alacritty = @(
   'C:\\Program Files\\Alacritty\\alacritty.exe'
 ) | Where-Object { Test-Path $_ } | Select-Object -First 1
 
+# Where red-dev's own surfaces are started from.
+#
+# boot.ps1 puts the binary in %LOCALAPPDATA%\\red-dev\\bin unless
+# RED_DEV_BIN_DIR names somewhere else, and puts that directory on PATH
+# — so the two answers between them cover a machine installed either
+# way, including one whose PATH this PowerShell has not picked up yet.
+$reddevDir = if ($env:RED_DEV_BIN_DIR) { $env:RED_DEV_BIN_DIR } else { (Join-Path $env:LOCALAPPDATA 'red-dev\\bin') }
+$surface = @(
+  (Join-Path $reddevDir 'red-dev.exe'),
+  (Get-Command 'red-dev.exe' -ErrorAction SilentlyContinue).Source
+) | Where-Object { $_ -and (Test-Path $_) } | Select-Object -First 1
+$surfaceArgs = ''
+${throughWsl}
 # A hotkey combo reduced to something two spellings can agree on.
 #
 # Windows re-spells the property on read-back: write CTRL+ALT+T, read
@@ -242,6 +322,17 @@ if ($alacritty) {
 
 New-Hot '${elevated.label}' '${elevated.combo}' (Join-Path $env:SystemRoot 'System32\\WindowsPowerShell\\v1.0\\powershell.exe') '-NoLogo' $true
 
+# The surfaces red-dev draws itself, all through the one binary.
+#
+# Skipped rather than pointed at nothing when there is no binary to
+# name: a .lnk with an empty target is a Start Menu entry that fails
+# silently on a key somebody was told works.
+if ($surface) {
+${surfaces}
+} else {
+  '(skipped) no red-dev.exe on this host, so the shortcuts for its own surfaces were not written'
+}
+
 # When something was rewritten, make sure the key came back.
 #
 # A write makes Explorer drop the registration, and waiting for the next
@@ -299,7 +390,7 @@ export async function installWindowsHotkeys(p: Platform): Promise<void> {
   const lines = out.split("\n").map((l) => l.trim()).filter(Boolean);
   for (const line of lines) log.plain(`       ${line}`);
   log.plain("       the elevated one prompts for consent when it opens");
-  log.plain("       Ctrl+Alt+T fires from normal windows, not while an Administrator window has focus");
+  log.plain("       they fire from normal windows, not while an Administrator window has focus");
   log.ok(`${lines.length} hotkey(s) in the Start Menu`);
 }
 

--- a/src/keys.test.ts
+++ b/src/keys.test.ts
@@ -19,6 +19,7 @@
 import { describe, expect, test } from "bun:test";
 import { ACTIONS } from "./actions/index.ts";
 import type { SemanticAction } from "./actions/index.ts";
+import { START_MENU_ACTIONS } from "./hotkeys.ts";
 import {
   fireEntry,
   firePlan,
@@ -103,27 +104,52 @@ describe("the list", () => {
     expect(terminal?.label).toBe("Terminal");
   });
 
-  test("on Windows, the two terminal actions are bound and carry no reason", () => {
-    // Named rather than "every row", which is what this used to assert.
-    // The Start Menu adapter carries these two; an action it has never
-    // carried is a different sentence, and the test below is the one
-    // that holds it.
-    for (const id of ["terminal.new", "terminal.elevated"]) {
+  test("on Windows, every action the Start Menu adapter claims is bound", () => {
+    // The acceptance criterion, read off the same list the adapter
+    // writes from: a chord printed here is a chord the .lnk carries.
+    // This is the row that used to hold the two terminal actions alone,
+    // while the other seven printed a chord a person could press to no
+    // effect — the viewer promising something the machine did not do.
+    for (const id of START_MENU_ACTIONS) {
       const entry = keyEntries(windows).find((e) => e.id === id);
       expect(entry?.state).toBe("bound");
       expect(entry?.reason).toBe("");
     }
+    // Named as well as derived, so the loop above cannot pass by being
+    // empty and so the set itself is a decision somebody has to change
+    // on purpose.
+    expect([...START_MENU_ACTIONS]).toEqual([
+      "terminal.new",
+      "terminal.elevated",
+      "menu.open",
+      "keys.viewer",
+      "emoji.pick",
+      "panel.network",
+      "panel.audio",
+      "panel.power",
+      "agent.launch",
+    ]);
   });
 
   test("an action the Windows adapter has never carried says so, and is not called broken", () => {
-    // The distinction that matters: the Start Menu adapter registers the
-    // entries it has, and the network Panel is not one of them yet.
+    // The distinction that matters, and the one widening the claimed set
+    // must not blur: the Start Menu adapter registers the entries it
+    // has, and `agent.multiplex` is deliberately not one — herdr has no
+    // Windows build, and it runs inside WSL, where a Start Menu .lnk
+    // written on every host cannot follow it.
+    //
     // Reporting that as "broken" would send whoever reads it looking for
-    // a shortcut nobody ever wrote — and reporting it as bound would be
-    // a chord that does nothing on the machine in front of them.
-    const panel = keyEntries(windows).find((e) => e.id === "panel.network");
-    expect(panel?.state).toBe("unsupported");
-    expect(panel?.reason).toContain("no shortcut for it yet");
+    // a shortcut nobody ever wrote. It is only visible from inside WSL:
+    // on a native Windows host the row is answered a step earlier, by
+    // the action not applying to `windows` at all.
+    const wsl = machine({ env: "wsl" });
+    const herdr = keyEntries(wsl).find((e) => e.id === "agent.multiplex");
+    expect(herdr?.state).toBe("unsupported");
+    expect(herdr?.reason).toContain("Windows Start Menu");
+    expect(herdr?.reason).toContain("no shortcut for it yet");
+    // Not the registry-failure sentence, which is the other silence and
+    // the one that means somebody has to fix a shortcut.
+    expect(herdr?.reason).not.toContain("no chord came back");
   });
 });
 
@@ -215,22 +241,12 @@ describe("searching", () => {
 
   test("the state is searchable, so 'unbound work' is one query", () => {
     expect(searchKeys(keyEntries(server), "unsupported")).toHaveLength(ACTIONS.length);
-    // On Windows the terminal pair is bound and the other surfaces are
-    // not, so the query answers with exactly what this machine does not
-    // register.
-    expect(searchKeys(entries, "unsupported").map((e) => e.id)).toEqual([
-      "menu.open",
-      "keys.viewer",
-      "emoji.pick",
-      "panel.network",
-      "panel.audio",
-      "panel.power",
-      "agent.launch",
-      // Unsupported here for the other of the two reasons the word
-      // covers: herdr has no Windows build, so this row's sentence is
-      // about the platform rather than about a missing shortcut.
-      "agent.multiplex",
-    ]);
+    // On Windows the adapter now claims everything that applies, so the
+    // query answers with the one row that does not: herdr, which has no
+    // Windows build. That is the platform sentence rather than the
+    // missing-shortcut one, and it is the whole of what this machine
+    // leaves unregistered.
+    expect(searchKeys(entries, "unsupported").map((e) => e.id)).toEqual(["agent.multiplex"]);
   });
 });
 


### PR DESCRIPTION
Automated AFK landing for #177. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #177

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/181"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789474274&installation_model_id=20659&pr_number=181&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F181&signature=0a944b77a1da7ccf54a94d7b786b102ccff0a47df8374397230b8c30148b984e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->