### PR TITLE
fix: #190 The VS Code extension and the herdr plugin install from published artifacts

### DIFF
--- a/src/agents.ts
+++ b/src/agents.ts
@@ -718,20 +718,18 @@ export function repairCopiedRedSkillsCurrent(
 }
 
 /**
- * Advance the red-skills checkout, and rebuild what was built from it.
+ * Advance the red-skills checkout, and the two artifacts beside it.
  *
  * convergeRedSkills asks whether red-skills is *wired*, and a wired
  * machine is one it has nothing left to do on — which is the right
  * answer for `install` and the wrong one for `update`. The checkout at
  * ~/.red-skills/current froze at the version that first wired this
  * machine and stayed there, while Claude's own plugin cache went on
- * updating through the marketplace. Two copies, one advancing, and the
- * one everything here builds from was the stationary one.
+ * updating through the marketplace. Two copies, and the one everything
+ * resolved through was the stationary one.
  *
- * So this is update's business, not converge's: the installer is
- * re-run, which is what fetches the newest tarball and repoints
- * `current`, and then anything built from that tree is rebuilt against
- * where it now points.
+ * So this is update's business, not converge's: the installer is re-run,
+ * which is what fetches the newest tarball and repoints `current`.
  */
 export async function updateRedSkills(p: Platform): Promise<void> {
   // Before the early return below, not after it. The Product skill is
@@ -743,6 +741,15 @@ export async function updateRedSkills(p: Platform): Promise<void> {
   await refreshProductSkill(p);
 
   const { sourceRoot, refreshRedSkillsExtensions } = await import("./red-skills-ext.ts");
+
+  // Also before it, and for a reason that used to point the other way.
+  // The extension and the herdr plugin were built out of the checkout,
+  // so a machine without one had nothing to rebuild; they now come from
+  // the published release, so a machine without a checkout is precisely
+  // a machine that can still be advanced. Gating them on the tree would
+  // leave exactly those machines behind.
+  await refreshRedSkillsExtensions(p);
+
   if (!sourceRoot()) {
     log.skip("red-skills: not installed, nothing to advance");
     return;
@@ -754,8 +761,6 @@ export async function updateRedSkills(p: Platform): Promise<void> {
   const after = realpathSync(sourceRoot() as string);
   if (before === after) log.skip(`red-skills already at ${after.split("/").pop()}`);
   else log.ok(`red-skills ${before.split("/").pop()} → ${after.split("/").pop()}`);
-
-  await refreshRedSkillsExtensions(p);
 }
 
 /**

--- a/src/herdr.test.ts
+++ b/src/herdr.test.ts
@@ -12,7 +12,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { bindHerdrDashboard, herdrConfigPath } from "./herdr.ts";
+import { bindHerdrDashboard, herdrConfigPath, unbindHerdrDashboard } from "./herdr.ts";
 import type { Platform } from "./platform.ts";
 
 const LINUX: Platform = {
@@ -97,6 +97,39 @@ describe("binding the dashboard", () => {
     await bindHerdrDashboard(WINDOWS);
     const path = herdrConfigPath(WINDOWS) as string;
     expect(readFileSync(path, "utf8")).toContain("invoke toggle-dashboard-windows");
+  });
+});
+
+describe("unbinding it again", () => {
+  test("takes the generated block back out", async () => {
+    const path = machine();
+    await bindHerdrDashboard(LINUX);
+    expect(await unbindHerdrDashboard(LINUX)).toBe(true);
+    expect(readFileSync(path, "utf8")).not.toContain("prefix+d");
+  });
+
+  test("leaves everything the operator wrote", async () => {
+    // The one rule the uninstall shares with the dotfiles: unhook
+    // without rewriting a file we do not own.
+    const mine = '[theme]\nname = "tokyo-night"\n\n[[keys.command]]\nkey = "prefix+g"\ntype = "popup"\ncommand = "lazygit"\n';
+    const path = machine(mine);
+    await bindHerdrDashboard(LINUX);
+    await unbindHerdrDashboard(LINUX);
+    expect(readFileSync(path, "utf8").trim()).toBe(mine.trim());
+  });
+
+  test("leaves a prefix+d of the user's own alone", async () => {
+    // The install refused to claim this key; the uninstall must not
+    // claim the right to delete what claimed it instead.
+    const mine = '[[keys.command]]\nkey = "prefix+d"\ntype = "popup"\ncommand = "lazygit"\n';
+    const path = machine(mine);
+    expect(await unbindHerdrDashboard(LINUX)).toBe(false);
+    expect(readFileSync(path, "utf8")).toBe(mine);
+  });
+
+  test("says no when there is nothing to unbind", async () => {
+    machine();
+    expect(await unbindHerdrDashboard(LINUX)).toBe(false);
   });
 });
 

--- a/src/herdr.ts
+++ b/src/herdr.ts
@@ -91,3 +91,31 @@ command = "herdr plugin action invoke ${toggleDashboardAction(p)} --plugin reddb
   log.ok("herdr: prefix+d opens the RedSkills dashboard");
   return true;
 }
+
+/**
+ * Take the binding back out when the plugin it invokes is removed.
+ *
+ * Only the generated block, found by its own header and ending at the
+ * blank line or end of file that closed it. A binding the operator wrote
+ * — including one that claims prefix+d, which the install deliberately
+ * refused to overwrite — is left exactly where it is. This is the same
+ * rule the dotfiles uninstall follows: unhook without rewriting a file
+ * we do not own.
+ */
+export async function unbindHerdrDashboard(p: Platform): Promise<boolean> {
+  const path = herdrConfigPath(p);
+  if (path === null || !existsSync(path)) return false;
+
+  const existing = await Bun.file(path).text();
+  const lines = existing.split("\n");
+  const start = lines.indexOf(GENERATED);
+  if (start === -1) return false;
+
+  let end = start + 1;
+  while (end < lines.length && lines[end]?.trim() !== "") end++;
+  const kept = [...lines.slice(0, start), ...lines.slice(end)].join("\n").trim();
+
+  await Bun.write(path, kept === "" ? "" : `${kept}\n`);
+  log.ok("herdr: the generated prefix+d binding is gone");
+  return true;
+}

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -1006,11 +1006,13 @@ export const TOOLS: Tool[] = [
     win: winget("BlenderFoundation.Blender"),
   },
   {
-    // Both build from the red-skills monorepo, which means a pnpm install
-    // of a turbo workspace the first time. The note exposes that cost;
-    // the setup still follows its uniform opt-out contract.
+    // Both come from the artifacts RedSkills already publishes: the
+    // `.vsix` and the plugin bundle are attached to every release, so
+    // neither needs a checkout, a pnpm install, or a build here. That is
+    // also the only way they can still be installed — the published
+    // package stopped carrying monorepo source.
     name: "red-skills-vscode",
-    about: "RedSkills panel for VS Code — builds from source, needs pnpm",
+    about: "RedSkills panel for VS Code — the published .vsix",
     scope: "optional",
     managed: true,
     u24: builtin("red-skills-vscode"),

--- a/src/red-skills-core.test.ts
+++ b/src/red-skills-core.test.ts
@@ -366,7 +366,7 @@ describe("the consumers that resolve through current", () => {
     }
   }
 
-  test("the extension builder still finds the source, and resolves past the link", async () => {
+  test("the layout is still readable through the link, and resolves past it", async () => {
     const home = fakeHome();
     const installs = fakeInstalls(["3.18.12"]);
     convergeRedSkillsCoreLayout({ home, installsDir: installs, platform: "linux" });
@@ -375,8 +375,8 @@ describe("the consumers that resolve through current", () => {
     await withHome(home, () => {
       expect(sourceRoot()).toBe(`${home}/.red-skills/current`);
       // The link is the only thing that moves and every version under
-      // it is immutable, so the resolved path is the whole freshness
-      // question for anything built out of the tree.
+      // it is immutable, so the resolved path is what names the version
+      // this machine is actually resolving through.
       expect(resolvedSource()).toBe(realpathSync(corePayloadDir(installs, "3.18.12")));
     });
   });

--- a/src/red-skills-ext.test.ts
+++ b/src/red-skills-ext.test.ts
@@ -1,17 +1,47 @@
 /**
- * The two extensions the red-skills installer leaves behind.
+ * The two RedSkills artifacts, installed from what CI already published.
  *
- * Its install.sh wires Claude, Codex and OpenCode and stops. The VS Code
- * extension and the herdr plugin live in the same monorepo, are
- * installed by hand, and therefore are not installed.
+ * Both used to be built here, out of ~/.red-skills/current, which meant a
+ * pnpm install of a 19-package workspace to produce a `.vsix` the release
+ * already carried. The published package stopped carrying monorepo
+ * source, so that build is now impossible as well as wasteful.
+ *
+ * What these cover is the converge as a machine experiences it: which
+ * release was asked for, which commands ran, what survives a GitHub that
+ * does not answer, and what an uninstall takes back.
  */
 
-import { describe, expect, test } from "bun:test";
-import { readFileSync } from "node:fs";
+import { afterEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import {
+  EXTENSION_ID,
+  HERDR_BUNDLE_ASSET,
+  HERDR_PLUGIN_SOURCE,
+  LEGACY_EXTENSION_ID,
+  REDSKILLS_REPO,
+  VSIX_ASSET,
+  assetCache,
+  installHerdrPlugin,
+  installVscodeExtension,
+  readRecord,
+  refreshRedSkillsExtensions,
+  uninstallHerdrPlugin,
+  uninstallVscodeExtension,
+  type ExtIo,
+} from "./red-skills-ext.ts";
 import { TOOLS, providerFor } from "./manifest.ts";
 import type { Platform } from "./platform.ts";
+import type { GhRelease } from "./providers.ts";
 
-function platform(over: Partial<Platform>): Platform {
+const savedHome = process.env["HOME"];
+
+afterEach(() => {
+  if (savedHome === undefined) delete process.env["HOME"];
+  else process.env["HOME"] = savedHome;
+});
+
+function platform(over: Partial<Platform> = {}): Platform {
   return {
     os: "linux", distro: "ubuntu", version: "24.04", codename: "noble",
     env: "wsl", arch: "x64",
@@ -20,51 +50,373 @@ function platform(over: Partial<Platform>): Platform {
   } as Platform;
 }
 
-const vscode = TOOLS.find((t) => t.name === "red-skills-vscode");
-const herdr = TOOLS.find((t) => t.name === "red-skills-herdr");
-const src = readFileSync("src/red-skills-ext.ts", "utf8");
+/** A machine with nothing on it but a HOME. No red-skills checkout. */
+function bareMachine(): string {
+  const root = mkdtempSync(`${tmpdir()}/red-skills-ext-`);
+  process.env["HOME"] = root;
+  return root;
+}
 
-describe("both are offered in the opt-out setup", () => {
+function release(tag: string, file: string): GhRelease {
+  return {
+    tag,
+    file,
+    url: `https://github.com/${REDSKILLS_REPO}/releases/download/${tag}/${file}`,
+    checksumUrl: null,
+  };
+}
+
+interface Recorder extends ExtIo {
+  /** Every command the converge ran, in order. */
+  commands: string[][];
+  /** Every asset glob it asked GitHub for. */
+  asked: string[];
+  /** Every asset it fetched. */
+  downloaded: string[];
+}
+
+/** An io that answers from memory and remembers what it was asked. */
+function fakeIo(over: Partial<ExtIo> & { tag?: string } = {}): Recorder {
+  const tag = over.tag ?? "v3.18.12";
+  const commands: string[][] = [];
+  const asked: string[] = [];
+  const downloaded: string[] = [];
+
+  const io: Recorder = {
+    commands,
+    asked,
+    downloaded,
+    clis: () => ["code"],
+    editorsWithExtension: async () => ["code"],
+    hasHerdr: () => true,
+    herdrHasPlugin: async () => true,
+    async resolve(glob: string) {
+      asked.push(glob);
+      const file =
+        glob === VSIX_ASSET ? `vscode-extension-red-skills-${tag.replace(/^v/, "")}.vsix` : glob;
+      return release(tag, file);
+    },
+    async download(rel: GhRelease) {
+      downloaded.push(rel.file);
+      const dir = assetCache();
+      mkdirSync(dir, { recursive: true });
+      const dest = `${dir}/${rel.file}`;
+      writeFileSync(dest, "vsix");
+      return dest;
+    },
+    async run(cmd: string[]) {
+      commands.push(cmd);
+      return 0;
+    },
+    ...over,
+  };
+  return io;
+}
+
+describe("the manifest still offers both", () => {
+  const vscode = TOOLS.find((t) => t.name === "red-skills-vscode");
+  const herdr = TOOLS.find((t) => t.name === "red-skills-herdr");
+
   test("are in the optional scope", () => {
     expect(vscode?.scope).toBe("optional");
     expect(herdr?.scope).toBe("optional");
   });
 
   test("herdr's is skipped on Windows, which has no stable herdr", () => {
-    const win = platform({ os: "windows", env: "windows" });
-    expect(providerFor(herdr!, win).kind).toBe("skip");
+    expect(providerFor(herdr!, platform({ os: "windows", env: "windows" })).kind).toBe("skip");
+  });
+
+  test("neither still advertises a build", () => {
+    // The note was the operator's warning that choosing this cost a pnpm
+    // install of a turbo workspace. There is no build left to warn about.
+    expect(vscode?.about).not.toContain("pnpm");
+    expect(vscode?.about).not.toContain("source");
   });
 });
 
-describe("what the run taught", () => {
-  test("looks for the .vsix at the workspace root", () => {
-    // `pnpm -C apps/vscode-redskilled package` writes to dist/ at the
-    // repo root, not under the app. The first version looked under the
-    // app, found nothing, and threw on a build that had succeeded.
-    expect(src).toContain("${root}/dist");
+describe("the extension comes from the release", () => {
+  test("resolves the published .vsix and installs it, with nothing built", async () => {
+    bareMachine();
+    const io = fakeIo();
+    await installVscodeExtension(io);
+
+    expect(io.asked).toEqual([VSIX_ASSET]);
+    expect(io.downloaded).toEqual(["vscode-extension-red-skills-3.18.12.vsix"]);
+    expect(io.commands).toHaveLength(1);
+    expect(io.commands[0]?.slice(0, 2)).toEqual(["code", "--install-extension"]);
+    expect(io.commands[0]?.at(-1)).toBe("--force");
+
+    // Nothing was built, and nothing looked for a checkout to build in.
+    const ran = io.commands.flat();
+    expect(ran).not.toContain("pnpm");
+    expect(ran).not.toContain("build");
+    expect(ran).not.toContain("package");
   });
 
-  test("hands the editors a path with the symlink resolved", () => {
-    // These are Windows programs even when invoked from a distro: they
-    // translate to \\wsl.localhost\... and open over 9P, where the
-    // `current` symlink does not survive. VSCodium reported ENOENT on a
-    // file that plainly existed.
-    expect(src).toContain("realpathSync");
+  test("a machine with no source tree installs it anyway", async () => {
+    const root = bareMachine();
+    // Nothing here — the published artifact no longer carries the tree
+    // this used to be built from, so this is the ordinary machine now.
+    expect(existsSync(`${root}/.red-skills`)).toBe(false);
+
+    const io = fakeIo();
+    await installVscodeExtension(io);
+    expect(readRecord().vscode).toEqual({ tag: "v3.18.12", editors: ["code"], id: EXTENSION_ID });
   });
 
-  test("installs into every editor found rather than asking which", () => {
-    expect(src).toContain('["code", "codium", "cursor"]');
+  test("goes into every editor found, and records only the ones that took it", async () => {
+    bareMachine();
+    const io = fakeIo({
+      clis: () => ["code", "codium", "cursor"],
+      async run(cmd: string[]) {
+        io.commands.push(cmd);
+        return cmd[0] === "codium" ? 1 : 0;
+      },
+    });
+    await installVscodeExtension(io);
+    expect(readRecord().vscode?.editors).toEqual(["code", "cursor"]);
   });
 
-  test("skips loudly when the host or the source is missing", () => {
-    expect(src).toContain("no VS Code-family editor installed");
-    expect(src).toContain("red-skills is not installed");
-    expect(src).toContain("herdr is not installed");
+  test("nothing is recorded when no editor took it", async () => {
+    bareMachine();
+    const io = fakeIo({ run: async () => 1 });
+    await installVscodeExtension(io);
+    expect(readRecord().vscode).toBeUndefined();
   });
 
-  test("only pays for the workspace when something needs it", () => {
-    // A pnpm install of this monorepo is not a side effect anyone
-    // should get from converging something else.
-    expect(src).toContain("already prepared");
+  test("no editor on the machine means no download at all", async () => {
+    bareMachine();
+    const io = fakeIo({ clis: () => [] });
+    await installVscodeExtension(io);
+    expect(io.asked).toEqual([]);
+    expect(io.downloaded).toEqual([]);
+  });
+});
+
+describe("the herdr plugin comes from the release", () => {
+  test("pins the install to the tag the published bundle came from", async () => {
+    bareMachine();
+    const io = fakeIo();
+    await installHerdrPlugin(platform(), io);
+
+    // The bundle asset is what proves the release published a plugin at
+    // all; the tag is what the install is held to. Unpinned, herdr reads
+    // the default branch, whose manifest can name a bundle no release has.
+    expect(io.asked).toEqual([HERDR_BUNDLE_ASSET]);
+    expect(io.commands[0]).toEqual([
+      "herdr", "plugin", "install", HERDR_PLUGIN_SOURCE, "--ref", "v3.18.12", "--yes",
+    ]);
+    expect(readRecord().herdr).toEqual({ tag: "v3.18.12" });
+  });
+
+  test("a machine with no source tree installs it anyway", async () => {
+    const root = bareMachine();
+    expect(existsSync(`${root}/.red-skills`)).toBe(false);
+
+    const io = fakeIo();
+    await installHerdrPlugin(platform(), io);
+    expect(readRecord().herdr?.tag).toBe("v3.18.12");
+    // The old fallback prepared the workspace and linked the checkout.
+    const ran = io.commands.flat();
+    expect(ran).not.toContain("pnpm");
+    expect(ran).not.toContain("link");
+  });
+
+  test("no herdr means nothing is asked of GitHub", async () => {
+    bareMachine();
+    const io = fakeIo({ hasHerdr: () => false });
+    await installHerdrPlugin(platform(), io);
+    expect(io.asked).toEqual([]);
+    expect(io.commands).toEqual([]);
+  });
+
+  test("a herdr that refuses the install records nothing and does not throw", async () => {
+    bareMachine();
+    const io = fakeIo({ run: async () => 1 });
+    await installHerdrPlugin(platform(), io);
+    expect(readRecord().herdr).toBeUndefined();
+  });
+});
+
+describe("a release that cannot be resolved", () => {
+  /** GitHub rate-limited, offline, or a release with no such asset. */
+  function unresolvable(): Partial<ExtIo> {
+    return {
+      resolve: async (glob: string) => {
+        throw new Error(`no asset matching '${glob}' in latest ${REDSKILLS_REPO} release`);
+      },
+    };
+  }
+
+  test("is reported and leaves the extension alone rather than throwing", async () => {
+    bareMachine();
+    const io = fakeIo(unresolvable());
+    // Not `rejects`: a converge that stops here abandons the dotfiles,
+    // themes and agents that come after it.
+    await installVscodeExtension(io);
+    expect(io.commands).toEqual([]);
+    expect(readRecord()).toEqual({});
+  });
+
+  test("is reported and leaves the herdr plugin alone rather than throwing", async () => {
+    bareMachine();
+    const io = fakeIo(unresolvable());
+    await installHerdrPlugin(platform(), io);
+    expect(io.commands).toEqual([]);
+    expect(readRecord()).toEqual({});
+  });
+
+  test("a failed download is the same kind of failure", async () => {
+    bareMachine();
+    const io = fakeIo({
+      download: async () => {
+        throw new Error("download failed 503");
+      },
+    });
+    await installVscodeExtension(io);
+    expect(io.commands).toEqual([]);
+    expect(readRecord()).toEqual({});
+  });
+
+  test("one artifact failing does not stop the other", async () => {
+    bareMachine();
+    const io = fakeIo({
+      async resolve(glob: string) {
+        io.asked.push(glob);
+        if (glob === VSIX_ASSET) throw new Error("GitHub API 403 — rate limited");
+        return release("v3.18.12", glob);
+      },
+    });
+    await refreshRedSkillsExtensions(platform(), io);
+    expect(io.asked).toEqual([VSIX_ASSET, HERDR_BUNDLE_ASSET]);
+    expect(readRecord().vscode).toBeUndefined();
+    expect(readRecord().herdr?.tag).toBe("v3.18.12");
+  });
+});
+
+describe("refresh advances against the release, not a checkout", () => {
+  test("does nothing when the recorded tag is the published one", async () => {
+    bareMachine();
+    const io = fakeIo();
+    await installVscodeExtension(io);
+    await installHerdrPlugin(platform(), io);
+
+    const after = fakeIo();
+    await refreshRedSkillsExtensions(platform(), after);
+    expect(after.downloaded).toEqual([]);
+    expect(after.commands).toEqual([]);
+  });
+
+  test("reinstalls both when the release moved", async () => {
+    bareMachine();
+    const io = fakeIo();
+    await installVscodeExtension(io);
+    await installHerdrPlugin(platform(), io);
+
+    const moved = fakeIo({ tag: "v3.19.0" });
+    await refreshRedSkillsExtensions(platform(), moved);
+    expect(moved.downloaded).toEqual(["vscode-extension-red-skills-3.19.0.vsix"]);
+    expect(moved.commands.map((c) => c[0])).toEqual(["code", "herdr"]);
+    expect(readRecord().vscode?.tag).toBe("v3.19.0");
+    expect(readRecord().herdr?.tag).toBe("v3.19.0");
+  });
+
+  test("a machine with neither installed is left alone", async () => {
+    bareMachine();
+    const io = fakeIo({
+      editorsWithExtension: async () => [],
+      herdrHasPlugin: async () => false,
+    });
+    await refreshRedSkillsExtensions(platform(), io);
+    // Absence is a choice. `update` must not advance a machine into
+    // software it never asked for.
+    expect(io.asked).toEqual([]);
+    expect(io.commands).toEqual([]);
+  });
+
+  test("an editor carrying the pre-rename extension still counts as installed", async () => {
+    // The app was renamed, so a machine converged before it carries
+    // `vscode-redskilled`. A probe that knew only the new id would report
+    // every such machine as not having it and leave it behind forever.
+    expect(LEGACY_EXTENSION_ID).not.toBe(EXTENSION_ID);
+    bareMachine();
+    const io = fakeIo();
+    await refreshRedSkillsExtensions(platform(), io);
+    expect(io.downloaded).toEqual(["vscode-extension-red-skills-3.18.12.vsix"]);
+  });
+});
+
+describe("uninstall takes back what this path installed", () => {
+  test("removes the extension from the editors that took it, and the cached asset", async () => {
+    bareMachine();
+    const io = fakeIo({ clis: () => ["code", "cursor"] });
+    await installVscodeExtension(io);
+    expect(existsSync(assetCache())).toBe(true);
+
+    const undo = fakeIo();
+    const removed = await uninstallVscodeExtension(undo);
+    expect(undo.commands).toEqual([
+      ["code", "--uninstall-extension", EXTENSION_ID],
+      ["cursor", "--uninstall-extension", EXTENSION_ID],
+    ]);
+    expect(removed).toHaveLength(2);
+    expect(existsSync(assetCache())).toBe(false);
+    expect(readRecord().vscode).toBeUndefined();
+  });
+
+  test("removes the herdr plugin and the binding red-dev generated", async () => {
+    bareMachine();
+    const io = fakeIo();
+    await installHerdrPlugin(platform(), io);
+
+    const { herdrConfigPath } = await import("./herdr.ts");
+    const config = herdrConfigPath(platform()) as string;
+    expect(readFileSync(config, "utf8")).toContain("prefix+d");
+
+    const undo = fakeIo();
+    const removed = await uninstallHerdrPlugin(platform(), undo);
+    expect(undo.commands[0]).toEqual(["herdr", "plugin", "uninstall", "reddb-io.red-skills"]);
+    expect(removed).toContain("reddb-io.red-skills");
+    expect(readFileSync(config, "utf8")).not.toContain("prefix+d");
+    expect(readRecord().herdr).toBeUndefined();
+  });
+
+  test("removes nothing on a machine this path never touched", async () => {
+    bareMachine();
+    const io = fakeIo();
+    expect(await uninstallVscodeExtension(io)).toEqual([]);
+    expect(await uninstallHerdrPlugin(platform(), io)).toEqual([]);
+    expect(io.commands).toEqual([]);
+  });
+
+  test("removes the extension under the id it was installed as", async () => {
+    // A machine converged before the rename has the old identifier in
+    // its editors; removing the new one would leave the old in place and
+    // report success.
+    const root = bareMachine();
+    mkdirSync(`${root}/.local/share/red-dev`, { recursive: true });
+    writeFileSync(
+      `${root}/.local/share/red-dev/red-skills-extensions.json`,
+      JSON.stringify({ vscode: { tag: "v3.3.0", editors: ["code"], id: LEGACY_EXTENSION_ID } }),
+    );
+
+    const io = fakeIo();
+    await uninstallVscodeExtension(io);
+    expect(io.commands).toEqual([["code", "--uninstall-extension", LEGACY_EXTENSION_ID]]);
+  });
+
+  test("the uninstall offer follows the record, not the machine", async () => {
+    bareMachine();
+    const { redSkillsExtensionRemovals } = await import("./uninstall.ts");
+    // Nothing installed by red-dev: an extension somebody added by hand
+    // is not this project's to take away.
+    expect(redSkillsExtensionRemovals(platform())).toEqual([]);
+
+    await installVscodeExtension(fakeIo());
+    await installHerdrPlugin(platform(), fakeIo());
+    expect(redSkillsExtensionRemovals(platform()).map((r) => r.tool.name)).toEqual([
+      "red-skills-vscode",
+      "red-skills-herdr",
+    ]);
   });
 });

--- a/src/red-skills-ext.ts
+++ b/src/red-skills-ext.ts
@@ -1,21 +1,39 @@
 /**
- * The two red-skills extensions the installer does not touch.
+ * The two RedSkills artifacts that are not npm packages.
  *
- * `scripts/install.sh` wires Claude, Codex and OpenCode and stops there.
- * The VS Code extension and the herdr plugin live in the same monorepo
- * and are installed by hand, which means in practice they are not
- * installed at all.
+ * The core and the plugins arrive through mise as `npm:` entries. The VS
+ * Code extension and the herdr plugin cannot: one is a `.vsix` an editor
+ * installs, the other a directory herdr registers. Both were therefore
+ * built here, out of the checkout at ~/.red-skills/current — a pnpm
+ * install of a 19-package turbo workspace, to produce a `.vsix` CI had
+ * already produced and attached to the release.
  *
- * Both need the source tree that red-skills already keeps at
- * ~/.red-skills/current, and both need its workspace dependencies. That
- * install is a large one — a 165 KB lockfile and a turbo workspace — so
- * it happens only when one of these is actually asked for, never as a
- * side effect of converging something else.
+ * That build is now impossible as well as wasteful. The published
+ * artifact stopped carrying monorepo source (red-skills ADR 0146), so
+ * the tree this used to build from is the one thing a converged machine
+ * no longer has. Both artifacts are resolved from the release instead:
+ *
+ *   vscode-extension-red-skills-<version>.vsix   installed into each editor
+ *   herdr-plugin-red-skills.bundle.min.mjs       the plugin's own entry
+ *
+ * The herdr half is worth stating exactly, because it is the one place
+ * where "install from the release" is not a download. herdr fetches the
+ * plugin directory itself, and that directory's build hook writes the
+ * released bundle over its entry — so what red-dev resolves is the
+ * release *tag*, and it pins the fetch to it. Asking for the bundle by
+ * name is what proves the release published one; without that, an
+ * unpinned install reads whatever the default branch says today and can
+ * name an asset no release has.
+ *
+ * Nothing here is fatal. A release that cannot be reached is a machine
+ * with an older extension on it, which is a far better outcome than a
+ * converge that stops before the steps after this one.
  */
 
-import { existsSync, mkdirSync, readFileSync, realpathSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, realpathSync, rmSync } from "node:fs";
 import { log, RedError } from "./log.ts";
 import type { Platform } from "./platform.ts";
+import type { GhRelease } from "./providers.ts";
 
 function home(): string {
   const h = process.env["HOME"] ?? process.env["USERPROFILE"];
@@ -32,54 +50,149 @@ export function sourceRoot(): string | null {
 /**
  * The version directory `current` points at.
  *
- * The symlink is the only thing that moves — the versions beneath it
- * are immutable, so the resolved path is the whole freshness question
- * for anything built out of the tree.
+ * Nothing here builds from it any more, but the layout it names is still
+ * how the rest of the machine resolves RedSkills, so the question keeps
+ * its answer in the module that has always owned it.
  */
 export function resolvedSource(): string | null {
   const root = sourceRoot();
   return root === null ? null : realpathSync(root);
 }
 
+// ------------------------------------------------------------ the release
+
+export const REDSKILLS_REPO = "reddb-io/red-skills";
+
 /**
- * Which checkout each artifact was last built from.
+ * The published extension.
  *
- * Neither artifact carries the red-skills version: the extension's own
- * package.json says 0.1.0 and stayed 0.1.0 across every release, and
- * the herdr plugin's manifest says 0.1.0 too. Asking the editor or
- * herdr what version it has answers a question about the artifact and
- * not about the source it came from, so the build records the source
- * itself. Comparing that to where `current` points now is the only
- * signal that does not lie.
+ * A glob and not a filename: the asset carries the release version, and
+ * reconstructing it from a version we already hold is exactly the guess
+ * `resolveGhRelease` exists to stop anyone making.
  */
-export interface BuildStamp {
-  vscode?: string;
-  herdr?: string;
+export const VSIX_ASSET = "vscode-extension-red-skills-*.vsix";
+
+/** The published herdr entry bundle, whose name does not move. */
+export const HERDR_BUNDLE_ASSET = "herdr-plugin-red-skills.bundle.min.mjs";
+
+/** The plugin directory herdr fetches, pinned to the resolved tag. */
+export const HERDR_PLUGIN_SOURCE = "reddb-io/red-skills/apps/herdr-plugin-red-skills";
+
+/**
+ * What the editors call the extension.
+ *
+ * Two spellings, because the app was renamed: a machine converged before
+ * the rename carries `vscode-redskilled` and one converged after carries
+ * `vscode-extension-red-skills`. Both count as "installed" when deciding
+ * what to refresh — a probe that knew only the new one would report every
+ * machine with the old extension as not having it, and leave it behind
+ * forever.
+ */
+export const EXTENSION_ID = "reddb-io.vscode-extension-red-skills";
+export const LEGACY_EXTENSION_ID = "reddb-io.vscode-redskilled";
+
+/** What herdr calls the plugin. */
+export const PLUGIN_ID = "reddb-io.red-skills";
+
+// ------------------------------------------------------------- the record
+
+/**
+ * What this path installed, and out of which release.
+ *
+ * Neither artifact can be asked. The extension reports its own version
+ * to the editor and herdr reports the plugin's, and neither is the
+ * release they came from — the old build recorded the checkout it read
+ * for the same reason. The record is also the only thing that means "we
+ * did this": both tools are `managed`, so nothing probes for them, and
+ * an uninstall driven by anything weaker would be removing an artifact
+ * on the evidence that it exists.
+ */
+export interface InstalledArtifact {
+  /** The release tag it was resolved from. */
+  tag: string;
+  /** For the extension: the editor CLIs that accepted it. */
+  editors?: string[];
+  /** For the extension: the identifier those editors know it by. */
+  id?: string;
+}
+
+export interface ExtensionRecord {
+  vscode?: InstalledArtifact;
+  herdr?: InstalledArtifact;
 }
 
 /** Computed rather than a constant: the tests move HOME between cases. */
-function stampPath(): string {
-  return `${home()}/.local/share/red-dev/red-skills-built.json`;
+function recordPath(): string {
+  return `${home()}/.local/share/red-dev/red-skills-extensions.json`;
 }
 
-export function readStamp(): BuildStamp {
-  const path = stampPath();
+/** Where a downloaded asset lands. Ours, so an uninstall may delete it. */
+export function assetCache(): string {
+  return `${home()}/.local/share/red-dev/red-skills-assets`;
+}
+
+export function readRecord(): ExtensionRecord {
+  const path = recordPath();
   if (!existsSync(path)) return {};
   try {
-    return JSON.parse(readFileSync(path, "utf8")) as BuildStamp;
+    return JSON.parse(readFileSync(path, "utf8")) as ExtensionRecord;
   } catch {
-    // A stamp we cannot read means "rebuild", which is the safe way to
-    // be wrong: the cost is one rebuild, not a permanently stale editor.
+    // A record we cannot read means "install again", which is the safe
+    // way to be wrong: the cost is one download, not an editor pinned to
+    // a release nobody can name.
     return {};
   }
 }
 
-export async function recordBuild(which: keyof BuildStamp): Promise<void> {
-  const source = resolvedSource();
-  if (source === null) return;
-  const path = stampPath();
+export async function writeRecord(patch: ExtensionRecord): Promise<void> {
+  const path = recordPath();
   mkdirSync(path.slice(0, path.lastIndexOf("/")), { recursive: true });
-  await Bun.write(path, `${JSON.stringify({ ...readStamp(), [which]: source }, null, 2)}\n`);
+  await Bun.write(path, `${JSON.stringify({ ...readRecord(), ...patch }, null, 2)}\n`);
+}
+
+/** Forget one artifact, or drop the record entirely once both are gone. */
+export async function forgetRecord(which: keyof ExtensionRecord): Promise<void> {
+  const rest = { ...readRecord() };
+  delete rest[which];
+  const path = recordPath();
+  if (Object.keys(rest).length === 0) {
+    rmSync(path, { force: true });
+    return;
+  }
+  await Bun.write(path, `${JSON.stringify(rest, null, 2)}\n`);
+}
+
+// ---------------------------------------------------------------- the seam
+
+/**
+ * Everything here that leaves the process.
+ *
+ * One object rather than module-level functions, so a test can assert
+ * what a converge *does* — which release was asked for, which commands
+ * ran, what the record says afterwards — without a network, an editor or
+ * a herdr. The production implementation below is the only place that
+ * knows any of those exist.
+ */
+export interface ExtIo {
+  /** Every VS Code-family CLI on this machine. */
+  clis(): string[];
+  /** Those of them that already carry the extension, under either id. */
+  editorsWithExtension(): Promise<string[]>;
+  /** Is herdr on PATH at all? */
+  hasHerdr(): boolean;
+  /** Does herdr already know the plugin? */
+  herdrHasPlugin(): Promise<boolean>;
+  /** The newest release carrying an asset matching `glob`. Throws if none. */
+  resolve(glob: string): Promise<GhRelease>;
+  /** Fetch one resolved asset; the path it landed at. */
+  download(release: GhRelease): Promise<string>;
+  /** Run a command and hand back its exit code, never a throw. */
+  run(cmd: string[]): Promise<number>;
+}
+
+/** Every VS Code-family CLI on this machine. */
+export function vscodeClis(): string[] {
+  return ["code", "codium", "cursor"].filter((c) => Bun.which(c));
 }
 
 /** Run a command and hand back its stdout, empty when it fails. */
@@ -93,203 +206,207 @@ async function capture(cmd: string[]): Promise<string> {
   }
 }
 
-const EXTENSION_ID = "reddb-io.vscode-redskilled";
-const PLUGIN_ID = "reddb-io.red-skills";
+export function defaultIo(): ExtIo {
+  return {
+    clis: vscodeClis,
 
-/** Editors that already have the extension, which are the ones to refresh. */
-async function editorsWithExtension(): Promise<string[]> {
-  const found: string[] = [];
-  for (const cli of vscodeClis()) {
-    if ((await capture([cli, "--list-extensions"])).includes(EXTENSION_ID)) found.push(cli);
-  }
-  return found;
-}
+    async editorsWithExtension(): Promise<string[]> {
+      const found: string[] = [];
+      for (const cli of vscodeClis()) {
+        const listed = await capture([cli, "--list-extensions"]);
+        if (listed.includes(EXTENSION_ID) || listed.includes(LEGACY_EXTENSION_ID)) found.push(cli);
+      }
+      return found;
+    },
 
-/** Does herdr already know the plugin? */
-async function herdrHasPlugin(): Promise<boolean> {
-  if (!Bun.which("herdr")) return false;
-  return (await capture(["herdr", "plugin", "list"])).includes(PLUGIN_ID);
-}
+    hasHerdr: () => Boolean(Bun.which("herdr")),
 
-/**
- * Rebuild whichever of the two is installed and behind the checkout.
- *
- * Only what is already there. Both are optional, and `update` advancing
- * a machine into software it never asked for would
- * be a worse bug than the staleness this fixes — so absence is left
- * alone and presence is kept current.
- */
-export async function refreshRedSkillsExtensions(p: Platform): Promise<void> {
-  const source = resolvedSource();
-  if (source === null) return;
-  const stamp = readStamp();
-  const version = source.split("/").pop();
+    async herdrHasPlugin(): Promise<boolean> {
+      if (!Bun.which("herdr")) return false;
+      return (await capture(["herdr", "plugin", "list"])).includes(PLUGIN_ID);
+    },
 
-  if ((await editorsWithExtension()).length === 0) {
-    log.skip("vscode extension: not installed, left alone");
-  } else if (stamp.vscode === source) {
-    log.skip(`vscode extension already built from ${version}`);
-  } else {
-    log.step(`vscode extension: rebuilding against ${version}`);
-    await installVscodeExtension();
-  }
+    async resolve(glob: string): Promise<GhRelease> {
+      const { resolveGhRelease } = await import("./providers.ts");
+      return await resolveGhRelease(REDSKILLS_REPO, glob);
+    },
 
-  if (!(await herdrHasPlugin())) {
-    log.skip("herdr plugin: not installed, left alone");
-  } else if (stamp.herdr === source) {
-    log.skip(`herdr plugin already installed from ${version}`);
-  } else {
-    log.step(`herdr plugin: reinstalling against ${version}`);
-    await installHerdrPlugin(p);
-  }
-}
+    async download(release: GhRelease): Promise<string> {
+      const dir = assetCache();
+      mkdirSync(dir, { recursive: true });
+      const dest = `${dir}/${release.file}`;
+      const { downloadVerified } = await import("./providers.ts");
+      await downloadVerified(release.url, dest, { checksumUrl: release.checksumUrl ?? undefined });
+      // Handed over with every link resolved.
+      //
+      // These editors are Windows programs even when invoked from a
+      // distro: they translate the path to \\wsl.localhost\... and open
+      // it over 9P, where a symlink anywhere above the file does not
+      // survive. VS Code has WSL integration and coped; VSCodium
+      // reported ENOENT on a file that plainly existed.
+      return realpathSync(dest);
+    },
 
-async function sh(cmd: string[], cwd?: string): Promise<number> {
-  const { spawnLogged } = await import("./providers.ts");
-  return await spawnLogged(cmd, cwd ? { cwd } : {});
+    async run(cmd: string[]): Promise<number> {
+      const { spawnLogged } = await import("./providers.ts");
+      return await spawnLogged(cmd);
+    },
+  };
 }
 
 /**
- * Make sure the workspace can build.
+ * Resolve one asset, or say why not and let the caller stand down.
  *
- * Separated so both callers pay for it once and only when needed. pnpm
- * comes from mise on every target red-dev sets up, so a missing one is a
- * broken converge rather than a reason to install node.
+ * The whole reason this returns null instead of throwing: a rate-limited
+ * GitHub, an offline machine or a release that has not published yet are
+ * all reasons to leave an artifact exactly as it is, and none of them is
+ * a reason to abandon the dotfiles, themes and agents that converge
+ * after this one.
  */
-async function prepareWorkspace(root: string): Promise<void> {
-  if (existsSync(`${root}/node_modules`)) {
-    log.skip("red-skills workspace already prepared");
-    return;
-  }
-  if (!Bun.which("pnpm")) {
-    throw new RedError("pnpm is not on PATH — run `red-dev install core` first");
-  }
-  log.step("red-skills: installing workspace dependencies (this is the slow part)");
-  if ((await sh(["pnpm", "install", "--frozen-lockfile"], root)) !== 0) {
-    throw new RedError("pnpm install failed in the red-skills workspace");
+async function resolveOrWarn(io: ExtIo, glob: string, what: string): Promise<GhRelease | null> {
+  try {
+    return await io.resolve(glob);
+  } catch (err) {
+    log.warn(`${what}: ${(err as Error).message}`);
+    log.skip(`${what}: left as it is — the rest of the converge continues`);
+    return null;
   }
 }
 
-/** Every VS Code-family CLI on this machine. */
-export function vscodeClis(): string[] {
-  return ["code", "codium", "cursor"].filter((c) => Bun.which(c));
-}
+// -------------------------------------------------------------- installing
 
 /**
- * Build the extension and install it into each editor present.
+ * Install the published extension into every editor present.
  *
- * The .vsix is never published — red-skills builds it from
- * src/packaging/vsix.ts rather than pulling in vsce — so there is no
- * download to prefer over this. Installed into every editor found,
- * because a machine with both VS Code and VSCodium wants it in the one
- * being used, and asking which is a question with no good default.
+ * Every editor found, because a machine with both VS Code and VSCodium
+ * wants it in the one being used, and asking which is a question with no
+ * good default.
  */
-export async function installVscodeExtension(): Promise<void> {
-  const clis = vscodeClis();
+export async function installVscodeExtension(
+  io: ExtIo = defaultIo(),
+  resolved?: GhRelease,
+): Promise<void> {
+  const clis = io.clis();
   if (clis.length === 0) {
     log.skip("vscode extension: no VS Code-family editor installed");
     return;
   }
 
-  const root = sourceRoot();
-  if (!root) {
-    log.skip("vscode extension: red-skills is not installed");
+  const release = resolved ?? (await resolveOrWarn(io, VSIX_ASSET, "vscode extension"));
+  if (!release) return;
+
+  let vsix: string;
+  try {
+    vsix = await io.download(release);
+  } catch (err) {
+    log.warn(`vscode extension: ${(err as Error).message}`);
+    log.skip("vscode extension: left as it is — the rest of the converge continues");
     return;
   }
 
-  await prepareWorkspace(root);
-
-  const app = `${root}/apps/vscode-redskilled`;
-  log.step("vscode extension: building");
-  if ((await sh(["pnpm", "-C", app, "build"], root)) !== 0) {
-    throw new RedError("the vscode extension failed to build");
-  }
-  if ((await sh(["pnpm", "-C", app, "package"], root)) !== 0) {
-    throw new RedError("the vscode extension failed to package");
-  }
-
-  // The repo root, not the app directory. `pnpm -C apps/... package`
-  // writes to dist/ at the workspace root — checked rather than assumed,
-  // after looking in the obvious place and finding nothing.
-  const glob = new Bun.Glob("*.vsix");
-  const found = [
-    ...glob.scanSync({ cwd: `${root}/dist`, absolute: true }),
-    ...(existsSync(`${app}/dist`)
-      ? glob.scanSync({ cwd: `${app}/dist`, absolute: true })
-      : []),
-  ].sort();
-  const vsix = found.pop();
-  if (!vsix) throw new RedError(`the build wrote no .vsix under ${root}/dist`);
-
-  // Handed over with the symlink resolved.
-  //
-  // These editors are Windows programs even when invoked from a distro:
-  // they translate the path to \\wsl.localhost\... and open it over 9P,
-  // where the `current` symlink does not survive. VS Code has WSL
-  // integration and coped; VSCodium reported ENOENT on a file that
-  // plainly existed. The real path works in both.
-  const real = realpathSync(vsix);
-
-  let installed = 0;
+  const editors: string[] = [];
   for (const cli of clis) {
-    if ((await sh([cli, "--install-extension", real, "--force"])) === 0) {
-      log.ok(`vscode extension installed into ${cli}`);
-      installed++;
+    if ((await io.run([cli, "--install-extension", vsix, "--force"])) === 0) {
+      log.ok(`vscode extension ${release.tag} installed into ${cli}`);
+      editors.push(cli);
     } else {
       log.warn(`${cli} refused the extension`);
     }
   }
-  // Only when something took it: stamping a refused install would
+
+  // Only when something took it: recording a refused install would
   // report the editor as current and never retry.
-  if (installed > 0) await recordBuild("vscode");
+  if (editors.length > 0) {
+    await writeRecord({ vscode: { tag: release.tag, editors, id: EXTENSION_ID } });
+  }
 }
 
 /**
- * Install the herdr plugin.
+ * Install the published herdr plugin.
  *
- * From GitHub when herdr can do it, which needs nothing local. That path
- * has been seen to fail on a machine whose plugin has to be built after
- * fetching, so the fallback is the one the plugin's own README
- * documents: prepare the workspace and link the directory.
+ * herdr fetches the plugin directory and its build hook materializes the
+ * released bundle over the entry, so nothing local is needed and nothing
+ * is built. The tag is pinned rather than left implicit: unpinned, herdr
+ * reads the default branch, whose manifest can name a bundle no release
+ * has published yet.
  *
- * Either way it ends with a key bound to it. An installed plugin herdr
- * gives no shortcut to is one nobody opens.
+ * It ends with a key bound to it. An installed plugin herdr gives no
+ * shortcut to is one nobody opens.
  */
-export async function installHerdrPlugin(p: Platform): Promise<void> {
-  if (!Bun.which("herdr")) {
+export async function installHerdrPlugin(
+  p: Platform,
+  io: ExtIo = defaultIo(),
+  resolved?: GhRelease,
+): Promise<void> {
+  if (!io.hasHerdr()) {
     log.skip("herdr plugin: herdr is not installed");
     return;
   }
 
-  log.step("herdr plugin: installing from GitHub");
-  const remote = await sh([
+  const release = resolved ?? (await resolveOrWarn(io, HERDR_BUNDLE_ASSET, "herdr plugin"));
+  if (!release) return;
+
+  log.step(`herdr plugin: installing ${release.tag} from the published release`);
+  const code = await io.run([
     "herdr",
     "plugin",
     "install",
-    "reddb-io/red-skills/apps/herdr-plugin",
+    HERDR_PLUGIN_SOURCE,
+    "--ref",
+    release.tag,
     "--yes",
   ]);
-  if (remote === 0) {
-    log.ok("herdr plugin installed from reddb-io/red-skills");
-    await recordBuild("herdr");
-    await bindDashboard(p);
+  if (code !== 0) {
+    log.warn(`herdr plugin: herdr refused the install (exit ${code})`);
+    log.skip("herdr plugin: left as it is — the rest of the converge continues");
     return;
   }
 
-  const root = sourceRoot();
-  if (!root) {
-    log.warn("herdr plugin: remote install failed and red-skills is not installed locally");
-    return;
+  log.ok(`herdr plugin ${release.tag} installed`);
+  await writeRecord({ herdr: { tag: release.tag } });
+  await bindDashboard(p, io);
+}
+
+/**
+ * Advance whichever of the two is installed and behind the release.
+ *
+ * Only what is already there. Both are optional, and `update` advancing
+ * a machine into software it never asked for would be a worse bug than
+ * the staleness this fixes — so absence is left alone and presence is
+ * kept current.
+ *
+ * The comparison is against the release tag, not against a checkout.
+ * That is the whole difference this slice makes: a machine with no
+ * source tree is now a machine that can still answer "is it current?".
+ */
+export async function refreshRedSkillsExtensions(
+  p: Platform,
+  io: ExtIo = defaultIo(),
+): Promise<void> {
+  const record = readRecord();
+
+  if ((await io.editorsWithExtension()).length === 0) {
+    log.skip("vscode extension: not installed, left alone");
+  } else {
+    const release = await resolveOrWarn(io, VSIX_ASSET, "vscode extension");
+    if (release && record.vscode?.tag === release.tag) {
+      log.skip(`vscode extension already at ${release.tag}`);
+    } else if (release) {
+      log.step(`vscode extension: installing ${release.tag}`);
+      await installVscodeExtension(io, release);
+    }
   }
 
-  log.step("herdr plugin: remote install failed — linking the local checkout instead");
-  await prepareWorkspace(root);
-  if ((await sh(["herdr", "plugin", "link", `${root}/apps/herdr-plugin`])) !== 0) {
-    throw new RedError("herdr refused to link the plugin");
+  if (!(await io.herdrHasPlugin())) {
+    log.skip("herdr plugin: not installed, left alone");
+  } else {
+    const release = await resolveOrWarn(io, HERDR_BUNDLE_ASSET, "herdr plugin");
+    if (release && record.herdr?.tag === release.tag) {
+      log.skip(`herdr plugin already at ${release.tag}`);
+    } else if (release) {
+      await installHerdrPlugin(p, io, release);
+    }
   }
-  log.ok("herdr plugin linked from the red-skills checkout");
-  await recordBuild("herdr");
-  await bindDashboard(p);
 }
 
 /**
@@ -297,11 +414,66 @@ export async function installHerdrPlugin(p: Platform): Promise<void> {
  * running server keeps the old config until it is told otherwise, which
  * is why the reload is asked for rather than left to the next launch.
  */
-async function bindDashboard(p: Platform): Promise<void> {
+async function bindDashboard(p: Platform, io: ExtIo): Promise<void> {
   try {
     const { bindHerdrDashboard } = await import("./herdr.ts");
-    if (await bindHerdrDashboard(p)) await sh(["herdr", "server", "reload-config"]);
+    if (await bindHerdrDashboard(p)) await io.run(["herdr", "server", "reload-config"]);
   } catch (err) {
     log.warn(`herdr keybinding: ${(err as Error).message}`);
   }
+}
+
+// ------------------------------------------------------------ uninstalling
+
+/**
+ * Take back exactly what this path put there, and nothing beside it.
+ *
+ * Driven by the record, so a machine red-dev never installed these on
+ * has nothing removed from it — the same rule the rest of the uninstall
+ * follows, applied to two artifacts no probe can speak for.
+ *
+ * The generated keybinding goes with the plugin, because it is a block
+ * this project wrote and it invokes a plugin that is about to stop
+ * existing. Nothing else in herdr's config is touched: that is where the
+ * operator's own keys live.
+ */
+export async function uninstallVscodeExtension(io: ExtIo = defaultIo()): Promise<string[]> {
+  const entry = readRecord().vscode;
+  if (!entry) return [];
+
+  const id = entry.id ?? EXTENSION_ID;
+  const removed: string[] = [];
+  for (const cli of entry.editors ?? []) {
+    if ((await io.run([cli, "--uninstall-extension", id])) === 0) removed.push(`${id} (${cli})`);
+    else log.warn(`${cli} could not remove ${id}`);
+  }
+
+  rmSync(assetCache(), { recursive: true, force: true });
+  await forgetRecord("vscode");
+  return removed;
+}
+
+export async function uninstallHerdrPlugin(
+  p: Platform,
+  io: ExtIo = defaultIo(),
+): Promise<string[]> {
+  const entry = readRecord().herdr;
+  if (!entry) return [];
+
+  const removed: string[] = [];
+  if ((await io.run(["herdr", "plugin", "uninstall", PLUGIN_ID])) === 0) removed.push(PLUGIN_ID);
+  else log.warn(`herdr could not remove ${PLUGIN_ID}`);
+
+  try {
+    const { unbindHerdrDashboard } = await import("./herdr.ts");
+    if (await unbindHerdrDashboard(p)) {
+      removed.push("herdr prefix+d binding");
+      await io.run(["herdr", "server", "reload-config"]);
+    }
+  } catch (err) {
+    log.warn(`herdr keybinding: ${(err as Error).message}`);
+  }
+
+  await forgetRecord("herdr");
+  return removed;
 }

--- a/src/red-skills-refresh.test.ts
+++ b/src/red-skills-refresh.test.ts
@@ -1,25 +1,28 @@
 /**
- * The two artifacts built from a checkout nothing advanced.
+ * The record that replaced the build stamp.
  *
- * `~/.red-skills/current` froze at the version that first wired the
- * machine: convergeRedSkills asks whether red-skills is *wired*, a wired
- * machine has nothing left to do, and so update never re-ran the
- * installer. Meanwhile Claude's own plugin cache kept updating through
- * the marketplace, so the daemon answered a newer version than the tree
- * the vscode extension and the herdr plugin were built from — two
- * copies, one moving, and everything here built out of the still one.
+ * While both artifacts were built here, the freshness question was "which
+ * checkout did this come out of" — neither can be asked its own version,
+ * because both report the artifact's rather than the release's. So the
+ * build recorded the tree it read.
  *
- * Neither artifact can be asked about it: both declare version 0.1.0 and
- * have declared 0.1.0 across every red-skills release, so asking the
- * editor or herdr answers about the artifact rather than its source. The
- * build records which checkout it read instead, and that record is what
- * these cover.
+ * There is no tree any more. The published package stopped carrying
+ * monorepo source, and both artifacts now come from the release, so the
+ * question is "which release did this come out of" and the record holds a
+ * tag. It is also the only artifact on the machine that means "red-dev
+ * did this", which is what an uninstall is entitled to act on.
  */
 
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, readFileSync, symlinkSync, unlinkSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, symlinkSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { readStamp, recordBuild, resolvedSource, sourceRoot } from "./red-skills-ext.ts";
+import {
+  forgetRecord,
+  readRecord,
+  resolvedSource,
+  sourceRoot,
+  writeRecord,
+} from "./red-skills-ext.ts";
 
 const saved = process.env["HOME"];
 
@@ -50,8 +53,7 @@ function point(root: string, version: string): void {
   symlinkSync(dir, link);
 }
 
-const stampFile = (root: string) =>
-  readFileSync(`${root}/.local/share/red-dev/red-skills-built.json`, "utf8");
+const recordFile = (root: string) => `${root}/.local/share/red-dev/red-skills-extensions.json`;
 
 describe("the checkout", () => {
   test("is found through the current symlink", () => {
@@ -67,53 +69,75 @@ describe("the checkout", () => {
 
   test("resolves to the version directory, not the symlink", () => {
     // The symlink is the only thing that moves and every version under
-    // it is immutable. Recording the symlink path would compare equal
-    // to itself forever and rebuild nothing, ever.
+    // it is immutable, so the resolved path is the whole freshness
+    // question for anything that reads the tree.
     const root = machine("v3.3.0");
     expect(resolvedSource()).toBe(`${root}/.red-skills/versions/v3.3.0`);
   });
+
+  test("neither artifact needs it any more", async () => {
+    // The record is written on a machine with no checkout at all. This
+    // is the fact the whole slice turns on: `sourceRoot()` being null
+    // used to mean "nothing can be installed".
+    const root = mkdtempSync(`${tmpdir()}/red-skills-`);
+    process.env["HOME"] = root;
+    expect(sourceRoot()).toBeNull();
+
+    await writeRecord({ vscode: { tag: "v3.18.12", editors: ["code"] } });
+    expect(readRecord().vscode?.tag).toBe("v3.18.12");
+  });
 });
 
-describe("the build stamp", () => {
-  test("records where the build read from", async () => {
+describe("the install record", () => {
+  test("holds the release tag, not a path into a tree", async () => {
     const root = machine("v3.3.0");
-    await recordBuild("vscode");
-    expect(readStamp().vscode).toBe(`${root}/.red-skills/versions/v3.3.0`);
-    expect(stampFile(root)).not.toContain("current");
+    await writeRecord({ vscode: { tag: "v3.18.12", editors: ["code"] } });
+    expect(readFileSync(recordFile(root), "utf8")).not.toContain(root);
   });
 
-  test("goes stale exactly when current moves", async () => {
-    // This is the whole mechanism: same tree, nothing to do; advanced
-    // tree, rebuild. Both directions, because a check that only ever
-    // says "rebuild" is as useless as one that never does.
+  test("goes stale exactly when the release moves", async () => {
+    // This is the whole mechanism: same tag, nothing to do; newer tag,
+    // install again. Both directions, because a check that only ever
+    // says "install" is as useless as one that never does.
     machine("v3.3.0");
-    await recordBuild("vscode");
-    expect(readStamp().vscode).toBe(resolvedSource() as string);
-
-    point(process.env["HOME"] as string, "v3.4.0");
-    expect(readStamp().vscode).not.toBe(resolvedSource());
+    await writeRecord({ vscode: { tag: "v3.18.12" } });
+    expect(readRecord().vscode?.tag).toBe("v3.18.12");
+    expect(readRecord().vscode?.tag).not.toBe("v3.19.0");
   });
 
   test("keeps the other artifact's entry", async () => {
-    // They advance independently: rebuilding the editor extension must
+    // They advance independently: reinstalling the editor extension must
     // not tell the next run that herdr is current too.
     machine("v3.3.0");
-    await recordBuild("herdr");
-    await recordBuild("vscode");
-    expect(readStamp()).toEqual({ herdr: resolvedSource() as string, vscode: resolvedSource() as string });
+    await writeRecord({ herdr: { tag: "v3.18.12" } });
+    await writeRecord({ vscode: { tag: "v3.19.0" } });
+    expect(readRecord()).toEqual({
+      herdr: { tag: "v3.18.12" },
+      vscode: { tag: "v3.19.0" },
+    });
   });
 
-  test("an unreadable stamp means rebuild, not skip", async () => {
+  test("an unreadable record means install again, not skip", () => {
     const root = machine("v3.3.0");
     mkdirSync(`${root}/.local/share/red-dev`, { recursive: true });
-    writeFileSync(`${root}/.local/share/red-dev/red-skills-built.json`, "{ truncated");
-    expect(readStamp()).toEqual({});
+    writeFileSync(recordFile(root), "{ truncated");
+    expect(readRecord()).toEqual({});
   });
 
-  test("nothing is recorded when there is no checkout", async () => {
-    const root = mkdtempSync(`${tmpdir()}/red-skills-`);
-    process.env["HOME"] = root;
-    await recordBuild("vscode");
-    expect(readStamp()).toEqual({});
+  test("forgetting one artifact leaves the other standing", async () => {
+    machine("v3.3.0");
+    await writeRecord({ herdr: { tag: "v3.18.12" }, vscode: { tag: "v3.18.12" } });
+    await forgetRecord("vscode");
+    expect(readRecord()).toEqual({ herdr: { tag: "v3.18.12" } });
+  });
+
+  test("forgetting the last one takes the file with it", async () => {
+    const root = machine("v3.3.0");
+    await writeRecord({ herdr: { tag: "v3.18.12" } });
+    await forgetRecord("herdr");
+    // Not an empty object left behind: nothing installed and a file
+    // saying so are different states, and only one of them is true.
+    expect(existsSync(recordFile(root))).toBe(false);
+    expect(readRecord()).toEqual({});
   });
 });

--- a/src/uninstall.ts
+++ b/src/uninstall.ts
@@ -26,6 +26,7 @@ import type { Platform } from "./platform.ts";
 // back from here, which is type-only and erased — there is no cycle at
 // run time.
 import { sshAccessRemoval } from "./ssh-access.ts";
+import { readRecord, uninstallHerdrPlugin, uninstallVscodeExtension } from "./red-skills-ext.ts";
 
 export interface Removal {
   tool: string;
@@ -155,6 +156,66 @@ export function removableTools(p: Platform): { tool: Tool; removal: Removal }[] 
   // not. See src/ssh-access.ts.
   const ssh = toolsInScope("core").find((tool) => tool.name === "ssh-server");
   if (ssh) out.push({ tool: ssh, removal: sshAccessRemoval(p) });
+
+  // The two RedSkills artifacts, which the loop cannot reach for the
+  // same two reasons: both are `managed`, so nothing probes for them,
+  // and both have a builtin provider, so `removalFor` has no package to
+  // name. What makes them removable anyway is the record the install
+  // writes — the only artifact on the machine that means "red-dev did
+  // this" rather than "an extension exists". No record, nothing offered:
+  // a machine that installed the extension by hand keeps it.
+  out.push(...redSkillsExtensionRemovals(p));
+  return out;
+}
+
+/**
+ * The removals the install record justifies, and only those.
+ *
+ * Exported so the record's authority over the offer is testable on its
+ * own: it is the whole difference between removing what we installed and
+ * removing what happens to be there.
+ */
+export function redSkillsExtensionRemovals(p: Platform): { tool: Tool; removal: Removal }[] {
+  // A home this process cannot name is a machine with no record to read,
+  // and that must not cost the operator the rest of the removal list.
+  let record;
+  try {
+    record = readRecord();
+  } catch {
+    return [];
+  }
+  const out: { tool: Tool; removal: Removal }[] = [];
+  const named = (name: string) => toolsInScope("optional").find((t) => t.name === name);
+
+  const vscode = named("red-skills-vscode");
+  if (vscode && record.vscode) {
+    const editors = record.vscode.editors ?? [];
+    out.push({
+      tool: vscode,
+      removal: {
+        tool: vscode.name,
+        how: `uninstall the extension from ${editors.join(", ") || "the editors it went into"}`,
+        run: async () => {
+          await uninstallVscodeExtension();
+        },
+      },
+    });
+  }
+
+  const herdr = named("red-skills-herdr");
+  if (herdr && record.herdr) {
+    out.push({
+      tool: herdr,
+      removal: {
+        tool: herdr.name,
+        how: "herdr plugin uninstall reddb-io.red-skills",
+        run: async () => {
+          await uninstallHerdrPlugin(p);
+        },
+      },
+    });
+  }
+
   return out;
 }
 


### PR DESCRIPTION
Automated AFK landing for #190. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #190

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/197"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789517921&installation_model_id=20659&pr_number=197&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F197&signature=6cb718cce85e416ad54c5fc4eb4dfc1cafdc8d9c50f88e7e2144d9e88c305bcf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->