### PR TITLE
fix: #186 The RedSkills core installs through mise, and the layout it lands in

### DIFF
--- a/src/host-state.ts
+++ b/src/host-state.ts
@@ -260,7 +260,15 @@ export function resolveRedskilledBin(home = homedir()): string | null {
   const cached = latestResidentBundle(`${root}/.cache/red-skills/bundles`);
   if (cached) return cached;
   const packaged = `${root}/.red-skills/current/packaging/npm/bin/red-skills-redskilled.mjs`;
-  return existsSync(packaged) ? packaged : null;
+  if (existsSync(packaged)) return packaged;
+  // The same client, one directory up, when the core came from mise.
+  // The published npm package *is* packaging/npm — that is the
+  // repository.directory it declares — so a `current` that names the
+  // package rather than a source checkout carries bin/ at its root.
+  // Checked after the checkout path rather than before it: a machine
+  // with both should prefer the tree it can also build from.
+  const packagedCore = `${root}/.red-skills/current/bin/red-skills-redskilled.mjs`;
+  return existsSync(packagedCore) ? packagedCore : null;
 }
 
 /** Derive the resident socket without creating its directory or starting a daemon. */
@@ -366,6 +374,9 @@ export async function readHostState(
 const WSL_HOST_STATE_PROGRAM = [
   'b=$(ls -1 "$HOME"/.red/redskilled/bundles/redskilled-*.bundle.min.mjs "$HOME"/.cache/red-skills/bundles/redskilled-*.bundle.min.mjs 2>/dev/null | sort -V | tail -1)',
   '[ -n "$b" ] || b="$HOME/.red-skills/current/packaging/npm/bin/red-skills-redskilled.mjs"',
+  // The mise-installed core is the published packaging/npm package, so
+  // its bin/ sits at the root of `current` instead of under it.
+  '[ -f "$b" ] || b="$HOME/.red-skills/current/bin/red-skills-redskilled.mjs"',
   '[ -f "$b" ] || exit 3',
   'n=$(command -v node 2>/dev/null || ls -1 /usr/local/bin/node /usr/bin/node "$HOME"/.local/share/mise/installs/node/*/bin/node "$HOME"/.volta/bin/node "$HOME"/.asdf/shims/node "$HOME"/.nodenv/shims/node "$HOME"/.nvm/versions/node/*/bin/node "$HOME"/.local/share/fnm/node-versions/*/installation/bin/node 2>/dev/null | sort -V | tail -1)',
   '[ -n "$n" ] || exit 3',

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -1106,6 +1106,32 @@ export const TOOLS: Tool[] = [
     win: builtin("hotkeys"),
   },
   {
+    // The RedSkills payload, which used to arrive as a curled
+    // install.sh and therefore never moved again. It is an npm package,
+    // so mise resolves it through the `npm:` backend and `red-dev
+    // update` carries it forward with the rest of the suite.
+    //
+    // Deliberately not `github:`. That backend scores release assets to
+    // put one executable on PATH; what is published here is a tree of
+    // bundles and bin shims, which is what npm is for.
+    //
+    // Half a migration on its own: mise installs into its own tree and
+    // every consumer on the machine resolves through
+    // ~/.red-skills/current. src/red-skills-core.ts is the other half,
+    // and runs straight after this entry does.
+    //
+    // Before the marketplace row below rather than after it: the row
+    // below wires agents against the payload, and wiring against a
+    // payload that is not there yet is the ordering bug that costs a
+    // whole converge.
+    name: "red-skills-core",
+    about: "the RedSkills runtime bundles, resolved and kept current by mise",
+    scope: "core",
+    managed: true,
+    u24: mise("npm:@reddb-io/red-skills", { alias: "red-skills" }),
+    win: mise("npm:@reddb-io/red-skills", { alias: "red-skills" }),
+  },
+  {
     // After the agents, never before: the installer detects which CLIs
     // exist and wires each one, so running it on a machine with none
     // configures nothing and reports success. It sits at the end of

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -684,6 +684,8 @@ export async function miseInstallSuite(platform: Platform): Promise<void> {
   log.step(`mise: installing ${entries} tools`);
   const code = await runMise([mise, "install"]);
   if (code !== 0) throw new RedError(`mise could not install the suite (exit ${code})`);
+
+  await linkRedSkillsCore();
 }
 
 /**
@@ -708,6 +710,25 @@ export async function miseUpgradeSuite(platform: Platform): Promise<void> {
   log.step(`mise: upgrading ${names.length} tools`);
   const code = await runMise([mise, "upgrade", "--yes", ...names]);
   if (code !== 0) log.err(`mise upgrade exited ${code}`);
+
+  // Even when the upgrade reported a failure: it names several tools at
+  // once, so a non-zero exit says one of them did not move, not that
+  // none did. Repointing at whatever is now installed is correct in
+  // both cases, and is a no-op when nothing changed.
+  await linkRedSkillsCore();
+}
+
+/**
+ * Move ~/.red-skills/current onto whatever mise has just installed.
+ *
+ * Here rather than inside the mise calls above because both of them
+ * reach the core: the suite pass installs it alongside everything else,
+ * and the upgrade pass is what advances it. A machine without the core
+ * gets nothing and no message.
+ */
+async function linkRedSkillsCore(): Promise<void> {
+  const { convergeRedSkillsCoreLayout } = await import("./red-skills-core.ts");
+  convergeRedSkillsCoreLayout();
 }
 
 async function runMise(cmd: string[]): Promise<number> {
@@ -1379,9 +1400,16 @@ export async function applyProvider(pr: Provider, ctx: ApplyContext): Promise<vo
         await ghInstall(pr.repo, pr.asset, pr.bin, pr.version);
       }
       return;
-    case "mise":
+    case "mise": {
       await miseInstall(pr, ctx.platform);
+      // mise puts a tool under its own installs tree and stops there,
+      // which is the whole story for a binary it also shims onto PATH.
+      // The RedSkills core is a tree the rest of the machine resolves
+      // through ~/.red-skills/current, so it needs the link moved too.
+      const { convergeCoreAfterMise } = await import("./red-skills-core.ts");
+      convergeCoreAfterMise(pr.spec);
       return;
+    }
     case "ppa":
       await ppaInstall(pr.ppa, pr.pkgs);
       return;

--- a/src/red-skills-core.test.ts
+++ b/src/red-skills-core.test.ts
@@ -1,0 +1,442 @@
+/**
+ * The RedSkills core, as a mise entry and as the layout it lands in.
+ *
+ * These are two halves of one change and they are tested together for
+ * the same reason they ship together: either alone leaves a machine
+ * where RedSkills is installed and nothing can find it. The entry is
+ * what makes the version move; the layout is what makes
+ * ~/.red-skills/current name the version that moved.
+ *
+ * Everything below runs against a fabricated mise installs tree and a
+ * temporary HOME, so it holds on a machine with no mise, no network and
+ * no RedSkills. The one thing that cannot be faked here is Windows, and
+ * the junction is pinned through the function that decides the link
+ * flavour rather than by creating one — the decision is the part that
+ * can regress, and getting it wrong is what would put the install
+ * behind developer mode.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { providerFor, TOOLS } from "./manifest.ts";
+import { miseEntries, miseToolNames, renderMiseConfig } from "./mise-config.ts";
+import type { Platform } from "./platform.ts";
+import {
+  convergeCoreAfterMise,
+  convergeRedSkillsCoreLayout,
+  corePayloadDir,
+  directoryLinkType,
+  installedCoreVersion,
+  miseInstallDirName,
+  redSkillsCurrentLink,
+  redSkillsVersionDir,
+  REDSKILLS_CORE_ALIAS,
+  REDSKILLS_CORE_SPEC,
+} from "./red-skills-core.ts";
+
+const UBUNTU: Platform = {
+  os: "linux",
+  distro: "ubuntu",
+  version: "24.04",
+  codename: "noble",
+  env: "desktop",
+  arch: "x64",
+  caps: { apt: true, gui: true, systemd: true, winget: false, flatpak: false },
+};
+
+const WINDOWS: Platform = {
+  ...UBUNTU,
+  os: "windows",
+  distro: null,
+  version: null,
+  codename: null,
+  env: "windows",
+  caps: { apt: false, gui: true, systemd: false, winget: true, flatpak: false },
+};
+
+const source = readFileSync(`${import.meta.dir}/red-skills-core.ts`, "utf8");
+
+/**
+ * A mise installs tree carrying the given versions.
+ *
+ * Shaped like the real one, including the selector links mise writes
+ * beside the exact versions — `latest` and the truncated series — since
+ * mistaking one of those for a version is the specific way version
+ * discovery goes wrong.
+ */
+function fakeInstalls(versions: string[], opts: { selectors?: boolean } = {}): string {
+  const dir = mkdtempSync(join(tmpdir(), "red-core-installs-"));
+  for (const version of versions) {
+    const payload = corePayloadDir(dir, version);
+    mkdirSync(join(payload, "bin"), { recursive: true });
+    writeFileSync(
+      join(payload, "package.json"),
+      `${JSON.stringify({ name: "@reddb-io/red-skills", version })}\n`,
+    );
+    writeFileSync(join(payload, "bin", "red-skills-redskilled.mjs"), "");
+  }
+  if (opts.selectors !== false && versions.length > 0) {
+    const newest = versions[versions.length - 1] as string;
+    symlinkSync(`./${newest}`, join(dir, "latest"));
+  }
+  return dir;
+}
+
+function fakeHome(): string {
+  return mkdtempSync(join(tmpdir(), "red-core-home-"));
+}
+
+describe("the manifest entry mise resolves", () => {
+  const row = TOOLS.find((t) => t.name === "red-skills-core");
+
+  test("the core is in the manifest, on every target", () => {
+    expect(row).toBeDefined();
+    expect(row!.scope).toBe("core");
+    for (const p of [UBUNTU, WINDOWS]) {
+      expect(providerFor(row!, p)).toEqual({
+        kind: "mise",
+        spec: REDSKILLS_CORE_SPEC,
+        alias: REDSKILLS_CORE_ALIAS,
+      });
+    }
+  });
+
+  test("it resolves through the npm backend, never through github", () => {
+    // `github:` scores release assets to put one executable on PATH.
+    // What is published here is a tree of bundles and bin shims, and
+    // lifting one file out of it produces something that starts and
+    // then cannot find the rest of itself.
+    expect(REDSKILLS_CORE_SPEC.startsWith("npm:")).toBe(true);
+  });
+
+  test("the fragment projects it at latest, under the name people type", () => {
+    for (const p of [UBUNTU, WINDOWS]) {
+      const entry = miseEntries(p).find((e) => e.spec === REDSKILLS_CORE_SPEC);
+      expect(entry, `${p.os}`).toEqual({
+        spec: REDSKILLS_CORE_SPEC,
+        alias: REDSKILLS_CORE_ALIAS,
+        version: "latest",
+      });
+    }
+  });
+
+  test("the rendered fragment declares both halves, and quotes the spec", () => {
+    // Unquoted, `npm:@reddb-io/red-skills = "latest"` is a TOML parse
+    // error, and a parse error here disables every tool in the file.
+    const out = renderMiseConfig(miseEntries(UBUNTU));
+    expect(out).toContain('red-skills = "npm:@reddb-io/red-skills"');
+    expect(out).toContain('red-skills = "latest"');
+  });
+
+  test("the projection is byte-identical across runs", () => {
+    // The fragment is rewritten on every converge and compared against
+    // disk to decide whether anything happened. A projection that
+    // depends on manifest order or on object key order turns every
+    // converge into a change and every change into a line claiming work
+    // that was not done.
+    const once = renderMiseConfig(miseEntries(UBUNTU));
+    const twice = renderMiseConfig(miseEntries(UBUNTU));
+    const reversed = renderMiseConfig([...miseEntries(UBUNTU)].reverse());
+    expect(twice).toBe(once);
+    expect(reversed).toBe(once);
+  });
+
+  test("`red-dev update` names it, so the version actually moves", () => {
+    // Bare `mise upgrade` would reach the user's own runtimes too, so
+    // the suite is upgraded by name — and a core missing from that list
+    // is a core that is declared and never advanced.
+    expect(miseToolNames(UBUNTU)).toContain(REDSKILLS_CORE_ALIAS);
+  });
+
+  test("the payload is declared before the row that wires agents to it", () => {
+    const names = TOOLS.map((t) => t.name);
+    expect(names.indexOf("red-skills-core")).toBeGreaterThan(-1);
+    expect(names.indexOf("red-skills-core")).toBeLessThan(names.indexOf("red-skills"));
+  });
+});
+
+describe("where mise puts it", () => {
+  test("a tool named through [tool_alias] installs under the alias", () => {
+    // Read off a real mise install rather than off its documentation:
+    // an aliased tool does not get the flattened spec directory, it
+    // gets the alias verbatim. The whole layout hangs on this string.
+    expect(miseInstallDirName({ spec: REDSKILLS_CORE_SPEC, alias: REDSKILLS_CORE_ALIAS }))
+      .toBe("red-skills");
+  });
+
+  test("a bare backend spec is flattened instead", () => {
+    expect(miseInstallDirName({ spec: "npm:@types/semver" })).toBe("npm-types-semver");
+    expect(miseInstallDirName({ spec: "npm:is-odd" })).toBe("npm-is-odd");
+  });
+
+  test("the newest exact version wins, compared as numbers", () => {
+    // Lexically, 3.9.0 sorts after 3.10.0 — the ordering bug that only
+    // shows up two years after it is written.
+    expect(installedCoreVersion(fakeInstalls(["3.9.0", "3.10.0"]))).toBe("3.10.0");
+  });
+
+  test("mise's own selector links are not mistaken for versions", () => {
+    // `latest` resolves to whichever version was asked for last. A
+    // per-version directory pointed at a moving target is not one.
+    const installs = fakeInstalls(["3.10.0"]);
+    expect(existsSync(join(installs, "latest"))).toBe(true);
+    expect(installedCoreVersion(installs)).toBe("3.10.0");
+  });
+
+  test("nothing installed is no opinion, not a failure", () => {
+    expect(installedCoreVersion(join(tmpdir(), "red-core-absent-xyz"))).toBeNull();
+  });
+});
+
+describe("the layout a converge lands in", () => {
+  test("the per-version directory exists and current resolves to it", () => {
+    const home = fakeHome();
+    const installs = fakeInstalls(["3.18.12"]);
+
+    const result = convergeRedSkillsCoreLayout({ home, installsDir: installs, platform: "linux" });
+
+    expect(result).not.toBeNull();
+    expect(result!.version).toBe("3.18.12");
+    expect(result!.changed).toBe(true);
+
+    const versions = redSkillsVersionDir(home, "3.18.12");
+    const current = redSkillsCurrentLink(home);
+    expect(versions).toBe(join(home, ".red-skills", "versions", "v3.18.12"));
+    expect(existsSync(versions)).toBe(true);
+    expect(realpathSync(current)).toBe(realpathSync(versions));
+    // And the version directory names the package set mise installed,
+    // rather than a copy of it.
+    expect(realpathSync(versions)).toBe(realpathSync(corePayloadDir(installs, "3.18.12")));
+  });
+
+  test("a newer install moves current and leaves the older version in place", () => {
+    const home = fakeHome();
+    convergeRedSkillsCoreLayout({
+      home,
+      installsDir: fakeInstalls(["3.18.12"]),
+      platform: "linux",
+    });
+
+    const upgraded = convergeRedSkillsCoreLayout({
+      home,
+      installsDir: fakeInstalls(["3.18.12", "3.19.0"]),
+      platform: "linux",
+    });
+
+    expect(upgraded!.version).toBe("3.19.0");
+    expect(existsSync(redSkillsVersionDir(home, "3.18.12"))).toBe(true);
+    expect(realpathSync(redSkillsCurrentLink(home)))
+      .toBe(realpathSync(redSkillsVersionDir(home, "3.19.0")));
+  });
+
+  test("mise having installed nothing leaves the machine alone", () => {
+    const home = fakeHome();
+    expect(
+      convergeRedSkillsCoreLayout({
+        home,
+        installsDir: join(tmpdir(), "red-core-absent-xyz"),
+        platform: "linux",
+      }),
+    ).toBeNull();
+    expect(existsSync(join(home, ".red-skills"))).toBe(false);
+  });
+
+  test("a version directory the one-liner already wrote is used as it stands", () => {
+    // Both install modes agree on the name of the per-version
+    // directory, which is what lets them converge the same machine
+    // without fighting over the tree: whoever gets there first owns its
+    // contents, and the other has only the link left to move.
+    const home = fakeHome();
+    const installs = fakeInstalls(["3.18.12"]);
+    const checkout = redSkillsVersionDir(home, "3.18.12");
+    mkdirSync(join(checkout, "scripts"), { recursive: true });
+    writeFileSync(join(checkout, "package.json"), "{}\n");
+
+    const result = convergeRedSkillsCoreLayout({ home, installsDir: installs, platform: "linux" });
+
+    expect(result!.changed).toBe(true);
+    expect(lstatSync(checkout).isSymbolicLink()).toBe(false);
+    expect(existsSync(join(checkout, "scripts"))).toBe(true);
+    expect(realpathSync(redSkillsCurrentLink(home))).toBe(realpathSync(checkout));
+  });
+
+  test("the layout step ignores every tool that is not the core", () => {
+    const home = fakeHome();
+    expect(
+      convergeCoreAfterMise("github:reddb-io/reddb", {
+        home,
+        installsDir: fakeInstalls(["3.18.12"]),
+        platform: "linux",
+      }),
+    ).toBeNull();
+    expect(existsSync(join(home, ".red-skills"))).toBe(false);
+  });
+});
+
+describe("a converge that has nothing to do", () => {
+  test("is a no-op when current already names the resolved version", () => {
+    const home = fakeHome();
+    const installs = fakeInstalls(["3.18.12"]);
+    convergeRedSkillsCoreLayout({ home, installsDir: installs, platform: "linux" });
+
+    const current = redSkillsCurrentLink(home);
+    const before = lstatSync(current).ino;
+
+    const again = convergeRedSkillsCoreLayout({ home, installsDir: installs, platform: "linux" });
+
+    expect(again!.changed).toBe(false);
+    expect(again!.version).toBe("3.18.12");
+    // Recreating the link would mint a new inode. Everything downstream
+    // stats this one path, so a converge that rewrites it on every run
+    // is a converge that reports work it did not do.
+    expect(lstatSync(current).ino).toBe(before);
+  });
+});
+
+describe("the Windows link", () => {
+  test("is a junction, which needs no developer mode", () => {
+    // A "dir" symlink on Windows needs SeCreateSymbolicLinkPrivilege,
+    // which an ordinary account only holds with developer mode on — a
+    // machine-wide setting an installer has no business demanding. A
+    // junction is an ordinary directory reparse point any user can
+    // create, so the install is not gated on anything.
+    expect(directoryLinkType("win32")).toBe("junction");
+  });
+
+  test("every other platform gets a plain directory symlink", () => {
+    expect(directoryLinkType("linux")).toBe("dir");
+    expect(directoryLinkType("darwin")).toBe("dir");
+  });
+
+  test("the link is created with that flavour, and never as a copy", () => {
+    // The directory-copy path is the class of bug
+    // repairCopiedRedSkillsCurrent exists to clean up after: a copied
+    // `current` is a snapshot that stops tracking the version it was
+    // taken from, and reports success forever.
+    expect(source).toContain("symlinkSync(target, path, directoryLinkType(platform))");
+    expect(source).not.toContain("cpSync(");
+    expect(source).not.toContain("copyFileSync(");
+  });
+
+  test("a real directory in the way is left alone rather than deleted", () => {
+    // Git Bash emulates a symlink as a copy, so `current` can be a real
+    // tree. Removing it here would be this module deleting data it did
+    // not create.
+    const home = fakeHome();
+    const current = redSkillsCurrentLink(home);
+    mkdirSync(current, { recursive: true });
+    writeFileSync(join(current, "mine.txt"), "keep");
+
+    expect(
+      convergeRedSkillsCoreLayout({
+        home,
+        installsDir: fakeInstalls(["3.18.12"]),
+        platform: "linux",
+      }),
+    ).toBeNull();
+    expect(existsSync(join(current, "mine.txt"))).toBe(true);
+  });
+});
+
+describe("the consumers that resolve through current", () => {
+  /** Run `fn` with HOME and USERPROFILE pointed at a fabricated machine. */
+  async function withHome<T>(home: string, fn: () => Promise<T> | T): Promise<T> {
+    const savedHome = process.env["HOME"];
+    const savedProfile = process.env["USERPROFILE"];
+    process.env["HOME"] = home;
+    delete process.env["USERPROFILE"];
+    try {
+      return await fn();
+    } finally {
+      if (savedHome === undefined) delete process.env["HOME"];
+      else process.env["HOME"] = savedHome;
+      if (savedProfile !== undefined) process.env["USERPROFILE"] = savedProfile;
+    }
+  }
+
+  test("the extension builder still finds the source, and resolves past the link", async () => {
+    const home = fakeHome();
+    const installs = fakeInstalls(["3.18.12"]);
+    convergeRedSkillsCoreLayout({ home, installsDir: installs, platform: "linux" });
+
+    const { resolvedSource, sourceRoot } = await import("./red-skills-ext.ts");
+    await withHome(home, () => {
+      expect(sourceRoot()).toBe(`${home}/.red-skills/current`);
+      // The link is the only thing that moves and every version under
+      // it is immutable, so the resolved path is the whole freshness
+      // question for anything built out of the tree.
+      expect(resolvedSource()).toBe(realpathSync(corePayloadDir(installs, "3.18.12")));
+    });
+  });
+
+  test("the host census still finds the resident client", async () => {
+    const home = fakeHome();
+    const installs = fakeInstalls(["3.18.12"]);
+    convergeRedSkillsCoreLayout({ home, installsDir: installs, platform: "linux" });
+
+    const { resolveRedskilledBin } = await import("./host-state.ts");
+    expect(resolveRedskilledBin(home)).toBe(
+      `${home}/.red-skills/current/bin/red-skills-redskilled.mjs`,
+    );
+  });
+
+  test("a source checkout still wins where it exists", async () => {
+    // The checkout path is checked first on purpose: a machine with
+    // both should prefer the tree it can also build the extension from.
+    const home = fakeHome();
+    const checkout = redSkillsVersionDir(home, "3.18.12");
+    mkdirSync(join(checkout, "packaging", "npm", "bin"), { recursive: true });
+    writeFileSync(join(checkout, "packaging", "npm", "bin", "red-skills-redskilled.mjs"), "");
+    convergeRedSkillsCoreLayout({
+      home,
+      installsDir: fakeInstalls(["3.18.12"]),
+      platform: "linux",
+    });
+
+    const { resolveRedskilledBin } = await import("./host-state.ts");
+    expect(resolveRedskilledBin(home)).toBe(
+      `${home}/.red-skills/current/packaging/npm/bin/red-skills-redskilled.mjs`,
+    );
+  });
+
+  test("the WSL rescue shim looks in both places too", () => {
+    // It runs inside a distro from native Windows and has no red-dev to
+    // ask, so the two candidate paths are written into the program
+    // itself. One of them missing is a distro that reports no host.
+    const hostState = readFileSync(`${import.meta.dir}/host-state.ts`, "utf8");
+    expect(hostState).toContain(
+      '.red-skills/current/packaging/npm/bin/red-skills-redskilled.mjs',
+    );
+    expect(hostState).toContain('.red-skills/current/bin/red-skills-redskilled.mjs');
+  });
+});
+
+describe("the converge path that runs the layout step", () => {
+  const providers = readFileSync(`${import.meta.dir}/providers.ts`, "utf8");
+
+  test("a mise install is followed by the link, or the core is installed and invisible", () => {
+    expect(providers).toContain("convergeCoreAfterMise(pr.spec)");
+  });
+
+  test("the suite install and the suite upgrade reach it as well", () => {
+    // `install core` runs the whole fragment in one pass and `update`
+    // upgrades it in one pass; neither goes through the per-tool
+    // provider above, so neither would move the link on its own.
+    const suite = providers.slice(providers.indexOf("export async function miseInstallSuite"));
+    expect(suite.slice(0, suite.indexOf("\n}"))).toContain("linkRedSkillsCore()");
+    const upgrade = providers.slice(providers.indexOf("export async function miseUpgradeSuite"));
+    expect(upgrade.slice(0, upgrade.indexOf("\n}"))).toContain("linkRedSkillsCore()");
+  });
+});

--- a/src/red-skills-core.ts
+++ b/src/red-skills-core.ts
@@ -1,0 +1,322 @@
+/**
+ * The RedSkills core: resolved by mise, linked into the layout everything reads.
+ *
+ * Until now the core arrived the way every reddb-io tool used to — a
+ * curled `install.sh` that fetched a release tarball. That works exactly
+ * once. Nothing on the machine afterwards knows the payload is old,
+ * because the only thing that could tell it is the same script, and the
+ * only way to run the script again is to remember to. It is the frozen
+ * -forever shape mise-config.ts was written about, applied to the one
+ * package the rest of this product talks to most.
+ *
+ * So the core becomes a manifest entry like everything else, and mise
+ * resolves it through its `npm:` backend at `latest`. Not `github:`:
+ * that backend scores release assets to put a single executable on
+ * PATH, and the payload here is a tree of bundles and shims rather than
+ * one binary. npm is where that tree is already published.
+ *
+ * ## The half that is not the entry
+ *
+ * mise installs into its own tree — `installs/<tool>/<version>` — and
+ * nothing on this machine looks there. `red-skills-ext`, the host
+ * census in host-state.ts and the WSL rescue shim all resolve through
+ * `~/.red-skills/current`, and they did so before this file existed.
+ * An entry that installs the core somewhere else and does not repoint
+ * that link converges a machine into the worst available state: the
+ * core is installed, everything reports success, and nothing can find
+ * it.
+ *
+ * That is why the entry and the layout ship together. The layout is:
+ *
+ *   ~/.red-skills/versions/v<version>   the package set for one version
+ *   ~/.red-skills/current               -> the newest of those
+ *
+ * which is the shape the standalone one-liner already produces, chosen
+ * for that reason rather than invented here.
+ *
+ * ## Links, not copies, and junctions on Windows
+ *
+ * The per-version directory is a link into mise's install rather than a
+ * copy of it. A copy doubles a 20 MB payload per version and, worse,
+ * has to be kept in step with the thing it was copied from.
+ *
+ * On Windows a plain symlink needs SeCreateSymbolicLinkPrivilege, which
+ * in practice means developer mode — a machine-wide setting an installer
+ * has no business demanding. A junction needs none of it: it is an
+ * ordinary directory reparse point any user can create. That is also
+ * what keeps the directory-copy emulation out of the picture entirely;
+ * `repairCopiedRedSkillsCurrent` exists to clean up after that class of
+ * bug, and the way not to need it is to never create a copy.
+ */
+
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readdirSync,
+  realpathSync,
+  rmdirSync,
+  rmSync,
+  symlinkSync,
+  type Stats,
+} from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+import { log } from "./log.ts";
+import { miseInstallRoot } from "./mise-config.ts";
+
+/**
+ * The backend-qualified name the manifest declares and mise resolves.
+ *
+ * Duplicated as a literal in manifest.ts rather than imported from
+ * here: manifest.ts is what mise-config.ts projects, and this module
+ * reads mise-config.ts, so an import would close a cycle around a
+ * top-level `const`. A test pins the two spellings against each other,
+ * which is the cheap half of the trade.
+ */
+export const REDSKILLS_CORE_SPEC = "npm:@reddb-io/red-skills";
+
+/** The short name [tool_alias] exposes, and the one people type. */
+export const REDSKILLS_CORE_ALIAS = "red-skills";
+
+/** How npm nests the package inside the install prefix mise hands it. */
+const CORE_PACKAGE = "@reddb-io/red-skills";
+
+/**
+ * The directory mise keeps one tool's versions under.
+ *
+ * Two spellings, because mise uses two. A tool named through
+ * [tool_alias] installs under the alias verbatim — `red-skills` —
+ * while a bare backend spec is flattened into a directory name:
+ * `npm:@types/semver` becomes `npm-types-semver`. Both were read off a
+ * real mise install rather than derived from its documentation, because
+ * the whole layout below hangs on getting this one string right.
+ */
+export function miseInstallDirName(entry: { spec: string; alias?: string }): string {
+  if (entry.alias) return entry.alias;
+  const colon = entry.spec.indexOf(":");
+  if (colon < 0) return entry.spec;
+  const backend = entry.spec.slice(0, colon);
+  const name = entry.spec.slice(colon + 1).replace(/^@/, "").replace(/[@/]/g, "-");
+  return `${backend}-${name}`;
+}
+
+/** Where mise keeps the installed versions of the core. */
+export function coreInstallsDir(env: NodeJS.ProcessEnv = process.env): string {
+  return join(
+    miseInstallRoot(env),
+    miseInstallDirName({ spec: REDSKILLS_CORE_SPEC, alias: REDSKILLS_CORE_ALIAS }),
+  );
+}
+
+/** The package tree inside one installed version. */
+export function corePayloadDir(installsDir: string, version: string): string {
+  return join(installsDir, version, "node_modules", CORE_PACKAGE);
+}
+
+/** `~/.red-skills/versions/v<version>` — the per-version directory. */
+export function redSkillsVersionDir(home: string, version: string): string {
+  return join(home, ".red-skills", "versions", `v${version}`);
+}
+
+/** `~/.red-skills/current` — the only thing that moves. */
+export function redSkillsCurrentLink(home: string): string {
+  return join(home, ".red-skills", "current");
+}
+
+const EXACT_VERSION = /^(\d+)\.(\d+)\.(\d+)$/;
+
+/**
+ * The newest version mise has installed, or null when it has installed none.
+ *
+ * Exact `x.y.z` directories only. mise writes `latest`, `3` and `3.18`
+ * beside them as symlinks into whichever exact version each selector
+ * resolved to; counting those would make the answer depend on which
+ * selectors this machine happened to ask for, and would name a link
+ * whose target moves under a per-version directory that must not.
+ *
+ * Sorted segment by segment rather than lexically, so 3.10.0 comes
+ * after 3.9.0 — the ordering bug that only shows up two years in.
+ */
+export function installedCoreVersion(installsDir: string): string | null {
+  let names: string[];
+  try {
+    names = readdirSync(installsDir);
+  } catch {
+    return null;
+  }
+
+  const versions = names
+    .map((name) => EXACT_VERSION.exec(name))
+    .filter((m): m is RegExpExecArray => m !== null)
+    .filter((m) => statOf(join(installsDir, m[0]))?.isSymbolicLink() === false)
+    .map((m) => ({
+      name: m[0],
+      parts: [Number(m[1]), Number(m[2]), Number(m[3])] as const,
+    }))
+    .sort((a, b) =>
+      a.parts[0] - b.parts[0] || a.parts[1] - b.parts[1] || a.parts[2] - b.parts[2]
+    );
+
+  return versions.at(-1)?.name ?? null;
+}
+
+/**
+ * The link flavour this platform can create without asking for rights.
+ *
+ * "junction" on Windows and "dir" everywhere else. Node ignores the
+ * type argument on POSIX, so the distinction only ever bites on the one
+ * platform where it matters — and there the wrong answer is not a
+ * cosmetic difference: a "dir" symlink needs
+ * SeCreateSymbolicLinkPrivilege, which an unprivileged account only has
+ * with developer mode on. A junction needs nothing.
+ */
+export function directoryLinkType(
+  platform: NodeJS.Platform = process.platform,
+): "junction" | "dir" {
+  return platform === "win32" ? "junction" : "dir";
+}
+
+export interface RedSkillsLayout {
+  /** The version `current` names once this returns. */
+  version: string;
+  /** `~/.red-skills/versions/v<version>`. */
+  versionDir: string;
+  /** `~/.red-skills/current`. */
+  current: string;
+  /** False when the machine was already in this state. */
+  changed: boolean;
+}
+
+export interface RedSkillsLayoutOptions {
+  /** Defaults to this user's home. Injected by the tests. */
+  home?: string;
+  /** Defaults to mise's installs directory for the core. */
+  installsDir?: string;
+  platform?: NodeJS.Platform;
+  env?: NodeJS.ProcessEnv;
+}
+
+/**
+ * Point the layout at whatever mise has installed.
+ *
+ * Answers null when there is nothing to point at — mise has not
+ * installed the core, or has installed a version whose payload is not
+ * where it should be. Null is "no opinion", never "broken": a machine
+ * that has never had the core is the ordinary state of a fresh install
+ * before the mise entry has run, and it must not travel as a failure.
+ *
+ * Non-destructive by construction. A per-version directory that already
+ * exists is used as it stands, whichever install mode created it, and
+ * only `current` is repointed. That is what lets this and the standalone
+ * one-liner converge the same machine without fighting over the tree:
+ * they agree on the name of the directory, so whoever gets there first
+ * owns its contents and the other one has nothing left to do.
+ */
+export function convergeRedSkillsCoreLayout(
+  opts: RedSkillsLayoutOptions = {},
+): RedSkillsLayout | null {
+  const env = opts.env ?? process.env;
+  const home = opts.home ?? homeOf(env);
+  const installsDir = opts.installsDir ?? coreInstallsDir(env);
+  const platform = opts.platform ?? process.platform;
+
+  const version = installedCoreVersion(installsDir);
+  if (version === null) return null;
+
+  const versionDir = redSkillsVersionDir(home, version);
+  const current = redSkillsCurrentLink(home);
+
+  // Asked before anything is written, and answered by resolving both
+  // ends rather than by reading the link's text. A converge runs often;
+  // recreating a link that already points where it should would churn
+  // the mtime of the one path every consumer stats.
+  if (resolvesTo(current, versionDir)) {
+    return { version, versionDir, current, changed: false };
+  }
+
+  if (!existsSync(versionDir)) {
+    const payload = corePayloadDir(installsDir, version);
+    if (!existsSync(payload)) return null;
+    if (!linkDirectory(payload, versionDir, platform)) return null;
+  }
+
+  if (!linkDirectory(versionDir, current, platform)) return null;
+
+  log.ok(`red-skills core ${version}: current -> ${versionDir}`);
+  return { version, versionDir, current, changed: true };
+}
+
+/**
+ * The layout step that belongs after a mise install.
+ *
+ * Keyed on the spec and silent for every other tool, so the provider in
+ * providers.ts stays a generic one call site wide instead of growing a
+ * table of per-tool afterthoughts.
+ */
+export function convergeCoreAfterMise(
+  spec: string,
+  opts: RedSkillsLayoutOptions = {},
+): RedSkillsLayout | null {
+  if (spec !== REDSKILLS_CORE_SPEC) return null;
+  return convergeRedSkillsCoreLayout(opts);
+}
+
+function homeOf(env: NodeJS.ProcessEnv): string {
+  return (env["HOME"] ?? env["USERPROFILE"] ?? homedir()).replace(/\\/g, "/");
+}
+
+function statOf(path: string): Stats | null {
+  try {
+    return lstatSync(path);
+  } catch {
+    return null;
+  }
+}
+
+/** Do these two paths name the same directory, once every link is followed? */
+function resolvesTo(link: string, target: string): boolean {
+  try {
+    return realpathSync(link) === realpathSync(target);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Replace `path` with a link to `target`, unless a real directory is there.
+ *
+ * A real directory in the way is somebody else's tree — a source
+ * checkout, or the copy Git Bash leaves behind when it emulates a
+ * symlink. Removing it to make room would be this function deleting
+ * data it did not create, so it declines and says so instead. The
+ * machine keeps what it has and the next converge asks again.
+ */
+function linkDirectory(target: string, path: string, platform: NodeJS.Platform): boolean {
+  const existing = statOf(path);
+  if (existing && existing.isDirectory() && !existing.isSymbolicLink()) {
+    log.warn(`red-skills: ${path} is a real directory, not a link — leaving it alone`);
+    return false;
+  }
+
+  mkdirSync(dirname(path), { recursive: true });
+  if (existing) removeLink(path);
+  symlinkSync(target, path, directoryLinkType(platform));
+  return true;
+}
+
+/**
+ * Unlink, and fall back to rmdir.
+ *
+ * A junction is a directory reparse point. Unlinking one is supported,
+ * but the failure if it ever is not would be an EPERM on the single
+ * path this whole module exists to move — cheap enough to catch.
+ */
+function removeLink(path: string): void {
+  try {
+    rmSync(path, { force: true });
+  } catch {
+    rmdirSync(path);
+  }
+}


### PR DESCRIPTION
Automated AFK landing for #186. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #186

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/193"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789515450&installation_model_id=20659&pr_number=193&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F193&signature=6c4a4848c845eada0c3365c074d6d33ac9c5de468388a84b95e9e954e36dbe2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->