### PR TITLE
fix: #178 A GNOME bindings adapter, so a chord fires on Linux at all

### DIFF
--- a/README.md
+++ b/README.md
@@ -839,6 +839,39 @@ that depend on it, rather than trusting the copy to have taken.
 > This target is **implemented and unproven** — no bare-metal Ubuntu has run it.
 > Start with `red-dev install --dry-run`.
 
+#### The chords, as GNOME custom keybindings
+
+The same nine keys the Start Menu carries on Windows, registered here as GNOME
+custom keybindings — one dconf entry each, name, command and accelerator:
+
+| Key | Opens |
+| --- | --- |
+| `Ctrl+Alt+T` | the terminal red-dev installed, not the session's default handler |
+| `Ctrl+Alt+Shift+M` | the red-dev menu |
+| `Ctrl+Alt+Shift+K` | the keys viewer — searchable, and a launcher |
+| `Ctrl+Alt+Shift+E` | the emoji picker |
+| `Ctrl+Alt+Shift+N` | the network panel |
+| `Ctrl+Alt+Shift+A` | the audio panel |
+| `Ctrl+Alt+Shift+P` | the power panel |
+| `Ctrl+Alt+Shift+G` | the Default agent |
+| `Ctrl+Alt+Shift+H` | the agent multiplexer, where herdr is installed |
+
+They live at `/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/red-dev-<action>/`
+rather than at GNOME's own `custom0`, `custom1`, …, so a converge adds, updates
+and withdraws its own entries and never touches a shortcut you set yourself —
+yours keep their place in the list. A converge that finds them already right
+writes nothing.
+
+GNOME's own `Ctrl+Alt+T` is cleared while red-dev holds that key, because two
+owners for one accelerator is undefined and GNOME's opens whatever
+`x-terminal-emulator` resolves to rather than the terminal red-dev installed.
+`gsettings reset` puts GNOME's default back the moment red-dev stops claiming it.
+
+`Ctrl+Alt+Shift+T` — the elevated shell — is the one action with no keybinding
+here. It is a Windows act; on Linux, `sudo` in the terminal you already have
+does it, so `red-dev keys` reports it unbound **with that reason** rather than
+choosing a second chord for it (ADR 0006).
+
 ### WSL — Ubuntu 24.04 or 26.04 under Windows
 
 ```bash
@@ -1136,7 +1169,7 @@ places to look — in this order.
 
 | Target | What does not work, and why |
 | --- | --- |
-| **Ubuntu desktop** | The `desktop` scope is implemented and **has never run on real hardware**. GNOME hotkeys, extensions and dock settings are not ported at all. |
+| **Ubuntu desktop** | The `desktop` scope is implemented and **has never run on real hardware** — the GNOME keybindings included. GNOME extensions and dock settings are not ported at all. |
 | **Ubuntu 26.04** | The `u26` manifest column exists and **no 26.04 machine has exercised it**. Package-name drift is undiscovered. |
 | **WSL** | Windows interop cannot work under `sudo -u <other-user>`: `WSL_INTEROP` points at a per-session socket that sudo drops. Real invocations run as you, so this affects test harnesses only. |
 | **Native Windows** | No switching to a *numbered* virtual desktop — Windows offers only sequential navigation, and reaching a specific one means an interface that changes between builds. No zellij session persistence across reboots. No `ble.sh`-style line editor. |

--- a/src/gnome-keys.test.ts
+++ b/src/gnome-keys.test.ts
@@ -1,0 +1,386 @@
+/**
+ * What a converge writes to a GNOME desktop, and what it must not.
+ *
+ * Nothing here can be answered by the machine the tests run on: dconf
+ * belongs to a signed-in session, and the interesting states — a machine
+ * that already matches, one carrying a person's own shortcuts, one still
+ * holding a red-dev entry the registry has since dropped — are states
+ * nobody would create by hand to find out. They are fixtures, and the
+ * plan is a pure function of them for exactly that reason.
+ *
+ * Four promises are held below. The writes are the ones GNOME reads,
+ * paths included; a converge that changes nothing writes nothing; a
+ * withdrawal reaches red-dev's own entries and no others; and an action
+ * this adapter will not bind is reported with a reason rather than
+ * handed a second chord — which is ADR 0006's rule and the one a
+ * well-meaning adapter breaks first.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { ACTIONS, actionById, parseChord } from "./actions/index.ts";
+import {
+  commandLine,
+  CUSTOM_ROOT,
+  GNOME_ACTIONS,
+  GNOME_BINDINGS,
+  gnomeAccel,
+  gnomeCustoms,
+  gnomePlan,
+  gnomeRefusal,
+  installGnomeKeys,
+  isOwned,
+  normalAccel,
+  ownedPath,
+  parseGvariantList,
+  type GnomeCustom,
+  type GnomeState,
+} from "./gnome-keys.ts";
+import { firePlan, keyEntries } from "./keys.ts";
+import type { Platform } from "./platform.ts";
+
+const MEDIA_KEYS = "org.gnome.settings-daemon.plugins.media-keys";
+const CUSTOM_SCHEMA = `${MEDIA_KEYS}.custom-keybinding`;
+
+const desktop: Platform = {
+  os: "linux",
+  distro: "ubuntu",
+  version: "24.04",
+  codename: "noble",
+  env: "desktop",
+  arch: "x64",
+  caps: { apt: true, gui: true, systemd: true, winget: false, flatpak: true },
+};
+
+/** Everything this machine could want is on PATH, so commands are fixed. */
+const anything = (cmd: string): string => `/usr/bin/${cmd}`;
+const nothing = (): string | null => null;
+
+const fire = (id: string) => firePlan(id, desktop, anything);
+
+/** A GNOME with nothing of its own and nothing of ours. */
+function bare(over: Partial<GnomeState> = {}): GnomeState {
+  return { list: [], owned: [], launchTerminal: ["<Primary><Alt>t"], ...over };
+}
+
+/** The state a machine is in once this adapter has converged onto it. */
+function converged(customs: readonly GnomeCustom[], theirs: readonly string[] = []): GnomeState {
+  return {
+    list: [...theirs, ...customs.map((c) => c.path)],
+    owned: customs.map((c) => ({ ...c })),
+    // Cleared, because red-dev holds Ctrl+Alt+T on a converged machine.
+    launchTerminal: [],
+  };
+}
+
+const { customs } = gnomeCustoms(fire);
+
+describe("the shortcuts a GNOME desktop is given", () => {
+  test("are the actions that apply here, minus the ones declared refused", () => {
+    // The criterion in one line and derived from the registry rather
+    // than repeated: an action added to `src/actions/` with `desktop`
+    // among its platforms fails this until somebody decides, out loud,
+    // whether it gets a chord here or a reason.
+    const applicable = ACTIONS.filter((a) => a.platforms.includes("desktop")).map((a) => a.id);
+    const answered = [...GNOME_ACTIONS, ...applicable.filter((id) => gnomeRefusal(id))];
+    expect([...answered].sort()).toEqual([...applicable].sort());
+  });
+
+  test("carry the registry's chord, spelled the way GTK spells one", () => {
+    // No second copy of any chord lives in this adapter. Change the
+    // registry and the accelerator moves with it; hard-code one here and
+    // this fails the moment they disagree.
+    for (const binding of GNOME_BINDINGS) {
+      const chord = actionById(binding.id)?.chord;
+      expect(chord).toBeDefined();
+      expect(binding.accel).toBe(gnomeAccel(parseChord(chord as string) as never) as string);
+    }
+    const accel = (id: string) => GNOME_BINDINGS.find((b) => b.id === id)?.accel;
+    expect(accel("terminal.new")).toBe("<Control><Alt>t");
+    expect(accel("keys.viewer")).toBe("<Shift><Control><Alt>k");
+  });
+
+  test("live at paths named after the action, never at GNOME's custom0", () => {
+    // Ownership is the path. GNOME's Settings allocates custom0,
+    // custom1, … and renumbers nothing, so an adapter picking the next
+    // free index would hand back a path somebody else's shortcut owns
+    // after a reorder — and withdrawal would then delete theirs.
+    expect(ownedPath("terminal.new")).toBe(`${CUSTOM_ROOT}red-dev-terminal-new/`);
+    expect(isOwned(ownedPath("panel.audio"))).toBe(true);
+    expect(isOwned(`${CUSTOM_ROOT}custom0/`)).toBe(false);
+    for (const binding of GNOME_BINDINGS) expect(binding.path).toBe(ownedPath(binding.id));
+  });
+
+  test("and are named so a person browsing GNOME's Settings sees whose they are", () => {
+    expect(GNOME_BINDINGS.map((b) => b.name)).toContain("red-dev: Keys viewer");
+    for (const binding of GNOME_BINDINGS) {
+      expect(binding.name).toBe(`red-dev: ${actionById(binding.id)?.label}`);
+    }
+  });
+});
+
+describe("what a converge writes", () => {
+  const steps = gnomePlan(bare(), customs);
+  const argvs = steps.map((s) => s.argv);
+
+  test("is name, command and binding, for each registered action", () => {
+    // The whole write per shortcut, path included, because the path is
+    // the allocation: a right name and command under the wrong path is a
+    // keybinding GNOME never reads, and two actions sharing one path is
+    // one shortcut overwriting the other.
+    for (const [id, name, command, accel] of [
+      ["terminal.new", "red-dev: Terminal", "alacritty", "<Control><Alt>t"],
+      ["menu.open", "red-dev: red-dev menu", "alacritty -e red-dev menu", "<Shift><Control><Alt>m"],
+      ["keys.viewer", "red-dev: Keys viewer", "alacritty -e red-dev keys", "<Shift><Control><Alt>k"],
+      ["emoji.pick", "red-dev: Emoji picker", "alacritty -e red-dev emoji", "<Shift><Control><Alt>e"],
+      ["panel.network", "red-dev: Network panel", "alacritty -e red-dev panel network", "<Shift><Control><Alt>n"],
+      ["panel.audio", "red-dev: Audio panel", "alacritty -e red-dev panel audio", "<Shift><Control><Alt>a"],
+      ["panel.power", "red-dev: Power panel", "alacritty -e red-dev panel power", "<Shift><Control><Alt>p"],
+      ["agent.launch", "red-dev: Default agent", "alacritty -e red-dev agents run", "<Shift><Control><Alt>g"],
+      ["agent.multiplex", "red-dev: Agent multiplexer", "alacritty -e herdr", "<Shift><Control><Alt>h"],
+    ] as const) {
+      const schema = `${CUSTOM_SCHEMA}:${CUSTOM_ROOT}red-dev-${id.replace(".", "-")}/`;
+      expect(argvs).toContainEqual(["set", schema, "name", name]);
+      expect(argvs).toContainEqual(["set", schema, "command", command]);
+      expect(argvs).toContainEqual(["set", schema, "binding", accel]);
+    }
+  });
+
+  test("then the list GNOME actually reads, once, with every path on it", () => {
+    // Values first and the list second: a path is inert until it is
+    // listed, so this order never leaves a listed shortcut half written.
+    const list = argvs.filter((a) => a[2] === "custom-keybindings");
+    expect(list).toHaveLength(1);
+    expect(list[0]?.[3]).toBe(`[${customs.map((c) => `'${c.path}'`).join(", ")}]`);
+    const values = argvs
+      .map((a, i) => (a[0] === "set" && a[1]?.startsWith(CUSTOM_SCHEMA) ? i : -1))
+      .filter((i) => i >= 0);
+    expect(Math.max(...values)).toBeLessThan(argvs.indexOf(list[0] as string[]));
+  });
+
+  test("and clears GNOME's own Ctrl+Alt+T, so the chord has one owner", () => {
+    // GNOME ships launch-terminal on the same key — which is why ADR
+    // 0006 adopted it rather than colliding with it — and it opens
+    // whatever the session's default handler is, not the terminal red-dev
+    // installed. Two grabs on one accelerator is not a behaviour to find
+    // out about on somebody's machine.
+    expect(argvs).toContainEqual(["set", MEDIA_KEYS, "terminal", "@as []"]);
+  });
+
+  test("the command is the one Enter runs in the viewer, not a second copy of it", () => {
+    // One decision, `firePlan`, feeding both. A chord and the viewer
+    // opening two different things is the failure this avoids, and it is
+    // the kind nobody notices until the day the two disagree.
+    const plan = firePlan("panel.network", desktop, anything);
+    const custom = customs.find((c) => c.path === ownedPath("panel.network"));
+    expect(custom?.command).toBe(commandLine(plan.ok ? plan.argv : []));
+  });
+
+  test("and is quoted where GNOME would otherwise split it into two arguments", () => {
+    expect(commandLine(["red-dev", "panel", "network"])).toBe("red-dev panel network");
+    expect(commandLine(["/opt/my tools/red-dev", "keys"])).toBe("'/opt/my tools/red-dev' keys");
+  });
+
+  test("an action with nothing here to run is skipped, and said to be skipped", () => {
+    // A keybinding pointing at a program that is not installed is a key
+    // somebody was told works. herdr is the one that is genuinely
+    // optional; on a machine with no terminal emulator at all, every
+    // surface lands here.
+    const withoutHerdr = gnomeCustoms((id) =>
+      firePlan(id, desktop, (cmd) => (cmd === "herdr" ? null : anything(cmd))),
+    );
+    expect(withoutHerdr.customs.map((c) => c.path)).not.toContain(ownedPath("agent.multiplex"));
+    expect(withoutHerdr.skipped.map((s) => s.id)).toEqual(["agent.multiplex"]);
+    expect(withoutHerdr.skipped[0]?.detail).toContain("herdr is not installed");
+
+    const headless = gnomeCustoms((id) => firePlan(id, desktop, nothing));
+    expect(headless.customs).toEqual([]);
+    expect(headless.skipped).toHaveLength(GNOME_BINDINGS.length);
+  });
+});
+
+describe("a converge that finds the machine already right", () => {
+  test("writes nothing at all", () => {
+    // Not a micro-optimisation: every step is a write to the person's
+    // own dconf, and a converge that rewrites four keys per action per
+    // run is one whose diff nobody can read — and whose log says it
+    // changed something every time it did not.
+    expect(gnomePlan(converged(customs), customs)).toEqual([]);
+  });
+
+  test("even where a person's own shortcuts share the list", () => {
+    const theirs = [`${CUSTOM_ROOT}custom0/`, `${CUSTOM_ROOT}custom1/`];
+    expect(gnomePlan(converged(customs, theirs), customs)).toEqual([]);
+  });
+
+  test("and where GNOME spells the accelerator its own way", () => {
+    // `<Primary>` is GTK's other name for Control and a hand-edited
+    // `<Alt><Control>T` means the same key. Comparing literally would
+    // rewrite every binding on every converge, which is the regression
+    // the Windows adapter shipped twice before its Normal() landed.
+    const state = converged(customs);
+    const rewritten = state.owned.map((c) => ({
+      ...c,
+      binding: c.binding.replace("<Control>", "<Primary>"),
+    }));
+    expect(gnomePlan({ ...state, owned: rewritten }, customs)).toEqual([]);
+    expect(normalAccel("<Primary><Alt>t")).toBe(normalAccel("<Alt><Control>T"));
+  });
+
+  test("but repairs one whose command has drifted", () => {
+    const state = converged(customs);
+    const stale = state.owned.map((c) =>
+      c.path === ownedPath("emoji.pick") ? { ...c, command: "xterm -e red-dev emoji" } : c,
+    );
+    const steps = gnomePlan({ ...state, owned: stale }, customs);
+    expect(steps.map((s) => s.argv)).toEqual([
+      ["set", `${CUSTOM_SCHEMA}:${ownedPath("emoji.pick")}`, "name", "red-dev: Emoji picker"],
+      ["set", `${CUSTOM_SCHEMA}:${ownedPath("emoji.pick")}`, "command", "alacritty -e red-dev emoji"],
+      ["set", `${CUSTOM_SCHEMA}:${ownedPath("emoji.pick")}`, "binding", "<Shift><Control><Alt>e"],
+    ]);
+  });
+
+  test("and the converge itself calls gsettings only to read", async () => {
+    // The same promise held one layer up, through the code a converge
+    // actually runs: a machine that matches is read and left alone.
+    const calls: string[][] = [];
+    const state = converged(customs, [`${CUSTOM_ROOT}custom0/`]);
+    const run = async (argv: string[]): Promise<string | null> => {
+      calls.push(argv);
+      return answer(argv, state);
+    };
+    await installGnomeKeys(desktop, run, fire);
+    expect(calls.length).toBeGreaterThan(0);
+    expect(calls.filter((a) => a[0] !== "get")).toEqual([]);
+  });
+
+  test("and a machine with no GNOME to ask is skipped rather than guessed at", async () => {
+    const calls: string[][] = [];
+    await installGnomeKeys(desktop, async (argv) => {
+      calls.push(argv);
+      return null;
+    }, fire);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual(["get", MEDIA_KEYS, "custom-keybindings"]);
+  });
+});
+
+describe("withdrawing what red-dev no longer registers", () => {
+  const mine = `${CUSTOM_ROOT}red-dev-panel-bluetooth/`;
+  const yours = `${CUSTOM_ROOT}custom0/`;
+  const state: GnomeState = {
+    list: [yours, mine, ...customs.map((c) => c.path)],
+    owned: [
+      { path: mine, name: "red-dev: Bluetooth panel", command: "alacritty -e red-dev panel bluetooth", binding: "<Shift><Control><Alt>b" },
+      ...customs.map((c) => ({ ...c })),
+    ],
+    launchTerminal: [],
+  };
+  const steps = gnomePlan(state, customs);
+
+  test("resets red-dev's own stale entry", () => {
+    expect(steps.map((s) => s.argv)).toContainEqual(["reset-recursively", `${CUSTOM_SCHEMA}:${mine}`]);
+  });
+
+  test("and touches nothing a person set themselves", () => {
+    // The one that would be invisible until somebody's shortcut stopped
+    // working: withdrawal reaches only paths carrying red-dev's own
+    // segment, and `custom0` is not one however long it has been there.
+    // The schema a step addresses is what decides whose setting it
+    // changes. `custom0` appears once below, inside the list value that
+    // keeps it — and nowhere as something being written or reset.
+    const argvs = steps.map((s) => s.argv);
+    expect(argvs.some((a) => (a[1] ?? "").includes("custom0"))).toBe(false);
+    expect(argvs).not.toContainEqual(["reset-recursively", `${CUSTOM_SCHEMA}:${yours}`]);
+  });
+
+  test("keeping their entry, in their order, in the list it rewrites", () => {
+    const list = steps.find((s) => s.argv[2] === "custom-keybindings");
+    expect(list?.argv[3]).toBe(`[${[yours, ...customs.map((c) => c.path)].map((p) => `'${p}'`).join(", ")}]`);
+    expect(parseGvariantList(list?.argv[3] as string)[0]).toBe(yours);
+  });
+
+  test("and the entry leaves the list before its values are reset", () => {
+    // The reverse of the order a write uses, and for the same reason: a
+    // listed path whose keys have been reset is a shortcut GNOME reads
+    // while it is half gone.
+    const argvs = steps.map((s) => s.argv);
+    const listed = argvs.findIndex((a) => a[2] === "custom-keybindings");
+    const reset = argvs.findIndex((a) => a[0] === "reset-recursively");
+    expect(listed).toBeGreaterThan(-1);
+    expect(listed).toBeLessThan(reset);
+  });
+
+  test("and GNOME's own launch-terminal binding comes back when red-dev drops that chord", () => {
+    // The takeover is exactly as reversible as everything else here.
+    // Only where red-dev is the one letting go: an empty
+    // launch-terminal binding on a machine red-dev never took it from is
+    // the person's own setting.
+    const withoutTerminal = customs.filter((c) => c.path !== ownedPath("terminal.new"));
+    const steps = gnomePlan(state, withoutTerminal);
+    expect(steps.map((s) => s.argv)).toContainEqual(["reset", MEDIA_KEYS, "terminal"]);
+
+    const untouched = gnomePlan({ ...bare(), launchTerminal: [] }, withoutTerminal);
+    expect(untouched.map((s) => s.argv)).not.toContainEqual(["reset", MEDIA_KEYS, "terminal"]);
+  });
+});
+
+describe("an action this adapter will not bind", () => {
+  test("is reported unbound, with the reason, on the row that keeps its chord", () => {
+    // ADR 0006: where a host will not take the chord, the adapter
+    // reports the action unbound with the reason. The elevated shell is
+    // that case on Linux — there is no such act here for a key to open.
+    const entry = keyEntries(desktop).find((e) => e.id === "terminal.elevated");
+    expect(entry?.state).toBe("unsupported");
+    expect(entry?.reason).toBe(gnomeRefusal("terminal.elevated") as string);
+    expect(entry?.reason).toContain("sudo in the terminal you already have");
+    // Not "broken": nobody has a shortcut to fix, and reporting it that
+    // way would send whoever reads it looking for one.
+    expect(entry?.reason).not.toContain("no chord came back");
+    // The chord it was given stays on the row, unbound. It is the same
+    // key on every target, and blanking it here would make the viewer
+    // disagree with the Windows machine the same person uses.
+    expect(entry?.chord).toBe("Ctrl+Alt+Shift+T");
+  });
+
+  test("and gets no second chord anywhere in the adapter", () => {
+    // The rule a well-meaning adapter breaks first: no substitute is
+    // invented for it, on any path, under any name.
+    expect(GNOME_ACTIONS).not.toContain("terminal.elevated");
+    expect(GNOME_BINDINGS.map((b) => b.id)).not.toContain("terminal.elevated");
+    expect(customs.map((c) => c.path)).not.toContain(ownedPath("terminal.elevated"));
+    const written = gnomePlan(bare(), customs).map((s) => s.argv.join(" ")).join("\n");
+    expect(written).not.toContain("red-dev-terminal-elevated");
+    // And no accelerator red-dev writes is one the registry did not
+    // choose, which is the general form of the same promise.
+    const chords = new Set(
+      ACTIONS.map((a) => gnomeAccel(parseChord(a.chord) as never)).filter(Boolean),
+    );
+    for (const custom of customs) expect(chords.has(custom.binding)).toBe(true);
+  });
+
+  test("and a chord GNOME has no name for is refused rather than approximated", () => {
+    // The other half of "never invents a local substitute", held on the
+    // spelling: a key this adapter cannot name for GTK produces no
+    // accelerator at all, rather than the nearest one it does know.
+    expect(gnomeAccel({ ctrl: true, alt: true, shift: false, win: false, key: "MOON" })).toBeNull();
+    expect(gnomeAccel({ ctrl: true, alt: true, shift: true, win: false, key: "PAGEUP" }))
+      .toBe("<Shift><Control><Alt>Page_Up");
+  });
+});
+
+/** What a machine in `state` answers to each read the converge makes. */
+function answer(argv: string[], state: GnomeState): string | null {
+  const [verb, schema, key] = argv;
+  if (verb !== "get") return "";
+  if (schema === MEDIA_KEYS && key === "custom-keybindings") {
+    return `[${state.list.map((p) => `'${p}'`).join(", ")}]`;
+  }
+  if (schema === MEDIA_KEYS && key === "terminal") {
+    return state.launchTerminal === null ? null : `[${state.launchTerminal.map((a) => `'${a}'`).join(", ")}]`;
+  }
+  const path = (schema ?? "").split(":")[1] ?? "";
+  const custom = state.owned.find((c) => c.path === path);
+  if (!custom) return null;
+  const value = key === "name" ? custom.name : key === "command" ? custom.command : custom.binding;
+  return `'${value}'`;
+}

--- a/src/gnome-keys.ts
+++ b/src/gnome-keys.ts
@@ -1,0 +1,595 @@
+/**
+ * The GNOME half of the semantic action registry — the adapter that
+ * makes a chord fire on Linux at all.
+ *
+ * Until this existed nothing registered a keybinding on a GNOME desktop:
+ * `red-dev keys` reported every action `unbound` there, and the panels,
+ * the emoji picker and the keys viewer were reachable only by typing
+ * their command. ADR 0006 fixed one chord family across targets
+ * precisely so the same key would work everywhere, and on the target
+ * red-dev was born for it worked nowhere.
+ *
+ * GNOME has no .lnk and no RegisterHotKey. What it has is dconf: a list
+ * of paths in `org.gnome.settings-daemon.plugins.media-keys
+ * custom-keybindings`, and under each of those paths a relocatable
+ * schema carrying a name, a command and an accelerator. Writing all
+ * four is registering a shortcut; the settings daemon picks it up
+ * without a logout.
+ *
+ * Which keys they are is not decided here. This module owns *how* a
+ * chord is registered on GNOME — the dconf paths, the accelerator
+ * spelling, the ownership — and reads *which* chord it is from
+ * `src/actions/`, per ADR 0006. The Windows adapter in src/hotkeys.ts is
+ * its sibling and reads exactly the same list.
+ *
+ * Three rules shape the rest.
+ *
+ * **Ownership is in the path.** GNOME's own Settings allocates
+ * `custom0`, `custom1`, …; red-dev allocates `red-dev-<id>` instead. A
+ * converge can then add, update and withdraw its own entries by name,
+ * and a person's custom keybindings are not merely left alone by
+ * accident — they are unreachable from here. A list rewritten by index
+ * is how somebody's own shortcut gets silently replaced by ours.
+ *
+ * **An action that cannot be registered is reported, not dropped.** ADR
+ * 0006 says an adapter never invents a local substitute: where GNOME
+ * will not take the chord the action is reported unbound with the
+ * reason, and no second key is chosen for it. `terminal.elevated` is
+ * that case today and is declared below rather than quietly missing —
+ * the same two-silence distinction the Windows adapter draws.
+ *
+ * **One owner per accelerator.** GNOME ships its own `Ctrl+Alt+T`
+ * (launch-terminal, whatever the session's default handler is), which is
+ * the same act red-dev's `terminal.new` performs on a machine where
+ * red-dev installed Alacritty. Two grabs of one accelerator is not a
+ * behaviour worth guessing at, so the built-in is cleared while red-dev
+ * holds the key and restored — `gsettings reset`, back to GNOME's own
+ * default — when it lets go.
+ */
+
+import { actionById, parseChord } from "./actions/index.ts";
+import type { Chord } from "./actions/index.ts";
+import type { FirePlan } from "./keys.ts";
+import { log } from "./log.ts";
+import type { Platform } from "./platform.ts";
+
+/** Where GNOME keeps every custom keybinding, its own and everyone's. */
+export const CUSTOM_ROOT =
+  "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/";
+
+const MEDIA_KEYS = "org.gnome.settings-daemon.plugins.media-keys";
+
+/** The relocatable schema each path under CUSTOM_ROOT carries. */
+const CUSTOM_SCHEMA = `${MEDIA_KEYS}.custom-keybinding`;
+
+/**
+ * The segment that says a path is red-dev's.
+ *
+ * GNOME's Settings writes `custom0`, `custom1`, … and renumbers nothing,
+ * so an adapter that allocated the next free index would hand back a
+ * path a person's shortcut may already own after a reorder. A name is
+ * stable, it is legible in `dconf dump`, and it makes withdrawal exact.
+ */
+const OWNED = "red-dev-";
+
+/** GNOME's own launch-terminal key, in the same schema. */
+const LAUNCH_TERMINAL = "terminal";
+
+/**
+ * The chord GNOME ships that key with, folded for comparison.
+ *
+ * GNOME's fact rather than red-dev's: the registry decides which chord
+ * `terminal.new` carries, and this is what the host already answers to.
+ * That they are the same key is the point — ADR 0006 adopts the key
+ * people already press instead of colliding with it — and it is why the
+ * built-in has to be cleared while red-dev holds it.
+ */
+const STOCK_LAUNCH_TERMINAL = "ALT+CONTROL+t";
+
+/** The dconf path red-dev registers an action at. */
+export function ownedPath(id: string): string {
+  // Dots are not a dconf path segment; `terminal.new` becomes
+  // `red-dev-terminal-new`, which is still the id read aloud.
+  return `${CUSTOM_ROOT}${OWNED}${id.replace(/\./g, "-")}/`;
+}
+
+/** Whether a path in GNOME's list is one red-dev wrote. */
+export function isOwned(path: string): boolean {
+  return path.startsWith(`${CUSTOM_ROOT}${OWNED}`);
+}
+
+/**
+ * The non-modifier key, spelled as GDK names it.
+ *
+ * Letters are lowercase, the named keys carry GDK's own capitalisation —
+ * `Page_Up`, `BackSpace`, `space` — and nothing else is guessed at. Null
+ * for a key this adapter has no GNOME name for, which is a refusal to
+ * report rather than an accelerator to invent.
+ */
+function gnomeKeyName(key: string): string | null {
+  if (/^[A-Z]$/.test(key)) return key.toLowerCase();
+  if (/^[0-9]$/.test(key)) return key;
+  if (/^F([1-9]|1[0-9]|2[0-4])$/.test(key)) return key;
+  const named: Record<string, string> = {
+    LEFT: "Left",
+    RIGHT: "Right",
+    UP: "Up",
+    DOWN: "Down",
+    DELETE: "Delete",
+    TAB: "Tab",
+    ESC: "Escape",
+    ENTER: "Return",
+    SPACE: "space",
+    BACKSPACE: "BackSpace",
+    HOME: "Home",
+    END: "End",
+    PAGEUP: "Page_Up",
+    PAGEDOWN: "Page_Down",
+    INSERT: "Insert",
+    PRINT: "Print",
+  };
+  return named[key] ?? null;
+}
+
+/**
+ * A chord in GTK's accelerator spelling — `<Control><Alt>t`.
+ *
+ * Modifier order is GTK's own, so what red-dev writes is what a person
+ * comparing it against GNOME's Settings sees. Null when the key has no
+ * GNOME name: an accelerator this adapter cannot spell is one GNOME
+ * would not take, and reporting that is the whole of its answer.
+ */
+export function gnomeAccel(chord: Chord): string | null {
+  const key = gnomeKeyName(chord.key);
+  if (!key) return null;
+  let mods = "";
+  if (chord.shift) mods += "<Shift>";
+  if (chord.ctrl) mods += "<Control>";
+  if (chord.alt) mods += "<Alt>";
+  // ADR 0006 keeps red-dev out of this family entirely and the registry
+  // validator rejects a chord that claims it. Spelled anyway, because an
+  // accelerator that silently dropped a modifier would register a
+  // different key from the one it was asked for.
+  if (chord.win) mods += "<Super>";
+  return `${mods}${key}`;
+}
+
+/**
+ * One spelling of an accelerator, for comparing two of them.
+ *
+ * The same idea as the `Normal()` function the Windows adapter had to
+ * grow, and for a related reason: GNOME's own defaults are written with
+ * `<Primary>` where red-dev writes `<Control>`, and a literal comparison
+ * against `['<Primary><Alt>t']` says "no collision" about the one
+ * collision this adapter exists to resolve. Order and case go too, so a
+ * hand-edited `<Alt><Control>T` still compares equal.
+ */
+export function normalAccel(accel: string): string {
+  const mods = [...accel.matchAll(/<([A-Za-z]+)>/g)]
+    .map((m) => (m[1] ?? "").toUpperCase())
+    .map((m) => (m === "PRIMARY" ? "CONTROL" : m))
+    .sort();
+  const key = accel.replace(/<[A-Za-z]+>/g, "").trim();
+  return [...mods, key.length === 1 ? key.toLowerCase() : key].join("+");
+}
+
+/** One action this adapter carries, and what its chord opens. */
+interface GnomeEntry {
+  id: string;
+  note: string;
+}
+
+/**
+ * The GNOME half of the registry — every action that applies to a
+ * desktop and that this adapter registers.
+ *
+ * Which key each one carries belongs to the registry and is read from
+ * it rather than repeated here. What is decided here is that the action
+ * gets a custom keybinding at all.
+ *
+ * `terminal.elevated` is deliberately absent and declared in REFUSED
+ * below: it applies to `desktop`, and there is no elevated-shell act on
+ * Linux for a chord to open. `agent.multiplex` is present — herdr runs
+ * natively here, which is exactly the machine it was written for — and
+ * is skipped at converge time, out loud, where herdr is not installed.
+ */
+const KEYBINDINGS: readonly GnomeEntry[] = [
+  { id: "terminal.new", note: "the terminal red-dev installed, not the session's default handler" },
+  { id: "menu.open", note: "red-dev's own menu, in a terminal of its own" },
+  { id: "keys.viewer", note: "this list, searchable — the remedy ADR 0006 promises" },
+  { id: "emoji.pick", note: "the picker, which writes the clipboard" },
+  { id: "panel.network", note: "network and DNS" },
+  { id: "panel.audio", note: "what the machine plays and hears" },
+  { id: "panel.power", note: "battery, and what drains it" },
+  { id: "agent.launch", note: "whichever host is the recorded Default agent" },
+  { id: "agent.multiplex", note: "herdr, where it is installed" },
+];
+
+/**
+ * An action that applies here and that GNOME will not be given a key
+ * for, with the sentence the keys viewer prints.
+ *
+ * Declared rather than omitted. ADR 0006 forbids inventing a local
+ * substitute, so the alternative to a chord is a reason — and a reason
+ * somebody wrote down beats an action quietly missing from the list
+ * above, which reads identically to one whose adapter half nobody has
+ * written yet.
+ */
+const REFUSED: readonly { id: string; reason: string }[] = [
+  {
+    id: "terminal.elevated",
+    reason:
+      "the GNOME keybindings adapter will not bind it: an elevated shell is the Windows act red-dev binds, "
+      + "and sudo in the terminal you already have does it here — so no second chord is chosen for it",
+  },
+];
+
+/**
+ * The actions this adapter carries an entry for, whether or not one came
+ * back with an accelerator.
+ *
+ * Exported for the same reason START_MENU_ACTIONS is: the keys viewer
+ * has to tell two silences apart. An action missing from the list is one
+ * this adapter never claimed; an action in it that produced no
+ * accelerator is the registry having lost something underneath a working
+ * adapter, and that is a bug rather than news.
+ */
+export const GNOME_ACTIONS: readonly string[] = KEYBINDINGS.map((entry) => entry.id);
+
+/** One registered shortcut, before this machine has been looked at. */
+export interface GnomeBinding {
+  id: string;
+  /** What GNOME's Settings shows, with red-dev's name on it. */
+  name: string;
+  /** The dconf path red-dev owns for this action. */
+  path: string;
+  /** The chord in GTK's spelling — `<Control><Alt>t`. */
+  accel: string;
+  note: string;
+}
+
+export const GNOME_BINDINGS: GnomeBinding[] = KEYBINDINGS.flatMap((entry) => {
+  const action = actionById(entry.id);
+  const chord = action ? parseChord(action.chord) : null;
+  const accel = chord ? gnomeAccel(chord) : null;
+  // An action that left the registry, or a chord GNOME has no name for,
+  // drops its shortcut rather than being written with an empty
+  // accelerator — which is a listed keybinding that fires nothing and
+  // reads, in Settings, as one somebody meant.
+  if (!action || !accel) return [];
+  return [{
+    id: entry.id,
+    // Prefixed, because the path is invisible in GNOME's Settings and
+    // the name is the only place a person browsing their shortcuts can
+    // see who put this one there.
+    name: `red-dev: ${action.label}`,
+    path: ownedPath(entry.id),
+    accel,
+    note: entry.note,
+  }];
+});
+
+/** The sentence for an action this adapter declines to register. */
+export function gnomeRefusal(id: string): string | null {
+  return REFUSED.find((r) => r.id === id)?.reason ?? null;
+}
+
+/** One custom keybinding, as the four values dconf actually holds. */
+export interface GnomeCustom {
+  path: string;
+  name: string;
+  command: string;
+  binding: string;
+}
+
+/** What this machine's dconf says right now. */
+export interface GnomeState {
+  /** `custom-keybindings`, in GNOME's order — a person's entries included. */
+  list: readonly string[];
+  /** What red-dev's own listed entries currently carry. */
+  owned: readonly GnomeCustom[];
+  /** GNOME's launch-terminal binding, or null where the key is absent. */
+  launchTerminal: readonly string[] | null;
+}
+
+/** One gsettings invocation, and what it is for. */
+export interface GnomeStep {
+  /** The arguments after `gsettings`, spawned without a shell. */
+  argv: string[];
+  /** One line for the converge log, or empty for a step not worth one. */
+  note: string;
+}
+
+/** `red-dev keys`' own decision, injected rather than imported. */
+export type FireLookup = (id: string) => FirePlan;
+
+/**
+ * A command line GNOME can spawn, from an argv red-dev decided.
+ *
+ * GNOME hands the string to `g_shell_parse_argv`, so an argument with a
+ * space in it has to arrive quoted or it becomes two arguments.
+ */
+export function commandLine(argv: readonly string[]): string {
+  return argv
+    .map((arg) => (/^[A-Za-z0-9_@%+=:,./-]+$/.test(arg) ? arg : `'${arg.replace(/'/g, `'\\''`)}'`))
+    .join(" ");
+}
+
+/** What each registered action opens, and what this machine cannot open. */
+export interface GnomeDesired {
+  customs: GnomeCustom[];
+  /** Registered actions with nothing here to run, and why. */
+  skipped: { id: string; detail: string }[];
+}
+
+/**
+ * The four values each shortcut needs, resolved against this machine.
+ *
+ * The command comes from `firePlan` — the same decision the keys viewer
+ * makes when Enter is pressed on a row — so a chord and the viewer can
+ * never open two different things. Where that decision refuses (no
+ * terminal emulator, herdr not installed) the shortcut is skipped and
+ * said to be skipped: a keybinding pointing at a program that is not
+ * there is a key somebody was told works.
+ */
+export function gnomeCustoms(fire: FireLookup): GnomeDesired {
+  const customs: GnomeCustom[] = [];
+  const skipped: { id: string; detail: string }[] = [];
+  for (const binding of GNOME_BINDINGS) {
+    const plan = fire(binding.id);
+    if (!plan.ok) {
+      skipped.push({ id: binding.id, detail: plan.detail });
+      continue;
+    }
+    customs.push({
+      path: binding.path,
+      name: binding.name,
+      command: commandLine(plan.argv),
+      binding: binding.accel,
+    });
+  }
+  return { customs, skipped };
+}
+
+function setCustom(path: string, key: string, value: string): string[] {
+  return ["set", `${CUSTOM_SCHEMA}:${path}`, key, value];
+}
+
+/** A GVariant array of strings, which is what `as` keys have to be given. */
+export function gvariantList(values: readonly string[]): string {
+  // `[]` alone is ambiguous to the parser and rejected; the type has to
+  // be spelled for the empty case.
+  return values.length === 0 ? "@as []" : `[${values.map((v) => `'${v}'`).join(", ")}]`;
+}
+
+function sameCustom(a: GnomeCustom, b: GnomeCustom): boolean {
+  return a.name === b.name
+    && a.command === b.command
+    && normalAccel(a.binding) === normalAccel(b.binding);
+}
+
+/**
+ * What has to be written, and nothing that does not.
+ *
+ * The order is the whole safety of it. A path is inert until it is in
+ * the list, so the values are written first and the list second — a
+ * listed path with no command is a shortcut GNOME reads while it is half
+ * written. Withdrawal runs the other way for the same reason: the entry
+ * leaves the list, and only then are its values reset.
+ *
+ * A converge that changes nothing returns nothing. That is not a
+ * micro-optimisation: every step here is a write to the person's own
+ * dconf, and a converge that rewrites four keys per action per run is
+ * one nobody can read the diff of.
+ */
+export function gnomePlan(state: GnomeState, desired: readonly GnomeCustom[]): GnomeStep[] {
+  const steps: GnomeStep[] = [];
+  const current = new Map(state.owned.map((c) => [c.path, c]));
+
+  for (const want of desired) {
+    const have = current.get(want.path);
+    if (have && sameCustom(have, want)) continue;
+    steps.push(
+      { argv: setCustom(want.path, "name", want.name), note: "" },
+      { argv: setCustom(want.path, "command", want.command), note: "" },
+      { argv: setCustom(want.path, "binding", want.binding), note: `${want.binding} → ${want.command}` },
+    );
+  }
+
+  // A person's entries keep their place and their order; red-dev's
+  // follow, in registry order. Rebuilding the list from red-dev's half
+  // alone is how somebody loses the shortcut they wrote last week.
+  const theirs = state.list.filter((path) => !isOwned(path));
+  const wanted = [...theirs, ...desired.map((d) => d.path)];
+  if (wanted.length !== state.list.length || wanted.some((p, i) => p !== state.list[i])) {
+    steps.push({
+      argv: ["set", MEDIA_KEYS, "custom-keybindings", gvariantList(wanted)],
+      note: `${desired.length} red-dev keybinding(s) listed, ${theirs.length} of your own kept`,
+    });
+  }
+
+  const keeping = new Set(desired.map((d) => d.path));
+  for (const path of state.list) {
+    if (!isOwned(path) || keeping.has(path)) continue;
+    steps.push({
+      argv: ["reset-recursively", `${CUSTOM_SCHEMA}:${path}`],
+      note: `withdrew ${path.slice(CUSTOM_ROOT.length).replace(/\/$/, "")}`,
+    });
+  }
+
+  steps.push(...launchTerminalSteps(state, desired));
+  return steps;
+}
+
+/**
+ * GNOME's own Ctrl+Alt+T, while red-dev holds that key.
+ *
+ * Cleared rather than left beside ours: it opens whatever
+ * `x-terminal-emulator` resolves to, red-dev's opens the terminal
+ * red-dev installed, and which of two grabs on one accelerator wins is
+ * not something to find out on somebody's machine. `reset` puts GNOME's
+ * default back the moment red-dev stops claiming the key, so the
+ * takeover is exactly as reversible as everything else here.
+ */
+function launchTerminalSteps(
+  state: GnomeState,
+  desired: readonly GnomeCustom[],
+): GnomeStep[] {
+  // Null means the key is not in this GNOME's schema, which is a machine
+  // to leave alone rather than a failure to report.
+  if (state.launchTerminal === null) return [];
+
+  const ours = new Set(desired.map((d) => normalAccel(d.binding)));
+  // Any collision, not only the stock one: a person may have moved
+  // launch-terminal onto another key, and whichever key it sits on it
+  // cannot be a key red-dev is also registering.
+  const held = state.launchTerminal.some((accel) => ours.has(normalAccel(accel)));
+  if (held) {
+    return [{
+      argv: ["set", MEDIA_KEYS, LAUNCH_TERMINAL, gvariantList([])],
+      note: "GNOME's own launch-terminal binding cleared, so the chord has one owner",
+    }];
+  }
+
+  // Restored only where red-dev is the one letting go: an empty
+  // launch-terminal binding on a machine red-dev never took it from is
+  // the person's own setting, and putting GNOME's default back over it
+  // would be this adapter reaching outside what it owns. The evidence
+  // that it was ours is the entry still in dconf, which withdrawal is
+  // removing in this same plan.
+  const wasOurs = state.launchTerminal.length === 0
+    && !ours.has(STOCK_LAUNCH_TERMINAL)
+    && state.owned.some((c) => normalAccel(c.binding) === STOCK_LAUNCH_TERMINAL);
+  if (wasOurs) {
+    return [{
+      argv: ["reset", MEDIA_KEYS, LAUNCH_TERMINAL],
+      note: "GNOME's own launch-terminal binding restored, because red-dev no longer claims that chord",
+    }];
+  }
+  return [];
+}
+
+/** A gsettings call, or null when it failed or the key is not there. */
+export type Gsettings = (argv: string[]) => Promise<string | null>;
+
+async function spawnGsettings(argv: string[]): Promise<string | null> {
+  try {
+    const proc = Bun.spawn(["gsettings", ...argv], {
+      stdout: "pipe",
+      stderr: "ignore",
+      stdin: "ignore",
+    });
+    const out = (await new Response(proc.stdout).text()).trim();
+    return (await proc.exited) === 0 ? out : null;
+  } catch {
+    // No gsettings on PATH at all. The caller reads null as "this
+    // machine has no GNOME to register anything with".
+    return null;
+  }
+}
+
+/** The strings inside a GVariant `as`, unescaped. */
+export function parseGvariantList(text: string): string[] {
+  const out: string[] = [];
+  for (const match of text.matchAll(/'((?:[^'\\]|\\.)*)'/g)) {
+    out.push((match[1] ?? "").replace(/\\(.)/g, "$1"));
+  }
+  return out;
+}
+
+/** The contents of a GVariant `s`, unescaped. */
+export function parseGvariantString(text: string): string {
+  const trimmed = text.trim();
+  if (trimmed.startsWith("'") && trimmed.endsWith("'") && trimmed.length >= 2) {
+    return trimmed.slice(1, -1).replace(/\\(.)/g, "$1");
+  }
+  return trimmed;
+}
+
+/** Read what this machine holds, or null where there is no GNOME to ask. */
+export async function readGnomeState(run: Gsettings): Promise<GnomeState | null> {
+  const listText = await run(["get", MEDIA_KEYS, "custom-keybindings"]);
+  if (listText === null) return null;
+
+  const list = parseGvariantList(listText);
+  const owned: GnomeCustom[] = [];
+  for (const path of list) {
+    if (!isOwned(path)) continue;
+    const schema = `${CUSTOM_SCHEMA}:${path}`;
+    const [name, command, binding] = await Promise.all([
+      run(["get", schema, "name"]),
+      run(["get", schema, "command"]),
+      run(["get", schema, "binding"]),
+    ]);
+    owned.push({
+      path,
+      name: parseGvariantString(name ?? ""),
+      command: parseGvariantString(command ?? ""),
+      binding: parseGvariantString(binding ?? ""),
+    });
+  }
+
+  const terminal = await run(["get", MEDIA_KEYS, LAUNCH_TERMINAL]);
+  return {
+    list,
+    owned,
+    launchTerminal: terminal === null ? null : parseGvariantList(terminal),
+  };
+}
+
+/**
+ * Register them, or say why this machine gets none.
+ *
+ * `run` and `fire` are injected for the reason every other decision in
+ * this project is: dconf and PATH are not answerable in a test, and what
+ * is worth pinning is that a converge on a machine that already matches
+ * writes nothing at all.
+ */
+export async function installGnomeKeys(
+  p: Platform,
+  run: Gsettings = spawnGsettings,
+  fire?: FireLookup,
+): Promise<void> {
+  if (p.env !== "desktop") {
+    log.skip("GNOME keybindings need a desktop session");
+    return;
+  }
+
+  const state = await readGnomeState(run);
+  if (!state) {
+    log.skip("no GNOME settings here, so nothing can register a chord");
+    return;
+  }
+
+  const lookup = fire ?? await defaultFire(p);
+  const { customs, skipped } = gnomeCustoms(lookup);
+  const steps = gnomePlan(state, customs);
+
+  for (const step of steps) {
+    const out = await run(step.argv);
+    if (out === null) {
+      // Named rather than swallowed: a key GNOME refused is a key
+      // nothing will press, and a converge that reported success over it
+      // is how the viewer comes to promise a chord the machine does not
+      // have.
+      log.warn(`gsettings refused \`${step.argv.join(" ")}\``);
+      continue;
+    }
+    if (step.note) log.plain(`       ${step.note}`);
+  }
+
+  for (const miss of skipped) log.plain(`       (skipped) ${miss.id}: ${miss.detail}`);
+
+  if (steps.length === 0) log.ok(`${customs.length} GNOME keybinding(s), already registered`);
+  else log.ok(`${customs.length} GNOME keybinding(s)`);
+}
+
+/** The keys viewer's own plan, loaded only where it is about to be used. */
+async function defaultFire(p: Platform): Promise<FireLookup> {
+  // Imported here rather than at the top because src/keys.ts is a
+  // consumer of this module — it reads GNOME_ACTIONS to answer whether a
+  // row is bound — and two modules importing each other at load time is
+  // a cycle nobody should have to reason about.
+  const { firePlan } = await import("./keys.ts");
+  return (id) => firePlan(id, p, (cmd) => Bun.which(cmd));
+}

--- a/src/keys.test.ts
+++ b/src/keys.test.ts
@@ -11,14 +11,15 @@
  *
  * Every platform here is a fixture. The interesting cases are the
  * targets this test process is not running on — a Windows host binds
- * both terminal actions, a Linux desktop binds neither because no GNOME
- * adapter exists yet, and a server has no display to press a key on —
- * and none of those is answerable by asking the machine underneath.
+ * through the Start Menu, a GNOME desktop through custom keybindings,
+ * and a server has no display to press a key on — and none of those is
+ * answerable by asking the machine underneath.
  */
 
 import { describe, expect, test } from "bun:test";
 import { ACTIONS } from "./actions/index.ts";
 import type { SemanticAction } from "./actions/index.ts";
+import { GNOME_ACTIONS } from "./gnome-keys.ts";
 import { START_MENU_ACTIONS } from "./hotkeys.ts";
 import {
   fireEntry,
@@ -131,6 +132,40 @@ describe("the list", () => {
     ]);
   });
 
+  test("on a GNOME desktop, every action the keybindings adapter registers is bound", () => {
+    // The acceptance criterion, read off the same list the adapter
+    // writes from. Until it landed this row read `unsupported` for all
+    // ten actions on the target red-dev was born for: the chords were
+    // printed, the ADR promised they were the same everywhere, and not
+    // one of them fired.
+    for (const id of GNOME_ACTIONS) {
+      const entry = keyEntries(desktop).find((e) => e.id === id);
+      expect(entry?.state).toBe("bound");
+      expect(entry?.reason).toBe("");
+    }
+    // Named as well as derived, so the loop cannot pass by being empty
+    // and so the set is a decision somebody has to change on purpose.
+    expect([...GNOME_ACTIONS]).toEqual([
+      "terminal.new",
+      "menu.open",
+      "keys.viewer",
+      "emoji.pick",
+      "panel.network",
+      "panel.audio",
+      "panel.power",
+      "agent.launch",
+      "agent.multiplex",
+    ]);
+  });
+
+  test("and the one it will not bind is the only unbound row there", () => {
+    // herdr's chord is bound here and not on Windows, which is the
+    // mirror image of the Start Menu's one gap — the same registry, two
+    // adapters, each honest about what its host can do.
+    const unbound = keyEntries(desktop).filter((e) => e.state !== "bound");
+    expect(unbound.map((e) => e.id)).toEqual(["terminal.elevated"]);
+  });
+
   test("an action the Windows adapter has never carried says so, and is not called broken", () => {
     // The distinction that matters, and the one widening the claimed set
     // must not blur: the Start Menu adapter registers the entries it
@@ -155,14 +190,15 @@ describe("the list", () => {
 
 describe("an action this target does not bind", () => {
   test("is listed, not hidden, and the reason says the target has no adapter", () => {
-    // Ubuntu desktop today: terminal.new applies here — GNOME ships the
-    // same chord for the same act — and nothing red-dev owns registers
-    // it, because the GNOME adapter is not written. Reporting that is
-    // the ADR's rule; dropping the row would make the viewer agree with
-    // a machine that is missing a feature.
-    const entry = keyEntries(desktop).find((e) => e.id === "terminal.new");
+    // A target with no adapter at all, which is the sentence Ubuntu
+    // desktop printed for every row until the GNOME adapter landed. It
+    // takes a fixture to reach now: the three targets that can press a
+    // key all have an adapter, so the only way to a machine without one
+    // is an action that applies where no adapter does. Kept, because
+    // that is the state every new target starts in.
+    const [entry] = keyEntries(server, only({ id: "terminal.new", platforms: ["server"] }));
     expect(entry?.state).toBe("unsupported");
-    expect(entry?.reason).toContain("no bindings adapter for desktop");
+    expect(entry?.reason).toContain("no bindings adapter for server");
   });
 
   test("that does not apply here at all says so, and names where it does", () => {
@@ -288,13 +324,14 @@ describe("what Enter runs", () => {
   });
 
   test("an unbound action still runs — that is what the viewer is for", async () => {
-    // Ubuntu desktop binds no chord today. Someone who opened the viewer
-    // to reach the terminal gets the terminal, rather than a row telling
-    // them the chord they came here to find does not work.
-    const [terminal] = keyEntries(desktop);
+    // A machine whose chord nothing registers still opens the thing.
+    // Someone who reached the viewer to find the terminal gets the
+    // terminal, rather than a row telling them the chord they came here
+    // to find does not work.
+    const [terminal] = keyEntries(server, only({ id: "terminal.new", platforms: ["server"] }));
     expect(terminal?.state).toBe("unsupported");
     const started: string[][] = [];
-    const outcome = await fireEntry(terminal!, desktop, (argv) => started.push(argv), anything);
+    const outcome = await fireEntry(terminal!, server, (argv) => started.push(argv), anything);
     expect(outcome.fired).toBe(true);
     expect(started[0]).toEqual(["alacritty"]);
   });

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -24,14 +24,15 @@
  * "unavailable" would bury it.
  *
  * Firing does not depend on binding. The Enter key runs the action even
- * where nothing registers its chord, which is the case on GNOME today —
- * an unbound action reachable from the viewer is the remedy the ADR
+ * where nothing registers its chord — an action an adapter declines is
+ * still reachable from the viewer, which is the remedy the ADR
  * promises, and refusing to run it would leave the target with neither
  * the chord nor the fallback.
  */
 
 import { ACTIONS, actionById, validateActions } from "./actions/index.ts";
 import type { SemanticAction } from "./actions/index.ts";
+import { GNOME_ACTIONS, GNOME_BINDINGS, gnomeRefusal } from "./gnome-keys.ts";
 import { START_MENU_ACTIONS, WINDOWS_HOTKEYS } from "./hotkeys.ts";
 import type { Platform } from "./platform.ts";
 
@@ -64,22 +65,30 @@ export interface KeyEntry {
 /**
  * What an adapter has to say about one action.
  *
- * Three answers, because an adapter that does not register a chord is
- * saying one of two very different things. `unclaimed` is "I have never
- * carried this action" — a feature whose adapter half has not landed,
- * which is news to live with. `missing` is "I carry it and no chord came
- * back", which is the registry having lost something underneath a working
- * adapter, and is a bug. A boolean would report either one as the other.
+ * Four answers, because an adapter that does not register a chord is
+ * saying one of three very different things. `unclaimed` is "I have
+ * never carried this action" — a feature whose adapter half has not
+ * landed, which is news to live with. `missing` is "I carry it and no
+ * chord came back", which is the registry having lost something
+ * underneath a working adapter, and is a bug. `refused` is "I carry the
+ * target it applies to and I will not bind it", which ADR 0006 requires
+ * to arrive with a reason and without a substitute chord — the GNOME
+ * adapter says it about the elevated shell. A boolean would report any
+ * of them as any other.
  */
-type Registration = "bound" | "missing" | "unclaimed";
+type Registration =
+  | { state: "bound" }
+  | { state: "missing" }
+  | { state: "unclaimed" }
+  | { state: "refused"; reason: string };
 
 /**
  * The thing that turns a chord into a registration on this target.
  *
- * One today: the Windows Start Menu `.lnk`, in src/hotkeys.ts. GNOME's
- * is not written yet, and its absence is reported rather than hidden —
- * that absence is precisely what someone reading the viewer on Ubuntu
- * needs to be told.
+ * Two of them: the Windows Start Menu `.lnk`, in src/hotkeys.ts, and
+ * GNOME's custom keybindings, in src/gnome-keys.ts. Both read which
+ * chord an action carries from the registry and own only how it is
+ * registered, which is ADR 0006's whole division of labour.
  */
 interface Adapter {
   /** Named the way the reason sentence needs to read. */
@@ -92,8 +101,27 @@ function adapterFor(p: Platform): Adapter | null {
     return {
       name: "Windows Start Menu",
       registers: (id) => {
-        if (!START_MENU_ACTIONS.includes(id)) return "unclaimed";
-        return WINDOWS_HOTKEYS.some((h) => h.id === id && h.combo !== null) ? "bound" : "missing";
+        if (!START_MENU_ACTIONS.includes(id)) return { state: "unclaimed" };
+        return WINDOWS_HOTKEYS.some((h) => h.id === id && h.combo !== null)
+          ? { state: "bound" }
+          : { state: "missing" };
+      },
+    };
+  }
+  if (p.env === "desktop") {
+    return {
+      name: "GNOME keybindings",
+      registers: (id) => {
+        // Before the claimed set, because a refusal is a decision
+        // somebody wrote down and "no shortcut for it yet" is the
+        // sentence for an action nobody has decided about. Reading them
+        // the same way would lose the reason.
+        const refusal = gnomeRefusal(id);
+        if (refusal) return { state: "refused", reason: refusal };
+        if (!GNOME_ACTIONS.includes(id)) return { state: "unclaimed" };
+        return GNOME_BINDINGS.some((b) => b.id === id)
+          ? { state: "bound" }
+          : { state: "missing" };
       },
     };
   }
@@ -150,7 +178,7 @@ export function keyEntries(
     }
 
     const registration = adapter.registers(action.id);
-    if (registration === "missing") {
+    if (registration.state === "missing") {
       return {
         ...head,
         state: "broken",
@@ -158,7 +186,15 @@ export function keyEntries(
       };
     }
 
-    if (registration === "unclaimed") {
+    if (registration.state === "refused") {
+      // The adapter's own sentence, unedited. ADR 0006 asks for the
+      // reason and forbids a substitute chord; the row keeps the chord
+      // the registry gave it, unbound, so nobody reads a second key
+      // into the gap.
+      return { ...head, state: "unsupported", reason: registration.reason };
+    }
+
+    if (registration.state === "unclaimed") {
       // The sibling of the no-adapter sentence above, and deliberately
       // worded like it: an adapter exists here, it simply has not grown
       // a shortcut for this action. Reported as the fact it is rather

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -1090,13 +1090,16 @@ export const TOOLS: Tool[] = [
   {
     // Core, not desktop or wsl, and that is not laziness.
     //
-    // The shortcuts have to be written from inside WSL, which reaches
-    // the Windows host, and from native Windows, which is the host —
-    // and no other scope covers both: wsl never applies on Windows,
-    // desktop never applies inside a distro. The builtin says so out
-    // loud on a target with no Windows behind it.
+    // The Start Menu shortcuts have to be written from inside WSL, which
+    // reaches the Windows host, and from native Windows, which is the
+    // host — and no other scope covers both: wsl never applies on
+    // Windows, desktop never applies inside a distro. Bare-metal Ubuntu
+    // is the third target with a keyboard to claim, and its adapter
+    // writes GNOME custom keybindings instead. The builtin picks the one
+    // that belongs to this host and says so out loud on a machine with
+    // neither, which is any server.
     name: "hotkeys",
-    about: "Ctrl+Alt+T and Ctrl+Alt+Shift+T, as Start Menu shortcuts",
+    about: "the chord family, as Start Menu shortcuts and GNOME custom keybindings",
     scope: "core",
     managed: true,
     u24: builtin("hotkeys"),

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -1498,8 +1498,17 @@ export async function applyProvider(pr: Provider, ctx: ApplyContext): Promise<vo
         return;
       }
       if (pr.name === "hotkeys") {
-        const { installWindowsHotkeys } = await import("./hotkeys.ts");
-        await installWindowsHotkeys(ctx.platform);
+        // One provider, one adapter per host. Which chords they register
+        // is the same list on both — src/actions/, per ADR 0006 — and
+        // only how they register differs: a Start Menu .lnk on Windows,
+        // a GNOME custom keybinding on a desktop.
+        if (ctx.platform.env === "windows" || ctx.platform.env === "wsl") {
+          const { installWindowsHotkeys } = await import("./hotkeys.ts");
+          await installWindowsHotkeys(ctx.platform);
+          return;
+        }
+        const { installGnomeKeys } = await import("./gnome-keys.ts");
+        await installGnomeKeys(ctx.platform);
         return;
       }
       if (pr.name === "wsl-sync") {


### PR DESCRIPTION
Automated AFK landing for #178. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #178

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/183"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789475582&installation_model_id=20659&pr_number=183&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F183&signature=ea473ddd8ebb699f91dbcf898d8e9af1b8093a666cfc5ba6225ca711de7bde24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->