### PR TITLE
fix: #191 The three generator hosts are invoked from the installed tree, never reimplemented

### DIFF
--- a/src/red-skills-hosts.test.ts
+++ b/src/red-skills-hosts.test.ts
@@ -14,10 +14,16 @@
  * host refused the call. So the runner is injected and what is asserted
  * is the argv that reached it — which also means all of this holds with
  * no red-skills, no marketplace and no agent CLI on the machine.
+ *
+ * Two of those describes go further and actually run a generator, out of
+ * a fixture tree with a real script in it. That is the only way to assert
+ * the thing the split exists for: a skill added to the tree appears on
+ * the machine with nothing here changed, and unwiring removes what the
+ * generator's own manifest recorded rather than what this repo guesses.
  */
 
 import { describe, expect, test } from "bun:test";
-import { mkdtempSync, readFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -26,7 +32,10 @@ import {
   REFRESH_HOSTS,
   readHostStamp,
   refreshSkillHosts,
+  unwireSkillHosts,
+  type HostContext,
   type HostRefreshOptions,
+  type SkillHostRefresh,
 } from "./red-skills-hosts.ts";
 
 const UBUNTU: Platform = {
@@ -44,6 +53,19 @@ const OLD = "/home/someone/.red-skills/versions/v3.3.0";
 const NEW = "/home/someone/.red-skills/versions/v3.4.0";
 
 const PLUGINS = ["dev", "memory"];
+
+const CTX: HostContext = { plugins: PLUGINS, source: NEW };
+
+/** The hosts red-dev drives with its own CLI calls. */
+const CLI_HOSTS = ["claude", "codex"];
+/** The hosts wired by the generators inside the installed tree. */
+const GENERATOR_HOSTS = ["opencode", "redcode", "pi"];
+
+function hostNamed(name: string): SkillHostRefresh {
+  const host = REFRESH_HOSTS.find((h) => h.name === name);
+  if (!host) throw new Error(`no host named ${name}`);
+  return host;
+}
 
 function home(): string {
   return mkdtempSync(join(tmpdir(), "red-hosts-home-"));
@@ -75,9 +97,21 @@ function refresh(
   });
 }
 
-/** The commands one host answered for, by the CLI they were addressed to. */
-function forHost(calls: string[][], cmd: string): string[] {
-  return calls.filter((c) => c[0] === cmd).map((c) => c.join(" "));
+/** What one host is asked, as lines, in the order it is asked. */
+function wireOf(host: SkillHostRefresh, ctx: HostContext = CTX): string[] {
+  return host.wire(ctx).map((s) => s.argv.join(" "));
+}
+
+/**
+ * The commands one host answered for.
+ *
+ * Matched against that host's own steps rather than against the CLI
+ * name: three of the five hosts are wired by a script path, and two of
+ * those three are the same script told which host it is working for.
+ */
+function forHost(calls: string[][], host: SkillHostRefresh, ctx: HostContext = CTX): string[] {
+  const mine = new Set(wireOf(host, ctx));
+  return calls.map((c) => c.join(" ")).filter((c) => mine.has(c));
 }
 
 describe("the hosts are refreshed when the resolved version moved", () => {
@@ -91,11 +125,7 @@ describe("the hosts are refreshed when the resolved version moved", () => {
 
     expect(out.every((o) => o.refreshed)).toBe(true);
     expect(out.map((o) => o.host)).toEqual(REFRESH_HOSTS.map((h) => h.name));
-    for (const host of REFRESH_HOSTS) {
-      expect(forHost(calls, host.cmd), host.name).toEqual(
-        host.argv(PLUGINS).map((c) => c.join(" ")),
-      );
-    }
+    expect(calls.map((c) => c.join(" "))).toEqual(REFRESH_HOSTS.flatMap((h) => wireOf(h)));
   });
 
   test("and issues them exactly once per host, not once per plugin set", async () => {
@@ -104,13 +134,16 @@ describe("the hosts are refreshed when the resolved version moved", () => {
     const { calls, run } = recorder();
     await refresh({ home: home(), source: NEW, run });
 
-    for (const host of REFRESH_HOSTS) {
-      const marketplace = forHost(calls, host.cmd).filter((c) => c.includes("marketplace"));
-      expect(marketplace.length, host.name).toBe(1);
+    for (const name of CLI_HOSTS) {
+      const host = hostNamed(name);
+      const marketplace = forHost(calls, host).filter((c) => c.includes("marketplace"));
+      expect(marketplace.length, name).toBe(1);
     }
-    expect(calls.length).toBe(
-      REFRESH_HOSTS.reduce((n, h) => n + h.argv(PLUGINS).length, 0),
-    );
+    // And the generators are invoked once each, whatever the plugin set:
+    // which plugins to render is the tree's question, not this repo's.
+    for (const name of GENERATOR_HOSTS) {
+      expect(forHost(calls, hostNamed(name)).length, name).toBe(1);
+    }
   });
 
   test("a converge whose resolved version is unchanged issues no host commands", async () => {
@@ -163,26 +196,31 @@ describe("a host that is not on the machine", () => {
     // The distinction is load-bearing for the stamp below: "we refreshed
     // it" and "it is not here" are different facts, and collapsing them
     // is how a host that arrives next week never gets refreshed at all.
-    const first = REFRESH_HOSTS[0] as (typeof REFRESH_HOSTS)[number];
-    const { calls, run } = recorder();
-    const out = await refresh({
-      home: home(),
-      source: NEW,
-      present: (cmd) => cmd !== first.cmd,
-      run,
-    });
+    // Asserted for every host in turn, because the generator hosts are
+    // absent from far more machines than Claude is.
+    for (const skip of REFRESH_HOSTS) {
+      const { calls, run } = recorder();
+      const out = await refresh({
+        home: home(),
+        source: NEW,
+        present: (cmd) => cmd !== skip.cmd,
+        run,
+      });
 
-    const skipped = out.find((o) => o.host === first.name);
-    expect(skipped?.refreshed).toBe(false);
-    expect(skipped?.reason).toContain("not installed");
-    expect(forHost(calls, first.cmd)).toEqual([]);
-    expect(out.filter((o) => o.host !== first.name).every((o) => o.refreshed)).toBe(true);
+      const skipped = out.find((o) => o.host === skip.name);
+      expect(skipped?.refreshed, skip.name).toBe(false);
+      expect(skipped?.reason, skip.name).toContain("not installed");
+      expect(forHost(calls, skip), skip.name).toEqual([]);
+      expect(out.filter((o) => o.host !== skip.name).every((o) => o.refreshed), skip.name).toBe(
+        true,
+      );
+    }
   });
 
   test("and is refreshed on the converge after it appears", async () => {
     // Absence must not be stamped. A skipped host recorded as current is
     // a host installed tomorrow and left on yesterday's tree forever.
-    const first = REFRESH_HOSTS[0] as (typeof REFRESH_HOSTS)[number];
+    const first = hostNamed("claude");
     const root = home();
     await refresh({ home: root, source: NEW, present: (c) => c !== first.cmd, run: recorder().run });
     expect(readHostStamp(root)[first.name]).toBeUndefined();
@@ -191,7 +229,7 @@ describe("a host that is not on the machine", () => {
     const out = await refresh({ home: root, source: NEW, run });
 
     expect(out.find((o) => o.host === first.name)?.refreshed).toBe(true);
-    expect(forHost(calls, first.cmd).length).toBeGreaterThan(0);
+    expect(forHost(calls, first).length).toBeGreaterThan(0);
     // And only that host: the others were already at this version.
     expect(calls.every((c) => c[0] === first.cmd)).toBe(true);
   });
@@ -211,9 +249,7 @@ describe("a host that refuses the refresh", () => {
     expect(out.find((o) => o.host === (first as { name: string }).name)?.refreshed).toBe(false);
     for (const host of rest) {
       expect(out.find((o) => o.host === host.name)?.refreshed, host.name).toBe(true);
-      expect(forHost(calls, host.cmd), host.name).toEqual(
-        host.argv(PLUGINS).map((c) => c.join(" ")),
-      );
+      expect(forHost(calls, host), host.name).toEqual(wireOf(host));
     }
   });
 
@@ -232,12 +268,12 @@ describe("a host that refuses the refresh", () => {
 
     expect(out.find((o) => o.host === (first as { name: string }).name)?.refreshed).toBe(false);
     for (const host of rest) {
-      expect(forHost(calls, host.cmd).length, host.name).toBeGreaterThan(0);
+      expect(forHost(calls, host).length, host.name).toBeGreaterThan(0);
     }
   });
 
   test("is retried on the next converge, because it was never stamped", async () => {
-    const first = REFRESH_HOSTS[0] as (typeof REFRESH_HOSTS)[number];
+    const first = hostNamed("claude");
     const root = home();
     const failing = recorder((cmd) => (cmd[0] === first.cmd ? 1 : 0));
     await refresh({ home: root, source: NEW, run: failing.run });
@@ -247,26 +283,86 @@ describe("a host that refuses the refresh", () => {
     const out = await refresh({ home: root, source: NEW, run });
 
     expect(out.find((o) => o.host === first.name)?.refreshed).toBe(true);
-    expect(forHost(calls, first.cmd)).toEqual(first.argv(PLUGINS).map((c) => c.join(" ")));
+    expect(forHost(calls, first)).toEqual(wireOf(first));
     expect(readHostStamp(root)[first.name]).toBe(NEW);
   });
 });
 
 describe("what the hosts are asked", () => {
-  test("every host refreshes the marketplace and each declared plugin", async () => {
+  test("the five hosts are the ones the spec settled, by name", () => {
+    expect(REFRESH_HOSTS.map((h) => h.name)).toEqual([...CLI_HOSTS, ...GENERATOR_HOSTS]);
+  });
+
+  test("Claude and Codex are red-dev's own CLI calls", () => {
+    // Not a script, not a generator: the two hosts with a marketplace are
+    // the two red-dev drives itself, and every argv it issues is
+    // addressed to the CLI whose presence gated the call.
+    for (const name of CLI_HOSTS) {
+      const host = hostNamed(name);
+      for (const step of [...host.wire(CTX), ...host.unwire(CTX)]) {
+        expect(step.argv[0], `${name}: ${step.argv.join(" ")}`).toBe(host.cmd);
+      }
+      expect(wireOf(host).some((c) => c.includes("marketplace")), name).toBe(true);
+    }
+  });
+
+  test("every host refreshes each declared plugin", async () => {
     // Derived from the argument, never a literal here: the plugin set is
     // the manifest's answer, and a test that wrote one down would be a
-    // second place for it to be declared.
-    for (const host of REFRESH_HOSTS) {
-      const argv = host.argv(PLUGINS);
-      expect(argv.every((c) => c[0] === host.cmd), host.name).toBe(true);
+    // second place for it to be declared. Only the CLI hosts take it —
+    // the generators read the tree they ship in.
+    for (const name of CLI_HOSTS) {
+      const host = hostNamed(name);
+      const argv = wireOf(host);
       for (const plugin of PLUGINS) {
         expect(
           argv.some((c) => c.includes(`${plugin}@red-skills`)),
-          `${host.name}/${plugin}`,
+          `${name}/${plugin}`,
         ).toBe(true);
       }
     }
+  });
+
+  test("Codex removes and re-adds, because it has no plugin update", () => {
+    // Codex's CLI has `marketplace upgrade` and `plugin add`, and no
+    // `plugin update` at all. So the refresh is a remove followed by an
+    // add of the same plugin, in that order, against the marketplace
+    // snapshot the line above them just upgraded.
+    const codex = hostNamed("codex");
+    const steps = codex.wire(CTX);
+    expect(steps[0]?.argv).toEqual(["codex", "plugin", "marketplace", "upgrade", "red-skills"]);
+    expect(steps.some((s) => s.argv.includes("update"))).toBe(false);
+
+    for (const plugin of PLUGINS) {
+      const at = steps.findIndex(
+        (s) => s.argv.includes("remove") && s.argv.includes(`${plugin}@red-skills`),
+      );
+      expect(at, plugin).toBeGreaterThan(-1);
+      expect(steps[at + 1]?.argv, plugin).toEqual([
+        "codex",
+        "plugin",
+        "add",
+        `${plugin}@red-skills`,
+      ]);
+      // The remove is the fallback half, not a precondition: a plugin
+      // this machine has never installed makes it exit non-zero, and
+      // that is not a broken host.
+      expect(steps[at]?.optional, plugin).toBe(true);
+      expect(steps[at + 1]?.optional, plugin).toBeUndefined();
+    }
+  });
+
+  test("a plugin Codex has never seen does not fail the host", async () => {
+    // The same fact as above, held at the trace: a non-zero `remove` is
+    // stepped over, the `add` still runs, and the host is stamped.
+    const root = home();
+    const codex = hostNamed("codex");
+    const { calls, run } = recorder((cmd) => (cmd.includes("remove") ? 1 : 0));
+    const out = await refresh({ home: root, source: NEW, hosts: [codex], run });
+
+    expect(out).toEqual([{ host: "codex", refreshed: true }]);
+    expect(calls.map((c) => c.join(" "))).toEqual(wireOf(codex));
+    expect(readHostStamp(root)["codex"]).toBe(NEW);
   });
 
   test("an empty plugin set still refreshes the marketplace", async () => {
@@ -274,9 +370,10 @@ describe("what the hosts are asked", () => {
     // the marketplace it registers is what a later opt-in reads.
     const { calls, run } = recorder();
     await refresh({ home: home(), source: NEW, plugins: [], run });
-    expect(calls.length).toBe(REFRESH_HOSTS.length);
-    for (const host of REFRESH_HOSTS) {
-      expect(forHost(calls, host.cmd).length, host.name).toBe(1);
+    const empty: HostContext = { plugins: [], source: NEW };
+    expect(calls.map((c) => c.join(" "))).toEqual(REFRESH_HOSTS.flatMap((h) => wireOf(h, empty)));
+    for (const name of CLI_HOSTS) {
+      expect(forHost(calls, hostNamed(name), empty).length, name).toBe(1);
     }
   });
 
@@ -293,11 +390,266 @@ describe("what the hosts are asked", () => {
     expect(wired).toBeGreaterThan(-1);
     expect(converge.slice(wired)).toContain("refreshSkillHosts");
   });
+});
 
-  test("the hosts are the ones red-dev knows how to drive, by name", () => {
-    // Claude and Codex are CLI calls red-dev makes itself. The generator
-    // hosts are invoked from the installed tree and arrive with that
-    // slice; the table is where they will land.
-    expect(REFRESH_HOSTS.map((h) => h.name)).toEqual(["claude", "codex"]);
+describe("the three generator hosts", () => {
+  test("are wired by invoking a script inside the installed tree", async () => {
+    // The split the spec settled, held at the argv. Nothing here spells
+    // out a plugin module, a skill path or an MCP entry: the whole of
+    // red-dev's contribution is naming a script under the checkout.
+    for (const name of GENERATOR_HOSTS) {
+      const host = hostNamed(name);
+      for (const step of [...host.wire(CTX), ...host.unwire(CTX)]) {
+        expect(step.argv[0], `${name}: ${step.argv.join(" ")}`).toStartWith(`${NEW}/scripts/`);
+        expect(step.argv[0], name).toEndWith(".sh");
+      }
+    }
+  });
+
+  test("take the resolved checkout as their source, not a path of our own", async () => {
+    // A generator renders the skills that ship beside it, so the tree it
+    // is invoked out of is the tree it renders. Moving the checkout has
+    // to move every command — a path pinned anywhere in this repo would
+    // render yesterday's tree on a machine mise has already advanced.
+    for (const name of GENERATOR_HOSTS) {
+      const host = hostNamed(name);
+      const old = host.wire({ plugins: PLUGINS, source: OLD });
+      expect(old.every((s) => s.argv.join(" ").includes(OLD)), name).toBe(true);
+      expect(old.some((s) => s.argv.join(" ").includes(NEW)), name).toBe(false);
+    }
+  });
+
+  test("are the same generator for OpenCode and RedCode, told which host", () => {
+    // RedCode is an OpenCode-compatible host: one generator, two config
+    // directories. Two implementations of that would be the drift this
+    // whole split exists to avoid, in miniature.
+    const opencode = hostNamed("opencode").wire(CTX)[0]?.argv ?? [];
+    const redcode = hostNamed("redcode").wire(CTX)[0]?.argv ?? [];
+    expect(opencode[0]).toBe(redcode[0]);
+    expect(opencode.slice(opencode.indexOf("--host"))).toEqual(["--host", "opencode"]);
+    expect(redcode.slice(redcode.indexOf("--host"))).toEqual(["--host", "redcode"]);
+  });
+
+  test("hand pi the checkout explicitly, because it can install from npm instead", () => {
+    const pi = hostNamed("pi").wire(CTX)[0]?.argv ?? [];
+    expect(pi[0]).toBe(`${NEW}/scripts/install-pi.sh`);
+    expect(pi.slice(1)).toEqual(["--source-dir", NEW, "--user"]);
+  });
+});
+
+/**
+ * A tree shaped like the installed checkout, with a real generator in it.
+ *
+ * The script is a stand-in for `scripts/install-opencode.sh` and holds
+ * only the part of its contract these tests are about: it renders every
+ * skill it finds under the tree it lives in, and it records every path
+ * it wrote in an uninstall manifest that its own `--uninstall` reads
+ * back. Everything red-dev knows about that contract is the two argv
+ * lines above; the rest is deliberately on the other side of the fence.
+ */
+function fixtureTree(skills: string[]): string {
+  const tree = mkdtempSync(join(tmpdir(), "red-hosts-tree-"));
+  mkdirSync(join(tree, "scripts"), { recursive: true });
+  const script = join(tree, "scripts", "install-opencode.sh");
+  writeFileSync(
+    script,
+    `#!/usr/bin/env bash
+set -euo pipefail
+tree="$(cd "$(dirname "$0")/.." && pwd)"
+action=install
+host=opencode
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --uninstall) action=uninstall ;;
+    --host) host="$2"; shift ;;
+  esac
+  shift
+done
+config="\${XDG_CONFIG_HOME:?}/$host"
+manifest="$config/redskills-install-manifest.txt"
+if [[ "$action" == "uninstall" ]]; then
+  if [[ -f "$manifest" ]]; then
+    while IFS= read -r path || [[ -n "$path" ]]; do
+      if [[ -n "$path" ]]; then rm -rf "$path"; fi
+    done < "$manifest"
+    rm -f "$manifest"
+  fi
+  exit 0
+fi
+mkdir -p "$config/skills"
+: > "$manifest"
+for skill in "$tree"/plugins/*/skills/*/SKILL.md; do
+  name="$(basename "$(dirname "$skill")")"
+  mkdir -p "$config/skills/$name"
+  cp "$skill" "$config/skills/$name/SKILL.md"
+  printf '%s\\n' "$config/skills/$name" >> "$manifest"
+done
+`,
+  );
+  chmodSync(script, 0o755);
+  for (const skill of skills) addSkill(tree, skill);
+  return tree;
+}
+
+/** One more skill in the tree, which is the only edit these tests make. */
+function addSkill(tree: string, name: string): void {
+  const dir = join(tree, "plugins", "dev", "skills", name);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "SKILL.md"), `---\nname: ${name}\n---\n`);
+}
+
+/** Runs the argv for real, against a config directory of our own. */
+function spawner(config: string): (cmd: string[]) => Promise<number> {
+  return async (cmd: string[]) => {
+    const proc = Bun.spawn(cmd, {
+      env: { ...process.env, XDG_CONFIG_HOME: config },
+      stdout: "ignore",
+      stderr: "ignore",
+      stdin: "ignore",
+    });
+    return await proc.exited;
+  };
+}
+
+function skillPath(config: string, host: string, name: string): string {
+  return join(config, host, "skills", name, "SKILL.md");
+}
+
+describe("no generator logic is reimplemented here", () => {
+  test("a skill added to the tree lands on the machine with nothing changed here", async () => {
+    // The reason for the whole split, made observable. The only edit
+    // between the two converges below is one directory inside a fixture
+    // tree — no table in this repo names a skill, so none had to grow a
+    // row for `arrived-later` to appear.
+    const tree = fixtureTree(["shipped"]);
+    const config = mkdtempSync(join(tmpdir(), "red-hosts-config-"));
+    const opencode = hostNamed("opencode");
+
+    const first = await refresh({
+      home: home(),
+      source: tree,
+      hosts: [opencode],
+      run: spawner(config),
+    });
+    expect(first).toEqual([{ host: "opencode", refreshed: true }]);
+    expect(existsSync(skillPath(config, "opencode", "shipped"))).toBe(true);
+    expect(existsSync(skillPath(config, "opencode", "arrived-later"))).toBe(false);
+
+    addSkill(tree, "arrived-later");
+    // A fresh home so the stamp does not skip: the point is what the
+    // generator renders, not when the walk decides to ask it.
+    const second = await refresh({
+      home: home(),
+      source: tree,
+      hosts: [opencode],
+      run: spawner(config),
+    });
+
+    expect(second).toEqual([{ host: "opencode", refreshed: true }]);
+    expect(existsSync(skillPath(config, "opencode", "arrived-later"))).toBe(true);
+    expect(existsSync(skillPath(config, "opencode", "shipped"))).toBe(true);
+  });
+});
+
+describe("unwiring a generator host", () => {
+  test("goes through the same script and removes exactly what the manifest recorded", async () => {
+    // The conservative removal belongs to the generator, because the
+    // manifest is the only record of what it wrote. A second opinion in
+    // this repo would be a list of paths that drifts from the tree —
+    // and the way it fails is by deleting somebody else's file.
+    const tree = fixtureTree(["shipped", "also-shipped"]);
+    const config = mkdtempSync(join(tmpdir(), "red-hosts-config-"));
+    const root = home();
+    const redcode = hostNamed("redcode");
+
+    await refresh({ home: root, source: tree, hosts: [redcode], run: spawner(config) });
+    expect(existsSync(skillPath(config, "redcode", "shipped"))).toBe(true);
+    expect(readHostStamp(root)["redcode"]).toBe(tree);
+
+    // Something the generator never wrote, in the directory it writes
+    // into. Nothing recorded it, so nothing may remove it.
+    const mine = join(config, "redcode", "skills", "hand-written");
+    mkdirSync(mine, { recursive: true });
+    writeFileSync(join(mine, "SKILL.md"), "mine\n");
+
+    const calls: string[][] = [];
+    const run = spawner(config);
+    const out = await unwireSkillHosts(UBUNTU, {
+      home: root,
+      source: tree,
+      plugins: PLUGINS,
+      present: () => true,
+      hosts: [redcode],
+      run: (cmd) => {
+        calls.push(cmd);
+        return run(cmd);
+      },
+    });
+
+    expect(out).toEqual([{ host: "redcode", unwired: true }]);
+    expect(calls.map((c) => c.join(" "))).toEqual([
+      `${tree}/scripts/install-opencode.sh --uninstall --global --host redcode`,
+    ]);
+    // What the manifest recorded is gone, and only that.
+    expect(existsSync(skillPath(config, "redcode", "shipped"))).toBe(false);
+    expect(existsSync(skillPath(config, "redcode", "also-shipped"))).toBe(false);
+    expect(existsSync(join(config, "redcode", "redskills-install-manifest.txt"))).toBe(false);
+    expect(existsSync(join(mine, "SKILL.md"))).toBe(true);
+    // And the host is no longer claimed as refreshed against that tree,
+    // so the next converge wires it again rather than skipping it.
+    expect(readHostStamp(root)["redcode"]).toBeUndefined();
+  });
+
+  test("with no checkout on the machine, unwires nothing rather than guessing", async () => {
+    // The scripts live in the tree. With no tree there is no record of
+    // what was written, and this repo does not hold a second copy of it.
+    const { calls, run } = recorder();
+    const out = await unwireSkillHosts(UBUNTU, {
+      home: home(),
+      source: null,
+      plugins: PLUGINS,
+      present: () => true,
+      run,
+    });
+
+    expect(calls).toEqual([]);
+    expect(out).toEqual([]);
+  });
+
+  test("a host that is not installed is skipped with a reason", async () => {
+    const { calls, run } = recorder();
+    const out = await unwireSkillHosts(UBUNTU, {
+      home: home(),
+      source: NEW,
+      plugins: PLUGINS,
+      present: (cmd) => cmd !== "pi",
+      run,
+    });
+
+    const pi = out.find((o) => o.host === "pi");
+    expect(pi?.unwired).toBe(false);
+    expect(pi?.reason).toContain("not installed");
+    expect(calls.some((c) => c.join(" ").includes("install-pi.sh"))).toBe(false);
+    expect(out.filter((o) => o.host !== "pi").every((o) => o.unwired)).toBe(true);
+  });
+
+  test("every host's removal is the undo of its own wiring", () => {
+    // Held for all five: the CLI hosts hand back their marketplace, the
+    // generator hosts hand back to the script that wired them.
+    for (const host of REFRESH_HOSTS) {
+      const steps = host.unwire(CTX);
+      expect(steps.length, host.name).toBeGreaterThan(0);
+      if (GENERATOR_HOSTS.includes(host.name)) {
+        expect(steps.map((s) => s.argv[0]), host.name).toEqual(
+          host.wire(CTX).map((s) => s.argv[0]),
+        );
+        expect(steps.every((s) => s.argv.includes("--uninstall")), host.name).toBe(true);
+      } else {
+        expect(steps.some((s) => s.argv.includes("marketplace")), host.name).toBe(true);
+        // Removing what may never have been added is allowed to fail: an
+        // uninstall that throws halfway leaves a host part-wired.
+        expect(steps.every((s) => s.optional === true), host.name).toBe(true);
+      }
+    }
   });
 });

--- a/src/red-skills-hosts.ts
+++ b/src/red-skills-hosts.ts
@@ -8,7 +8,8 @@
  *
  * Refreshing a host is a marketplace update plus one plugin update per
  * declared plugin — several CLI invocations and a network round trip
- * each, per host, and the plan is for five hosts. A converge runs often
+ * each, per host, across five hosts — and for three of them a generator
+ * run that walks the whole skill tree. A converge runs often
  * and the overwhelming majority of them resolve the version they resolved
  * last time, so running the walk unconditionally is a cost paid on every
  * converge for a result identical to doing nothing.
@@ -35,6 +36,34 @@
  * its own reasons — a half-written config, a login that expired. That is
  * a fact about that host, so it is reported against that host and the
  * rest of the walk continues.
+ *
+ * ## Two kinds of host, and why they are not symmetrical
+ *
+ * Claude and Codex are CLI calls red-dev makes itself: both expose a
+ * marketplace and a plugin cache, and refreshing them is a handful of
+ * arguments spelled out here.
+ *
+ * OpenCode, RedCode and pi have no marketplace. Their surface is
+ * generated — plugin modules, skill trees, MCP and TUI config — by
+ * scripts that ship inside the RedSkills tree, beside the skills they
+ * render. So this file invokes those scripts and never reimplements
+ * them: a generator ported into this repo would be separated from the
+ * tree it renders, and a skill added to RedSkills would have to wait for
+ * a red-dev release before it could appear on anyone's machine.
+ *
+ * The scripts are addressed by path inside the resolved checkout, which
+ * is also how each one finds the tree it renders — it resolves its own
+ * repo root from `dirname $0/..`. Invoking `<source>/scripts/...` is
+ * therefore the whole of "with the tree as their source".
+ *
+ * ## Unwiring goes back through the same scripts
+ *
+ * The generators write an uninstall manifest recording every path they
+ * created, and their `--uninstall` removes what that manifest names and
+ * nothing else. That conservatism is the point: a config directory holds
+ * files nobody here put there. So unwiring is the same script with one
+ * more flag, exactly as the standalone installer calls it, rather than a
+ * second opinion in this repo about what RedSkills left behind.
  */
 
 import { existsSync, mkdirSync, readFileSync } from "node:fs";
@@ -44,54 +73,147 @@ import type { Platform } from "./platform.ts";
 import type { Tool } from "./manifest.ts";
 
 /**
- * One host red-dev refreshes, and the commands that refresh it.
+ * One command in a host's wiring.
  *
- * `argv` is a function of the plugin set rather than a fixed list: which
- * plugins this machine carries is the manifest's answer, and a table that
- * wrote them down would be a second place for that to be declared.
+ * `optional` is what `try_run … || true` is in the shared installer, and
+ * it is load-bearing rather than decorative: removing a plugin that was
+ * never installed exits non-zero, and treating that as a failed host
+ * would leave a machine permanently unstamped and permanently rewalked.
  */
+export interface HostStep {
+  /** The command, as argv. */
+  argv: string[];
+  /** A non-zero exit here is reported, and the host carries on. */
+  optional?: boolean;
+}
+
+/**
+ * What a host's commands are a function of.
+ *
+ * The plugin set because which plugins this machine carries is the
+ * manifest's answer, and a table that wrote them down would be a second
+ * place for that to be declared. The checkout because three of the five
+ * hosts are wired by scripts that live inside it.
+ */
+export interface HostContext {
+  /** The plugin set this machine declares. */
+  plugins: readonly string[];
+  /** The resolved checkout — `~/.red-skills/versions/v<x>`, resolved. */
+  source: string;
+}
+
+/** One host red-dev wires RedSkills into, and how. */
 export interface SkillHostRefresh {
   /** Key in the stamp, and the name that appears in a log line. */
   name: string;
   /** The command that has to be on PATH for this host to exist. */
   cmd: string;
-  /** The refresh, as argv, in the order it has to be issued. */
-  argv: (plugins: readonly string[]) => string[][];
+  /** The refresh, in the order it has to be issued. */
+  wire: (ctx: HostContext) => HostStep[];
+  /** The removal, in the order it has to be issued. */
+  unwire: (ctx: HostContext) => HostStep[];
+}
+
+/** A command whose failure fails the host. */
+function must(...argv: string[]): HostStep {
+  return { argv };
+}
+
+/** A command whose failure is reported and stepped over. */
+function may(...argv: string[]): HostStep {
+  return { argv, optional: true };
 }
 
 /**
- * The hosts red-dev drives itself.
+ * A generator inside the installed tree, addressed by path.
  *
- * Claude and Codex are CLI calls, and each answers in its own currency —
- * both spellings were read off the installed CLIs rather than assumed:
+ * The path is the whole contract. Each script resolves its own repo root
+ * from where it sits, so naming it under `source` is what hands it the
+ * tree — there is no second flag saying which checkout to render, and
+ * inventing one here would be a place for the two to disagree.
+ */
+function generator(source: string, script: string): string {
+  return `${source}/scripts/${script}`;
+}
+
+/**
+ * OpenCode and RedCode, which are the same generator with a `--host`.
+ *
+ * RedCode is an OpenCode-compatible host: same generated surface, a
+ * different config directory. The shared installer expresses that as one
+ * function called twice, and so does this — a second table row spelling
+ * the same three flags out again is a place for them to drift.
+ */
+function opencodeCompatible(host: string): SkillHostRefresh {
+  const script = (source: string) => generator(source, "install-opencode.sh");
+  return {
+    name: host,
+    cmd: host,
+    wire: ({ source }) => [must(script(source), "--global", "--host", host)],
+    unwire: ({ source }) => [must(script(source), "--uninstall", "--global", "--host", host)],
+  };
+}
+
+/**
+ * The five hosts, and what each one is asked.
+ *
+ * Claude and Codex answer in their own currency, and both spellings were
+ * read off the installed CLIs rather than assumed:
  *
  *   claude  `plugin marketplace update <name>`  then `plugin update <p>`
  *   codex   `plugin marketplace upgrade <name>` then `plugin add <p>`
  *
- * Codex has no `plugin update`. Its `add` reinstalls from the refreshed
- * marketplace snapshot, which is the same fallback the marketplace
- * repair in agents.ts already relies on.
+ * Codex has no `plugin update` at all, so a refresh there is a remove
+ * followed by an add: the add reinstalls from the marketplace snapshot
+ * the line above it just upgraded. The remove is optional because a
+ * plugin that is not installed yet — the first converge on this machine,
+ * or a plugin the operator only just opted in to — makes it exit
+ * non-zero, and that is not a broken host.
  *
- * OpenCode, RedCode and pi are refreshed by the generators inside the
- * installed tree rather than by commands red-dev spells out, so they join
- * this table with the slice that invokes them.
+ * OpenCode, RedCode and pi are the tree's own generators, invoked with
+ * the tree as their source. pi takes `--source-dir` as well as the path,
+ * because it can install its packages from npm instead and the local
+ * checkout is what pins every host on this machine to one version.
  */
 export const REFRESH_HOSTS: readonly SkillHostRefresh[] = [
   {
     name: "claude",
     cmd: "claude",
-    argv: (plugins) => [
-      ["claude", "plugin", "marketplace", "update", "red-skills"],
-      ...plugins.map((p) => ["claude", "plugin", "update", `${p}@red-skills`]),
+    wire: ({ plugins }) => [
+      must("claude", "plugin", "marketplace", "update", "red-skills"),
+      ...plugins.map((p) => must("claude", "plugin", "update", `${p}@red-skills`)),
+    ],
+    unwire: ({ plugins }) => [
+      // `--keep-data`, matching the shared installer: unwiring a host is
+      // not a request to delete whatever the plugin stored for you.
+      ...plugins.map((p) => may("claude", "plugin", "remove", "--keep-data", p)),
+      may("claude", "plugin", "marketplace", "remove", "red-skills"),
     ],
   },
   {
     name: "codex",
     cmd: "codex",
-    argv: (plugins) => [
-      ["codex", "plugin", "marketplace", "upgrade", "red-skills"],
-      ...plugins.map((p) => ["codex", "plugin", "add", `${p}@red-skills`]),
+    wire: ({ plugins }) => [
+      must("codex", "plugin", "marketplace", "upgrade", "red-skills"),
+      ...plugins.flatMap((p) => [
+        may("codex", "plugin", "remove", `${p}@red-skills`),
+        must("codex", "plugin", "add", `${p}@red-skills`),
+      ]),
     ],
+    unwire: ({ plugins }) => [
+      ...plugins.map((p) => may("codex", "plugin", "remove", `${p}@red-skills`)),
+      may("codex", "plugin", "marketplace", "remove", "red-skills"),
+    ],
+  },
+  opencodeCompatible("opencode"),
+  opencodeCompatible("redcode"),
+  {
+    name: "pi",
+    cmd: "pi",
+    wire: ({ source }) => [
+      must(generator(source, "install-pi.sh"), "--source-dir", source, "--user"),
+    ],
+    unwire: ({ source }) => [must(generator(source, "install-pi.sh"), "--uninstall", "--user")],
   },
 ];
 
@@ -199,6 +321,7 @@ export async function refreshSkillHosts(
 
   const version = versionOf(source);
   const stamp = readHostStamp(home);
+  const ctx: HostContext = { plugins, source };
   const out: HostRefreshOutcome[] = [];
 
   for (const host of hosts) {
@@ -216,7 +339,7 @@ export async function refreshSkillHosts(
     }
 
     log.step(`${host.name}: refreshing red-skills against ${version}`);
-    const failure = await refreshOne(host, plugins, run);
+    const failure = await runSteps(host.wire(ctx), run);
     if (failure !== null) {
       // Reported and survived. The stamp keeps whatever it held, so the
       // next converge asks this host again.
@@ -234,22 +357,105 @@ export async function refreshSkillHosts(
   return out;
 }
 
-/** Runs one host's commands, and answers the first failure or null. */
-async function refreshOne(
-  host: SkillHostRefresh,
-  plugins: readonly string[],
+/** Runs one host's commands, and answers the first hard failure or null. */
+async function runSteps(
+  steps: readonly HostStep[],
   run: (cmd: string[]) => Promise<number>,
 ): Promise<string | null> {
-  for (const cmd of host.argv(plugins)) {
+  for (const step of steps) {
+    const what = step.argv.join(" ");
     let code: number;
     try {
-      code = await run(cmd);
+      code = await run(step.argv);
     } catch (error) {
-      return `${cmd.join(" ")} could not be run: ${(error as Error).message}`;
+      if (step.optional) {
+        log.warn(`${what} could not be run: ${(error as Error).message}`);
+        continue;
+      }
+      return `${what} could not be run: ${(error as Error).message}`;
     }
-    if (code !== 0) return `${cmd.join(" ")} exited ${code}`;
+    if (code === 0) continue;
+    if (step.optional) {
+      log.skip(`${what} exited ${code}, which this step is allowed to do`);
+      continue;
+    }
+    return `${what} exited ${code}`;
   }
   return null;
+}
+
+/** What one host did on the way out, or the reason it did nothing. */
+export interface HostUnwireOutcome {
+  /** The host's name in REFRESH_HOSTS. */
+  host: string;
+  /** True only when every required command for this host succeeded. */
+  unwired: boolean;
+  /** Why not, present exactly when `unwired` is false. */
+  reason?: string;
+}
+
+/**
+ * Take RedSkills back out of every host on the machine.
+ *
+ * The generator hosts route through the same scripts that wired them,
+ * which remove what their own manifest recorded and leave everything
+ * else alone — see the header. Claude and Codex are the CLI calls that
+ * undo the CLI calls above.
+ *
+ * With no checkout there is nothing to unwire *through*: the scripts
+ * live in the tree, and this repo deliberately holds no second opinion
+ * about which files RedSkills wrote. So a machine with no checkout is
+ * left alone and says so, rather than being guessed at.
+ *
+ * A host that comes out has its stamp entry dropped. The stamp means
+ * "this host has been refreshed against that checkout", which stops
+ * being true the moment the host is unwired — leaving it would let the
+ * next converge skip re-wiring a host that no longer has anything.
+ */
+export async function unwireSkillHosts(
+  p: Platform,
+  opts: HostRefreshOptions = {},
+): Promise<HostUnwireOutcome[]> {
+  const home = opts.home ?? homeOf();
+  const hosts = opts.hosts ?? REFRESH_HOSTS;
+
+  const source = opts.source !== undefined ? opts.source : await currentSource();
+  if (source === null) {
+    log.skip("red-skills: not installed, no host to unwire");
+    return [];
+  }
+
+  const plugins = opts.plugins ?? (await declaredPlugins(p, opts.tools));
+  const present = opts.present ?? (await presenceProbe());
+  const run = opts.run ?? (await defaultRunner());
+
+  const ctx: HostContext = { plugins, source };
+  const stamp = readHostStamp(home);
+  const out: HostUnwireOutcome[] = [];
+
+  for (const host of hosts) {
+    if (!present(host.cmd)) {
+      out.push({ host: host.name, unwired: false, reason: `${host.cmd} is not installed` });
+      continue;
+    }
+
+    log.step(`${host.name}: removing red-skills`);
+    const failure = await runSteps(host.unwire(ctx), run);
+    if (failure !== null) {
+      log.warn(`${host.name}: ${failure}`);
+      out.push({ host: host.name, unwired: false, reason: failure });
+      continue;
+    }
+
+    if (host.name in stamp) {
+      delete stamp[host.name];
+      await writeHostStamp(home, stamp);
+    }
+    log.ok(`${host.name}: red-skills removed`);
+    out.push({ host: host.name, unwired: true });
+  }
+
+  return out;
 }
 
 async function currentSource(): Promise<string | null> {


### PR DESCRIPTION
Automated AFK landing for #191. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #191

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/198"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789518298&installation_model_id=20659&pr_number=198&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F198&signature=b55f71bad38317912f023ebe62b5e087ef34eba1375c28b19a3871bccecd9269"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->