### PR TITLE
fix: #189 Hosts are refreshed only when the resolved version changed

### DIFF
--- a/src/agents.ts
+++ b/src/agents.ts
@@ -1054,16 +1054,25 @@ export async function convergeRedSkills(p: Platform): Promise<void> {
   const missing = await unwiredSkillHosts();
   if (missing.length === 0) {
     log.skip(`red-skills already wired into ${present.map((h) => h.cmd).join(", ")}`);
-    return;
+  } else {
+    log.step(`red-skills: not wired into ${missing.map((h) => h.cmd).join(", ")}`);
+    await installRedSkills();
+    // The RedSkills generator owns the provider/MCP portions of opencode.json;
+    // red-dev owns terminal-following theme/input defaults. Re-apply our small
+    // merge after generation so a first RedCode migration converges in one run.
+    if (commandPath("redcode")) {
+      const { applyRedcode } = await import("./terminal-surfaces.ts");
+      await applyRedcode(p);
+    }
   }
 
-  log.step(`red-skills: not wired into ${missing.map((h) => h.cmd).join(", ")}`);
-  await installRedSkills();
-  // The RedSkills generator owns the provider/MCP portions of opencode.json;
-  // red-dev owns terminal-following theme/input defaults. Re-apply our small
-  // merge after generation so a first RedCode migration converges in one run.
-  if (commandPath("redcode")) {
-    const { applyRedcode } = await import("./terminal-surfaces.ts");
-    await applyRedcode(p);
-  }
+  // On both paths, and where the early return used to be. Being wired is
+  // not the same as being current: mise advances the version underneath a
+  // machine that was wired months ago, and the hosts read a marketplace
+  // cache that only moves when something tells it to.
+  //
+  // Free when nothing moved — the walk is gated on the resolved checkout,
+  // so an ordinary converge issues no host commands at all.
+  const { refreshSkillHosts } = await import("./red-skills-hosts.ts");
+  await refreshSkillHosts(p);
 }

--- a/src/red-skills-hosts.test.ts
+++ b/src/red-skills-hosts.test.ts
@@ -1,0 +1,303 @@
+/**
+ * What a converge asks the agent hosts to do, and when it asks nothing.
+ *
+ * A marketplace update plus one plugin update per declared plugin, across
+ * every host on the machine, is a walk of several CLIs and a network
+ * round trip each. Run on every converge it is pure cost: the overwhelming
+ * majority of converges resolve the same red-skills version they resolved
+ * last time, and refreshing a host against a tree it already read changes
+ * nothing on the machine.
+ *
+ * The observable these tests hold is the command trace, never an internal
+ * flag. A refresh that "decided" not to run and issued the commands
+ * anyway is the bug; so is one that reports a host as current after the
+ * host refused the call. So the runner is injected and what is asserted
+ * is the argv that reached it — which also means all of this holds with
+ * no red-skills, no marketplace and no agent CLI on the machine.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import type { Platform } from "./platform.ts";
+import {
+  REFRESH_HOSTS,
+  readHostStamp,
+  refreshSkillHosts,
+  type HostRefreshOptions,
+} from "./red-skills-hosts.ts";
+
+const UBUNTU: Platform = {
+  os: "linux",
+  distro: "ubuntu",
+  version: "24.04",
+  codename: "noble",
+  env: "desktop",
+  arch: "x64",
+  caps: { apt: true, gui: true, systemd: true, winget: false, flatpak: false },
+};
+
+/** Two versions of the same checkout: the resolved path is what moves. */
+const OLD = "/home/someone/.red-skills/versions/v3.3.0";
+const NEW = "/home/someone/.red-skills/versions/v3.4.0";
+
+const PLUGINS = ["dev", "memory"];
+
+function home(): string {
+  return mkdtempSync(join(tmpdir(), "red-hosts-home-"));
+}
+
+/** Collects the argv a refresh issued, and answers with `code`. */
+function recorder(code: (cmd: string[]) => number = () => 0): {
+  calls: string[][];
+  run: (cmd: string[]) => Promise<number>;
+} {
+  const calls: string[][] = [];
+  return {
+    calls,
+    run: async (cmd: string[]) => {
+      calls.push(cmd);
+      return code(cmd);
+    },
+  };
+}
+
+/** A machine with every declared host installed, at `source`. */
+function refresh(
+  opts: HostRefreshOptions & { source: string },
+): ReturnType<typeof refreshSkillHosts> {
+  return refreshSkillHosts(UBUNTU, {
+    plugins: PLUGINS,
+    present: () => true,
+    ...opts,
+  });
+}
+
+/** The commands one host answered for, by the CLI they were addressed to. */
+function forHost(calls: string[][], cmd: string): string[] {
+  return calls.filter((c) => c[0] === cmd).map((c) => c.join(" "));
+}
+
+describe("the hosts are refreshed when the resolved version moved", () => {
+  test("a first converge refreshes every host once", async () => {
+    // Nothing stamped yet, which is the state of a machine that has never
+    // been refreshed. Unknown is not "current": an empty stamp has to
+    // mean refresh, or a machine gets its first refresh never.
+    const root = home();
+    const { calls, run } = recorder();
+    const out = await refresh({ home: root, source: NEW, run });
+
+    expect(out.every((o) => o.refreshed)).toBe(true);
+    expect(out.map((o) => o.host)).toEqual(REFRESH_HOSTS.map((h) => h.name));
+    for (const host of REFRESH_HOSTS) {
+      expect(forHost(calls, host.cmd), host.name).toEqual(
+        host.argv(PLUGINS).map((c) => c.join(" ")),
+      );
+    }
+  });
+
+  test("and issues them exactly once per host, not once per plugin set", async () => {
+    // The failure this pins is a loop nested one level too deep: the
+    // marketplace refreshed once per plugin rather than once per host.
+    const { calls, run } = recorder();
+    await refresh({ home: home(), source: NEW, run });
+
+    for (const host of REFRESH_HOSTS) {
+      const marketplace = forHost(calls, host.cmd).filter((c) => c.includes("marketplace"));
+      expect(marketplace.length, host.name).toBe(1);
+    }
+    expect(calls.length).toBe(
+      REFRESH_HOSTS.reduce((n, h) => n + h.argv(PLUGINS).length, 0),
+    );
+  });
+
+  test("a converge whose resolved version is unchanged issues no host commands", async () => {
+    // The whole point of the slice. Not "issues fewer" and not "issues
+    // them and they no-op" — the trace is empty.
+    const root = home();
+    await refresh({ home: root, source: NEW, run: recorder().run });
+
+    const { calls, run } = recorder();
+    const out = await refresh({ home: root, source: NEW, run });
+
+    expect(calls).toEqual([]);
+    expect(out.every((o) => !o.refreshed)).toBe(true);
+    for (const o of out) expect(o.reason, o.host).toContain("v3.4.0");
+  });
+
+  test("a version that moved afterwards refreshes them again", async () => {
+    // Both directions, because a gate that only ever says "skip" is as
+    // broken as one that never does.
+    const root = home();
+    await refresh({ home: root, source: OLD, run: recorder().run });
+
+    const { calls, run } = recorder();
+    const out = await refresh({ home: root, source: NEW, run });
+
+    expect(out.every((o) => o.refreshed)).toBe(true);
+    expect(calls.length).toBeGreaterThan(0);
+    for (const host of REFRESH_HOSTS) {
+      expect(readHostStamp(root)[host.name], host.name).toBe(NEW);
+    }
+  });
+
+  test("red-skills absent from the machine refreshes nothing", async () => {
+    const { calls, run } = recorder();
+    const out = await refreshSkillHosts(UBUNTU, {
+      home: home(),
+      source: null,
+      plugins: PLUGINS,
+      present: () => true,
+      run,
+    });
+
+    expect(calls).toEqual([]);
+    expect(out).toEqual([]);
+  });
+});
+
+describe("a host that is not on the machine", () => {
+  test("is skipped with a reason rather than counted as refreshed", async () => {
+    // The distinction is load-bearing for the stamp below: "we refreshed
+    // it" and "it is not here" are different facts, and collapsing them
+    // is how a host that arrives next week never gets refreshed at all.
+    const first = REFRESH_HOSTS[0] as (typeof REFRESH_HOSTS)[number];
+    const { calls, run } = recorder();
+    const out = await refresh({
+      home: home(),
+      source: NEW,
+      present: (cmd) => cmd !== first.cmd,
+      run,
+    });
+
+    const skipped = out.find((o) => o.host === first.name);
+    expect(skipped?.refreshed).toBe(false);
+    expect(skipped?.reason).toContain("not installed");
+    expect(forHost(calls, first.cmd)).toEqual([]);
+    expect(out.filter((o) => o.host !== first.name).every((o) => o.refreshed)).toBe(true);
+  });
+
+  test("and is refreshed on the converge after it appears", async () => {
+    // Absence must not be stamped. A skipped host recorded as current is
+    // a host installed tomorrow and left on yesterday's tree forever.
+    const first = REFRESH_HOSTS[0] as (typeof REFRESH_HOSTS)[number];
+    const root = home();
+    await refresh({ home: root, source: NEW, present: (c) => c !== first.cmd, run: recorder().run });
+    expect(readHostStamp(root)[first.name]).toBeUndefined();
+
+    const { calls, run } = recorder();
+    const out = await refresh({ home: root, source: NEW, run });
+
+    expect(out.find((o) => o.host === first.name)?.refreshed).toBe(true);
+    expect(forHost(calls, first.cmd).length).toBeGreaterThan(0);
+    // And only that host: the others were already at this version.
+    expect(calls.every((c) => c[0] === first.cmd)).toBe(true);
+  });
+});
+
+describe("a host that refuses the refresh", () => {
+  test("does not prevent the others", async () => {
+    // One CLI broken for its own reasons — a half-written config, an
+    // expired login — is the ordinary state of a machine with several
+    // agents on it. It cannot be allowed to end the walk.
+    const [first, ...rest] = REFRESH_HOSTS;
+    expect(rest.length).toBeGreaterThan(0);
+
+    const { calls, run } = recorder((cmd) => (cmd[0] === (first as { cmd: string }).cmd ? 1 : 0));
+    const out = await refresh({ home: home(), source: NEW, run });
+
+    expect(out.find((o) => o.host === (first as { name: string }).name)?.refreshed).toBe(false);
+    for (const host of rest) {
+      expect(out.find((o) => o.host === host.name)?.refreshed, host.name).toBe(true);
+      expect(forHost(calls, host.cmd), host.name).toEqual(
+        host.argv(PLUGINS).map((c) => c.join(" ")),
+      );
+    }
+  });
+
+  test("a runner that throws is a failed host, not a failed converge", async () => {
+    const [first, ...rest] = REFRESH_HOSTS;
+    const calls: string[][] = [];
+    const out = await refresh({
+      home: home(),
+      source: NEW,
+      run: async (cmd) => {
+        if (cmd[0] === (first as { cmd: string }).cmd) throw new Error("spawn failed");
+        calls.push(cmd);
+        return 0;
+      },
+    });
+
+    expect(out.find((o) => o.host === (first as { name: string }).name)?.refreshed).toBe(false);
+    for (const host of rest) {
+      expect(forHost(calls, host.cmd).length, host.name).toBeGreaterThan(0);
+    }
+  });
+
+  test("is retried on the next converge, because it was never stamped", async () => {
+    const first = REFRESH_HOSTS[0] as (typeof REFRESH_HOSTS)[number];
+    const root = home();
+    const failing = recorder((cmd) => (cmd[0] === first.cmd ? 1 : 0));
+    await refresh({ home: root, source: NEW, run: failing.run });
+    expect(readHostStamp(root)[first.name]).toBeUndefined();
+
+    const { calls, run } = recorder();
+    const out = await refresh({ home: root, source: NEW, run });
+
+    expect(out.find((o) => o.host === first.name)?.refreshed).toBe(true);
+    expect(forHost(calls, first.cmd)).toEqual(first.argv(PLUGINS).map((c) => c.join(" ")));
+    expect(readHostStamp(root)[first.name]).toBe(NEW);
+  });
+});
+
+describe("what the hosts are asked", () => {
+  test("every host refreshes the marketplace and each declared plugin", async () => {
+    // Derived from the argument, never a literal here: the plugin set is
+    // the manifest's answer, and a test that wrote one down would be a
+    // second place for it to be declared.
+    for (const host of REFRESH_HOSTS) {
+      const argv = host.argv(PLUGINS);
+      expect(argv.every((c) => c[0] === host.cmd), host.name).toBe(true);
+      for (const plugin of PLUGINS) {
+        expect(
+          argv.some((c) => c.includes(`${plugin}@red-skills`)),
+          `${host.name}/${plugin}`,
+        ).toBe(true);
+      }
+    }
+  });
+
+  test("an empty plugin set still refreshes the marketplace", async () => {
+    // A machine that opted every plugin out still carries the core, and
+    // the marketplace it registers is what a later opt-in reads.
+    const { calls, run } = recorder();
+    await refresh({ home: home(), source: NEW, plugins: [], run });
+    expect(calls.length).toBe(REFRESH_HOSTS.length);
+    for (const host of REFRESH_HOSTS) {
+      expect(forHost(calls, host.cmd).length, host.name).toBe(1);
+    }
+  });
+
+  test("the converge reaches the refresh on the already-wired path too", () => {
+    // Asserted against the source because it is not observable any other
+    // way without an agent CLI in the loop, and because the failure it
+    // guards is precise: convergeRedSkills used to return at "already
+    // wired", which is every ordinary converge. A refresh written and
+    // never reached from there would leave the version moving under a
+    // machine whose hosts are never told.
+    const src = readFileSync(`${import.meta.dir}/agents.ts`, "utf8");
+    const converge = src.slice(src.indexOf("export async function convergeRedSkills"));
+    const wired = converge.indexOf("already wired into");
+    expect(wired).toBeGreaterThan(-1);
+    expect(converge.slice(wired)).toContain("refreshSkillHosts");
+  });
+
+  test("the hosts are the ones red-dev knows how to drive, by name", () => {
+    // Claude and Codex are CLI calls red-dev makes itself. The generator
+    // hosts are invoked from the installed tree and arrive with that
+    // slice; the table is where they will land.
+    expect(REFRESH_HOSTS.map((h) => h.name)).toEqual(["claude", "codex"]);
+  });
+});

--- a/src/red-skills-hosts.ts
+++ b/src/red-skills-hosts.ts
@@ -1,0 +1,273 @@
+/**
+ * Refreshing the agent hosts, gated on the version actually having moved.
+ *
+ * Once mise owns the RedSkills version, a converge has a fact it never
+ * had before: the resolved checkout under `~/.red-skills/current`, which
+ * changes exactly when a new package set landed and never otherwise. That
+ * fact is what this module spends.
+ *
+ * Refreshing a host is a marketplace update plus one plugin update per
+ * declared plugin — several CLI invocations and a network round trip
+ * each, per host, and the plan is for five hosts. A converge runs often
+ * and the overwhelming majority of them resolve the version they resolved
+ * last time, so running the walk unconditionally is a cost paid on every
+ * converge for a result identical to doing nothing.
+ *
+ * ## The stamp is per host, not per machine
+ *
+ * A single "last refreshed at" would be wrong in both directions. A host
+ * installed after the last refresh would be recorded as current on a tree
+ * it never read, and a host that refused the call would mark the whole
+ * machine as done. So each host records the checkout it was last
+ * refreshed against, exactly the way red-skills-ext.ts records the
+ * checkout each artifact was last built from — and for the same reason:
+ * asking the host what version it has answers a question about the
+ * marketplace cache rather than about the tree behind it.
+ *
+ * Only a host that succeeded is stamped. Absence, refusal and a crash all
+ * leave the entry as it was, so the next converge asks again. The cost of
+ * being wrong that way is one extra refresh; the cost of the other way is
+ * a host frozen on an old tree with nothing anywhere saying so.
+ *
+ * ## One failure does not end the walk
+ *
+ * A machine with several agents on it usually has one of them broken for
+ * its own reasons — a half-written config, a login that expired. That is
+ * a fact about that host, so it is reported against that host and the
+ * rest of the walk continues.
+ */
+
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
+
+import { log } from "./log.ts";
+import type { Platform } from "./platform.ts";
+import type { Tool } from "./manifest.ts";
+
+/**
+ * One host red-dev refreshes, and the commands that refresh it.
+ *
+ * `argv` is a function of the plugin set rather than a fixed list: which
+ * plugins this machine carries is the manifest's answer, and a table that
+ * wrote them down would be a second place for that to be declared.
+ */
+export interface SkillHostRefresh {
+  /** Key in the stamp, and the name that appears in a log line. */
+  name: string;
+  /** The command that has to be on PATH for this host to exist. */
+  cmd: string;
+  /** The refresh, as argv, in the order it has to be issued. */
+  argv: (plugins: readonly string[]) => string[][];
+}
+
+/**
+ * The hosts red-dev drives itself.
+ *
+ * Claude and Codex are CLI calls, and each answers in its own currency —
+ * both spellings were read off the installed CLIs rather than assumed:
+ *
+ *   claude  `plugin marketplace update <name>`  then `plugin update <p>`
+ *   codex   `plugin marketplace upgrade <name>` then `plugin add <p>`
+ *
+ * Codex has no `plugin update`. Its `add` reinstalls from the refreshed
+ * marketplace snapshot, which is the same fallback the marketplace
+ * repair in agents.ts already relies on.
+ *
+ * OpenCode, RedCode and pi are refreshed by the generators inside the
+ * installed tree rather than by commands red-dev spells out, so they join
+ * this table with the slice that invokes them.
+ */
+export const REFRESH_HOSTS: readonly SkillHostRefresh[] = [
+  {
+    name: "claude",
+    cmd: "claude",
+    argv: (plugins) => [
+      ["claude", "plugin", "marketplace", "update", "red-skills"],
+      ...plugins.map((p) => ["claude", "plugin", "update", `${p}@red-skills`]),
+    ],
+  },
+  {
+    name: "codex",
+    cmd: "codex",
+    argv: (plugins) => [
+      ["codex", "plugin", "marketplace", "upgrade", "red-skills"],
+      ...plugins.map((p) => ["codex", "plugin", "add", `${p}@red-skills`]),
+    ],
+  },
+];
+
+/** Which checkout each host was last refreshed against. */
+export type HostStamp = Record<string, string>;
+
+/** What one host did, or the reason it did nothing. */
+export interface HostRefreshOutcome {
+  /** The host's name in REFRESH_HOSTS. */
+  host: string;
+  /** True only when every command for this host succeeded. */
+  refreshed: boolean;
+  /** Why not, present exactly when `refreshed` is false. */
+  reason?: string;
+}
+
+/**
+ * Everything the walk needs from outside itself.
+ *
+ * All of it has a real default and exists for the tests: a refresh is a
+ * sequence of commands issued to CLIs that may not be installed, against
+ * a checkout that may not exist, and the thing worth pinning is which
+ * commands ran and which did not.
+ */
+export interface HostRefreshOptions {
+  /** Defaults to this user's home. The stamp lives under it. */
+  home?: string;
+  /** The resolved checkout. Defaults to `resolvedSource()`. */
+  source?: string | null;
+  /** The plugin set. Defaults to whatever the manifest declares. */
+  plugins?: readonly string[];
+  /** The manifest to derive the plugin set from. Defaults to TOOLS. */
+  tools?: readonly Tool[];
+  /** The hosts to walk. Defaults to REFRESH_HOSTS. */
+  hosts?: readonly SkillHostRefresh[];
+  /** Is this host's command on PATH? Defaults to `commandPath`. */
+  present?: (cmd: string) => boolean;
+  /** Runs one argv and answers its exit code. Defaults to spawnLogged. */
+  run?: (cmd: string[]) => Promise<number>;
+}
+
+function homeOf(): string {
+  const h = process.env["HOME"] ?? process.env["USERPROFILE"] ?? "";
+  return h.replace(/\\/g, "/");
+}
+
+/** Computed rather than a constant: the tests move home between cases. */
+export function hostStampPath(home: string): string {
+  return `${home}/.local/share/red-dev/red-skills-hosts.json`;
+}
+
+export function readHostStamp(home: string): HostStamp {
+  const path = hostStampPath(home);
+  if (!existsSync(path)) return {};
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as unknown;
+    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+    return parsed as HostStamp;
+  } catch {
+    // A stamp we cannot read means refresh, which is the safe way to be
+    // wrong: the cost is one extra walk, not a permanently stale host.
+    return {};
+  }
+}
+
+async function writeHostStamp(home: string, stamp: HostStamp): Promise<void> {
+  const path = hostStampPath(home);
+  mkdirSync(path.slice(0, path.lastIndexOf("/")), { recursive: true });
+  await Bun.write(path, `${JSON.stringify(stamp, null, 2)}\n`);
+}
+
+/** `v3.4.0` out of the resolved path, for a log line a person reads. */
+function versionOf(source: string): string {
+  return source.split("/").pop() ?? source;
+}
+
+/**
+ * Refresh every host whose recorded checkout is not the one resolved now.
+ *
+ * Answers one outcome per host in table order, including the hosts it
+ * left alone — "absent", "already current" and "refused" are three
+ * different facts and a caller that wants to report them needs to be able
+ * to tell them apart.
+ *
+ * With no checkout at all there is nothing to refresh against, and that
+ * is not a failure: it is the ordinary state of a machine before the mise
+ * entry has installed the core. It answers with no outcomes at all.
+ */
+export async function refreshSkillHosts(
+  p: Platform,
+  opts: HostRefreshOptions = {},
+): Promise<HostRefreshOutcome[]> {
+  const home = opts.home ?? homeOf();
+  const hosts = opts.hosts ?? REFRESH_HOSTS;
+
+  const source = opts.source !== undefined ? opts.source : await currentSource();
+  if (source === null) {
+    log.skip("red-skills: not installed, no host to refresh");
+    return [];
+  }
+
+  const plugins = opts.plugins ?? (await declaredPlugins(p, opts.tools));
+  const present = opts.present ?? (await presenceProbe());
+  const run = opts.run ?? (await defaultRunner());
+
+  const version = versionOf(source);
+  const stamp = readHostStamp(home);
+  const out: HostRefreshOutcome[] = [];
+
+  for (const host of hosts) {
+    if (!present(host.cmd)) {
+      // Deliberately not stamped: a host that arrives next week has to be
+      // refreshed then, and recording it now would say it already was.
+      out.push({ host: host.name, refreshed: false, reason: `${host.cmd} is not installed` });
+      continue;
+    }
+
+    if (stamp[host.name] === source) {
+      log.skip(`${host.name}: red-skills already refreshed at ${version}`);
+      out.push({ host: host.name, refreshed: false, reason: `already refreshed at ${version}` });
+      continue;
+    }
+
+    log.step(`${host.name}: refreshing red-skills against ${version}`);
+    const failure = await refreshOne(host, plugins, run);
+    if (failure !== null) {
+      // Reported and survived. The stamp keeps whatever it held, so the
+      // next converge asks this host again.
+      log.warn(`${host.name}: ${failure}`);
+      out.push({ host: host.name, refreshed: false, reason: failure });
+      continue;
+    }
+
+    stamp[host.name] = source;
+    await writeHostStamp(home, stamp);
+    log.ok(`${host.name}: red-skills refreshed to ${version}`);
+    out.push({ host: host.name, refreshed: true });
+  }
+
+  return out;
+}
+
+/** Runs one host's commands, and answers the first failure or null. */
+async function refreshOne(
+  host: SkillHostRefresh,
+  plugins: readonly string[],
+  run: (cmd: string[]) => Promise<number>,
+): Promise<string | null> {
+  for (const cmd of host.argv(plugins)) {
+    let code: number;
+    try {
+      code = await run(cmd);
+    } catch (error) {
+      return `${cmd.join(" ")} could not be run: ${(error as Error).message}`;
+    }
+    if (code !== 0) return `${cmd.join(" ")} exited ${code}`;
+  }
+  return null;
+}
+
+async function currentSource(): Promise<string | null> {
+  const { resolvedSource } = await import("./red-skills-ext.ts");
+  return resolvedSource();
+}
+
+async function declaredPlugins(p: Platform, tools?: readonly Tool[]): Promise<string[]> {
+  const { redSkillsPluginNames } = await import("./red-skills-plugins.ts");
+  return redSkillsPluginNames(p, tools);
+}
+
+async function presenceProbe(): Promise<(cmd: string) => boolean> {
+  const { commandPath } = await import("./agents.ts");
+  return (cmd: string) => commandPath(cmd) !== null;
+}
+
+async function defaultRunner(): Promise<(cmd: string[]) => Promise<number>> {
+  const { spawnLogged } = await import("./providers.ts");
+  return (cmd: string[]) => spawnLogged(cmd);
+}


### PR DESCRIPTION
Automated AFK landing for #189. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #189

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/196"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789517319&installation_model_id=20659&pr_number=196&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F196&signature=e1f0b54f910d9d7974fcd3a9db600a0e767a4a32138304991384a7e8ca00f214"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->