### PR TITLE
fix(red): opt this directory into the dev plugin so validation runs

### DIFF
--- a/.red/config.yaml
+++ b/.red/config.yaml
@@ -10,6 +10,13 @@
 # runs, so a worker's local verdict and the merge queue's cannot drift.
 plugins:
   dev:
+    # Everything below is inert without this line. The activation gate is
+    # strict opt-in per directory (ADR 0067/0116): a `plugins.dev` block
+    # without `enabled: true` is discarded WHOLE — the standing drain and the
+    # validation moments included — and the engine then reports each moment as
+    # undeclared, which reads as the engine not seeing a file that is plainly
+    # here. Every Worker on this repo ran ungated until 2026-08-16 (#3939).
+    enabled: true
     afk:
       # A standing drain, so the queue keeps moving across a daemon restart.
       #


### PR DESCRIPTION
Every Worker on this repo has been running with **no local validation gate**.

The `plugins.dev.afk.validation` block is declared exactly as documented — and discarded whole. The activation gate is strict opt-in per directory (ADR 0067/0116): a `plugins.dev` block without `enabled: true` is dropped before any key under it is read, the standing drain included. The engine then reported each moment as `skip (undeclared)`, which reads as the engine failing to see a file that is plainly there.

That combination is why it survived 19 landed tickets: the drain reported success at every step, and CI happened to be green.

**Verified against the loader, before and after this line:**

```
BEFORE  gateClosed=true
Validation moments — iteration: skip (plugin inert here); post_done: skip (plugin inert here); landing: skip (plugin inert here)
  — `plugins.dev.enabled` is not `true` in .red/config.yaml, so the entire `plugins.dev` block is discarded (ADR 0067)

AFTER   gateClosed=false
Validation moments — iteration: declared [bun test]; post_done: declared [bun run typecheck; bun test]; landing: declared [bun run typecheck; bun test]
```

The narration above is itself the other half of this fix, landing separately in reddb-io/red-skills#3939 — until it ships, a repo in this state is told the wrong thing.

Refs reddb-io/red-skills#3939

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JJDnFnkFDW8WkR3Fk1ysGw

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/184"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789482240&installation_model_id=20659&pr_number=184&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F184&signature=2bbc642f145acc10bdcf082fe30bc7ba505d1cfb3f751ce511665f680bcf2a1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->