### PR TITLE
fix: #187 The plugin set comes from the manifest, opt-out per plugin

### DIFF
--- a/src/agents.ts
+++ b/src/agents.ts
@@ -23,6 +23,7 @@ import {
   unlinkSync,
 } from "node:fs";
 import { log, RedError } from "./log.ts";
+import type { Tool } from "./manifest.ts";
 import { tlsTrustFailure, unattendedEnvironment } from "./unattended.ts";
 import type { Platform } from "./platform.ts";
 
@@ -880,6 +881,28 @@ export async function codexMarketplaceIsGithub(): Promise<boolean | null> {
 }
 
 /**
+ * What a marketplace repair needs from outside itself.
+ *
+ * Both fields have real defaults and exist for the tests: a repair is a
+ * sequence of commands issued to a CLI that may not be installed, and
+ * the thing worth pinning is *which* commands, against *which* declared
+ * plugin set. Injecting the runner is what lets that be asserted without
+ * an agent, a marketplace or a network in the loop.
+ */
+export interface MarketplaceRepair {
+  /** Runs one argv and answers its exit code. Defaults to spawnLogged. */
+  run?: (cmd: string[]) => Promise<number>;
+  /** The manifest to derive the plugin set from. Defaults to TOOLS. */
+  tools?: readonly Tool[];
+}
+
+async function repairRunner(opts: MarketplaceRepair): Promise<(cmd: string[]) => Promise<number>> {
+  if (opts.run) return opts.run;
+  const { spawnLogged } = await import("./providers.ts");
+  return (cmd: string[]) => spawnLogged(cmd);
+}
+
+/**
  * Repoint Claude's marketplace from the frozen directory to GitHub.
  *
  * Remove, re-add by repo, reinstall the plugins — the same five steps
@@ -887,23 +910,32 @@ export async function codexMarketplaceIsGithub(): Promise<boolean | null> {
  * set-source`. The plugins have to be reinstalled: they were installed
  * from a marketplace that no longer exists under that name.
  *
+ * Which plugins is the manifest's answer, not this function's. A machine
+ * that opted `brain` out has no entry for it, so a repair that named it
+ * here would reinstall precisely what the operator removed.
+ *
  * Not destructive in any way that matters. Everything removed here is
  * re-created from the origin in the same run, and the source cache under
  * ~/.red-skills is left alone.
  */
-export async function repointClaudeMarketplace(): Promise<void> {
-  const { spawnLogged } = await import("./providers.ts");
+export async function repointClaudeMarketplace(
+  p: Platform,
+  opts: MarketplaceRepair = {},
+): Promise<void> {
+  const run = await repairRunner(opts);
+  const { redSkillsPluginNames } = await import("./red-skills-plugins.ts");
+
   log.step("red-skills: marketplace points at a local directory — repointing at GitHub");
   log.plain("     A directory source cannot receive updates. Claude re-reads the");
   log.plain("     same snapshot and records a new timestamp, so a stuck machine");
   log.plain("     reports itself as current.");
 
-  await spawnLogged(["claude", "plugin", "marketplace", "remove", "red-skills"]);
-  if ((await spawnLogged(["claude", "plugin", "marketplace", "add", "reddb-io/red-skills"])) !== 0) {
+  await run(["claude", "plugin", "marketplace", "remove", "red-skills"]);
+  if ((await run(["claude", "plugin", "marketplace", "add", "reddb-io/red-skills"])) !== 0) {
     throw new RedError("could not add the red-skills marketplace from GitHub");
   }
-  for (const plugin of ["dev", "memory", "brain"]) {
-    await spawnLogged(["claude", "plugin", "install", `${plugin}@red-skills`]);
+  for (const plugin of redSkillsPluginNames(p, opts.tools)) {
+    await run(["claude", "plugin", "install", `${plugin}@red-skills`]);
   }
   log.ok("red-skills marketplace now tracks reddb-io/red-skills");
 }
@@ -912,23 +944,30 @@ export async function repointClaudeMarketplace(): Promise<void> {
  * Repoint Codex's marketplace from a local snapshot to GitHub.
  *
  * Codex keeps plugin enablement when a marketplace is removed, but the
- * explicit add calls refresh the cache for the three RedSkills plugins
- * that contribute skills, hooks, and MCP servers.
+ * explicit add calls refresh the cache for whichever RedSkills plugins
+ * this machine declares — they are what contribute skills, hooks and MCP
+ * servers, and the set comes from the manifest for the same reason it
+ * does above.
  */
-export async function repointCodexMarketplace(): Promise<void> {
-  const { spawnLogged } = await import("./providers.ts");
+export async function repointCodexMarketplace(
+  p: Platform,
+  opts: MarketplaceRepair = {},
+): Promise<void> {
+  const run = await repairRunner(opts);
+  const { redSkillsPluginNames } = await import("./red-skills-plugins.ts");
+
   log.step("red-skills: Codex marketplace points at a local directory — repointing at GitHub");
   log.plain("     A local Codex marketplace can leave MCP launchers looking");
   log.plain("     for a Git marketplace checkout that does not exist.");
 
-  if ((await spawnLogged(["codex", "plugin", "marketplace", "remove", "red-skills"])) !== 0) {
+  if ((await run(["codex", "plugin", "marketplace", "remove", "red-skills"])) !== 0) {
     throw new RedError("could not remove the local red-skills marketplace from Codex");
   }
-  if ((await spawnLogged(["codex", "plugin", "marketplace", "add", "reddb-io/red-skills"])) !== 0) {
+  if ((await run(["codex", "plugin", "marketplace", "add", "reddb-io/red-skills"])) !== 0) {
     throw new RedError("could not add the red-skills marketplace to Codex from GitHub");
   }
-  for (const plugin of ["dev", "memory", "brain"]) {
-    if ((await spawnLogged(["codex", "plugin", "add", `${plugin}@red-skills`])) !== 0) {
+  for (const plugin of redSkillsPluginNames(p, opts.tools)) {
+    if ((await run(["codex", "plugin", "add", `${plugin}@red-skills`])) !== 0) {
       throw new RedError(`could not install ${plugin}@red-skills into Codex`);
     }
   }
@@ -1006,10 +1045,10 @@ export async function convergeRedSkills(p: Platform): Promise<void> {
   // a local directory is wired and permanently stale, which no amount
   // of reinstalling the same installer will fix.
   if (commandPath("claude") && (await claudeMarketplaceIsGithub()) === false) {
-    await repointClaudeMarketplace();
+    await repointClaudeMarketplace(p);
   }
   if (commandPath("codex") && (await codexMarketplaceIsGithub()) === false) {
-    await repointCodexMarketplace();
+    await repointCodexMarketplace(p);
   }
 
   const missing = await unwiredSkillHosts();

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -1131,6 +1131,47 @@ export const TOOLS: Tool[] = [
     u24: mise("npm:@reddb-io/red-skills", { alias: "red-skills" }),
     win: mise("npm:@reddb-io/red-skills", { alias: "red-skills" }),
   },
+  // The plugins, one row each, and that is the point of them being here.
+  //
+  // They used to be a literal — ["dev", "memory", "brain"] — written out
+  // in two loops in agents.ts, so every machine carried all three
+  // whether or not anybody used them, and a fourth plugin was an edit in
+  // two places that could disagree. A row is the opt-out this product
+  // already has for everything else: delete it and nothing installs, no
+  // entry is projected into the fragment, and the loops that reinstall
+  // plugins after a marketplace repair have nothing to reinstall.
+  //
+  // In dependency order, which the loops preserve: memory declares dev.
+  //
+  // Rows rather than one row with a list, because a list would inherit
+  // nothing. Each of these is a mise entry, so `mise upgrade` advances
+  // it and `mise prune` reclaims the versions it leaves behind, which is
+  // the whole argument for spending an entry per plugin. src/red-skills-
+  // plugins.ts derives the set back out of this.
+  {
+    name: "red-skills-dev",
+    about: "RedSkills dev plugin — engineering skills for coding agents",
+    scope: "core",
+    managed: true,
+    u24: mise("npm:@reddb-io/red-skills-dev", { alias: "red-skills-dev" }),
+    win: mise("npm:@reddb-io/red-skills-dev", { alias: "red-skills-dev" }),
+  },
+  {
+    name: "red-skills-memory",
+    about: "RedSkills memory plugin — governed operational memory, on top of dev",
+    scope: "core",
+    managed: true,
+    u24: mise("npm:@reddb-io/red-skills-memory", { alias: "red-skills-memory" }),
+    win: mise("npm:@reddb-io/red-skills-memory", { alias: "red-skills-memory" }),
+  },
+  {
+    name: "red-skills-brain",
+    about: "RedSkills brain plugin — a project-local knowledge repository",
+    scope: "core",
+    managed: true,
+    u24: mise("npm:@reddb-io/red-skills-brain", { alias: "red-skills-brain" }),
+    win: mise("npm:@reddb-io/red-skills-brain", { alias: "red-skills-brain" }),
+  },
   {
     // After the agents, never before: the installer detects which CLIs
     // exist and wires each one, so running it on a machine with none

--- a/src/red-skills-plugins.test.ts
+++ b/src/red-skills-plugins.test.ts
@@ -1,0 +1,270 @@
+/**
+ * The plugin set, as something the manifest declares rather than a literal.
+ *
+ * `dev`, `memory` and `brain` used to be spelled out in two loops in
+ * agents.ts. That is two costs: a machine that only ever uses one still
+ * carried all three, and adding a fourth meant editing two places that
+ * were free to disagree — the kind of pair that is correct on the day it
+ * is written and wrong within a release.
+ *
+ * So the tests below never name the set they expect from the manifest.
+ * They assert the *relationship*: whatever the manifest declares is what
+ * the fragment projects and what the marketplace repairs install, and a
+ * fixture manifest declaring something else moves both. A test that
+ * repeated the literal would be the third place to keep in step.
+ *
+ * Everything runs against the pure projection and an injected runner, so
+ * it holds with no mise, no network, no agent CLI and no RedSkills on
+ * the machine.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { repointClaudeMarketplace, repointCodexMarketplace } from "./agents.ts";
+import { TOOLS, type Tool } from "./manifest.ts";
+import { convergeMiseConfig, miseConfigPath, miseEntries, miseToolNames } from "./mise-config.ts";
+import type { Platform } from "./platform.ts";
+import { REDSKILLS_CORE_SPEC } from "./red-skills-core.ts";
+import {
+  redSkillsPluginEntries,
+  redSkillsPluginNames,
+  REDSKILLS_PLUGIN_PREFIX,
+} from "./red-skills-plugins.ts";
+
+const UBUNTU: Platform = {
+  os: "linux",
+  distro: "ubuntu",
+  version: "24.04",
+  codename: "noble",
+  env: "desktop",
+  arch: "x64",
+  caps: { apt: true, gui: true, systemd: true, winget: false, flatpak: false },
+};
+
+const WINDOWS: Platform = {
+  ...UBUNTU,
+  os: "windows",
+  distro: null,
+  version: null,
+  codename: null,
+  env: "windows",
+  caps: { apt: false, gui: true, systemd: false, winget: true, flatpak: false },
+};
+
+/** One plugin row, shaped exactly like the ones in the manifest. */
+function pluginRow(name: string): Tool {
+  const provider = {
+    kind: "mise",
+    spec: `${REDSKILLS_PLUGIN_PREFIX}${name}`,
+    alias: `red-skills-${name}`,
+  } as const;
+  return {
+    name: `red-skills-${name}`,
+    scope: "core",
+    managed: true,
+    u24: provider,
+    win: provider,
+  };
+}
+
+/** A manifest declaring these plugins and nothing else. */
+function fixtureManifest(...plugins: string[]): Tool[] {
+  return plugins.map(pluginRow);
+}
+
+/** The plugin set as it stands in the real manifest, derived not typed out. */
+const DECLARED = redSkillsPluginNames(UBUNTU);
+
+/** Collects the argv a repair would have run, and reports success. */
+function recorder(): { calls: string[][]; run: (cmd: string[]) => Promise<number> } {
+  const calls: string[][] = [];
+  return {
+    calls,
+    run: async (cmd: string[]) => {
+      calls.push(cmd);
+      return 0;
+    },
+  };
+}
+
+describe("the plugin set comes from the manifest", () => {
+  test("the manifest declares plugins at all, each as its own npm entry", () => {
+    // The floor under every other test here: a derivation over an empty
+    // manifest passes them all and converges nothing.
+    expect(DECLARED.length).toBeGreaterThan(0);
+    for (const entry of redSkillsPluginEntries(UBUNTU)) {
+      expect(entry.spec.startsWith("npm:")).toBe(true);
+      expect(entry.version).toBe("latest");
+      expect(entry.alias).toBeDefined();
+    }
+  });
+
+  test("the core is a payload, not a plugin", () => {
+    // They share a prefix on npm and nothing else: the core carries the
+    // marketplace manifests every plugin is listed in, so counting it as
+    // one would install it twice and offer it as something to opt out of.
+    expect(redSkillsPluginEntries(UBUNTU).map((e) => e.spec)).not.toContain(REDSKILLS_CORE_SPEC);
+  });
+
+  test("the fragment projects one entry per declared plugin, and none besides", () => {
+    for (const p of [UBUNTU, WINDOWS]) {
+      const specs = miseEntries(p)
+        .map((e) => e.spec)
+        .filter((s) => s.startsWith(REDSKILLS_PLUGIN_PREFIX));
+      expect(specs, `${p.os}`).toEqual(
+        redSkillsPluginNames(p).map((n) => `${REDSKILLS_PLUGIN_PREFIX}${n}`),
+      );
+    }
+  });
+
+  test("a plugin the manifest does not declare gets no entry", () => {
+    // `internal` is published beside the three that ship — maintainer-only
+    // skills for operating the red-skills repository. Nothing declares it
+    // here, so nothing should install it.
+    expect(DECLARED).not.toContain("internal");
+    const rendered = miseEntries(UBUNTU).map((e) => e.spec);
+    expect(rendered).not.toContain(`${REDSKILLS_PLUGIN_PREFIX}internal`);
+  });
+
+  test("entries inherit `mise upgrade`, which is what being an entry buys", () => {
+    // Bare `mise upgrade` would reach the user's own runtimes, so the
+    // suite is upgraded by name. A plugin missing from that list is
+    // declared and never advanced — the frozen-forever shape again.
+    const names = miseToolNames(UBUNTU);
+    for (const entry of redSkillsPluginEntries(UBUNTU)) {
+      expect(names).toContain(entry.alias ?? entry.spec);
+    }
+  });
+});
+
+describe("the set is derived, not written down", () => {
+  test("a fixture manifest with a different set produces a different projection", () => {
+    const fixture = fixtureManifest("dev", "sparkle");
+    expect(redSkillsPluginNames(UBUNTU, fixture)).toEqual(["dev", "sparkle"]);
+    expect(miseEntries(UBUNTU, fixture).map((e) => e.spec)).toEqual([
+      `${REDSKILLS_PLUGIN_PREFIX}dev`,
+      `${REDSKILLS_PLUGIN_PREFIX}sparkle`,
+    ]);
+  });
+
+  test("no hard-coded plugin list is left in the loops that install them", () => {
+    // The literal this slice exists to remove. Asserted against the
+    // source because the absence of a list is not observable any other
+    // way: a second copy would agree with the manifest on the day it was
+    // written and drift from it silently afterwards.
+    const src = readFileSync(`${import.meta.dir}/agents.ts`, "utf8");
+    expect(src).not.toContain(`["dev", "memory", "brain"]`);
+    expect(src).toContain("redSkillsPluginNames");
+  });
+});
+
+/** The `<plugin>@red-skills` arguments a repair asked a host to install. */
+function installedBy(calls: string[][]): string[] {
+  return calls
+    .map((cmd) => cmd.find((arg) => arg.endsWith("@red-skills")))
+    .filter((arg): arg is string => arg !== undefined)
+    .map((arg) => arg.replace("@red-skills", ""));
+}
+
+async function claudeCalls(tools: readonly Tool[]): Promise<string[][]> {
+  const { calls, run } = recorder();
+  await repointClaudeMarketplace(UBUNTU, { run, tools });
+  return calls;
+}
+
+async function codexCalls(tools: readonly Tool[]): Promise<string[][]> {
+  const { calls, run } = recorder();
+  await repointCodexMarketplace(UBUNTU, { run, tools });
+  return calls;
+}
+
+describe("the loops that reinstall plugins after a repair", () => {
+  test("Claude installs one plugin per manifest entry, in manifest order", async () => {
+    // Order included: the manifest is where the dependency order between
+    // plugins is expressed — memory builds on dev — so a repair that
+    // installs them in some other order is one that can fail on a clean
+    // host for a reason nothing on screen explains.
+    expect(installedBy(await claudeCalls(TOOLS))).toEqual(DECLARED);
+  });
+
+  test("Codex installs the same set from the same source", async () => {
+    expect(installedBy(await codexCalls(TOOLS))).toEqual(DECLARED);
+  });
+
+  test("a fixture manifest moves both loops with it", async () => {
+    const fixture = fixtureManifest("dev", "sparkle");
+    expect(installedBy(await claudeCalls(fixture))).toEqual(["dev", "sparkle"]);
+    expect(installedBy(await codexCalls(fixture))).toEqual(["dev", "sparkle"]);
+  });
+
+  test("opting a plugin out installs nothing for it", async () => {
+    const kept = DECLARED[0] as string;
+    const dropped = DECLARED.filter((n) => n !== kept);
+    expect(dropped.length).toBeGreaterThan(0);
+
+    const fixture = fixtureManifest(kept);
+    for (const calls of [await claudeCalls(fixture), await codexCalls(fixture)]) {
+      expect(installedBy(calls)).toEqual([kept]);
+      for (const name of dropped) {
+        expect(calls.flat().join(" ")).not.toContain(`${name}@red-skills`);
+      }
+    }
+  });
+
+  test("the marketplace itself is still repaired, whatever the plugin set is", async () => {
+    // The plugins are the second half of the repair. Deriving their set
+    // must not quietly drop the first half, which is the re-registration
+    // the whole function exists for.
+    const calls = await claudeCalls([]);
+    expect(calls.map((cmd) => cmd.join(" "))).toEqual([
+      "claude plugin marketplace remove red-skills",
+      "claude plugin marketplace add reddb-io/red-skills",
+    ]);
+  });
+});
+
+describe("opting a plugin out", () => {
+  test("removes its entry from the fragment", () => {
+    const kept = DECLARED[0] as string;
+    const fixture = fixtureManifest(kept);
+    const specs = miseEntries(UBUNTU, fixture).map((e) => e.spec);
+    expect(specs).toEqual([`${REDSKILLS_PLUGIN_PREFIX}${kept}`]);
+    for (const name of DECLARED.filter((n) => n !== kept)) {
+      expect(specs).not.toContain(`${REDSKILLS_PLUGIN_PREFIX}${name}`);
+    }
+  });
+
+  test("and a converge after it stops declaring it, so nothing reinstalls it", () => {
+    // The failure this pins is the sticky one: the fragment is written
+    // once and left alone, so an opted-out plugin keeps being installed
+    // by `mise install` from a file nobody rewrote.
+    const home = mkdtempSync(join(tmpdir(), "red-plugins-home-"));
+    const all = fixtureManifest(...DECLARED);
+    const dropped = DECLARED[DECLARED.length - 1] as string;
+    const kept = DECLARED.filter((n) => n !== dropped);
+
+    const first = convergeMiseConfig(UBUNTU, { home, tools: all });
+    expect(first.changed).toBe(true);
+    expect(readFileSync(miseConfigPath(home), "utf8")).toContain(
+      `${REDSKILLS_PLUGIN_PREFIX}${dropped}`,
+    );
+
+    const second = convergeMiseConfig(UBUNTU, { home, tools: fixtureManifest(...kept) });
+    expect(second.changed).toBe(true);
+    const fragment = readFileSync(miseConfigPath(home), "utf8");
+    expect(fragment).not.toContain(`${REDSKILLS_PLUGIN_PREFIX}${dropped}`);
+    for (const name of kept) {
+      expect(fragment).toContain(`${REDSKILLS_PLUGIN_PREFIX}${name}`);
+    }
+  });
+
+  test("a converge that changes nothing rewrites nothing", () => {
+    const home = mkdtempSync(join(tmpdir(), "red-plugins-home-"));
+    const tools = fixtureManifest(...DECLARED);
+    expect(convergeMiseConfig(UBUNTU, { home, tools }).changed).toBe(true);
+    expect(convergeMiseConfig(UBUNTU, { home, tools }).changed).toBe(false);
+  });
+});

--- a/src/red-skills-plugins.ts
+++ b/src/red-skills-plugins.ts
@@ -1,0 +1,71 @@
+/**
+ * Which RedSkills plugins this machine carries, derived from the manifest.
+ *
+ * `dev`, `memory` and `brain` used to be a literal, written out twice —
+ * once in the Claude marketplace repair and once in the Codex one. Two
+ * costs came with that. A machine that only ever uses `dev` still
+ * installed all three, because an unconditional list is not a choice
+ * anybody made. And adding a fourth plugin meant editing two places that
+ * were free to disagree: the pair was correct the day it was written and
+ * had no way of staying that way.
+ *
+ * So a plugin becomes a manifest entry like every other optional item.
+ * The manifest is already where "what this machine has" is declared, and
+ * an entry inherits `mise upgrade` and `mise prune` for free — which is
+ * the whole reason to spend the entry rather than invent a plugin list
+ * of our own. Opting one out is deleting its row: no entry, no mise
+ * install, and nothing for the repairs to reinstall.
+ *
+ * ## Derived from the projection, not from the rows
+ *
+ * The set comes out of `miseEntries`, the same pure function that
+ * renders the fragment, rather than out of TOOLS directly. That is what
+ * makes "the fragment and the loops agree" true by construction instead
+ * of by inspection: there is one filter, over one list, and a plugin a
+ * platform declines through a `skip` column disappears from both at once.
+ *
+ * ## The short name is the package name
+ *
+ * A plugin is published as `@reddb-io/red-skills-<name>`, and the hosts
+ * install it as `<name>@red-skills`. The two spellings are one fact, so
+ * the short name is read off the spec rather than declared a second time
+ * beside it — a `name: "dev"` field on the row would be one more pair
+ * that can disagree, which is the thing this file exists to remove.
+ *
+ * The core (`npm:@reddb-io/red-skills`, no suffix) is deliberately not
+ * matched: it carries the marketplace manifests the plugins are listed
+ * in, so counting it as a plugin would install it twice and offer the
+ * payload itself as something to opt out of.
+ */
+
+import { TOOLS, type Tool } from "./manifest.ts";
+import { miseEntries, type MiseEntry } from "./mise-config.ts";
+import type { Platform } from "./platform.ts";
+
+/**
+ * The spec every plugin package shares, and the core does not.
+ *
+ * The trailing hyphen is load-bearing: without it this matches
+ * `npm:@reddb-io/red-skills` too.
+ */
+export const REDSKILLS_PLUGIN_PREFIX = "npm:@reddb-io/red-skills-";
+
+/** The plugin entries this platform's manifest projects, in manifest order. */
+export function redSkillsPluginEntries(
+  p: Platform,
+  tools: readonly Tool[] = TOOLS,
+): MiseEntry[] {
+  return miseEntries(p, tools).filter((e) => e.spec.startsWith(REDSKILLS_PLUGIN_PREFIX));
+}
+
+/**
+ * The names the agent hosts know them by: `dev`, `memory`, `brain`.
+ *
+ * Manifest order is preserved, because it is the order the plugins have
+ * to be installed in — `memory` declares `dev` as a dependency, and a
+ * host asked for the dependent first is a host that can fail on a clean
+ * machine for a reason nothing on screen explains.
+ */
+export function redSkillsPluginNames(p: Platform, tools: readonly Tool[] = TOOLS): string[] {
+  return redSkillsPluginEntries(p, tools).map((e) => e.spec.slice(REDSKILLS_PLUGIN_PREFIX.length));
+}

--- a/src/red-skills.test.ts
+++ b/src/red-skills.test.ts
@@ -268,19 +268,21 @@ describe("a marketplace that reports updates it cannot receive", () => {
   test("the repair reinstalls the plugins it removed", () => {
     // They came from a marketplace that no longer exists under that
     // name, so re-adding the source is not enough on its own.
+    //
+    // Which plugins is no longer written here: the set is the manifest's,
+    // and src/red-skills-plugins.test.ts asserts the commands a repair
+    // actually issues against it. What is left to pin at this level is
+    // that the reinstall step still exists at all.
     const repair = src.slice(src.indexOf("export async function repointClaudeMarketplace"));
-    for (const plugin of ["dev", "memory", "brain"]) {
-      expect(repair).toContain(plugin);
-    }
+    expect(repair).toContain("redSkillsPluginNames");
+    expect(repair).toContain("@red-skills");
   });
 
   test("the Codex repair refreshes the plugins that provide MCPs", () => {
     const repair = src.slice(src.indexOf("export async function repointCodexMarketplace"));
     expect(repair).toContain("plugin");
     expect(repair).toContain("marketplace");
-    for (const plugin of ["dev", "memory", "brain"]) {
-      expect(repair).toContain(plugin);
-    }
+    expect(repair).toContain("redSkillsPluginNames");
   });
 
   test("castle has the repo-local fallback Codex already searches", () => {


### PR DESCRIPTION
Automated AFK landing for #187. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #187

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/194"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789516494&installation_model_id=20659&pr_number=194&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F194&signature=805097af1b1adcdcb664a6211e55bce18c3c5e437bfa9e7162f1c3cbec777e19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->