### PR TITLE
fix: #188 Retention: mise prune at the end of update, and the one-time legacy cleanup

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -785,6 +785,17 @@ async function cmdUpdate(p: Platform, inv: Invocation): Promise<number> {
     // Upgrading can leave the manifest unsatisfied (a package removed, a
     // binary replaced), so always re-converge afterwards.
     converge: () => cmdInstall(p, inv, "update"),
+
+    // And then the versions nobody points at any more, which nothing on
+    // this machine collected before. Last, after the converge has
+    // installed whatever the upgrade left unsatisfied: mise prunes what
+    // no config names, and a prune before the converge would be reading
+    // a config that is not final yet.
+    prune: async () => {
+      if (inv.dryRun) return;
+      const { misePruneSuite } = await import("./providers.ts");
+      await misePruneSuite(p);
+    },
   };
 
   const run = await runUpdate(

--- a/src/migrations.ts
+++ b/src/migrations.ts
@@ -352,6 +352,57 @@ return {}
       }
     },
   },
+  {
+    id: "2026-08-16-red-skills-legacy-retention",
+    describe: "clear the RedSkills state the old install mode left behind",
+    /**
+     * The second half of handing RedSkills to mise, and the half mise
+     * cannot do.
+     *
+     * `mise prune` now runs at the end of every update, and it collects
+     * the versions it installed. What it will never look at is the
+     * shape the curled installer produced — extracted trees under
+     * ~/.red-skills/versions, the tarballs they were unpacked from, and
+     * the copy each agent host kept of every plugin version it has ever
+     * carried. Measured on one developer machine: about 1.16 GB, none
+     * of it collected by anything, because the only thing that could
+     * have was the same install script.
+     *
+     * This removes, which the rule at the top of this file says a
+     * migration must not — the same exception the release-binary
+     * handover above pays for, and drawn as narrowly. Everything it
+     * takes is derived: a published artifact extracted a second time, a
+     * tarball already unpacked, a plugin copy the host rebuilds on
+     * demand. What anything resolves through is protected by name in
+     * red-skills-retention.ts rather than by not being reached, and the
+     * plan is empty on a machine that has nothing left over — which is
+     * what makes a second run a no-op instead of a second deletion.
+     */
+    applies: async (p) => {
+      void p;
+      const { planLegacyRedSkillsCleanup } = await import("./red-skills-retention.ts");
+      return planLegacyRedSkillsCleanup().length > 0;
+    },
+    run: async (p) => {
+      void p;
+      const { clearLegacyRedSkills } = await import("./red-skills-retention.ts");
+      const { formatBytes } = await import("./reclaim.ts");
+
+      const { removed, bytes } = clearLegacyRedSkills();
+      if (removed.length === 0) {
+        log.skip("nothing left behind — mise owns every version on this machine");
+        return;
+      }
+
+      // Named one by one, and then totalled. A deletion that reports
+      // only a number is one nobody can check afterwards, and this is
+      // the single migration in the ledger that takes a gigabyte.
+      for (const item of removed) {
+        log.plain(`       removed ${item.path} (${formatBytes(item.bytes)})`);
+      }
+      log.plain(`       ${removed.length} left over, ${formatBytes(bytes)} back`);
+    },
+  },
 ];
 
 /**

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -719,6 +719,46 @@ export async function miseUpgradeSuite(platform: Platform): Promise<void> {
 }
 
 /**
+ * The argv that collects the versions nothing points at any more.
+ *
+ * Split out from the call below so the one thing that can be wrong here
+ * is testable on a machine with no mise: which tools it is allowed to
+ * reach. Named tool by tool for the same reason the upgrade above is —
+ * bare, mise prunes every unused version in the active config, and the
+ * user's old Node is not ours to collect. `--tools` keeps it off their
+ * tracked configuration links too, which are not versions at all.
+ */
+export function misePruneCommand(mise: string, names: string[]): string[] {
+  return [mise, "prune", "--tools", ...names];
+}
+
+/**
+ * Retire the versions the upgrade left behind.
+ *
+ * The policy is mise's, deliberately: it already knows which versions
+ * no config still names, and a keep-N of our own would be
+ * reimplementing the half of the tool we adopted it for. Nothing on
+ * this machine pruned anything before this existed — measured at about
+ * a gigabyte of RedSkills alone, one install at a time.
+ *
+ * A failure is a warning. This is the last thing an update does and the
+ * least important of them: a machine that could not collect its old
+ * versions is still a machine that updated.
+ */
+export async function misePruneSuite(platform: Platform): Promise<void> {
+  const mise = Bun.which("mise");
+  if (!mise) return;
+
+  const { miseToolNames } = await import("./mise-config.ts");
+  const names = miseToolNames(platform);
+  if (names.length === 0) return;
+
+  log.step(`mise: pruning unused versions of ${names.length} tools`);
+  const code = await runMise(misePruneCommand(mise, names));
+  if (code !== 0) log.warn(`mise prune exited ${code}`);
+}
+
+/**
  * Move ~/.red-skills/current onto whatever mise has just installed.
  *
  * Here rather than inside the mise calls above because both of them

--- a/src/red-skills-retention.test.ts
+++ b/src/red-skills-retention.test.ts
@@ -1,0 +1,355 @@
+/**
+ * Retention: the prune that runs forever, and the cleanup that runs once.
+ *
+ * Both halves are about deleting, so every test below is written from
+ * the other side of that: what survives. A retention pass that reclaims
+ * a gigabyte and takes the tree the machine resolves through has not
+ * saved anybody anything.
+ *
+ * The cleanup runs against a fabricated home — versions, tarballs and
+ * two hosts' plugin caches, shaped like the ones measured on a real
+ * machine — so it holds with no RedSkills, no mise and no agent host
+ * installed. The prune is pinned as the command it issues and the place
+ * in the update it issues it from, because there is no mise here to run
+ * it against.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { captureTo } from "./log.ts";
+import { MIGRATIONS } from "./migrations.ts";
+import { misePruneCommand } from "./providers.ts";
+import {
+  clearLegacyRedSkills,
+  planLegacyRedSkillsCleanup,
+  type LegacyItem,
+} from "./red-skills-retention.ts";
+import { runUpdate, updateStageOrder } from "./update-order.ts";
+
+/** A file of a known size, so the report has something to add up. */
+function fileOf(path: string, bytes: number): void {
+  mkdirSync(join(path, ".."), { recursive: true });
+  writeFileSync(path, "x".repeat(bytes));
+}
+
+function versionTree(home: string, version: string): string {
+  const dir = join(home, ".red-skills", "versions", `v${version}`);
+  fileOf(join(dir, "package.json"), 64);
+  fileOf(join(dir, "src", "index.ts"), 512);
+  return dir;
+}
+
+function pluginCopy(home: string, host: string, plugin: string, version: string): string {
+  const dir = join(home, `.${host}`, "plugins", "cache", "red-skills", plugin, version);
+  fileOf(join(dir, "plugin.json"), 128);
+  return dir;
+}
+
+function claudeRecords(home: string, paths: string[]): void {
+  const path = join(home, ".claude", "plugins", "installed_plugins.json");
+  mkdirSync(join(path, ".."), { recursive: true });
+  writeFileSync(
+    path,
+    JSON.stringify({
+      version: 2,
+      plugins: Object.fromEntries(
+        paths.map((installPath, i) => [`p${i}@red-skills`, [{ scope: "user", installPath }]]),
+      ),
+    }),
+  );
+}
+
+/**
+ * The machine this whole slice was measured on, in miniature.
+ *
+ * Fourteen extracted trees became three, and twenty-five plugin copies
+ * became four, but every shape that decides an outcome is here: a
+ * `current` link, an older tree beside it, a retained tarball, two
+ * hosts, and a copy one of them still records as installed.
+ */
+function legacyHome(): { home: string; current: string; superseded: string } {
+  const home = mkdtempSync(join(tmpdir(), "red-retention-"));
+
+  const superseded = versionTree(home, "3.17.1");
+  versionTree(home, "3.0.4");
+  const current = versionTree(home, "3.18.12");
+  symlinkSync(current, join(home, ".red-skills", "current"), "dir");
+
+  fileOf(join(home, ".red-skills", "cache", "v3.17.1.tar.gz"), 4096);
+  fileOf(join(home, ".red-skills", "cache", "v3.18.12.tar.gz"), 4096);
+
+  pluginCopy(home, "claude", "dev", "3.0.4");
+  const pinned = pluginCopy(home, "claude", "dev", "3.17.1");
+  pluginCopy(home, "claude", "dev", "3.18.12");
+  claudeRecords(home, [pinned]);
+
+  pluginCopy(home, "codex", "dev", "3.17.1");
+  pluginCopy(home, "codex", "dev", "3.18.12");
+
+  return { home, current, superseded };
+}
+
+function paths(items: LegacyItem[]): string[] {
+  return items.map((item) => item.path).sort();
+}
+
+describe("the one-time cleanup", () => {
+  test("removes the trees, the tarballs and the superseded plugin copies", () => {
+    const { home, superseded } = legacyHome();
+
+    const { removed, bytes } = clearLegacyRedSkills({ home });
+
+    expect(paths(removed)).toEqual(
+      [
+        join(home, ".claude", "plugins", "cache", "red-skills", "dev", "3.0.4"),
+        join(home, ".codex", "plugins", "cache", "red-skills", "dev", "3.17.1"),
+        join(home, ".red-skills", "cache", "v3.17.1.tar.gz"),
+        join(home, ".red-skills", "cache", "v3.18.12.tar.gz"),
+        join(home, ".red-skills", "versions", "v3.0.4"),
+        superseded,
+      ].sort(),
+    );
+    for (const item of removed) expect(existsSync(item.path)).toBe(false);
+
+    // What was reclaimed, which is the only number anybody reads: two
+    // trees at 576 bytes, two tarballs at 4096 and two plugin copies at
+    // 128. A report that names paths and not sizes cannot answer the
+    // question this slice exists for.
+    expect(bytes).toBe(2 * 576 + 2 * 4096 + 2 * 128);
+    expect(removed.map((item) => item.kind).sort()).toEqual([
+      "plugin-copy",
+      "plugin-copy",
+      "tarball",
+      "tarball",
+      "version-tree",
+      "version-tree",
+    ]);
+  });
+
+  test("a second run removes nothing further and still succeeds", () => {
+    const { home } = legacyHome();
+    clearLegacyRedSkills({ home });
+
+    const again = clearLegacyRedSkills({ home });
+
+    expect(again.removed).toEqual([]);
+    expect(again.bytes).toBe(0);
+    expect(planLegacyRedSkillsCleanup({ home })).toEqual([]);
+  });
+
+  test("a machine that never had the old install mode has nothing to clear", () => {
+    const home = mkdtempSync(join(tmpdir(), "red-retention-fresh-"));
+    expect(planLegacyRedSkillsCleanup({ home })).toEqual([]);
+    expect(clearLegacyRedSkills({ home }).removed).toEqual([]);
+  });
+});
+
+describe("what the cleanup must never take", () => {
+  test("the version current resolves to, and the link itself", () => {
+    const { home, current } = legacyHome();
+
+    clearLegacyRedSkills({ home });
+
+    expect(existsSync(current)).toBe(true);
+    expect(existsSync(join(current, "package.json"))).toBe(true);
+    expect(existsSync(join(home, ".red-skills", "current"))).toBe(true);
+  });
+
+  test("a copy a host still records as installed, or the newest it holds", () => {
+    const { home } = legacyHome();
+
+    clearLegacyRedSkills({ home });
+
+    const claude = join(home, ".claude", "plugins", "cache", "red-skills", "dev");
+    // Recorded as installed, and older than one it also has: the host
+    // is resolving through it, which makes it the plugin rather than a
+    // leftover copy of it.
+    expect(existsSync(join(claude, "3.17.1"))).toBe(true);
+    expect(existsSync(join(claude, "3.18.12"))).toBe(true);
+    expect(existsSync(join(home, ".codex", "plugins", "cache", "red-skills", "dev", "3.18.12")))
+      .toBe(true);
+  });
+
+  test("a version directory that is a link into mise's installs", () => {
+    // The layout red-skills-core.ts maintains. It costs nothing, and
+    // what it points at is mise's to prune — deleting through it would
+    // take an install mise still believes it has.
+    const home = mkdtempSync(join(tmpdir(), "red-retention-linked-"));
+    const installs = mkdtempSync(join(tmpdir(), "red-retention-installs-"));
+    fileOf(join(installs, "3.17.1", "package.json"), 64);
+    const linked = join(home, ".red-skills", "versions", "v3.17.1");
+    mkdirSync(join(home, ".red-skills", "versions"), { recursive: true });
+    symlinkSync(join(installs, "3.17.1"), linked, "dir");
+    const current = versionTree(home, "3.18.12");
+    symlinkSync(current, join(home, ".red-skills", "current"), "dir");
+
+    expect(planLegacyRedSkillsCleanup({ home })).toEqual([]);
+    expect(existsSync(linked)).toBe(true);
+    expect(existsSync(join(installs, "3.17.1", "package.json"))).toBe(true);
+  });
+
+  test("every tree, when current does not resolve to one", () => {
+    // Nothing is protected on a machine whose link is dangling or
+    // absent, and a prune with nothing protected is one that takes the
+    // tree the next converge is about to point at.
+    const home = mkdtempSync(join(tmpdir(), "red-retention-dangling-"));
+    const tree = versionTree(home, "3.17.1");
+    symlinkSync(join(home, ".red-skills", "versions", "v9.9.9"), join(home, ".red-skills", "current"), "dir");
+
+    expect(planLegacyRedSkillsCleanup({ home }).filter((i) => i.kind === "version-tree")).toEqual([]);
+    expect(existsSync(tree)).toBe(true);
+  });
+
+  test("a host whose record of what it installed cannot be read", () => {
+    // An unparseable record is not evidence that nothing is installed.
+    // The other host is unaffected: refusing one is not refusing all.
+    const { home } = legacyHome();
+    writeFileSync(join(home, ".claude", "plugins", "installed_plugins.json"), "{ not json");
+
+    const plan = planLegacyRedSkillsCleanup({ home });
+
+    expect(plan.filter((i) => i.path.includes(".claude"))).toEqual([]);
+    expect(paths(plan.filter((i) => i.path.includes(".codex")))).toEqual([
+      join(home, ".codex", "plugins", "cache", "red-skills", "dev", "3.17.1"),
+    ]);
+  });
+
+  test("a directory under a plugin whose name is not a version", () => {
+    // Put there by something this module does not understand, which is
+    // the whole reason not to delete it.
+    const home = mkdtempSync(join(tmpdir(), "red-retention-odd-"));
+    pluginCopy(home, "claude", "dev", "3.18.12");
+    const odd = pluginCopy(home, "claude", "dev", "staging-2841cf97");
+
+    expect(planLegacyRedSkillsCleanup({ home })).toEqual([]);
+    expect(existsSync(odd)).toBe(true);
+  });
+});
+
+describe("the migration that runs it", () => {
+  const migration = MIGRATIONS.find((m) => m.id === "2026-08-16-red-skills-legacy-retention");
+
+  /** Run `fn` with HOME pointed at a fabricated machine. */
+  async function withHome<T>(home: string, fn: () => Promise<T> | T): Promise<T> {
+    const saved = process.env["HOME"];
+    const savedProfile = process.env["USERPROFILE"];
+    process.env["HOME"] = home;
+    delete process.env["USERPROFILE"];
+    try {
+      return await fn();
+    } finally {
+      if (saved === undefined) delete process.env["HOME"];
+      else process.env["HOME"] = saved;
+      if (savedProfile !== undefined) process.env["USERPROFILE"] = savedProfile;
+    }
+  }
+
+  test("is in the ledger, so it runs once and is recorded", () => {
+    expect(migration).toBeDefined();
+    expect(migration!.describe).toContain("RedSkills");
+  });
+
+  test("applies to a machine carrying the old install mode, and clears it", async () => {
+    const { home, current, superseded } = legacyHome();
+    const lines: string[] = [];
+
+    await withHome(home, async () => {
+      expect(await migration!.applies({} as never)).toBe(true);
+      const release = captureTo((line) => lines.push(line));
+      try {
+        await migration!.run({} as never);
+      } finally {
+        release();
+      }
+      // The ledger is a promise rather than a guarantee, so the second
+      // run is asked the same question the first was.
+      expect(await migration!.applies({} as never)).toBe(false);
+    });
+
+    expect(existsSync(superseded)).toBe(false);
+    expect(existsSync(current)).toBe(true);
+    // What it took, path by path, and then the one line with the number
+    // this whole slice exists for.
+    expect(lines.filter((line) => line.includes(superseded))).toHaveLength(1);
+    expect(lines.at(-1)).toContain("6 left over");
+    expect(lines.at(-1)).toContain("back");
+  });
+
+  test("a second run removes nothing further and reports success", async () => {
+    const { home } = legacyHome();
+    const lines: string[] = [];
+
+    await withHome(home, async () => {
+      const release = captureTo((line) => lines.push(line));
+      try {
+        await migration!.run({} as never);
+        lines.length = 0;
+        // Run rather than skipped through `applies`: a ledger entry can
+        // be lost with a preferences file, and the migration has to be
+        // safe to run again on its own terms.
+        await migration!.run({} as never);
+      } finally {
+        release();
+      }
+    });
+
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain("mise owns every version");
+  });
+
+  test("does not apply to a machine with nothing left behind", async () => {
+    const home = mkdtempSync(join(tmpdir(), "red-retention-clean-"));
+    await withHome(home, async () => {
+      expect(await migration!.applies({} as never)).toBe(false);
+    });
+  });
+});
+
+describe("the prune that retires versions from here on", () => {
+  test("is mise's own, over the tools this repo declares", () => {
+    // Bare `mise prune` would reach the user's own runtimes, for the
+    // same reason `mise upgrade` is named tool by tool: their unused
+    // Node versions are not ours to collect. `--tools` keeps it off
+    // their tracked config links as well.
+    const argv = misePruneCommand("/usr/bin/mise", ["red", "tq", "red-skills"]);
+    expect(argv).toEqual(["/usr/bin/mise", "prune", "--tools", "red", "tq", "red-skills"]);
+  });
+
+  test("runs at the end of the update, after the tools are upgraded", () => {
+    const order = updateStageOrder();
+    expect(order.at(-1)).toBe("prune");
+    expect(order.indexOf("suite")).toBeLessThan(order.indexOf("prune"));
+    expect(order.indexOf("converge")).toBeLessThan(order.indexOf("prune"));
+  });
+
+  test("is the command the update's last stage issues", () => {
+    // Read off main.ts rather than run, because running it needs a mise
+    // and a machine with versions to collect. What can regress here is
+    // the wiring: a stage declared in the order and left doing nothing
+    // is retention that reports success and prunes nothing.
+    const main = readFileSync(`${import.meta.dir}/main.ts`, "utf8");
+    const stage = main.slice(main.indexOf("    prune: async ()"));
+    expect(stage.slice(0, stage.indexOf("},"))).toContain("misePruneSuite(p)");
+  });
+
+  test("a prune that fails does not fail the update", async () => {
+    // It is the last thing an update does and the least important: a
+    // machine that could not collect its old versions is still a
+    // machine that updated. The answer stays the converge's.
+    const failures: string[] = [];
+    const run = await runUpdate(
+      async (stage) => {
+        if (stage === "prune") throw new Error("mise prune exited 1");
+        return stage === "converge" ? 0 : undefined;
+      },
+      (stage, message, fatal) => failures.push(`${stage}${fatal ? "!" : ""}: ${message}`),
+    );
+
+    expect(run.code).toBe(0);
+    expect(run.ran.at(-1)).toBe("prune");
+    expect(failures).toEqual(["prune: mise prune exited 1"]);
+  });
+});

--- a/src/red-skills-retention.ts
+++ b/src/red-skills-retention.ts
@@ -1,0 +1,330 @@
+/**
+ * Retention for RedSkills: what mise prunes, and what nothing prunes.
+ *
+ * Nothing on this machine ever removed a RedSkills version. Measured on
+ * one developer host before this file existed: 1003 MB of extracted
+ * trees under ~/.red-skills/versions, 93 MB of retained tarballs under
+ * ~/.red-skills/cache and 69 MB of per-version plugin copies inside the
+ * agent hosts — about 1.16 GB, all of it accumulated one install at a
+ * time by something that only ever added.
+ *
+ * From here the versions are mise's, and so is the policy that retires
+ * them: `mise prune` at the end of an update deletes the versions no
+ * config still names. Writing a keep-N of our own would be
+ * reimplementing the half of the tool we adopted it for.
+ *
+ * What mise cannot collect is everything above — a shape it never
+ * created and therefore will never look at. That is what this module
+ * removes, once, and it is the reason the two halves are separate
+ * rather than one pass: pruning is a policy that runs forever, and this
+ * is a migration that runs on a machine carrying the old install mode's
+ * leftovers and then has nothing left to do.
+ *
+ * ## The line this draws
+ *
+ * migrations.ts says a migration may repair and must not remove, and
+ * the exception here is drawn as narrowly as the one the release-binary
+ * handover already pays for: everything below is *derived* state — a
+ * published artifact extracted a second time, a tarball already
+ * unpacked, a plugin copy the host rebuilds on demand — and the tree
+ * anything resolves through is protected explicitly rather than by
+ * being missed.
+ *
+ * Three protections carry that:
+ *
+ *  - `~/.red-skills/current` is resolved first, and the version it
+ *    names is never a candidate. If it does not resolve at all, the
+ *    version trees are left alone entirely: a prune with nothing
+ *    protected is one that would take the tree the machine is about to
+ *    use.
+ *  - A version directory that is a link is left alone. Those are the
+ *    new layout's links into mise's installs; they cost nothing, and
+ *    what they point at is mise's to prune, not ours to delete through.
+ *  - A host's plugin copy is removed only when the host has a newer one
+ *    and does not record this one as installed. A copy a host still
+ *    resolves through is not derived state, it is the plugin.
+ */
+
+import {
+  existsSync,
+  lstatSync,
+  readdirSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/** What kind of leftover this is, so the report can group them. */
+export type LegacyKind = "version-tree" | "tarball" | "plugin-copy";
+
+export interface LegacyItem {
+  path: string;
+  kind: LegacyKind;
+  /** What removing it gives back, which is the whole point of removing it. */
+  bytes: number;
+}
+
+export interface LegacyCleanupOptions {
+  /** Defaults to this user's home. Injected by the tests. */
+  home?: string;
+  env?: NodeJS.ProcessEnv;
+}
+
+/**
+ * A host that keeps its own copy of each plugin version.
+ *
+ * The Spec is explicit that this work removes RedSkills' duplication
+ * rather than the host's: a host caches a plugin per version whatever
+ * the marketplace source is, and that is its business. What is
+ * collected here is the *history* — the versions it kept after moving
+ * on — which no host ever revisits and none of them delete.
+ */
+interface HostPluginCache {
+  /** `<host>/plugins/cache`, under which each marketplace has a directory. */
+  cache: string;
+  /**
+   * The copies this host records as installed, or null when it has a
+   * record this module could not read. Null refuses the host outright:
+   * an unreadable record is not evidence that nothing is installed.
+   */
+  installed: () => Set<string> | null;
+}
+
+/** The marketplace name both hosts file RedSkills plugins under. */
+const MARKETPLACE = "red-skills";
+
+const EXACT_VERSION = /^(\d+)\.(\d+)\.(\d+)$/;
+
+export function hostPluginCaches(home: string): HostPluginCache[] {
+  return [
+    {
+      cache: join(home, ".claude", "plugins", "cache"),
+      installed: () => claudeInstalledPaths(home),
+    },
+    // Codex records that a plugin is enabled in config.toml and not
+    // where it put it, so there is nothing to read back. It keeps one
+    // version per plugin in practice, and the newest-version protection
+    // below is what covers it.
+    { cache: join(home, ".codex", "plugins", "cache"), installed: () => new Set<string>() },
+  ];
+}
+
+/**
+ * Everything the old install mode left behind, and nothing else.
+ *
+ * A plan rather than a sweep: the migration removes exactly what this
+ * returns, the tests assert against it without deleting anything, and
+ * an empty plan is what makes a second run a no-op instead of a second
+ * deletion.
+ */
+export function planLegacyRedSkillsCleanup(opts: LegacyCleanupOptions = {}): LegacyItem[] {
+  const home = opts.home ?? homeOf(opts.env ?? process.env);
+  return [
+    ...supersededVersionTrees(home),
+    ...retainedTarballs(home),
+    ...hostPluginCaches(home).flatMap((host) => supersededPluginCopies(host)),
+  ];
+}
+
+export interface LegacyCleanup {
+  removed: LegacyItem[];
+  /** The sum of what was removed, for the one line worth reading. */
+  bytes: number;
+}
+
+/**
+ * Remove the plan, and report what actually went.
+ *
+ * An item that cannot be removed is dropped from the report rather than
+ * thrown: this runs unattended, and one locked directory is not a
+ * reason to abandon the gigabyte beside it. It stays in the plan, so
+ * the next run asks again.
+ */
+export function clearLegacyRedSkills(opts: LegacyCleanupOptions = {}): LegacyCleanup {
+  const removed: LegacyItem[] = [];
+  for (const item of planLegacyRedSkillsCleanup(opts)) {
+    try {
+      rmSync(item.path, { recursive: true, force: true });
+    } catch {
+      continue;
+    }
+    if (existsSync(item.path)) continue;
+    removed.push(item);
+  }
+  return { removed, bytes: removed.reduce((sum, item) => sum + item.bytes, 0) };
+}
+
+/**
+ * The extracted trees under ~/.red-skills/versions, minus the live one.
+ *
+ * Only real directories: a link there is the layout red-skills-core.ts
+ * maintains, pointing into mise's installs, and removing it would both
+ * cost nothing and risk deleting through it.
+ */
+function supersededVersionTrees(home: string): LegacyItem[] {
+  const versions = join(home, ".red-skills", "versions");
+  const current = resolved(join(home, ".red-skills", "current"));
+  if (current === null) return [];
+
+  const out: LegacyItem[] = [];
+  for (const name of listing(versions)) {
+    const path = join(versions, name);
+    const stat = statOf(path);
+    if (!stat || stat.isSymbolicLink() || !stat.isDirectory()) continue;
+    if (resolved(path) === current) continue;
+    out.push({ path, kind: "version-tree", bytes: treeBytes(path) });
+  }
+  return out;
+}
+
+/**
+ * The tarballs ~/.red-skills/cache kept after unpacking them.
+ *
+ * The directory itself stays. It is where the standalone installer
+ * downloads to, and on a machine that still uses it an absent cache
+ * directory is a thing to recreate rather than a thing to have.
+ */
+function retainedTarballs(home: string): LegacyItem[] {
+  const cache = join(home, ".red-skills", "cache");
+  const out: LegacyItem[] = [];
+  for (const name of listing(cache)) {
+    if (!name.endsWith(".tar.gz")) continue;
+    const path = join(cache, name);
+    const stat = statOf(path);
+    if (!stat || stat.isSymbolicLink() || !stat.isFile()) continue;
+    out.push({ path, kind: "tarball", bytes: stat.size });
+  }
+  return out;
+}
+
+/**
+ * One host's superseded plugin copies.
+ *
+ * Per plugin, the highest version stays and everything below it goes,
+ * along with anything the host names as installed — which is what keeps
+ * a host that is deliberately on an older version working. A directory
+ * whose name is not a version is left alone too: it was put there by
+ * something this module does not understand.
+ */
+function supersededPluginCopies(host: HostPluginCache): LegacyItem[] {
+  const installed = host.installed();
+  if (installed === null) return [];
+
+  const root = join(host.cache, MARKETPLACE);
+  const out: LegacyItem[] = [];
+  for (const plugin of listing(root)) {
+    const pluginDir = join(root, plugin);
+    const versions = listing(pluginDir)
+      .map((name) => ({ name, parts: versionParts(name) }))
+      .filter((v): v is { name: string; parts: number[] } => v.parts !== null)
+      .sort((a, b) => compareVersions(a.parts, b.parts));
+
+    // Everything but the last, which is the newest this host holds.
+    for (const version of versions.slice(0, -1)) {
+      const path = join(pluginDir, version.name);
+      if (installed.has(path)) continue;
+      const stat = statOf(path);
+      if (!stat || stat.isSymbolicLink() || !stat.isDirectory()) continue;
+      out.push({ path, kind: "plugin-copy", bytes: treeBytes(path) });
+    }
+  }
+  return out;
+}
+
+/**
+ * The copies Claude Code records as installed, by path.
+ *
+ * Claude writes the install path of every plugin it carries into
+ * installed_plugins.json, which makes "is anything resolving through
+ * this directory" a question with an answer rather than a guess. A file
+ * that is there and cannot be parsed answers null, and the caller
+ * leaves the whole host alone.
+ */
+function claudeInstalledPaths(home: string): Set<string> | null {
+  const path = join(home, ".claude", "plugins", "installed_plugins.json");
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf8");
+  } catch {
+    // Absent, which is a host that has installed nothing.
+    return new Set<string>();
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as { plugins?: Record<string, { installPath?: unknown }[]> };
+    const out = new Set<string>();
+    for (const entries of Object.values(parsed.plugins ?? {})) {
+      for (const entry of entries ?? []) {
+        if (typeof entry?.installPath === "string") out.add(normalise(entry.installPath));
+      }
+    }
+    return out;
+  } catch {
+    return null;
+  }
+}
+
+function homeOf(env: NodeJS.ProcessEnv): string {
+  return normalise(env["HOME"] ?? env["USERPROFILE"] ?? homedir());
+}
+
+function normalise(path: string): string {
+  return path.replace(/\\/g, "/");
+}
+
+function listing(dir: string): string[] {
+  try {
+    return readdirSync(dir).sort();
+  } catch {
+    return [];
+  }
+}
+
+function statOf(path: string) {
+  try {
+    return lstatSync(path);
+  } catch {
+    return null;
+  }
+}
+
+/** The path a link ends at, or null when there is nothing at the end of it. */
+function resolved(path: string): string | null {
+  try {
+    return realpathSync(path);
+  } catch {
+    return null;
+  }
+}
+
+function versionParts(name: string): number[] | null {
+  const m = EXACT_VERSION.exec(name);
+  return m ? [Number(m[1]), Number(m[2]), Number(m[3])] : null;
+}
+
+/** Segment by segment, so 3.10.0 comes after 3.9.0. */
+function compareVersions(a: number[], b: number[]): number {
+  for (let i = 0; i < 3; i++) {
+    const diff = (a[i] ?? 0) - (b[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
+/**
+ * What one tree occupies, following nothing.
+ *
+ * Walked rather than shelled out to `du`, which does not exist on every
+ * target this runs on, and counted with lstat so a link inside the tree
+ * contributes its own size instead of the size of whatever it names.
+ */
+function treeBytes(path: string): number {
+  const stat = statOf(path);
+  if (!stat) return 0;
+  if (!stat.isDirectory() || stat.isSymbolicLink()) return stat.size;
+  let total = 0;
+  for (const name of listing(path)) total += treeBytes(join(path, name));
+  return total;
+}

--- a/src/update-order.test.ts
+++ b/src/update-order.test.ts
@@ -36,8 +36,10 @@ describe("an update", () => {
     expect(ran.indexOf("agents")).toBeLessThan(ran.indexOf("converge"));
     // The whole sequence, so the mise-managed suite cannot be moved
     // after the agents that may be installed on top of it without this
-    // saying so.
-    expect(ran).toEqual(["system", "red-skills", "suite", "agents", "converge"]);
+    // saying so — and so the prune stays after everything that
+    // installs, which is what makes it collect versions rather than the
+    // ones this run was about to put down.
+    expect(ran).toEqual(["system", "red-skills", "suite", "agents", "converge", "prune"]);
     expect(updateStageOrder()).toEqual(ran);
   });
 
@@ -60,7 +62,7 @@ describe("an update", () => {
     // that already succeeded. A machine that stops updating the moment
     // one vendor is down never finishes updating.
     const { ran, failures } = await walk({ "red-skills": "GitHub API 503", agents: "codex failed" });
-    expect(ran).toEqual(["system", "red-skills", "suite", "agents", "converge"]);
+    expect(ran).toEqual(["system", "red-skills", "suite", "agents", "converge", "prune"]);
     expect(failures).toEqual(["red-skills: GitHub API 503", "agents: codex failed"]);
   });
 

--- a/src/update-order.ts
+++ b/src/update-order.ts
@@ -16,14 +16,18 @@
  *             reached at all until one asked it to
  *   agents    each host by its own publisher's mechanism, after the
  *             runtimes it may need have been advanced above it
- *   converge  last, always: upgrading can leave the manifest unsatisfied
- *             — a package removed, a binary replaced — and the converge
- *             is what notices
+ *   converge  upgrading can leave the manifest unsatisfied — a package
+ *             removed, a binary replaced — and the converge is what
+ *             notices
+ *   prune     after everything is installed and converged, never
+ *             before: mise collects the versions no config still names,
+ *             and the config is not final until the converge has had
+ *             its say
  *
  * — so it is declared once, in one place, and executed by walking it.
  */
 
-export type UpdateStage = "system" | "red-skills" | "suite" | "agents" | "converge";
+export type UpdateStage = "system" | "red-skills" | "suite" | "agents" | "converge" | "prune";
 
 export interface UpdateStageSpec {
   stage: UpdateStage;
@@ -42,6 +46,10 @@ export const UPDATE_STAGES: readonly UpdateStageSpec[] = [
   { stage: "suite" },
   { stage: "agents" },
   { stage: "converge", fatal: true },
+  // Not fatal, and last: retention is the one stage whose failure costs
+  // disk rather than correctness. An update that could not prune is
+  // still an update, and the exit code stays the converge's.
+  { stage: "prune" },
 ];
 
 /** The stages in order, for a caller that only wants the sequence. */


### PR DESCRIPTION
Automated AFK landing for #188. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #188

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/195"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789516594&installation_model_id=20659&pr_number=195&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F195&signature=6cfc9bac275cc69edcffe3981432d0935f16f9f7c35f8ac48db66dca1eab0483"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->