### PR TITLE
fix: #192 Arbitration: where red-dev is present, the Directory-sourced marketplace wins

### DIFF
--- a/src/agents.ts
+++ b/src/agents.ts
@@ -23,7 +23,6 @@ import {
   unlinkSync,
 } from "node:fs";
 import { log, RedError } from "./log.ts";
-import type { Tool } from "./manifest.ts";
 import { tlsTrustFailure, unattendedEnvironment } from "./unattended.ts";
 import type { Platform } from "./platform.ts";
 
@@ -807,177 +806,25 @@ async function cliNamesRedSkills(cmd: string[]): Promise<boolean> {
 }
 
 /**
- * Whether Claude's marketplace points at GitHub rather than at a
- * directory on this disk.
+ * Where the marketplace registration is decided, and why it is not here.
  *
- * The vendor installer registers `~/.red-skills/current`, which is a
- * symlink into a versioned snapshot taken the day it ran. Claude then
- * does exactly what it was asked: auto-update re-reads that directory,
- * finds it unchanged, and records a fresh lastUpdated. The machine
- * reports "Updated today" and sits on the version it was installed
- * with — 3.3.0 against 3.3.7 upstream, for a week, with nothing
- * anywhere saying so.
+ * This file used to hold the other side of it: a pair of probes asking
+ * whether each host's marketplace pointed at GitHub, and a pair of
+ * repairs that repointed a directory-registered host back at
+ * `reddb-io/red-skills`. That was right while nothing on the machine
+ * moved `~/.red-skills/current` — a directory source meant a host frozen
+ * at its install-day snapshot, reporting "Updated today" against a
+ * version a week behind.
  *
- * "Is red-skills in the list" cannot see that: the name is present
- * either way. The source is what distinguishes a marketplace that can
- * receive updates from one that only appears to.
+ * mise moves it now, so the directory is the only source pinned to the
+ * version this machine resolved, and red-dev registers from it. Keeping
+ * the repair beside that would be one converge evicting the registration
+ * the previous one made — the endless eviction the arbitration exists to
+ * end, with both ends of it in this repo.
+ *
+ * red-skills-registration.ts owns all of it: the boundary read, the
+ * declaration, and the read-back that proves it took.
  */
-export async function claudeMarketplaceIsGithub(): Promise<boolean | null> {
-  const home = process.env["HOME"] ?? process.env["USERPROFILE"];
-  if (!home) return null;
-  const path = `${home.replace(/\\/g, "/")}/.claude/plugins/known_marketplaces.json`;
-  if (!existsSync(path)) return null;
-  try {
-    const known = JSON.parse(await Bun.file(path).text()) as Record<
-      string,
-      { source?: { source?: string } }
-    >;
-    const entry = known["red-skills"];
-    if (!entry) return null;
-    return entry.source?.source === "github";
-  } catch {
-    // Unreadable is not the same as wrong. Null means "no opinion", and
-    // the caller leaves the machine alone rather than repointing a
-    // marketplace on a guess.
-    return null;
-  }
-}
-
-function tomlStringValue(line: string, key: string): string | null {
-  const match = line.match(new RegExp(`^\\s*${key}\\s*=\\s*"([^"]*)"\\s*$`));
-  return match?.[1] ?? null;
-}
-
-/**
- * Whether Codex's marketplace points at GitHub rather than a local
- * red-skills snapshot.
- *
- * Codex records marketplace sources in config.toml. A local source has
- * the same failure mode as Claude's directory marketplace: RedSkills
- * appears installed and enabled, but MCP launchers that fall back to
- * Codex's Git marketplace checkout have nowhere to go.
- */
-export async function codexMarketplaceIsGithub(): Promise<boolean | null> {
-  const home = process.env["HOME"] ?? process.env["USERPROFILE"];
-  if (!home) return null;
-  const path = `${home.replace(/\\/g, "/")}/.codex/config.toml`;
-  if (!existsSync(path)) return null;
-
-  try {
-    const lines = (await Bun.file(path).text()).split(/\r?\n/);
-    let inTable = false;
-    for (const line of lines) {
-      const table = line.match(/^\s*\[([^\]]+)\]\s*$/);
-      if (table) {
-        inTable = table[1] === "marketplaces.red-skills";
-        continue;
-      }
-      if (!inTable) continue;
-      const sourceType = tomlStringValue(line, "source_type");
-      if (sourceType !== null) return sourceType === "git";
-    }
-    return null;
-  } catch {
-    // Unreadable is not the same as wrong. Null means "no opinion", and
-    // the caller leaves the machine alone rather than repointing a
-    // marketplace on a guess.
-    return null;
-  }
-}
-
-/**
- * What a marketplace repair needs from outside itself.
- *
- * Both fields have real defaults and exist for the tests: a repair is a
- * sequence of commands issued to a CLI that may not be installed, and
- * the thing worth pinning is *which* commands, against *which* declared
- * plugin set. Injecting the runner is what lets that be asserted without
- * an agent, a marketplace or a network in the loop.
- */
-export interface MarketplaceRepair {
-  /** Runs one argv and answers its exit code. Defaults to spawnLogged. */
-  run?: (cmd: string[]) => Promise<number>;
-  /** The manifest to derive the plugin set from. Defaults to TOOLS. */
-  tools?: readonly Tool[];
-}
-
-async function repairRunner(opts: MarketplaceRepair): Promise<(cmd: string[]) => Promise<number>> {
-  if (opts.run) return opts.run;
-  const { spawnLogged } = await import("./providers.ts");
-  return (cmd: string[]) => spawnLogged(cmd);
-}
-
-/**
- * Repoint Claude's marketplace from the frozen directory to GitHub.
- *
- * Remove, re-add by repo, reinstall the plugins — the same five steps
- * anyone doing this by hand runs, because there is no `marketplace
- * set-source`. The plugins have to be reinstalled: they were installed
- * from a marketplace that no longer exists under that name.
- *
- * Which plugins is the manifest's answer, not this function's. A machine
- * that opted `brain` out has no entry for it, so a repair that named it
- * here would reinstall precisely what the operator removed.
- *
- * Not destructive in any way that matters. Everything removed here is
- * re-created from the origin in the same run, and the source cache under
- * ~/.red-skills is left alone.
- */
-export async function repointClaudeMarketplace(
-  p: Platform,
-  opts: MarketplaceRepair = {},
-): Promise<void> {
-  const run = await repairRunner(opts);
-  const { redSkillsPluginNames } = await import("./red-skills-plugins.ts");
-
-  log.step("red-skills: marketplace points at a local directory — repointing at GitHub");
-  log.plain("     A directory source cannot receive updates. Claude re-reads the");
-  log.plain("     same snapshot and records a new timestamp, so a stuck machine");
-  log.plain("     reports itself as current.");
-
-  await run(["claude", "plugin", "marketplace", "remove", "red-skills"]);
-  if ((await run(["claude", "plugin", "marketplace", "add", "reddb-io/red-skills"])) !== 0) {
-    throw new RedError("could not add the red-skills marketplace from GitHub");
-  }
-  for (const plugin of redSkillsPluginNames(p, opts.tools)) {
-    await run(["claude", "plugin", "install", `${plugin}@red-skills`]);
-  }
-  log.ok("red-skills marketplace now tracks reddb-io/red-skills");
-}
-
-/**
- * Repoint Codex's marketplace from a local snapshot to GitHub.
- *
- * Codex keeps plugin enablement when a marketplace is removed, but the
- * explicit add calls refresh the cache for whichever RedSkills plugins
- * this machine declares — they are what contribute skills, hooks and MCP
- * servers, and the set comes from the manifest for the same reason it
- * does above.
- */
-export async function repointCodexMarketplace(
-  p: Platform,
-  opts: MarketplaceRepair = {},
-): Promise<void> {
-  const run = await repairRunner(opts);
-  const { redSkillsPluginNames } = await import("./red-skills-plugins.ts");
-
-  log.step("red-skills: Codex marketplace points at a local directory — repointing at GitHub");
-  log.plain("     A local Codex marketplace can leave MCP launchers looking");
-  log.plain("     for a Git marketplace checkout that does not exist.");
-
-  if ((await run(["codex", "plugin", "marketplace", "remove", "red-skills"])) !== 0) {
-    throw new RedError("could not remove the local red-skills marketplace from Codex");
-  }
-  if ((await run(["codex", "plugin", "marketplace", "add", "reddb-io/red-skills"])) !== 0) {
-    throw new RedError("could not add the red-skills marketplace to Codex from GitHub");
-  }
-  for (const plugin of redSkillsPluginNames(p, opts.tools)) {
-    if ((await run(["codex", "plugin", "add", `${plugin}@red-skills`])) !== 0) {
-      throw new RedError(`could not install ${plugin}@red-skills into Codex`);
-    }
-  }
-  log.ok("Codex red-skills marketplace now tracks reddb-io/red-skills");
-}
 
 function configHome(): string {
   const home = process.env["HOME"] ?? process.env["USERPROFILE"] ?? "";
@@ -1046,16 +893,6 @@ export async function convergeRedSkills(p: Platform): Promise<void> {
   const { refreshProductSkill } = await import("./product-skill.ts");
   await refreshProductSkill(p);
 
-  // Before asking whether it is wired: a marketplace registered against
-  // a local directory is wired and permanently stale, which no amount
-  // of reinstalling the same installer will fix.
-  if (commandPath("claude") && (await claudeMarketplaceIsGithub()) === false) {
-    await repointClaudeMarketplace(p);
-  }
-  if (commandPath("codex") && (await codexMarketplaceIsGithub()) === false) {
-    await repointCodexMarketplace(p);
-  }
-
   const missing = await unwiredSkillHosts();
   if (missing.length === 0) {
     log.skip(`red-skills already wired into ${present.map((h) => h.cmd).join(", ")}`);
@@ -1070,6 +907,18 @@ export async function convergeRedSkills(p: Platform): Promise<void> {
       await applyRedcode(p);
     }
   }
+
+  // After the installer, never before it, because red-dev has the last
+  // word on this machine. The standalone one-liner registers from GitHub
+  // wherever it runs — including from the line above — and where red-dev
+  // is present the directory it advances is the declared source. Running
+  // this first would leave the installer's registration standing until
+  // the next converge.
+  //
+  // Free when the registration is already ours: the hosts are asked what
+  // they recorded, and an ordinary converge issues no commands at all.
+  const { convergeMarketplaceOwnership } = await import("./red-skills-registration.ts");
+  await convergeMarketplaceOwnership(p);
 
   // On both paths, and where the early return used to be. Being wired is
   // not the same as being current: mise advances the version underneath a

--- a/src/drift.ts
+++ b/src/drift.ts
@@ -503,33 +503,55 @@ async function checkWslDistro(p: Platform): Promise<DriftCheck> {
 }
 
 /**
- * Whether red-skills can actually receive updates.
+ * Whether the marketplace reads the version this machine resolved.
  *
- * A marketplace registered against a local directory is the worst kind
- * of wrong: Claude re-reads the snapshot, finds it unchanged, and writes
- * a fresh timestamp — so the machine reports itself current while
- * sitting on whatever version the installer captured. Seen at 3.3.0
- * against 3.3.7 upstream, reporting "Updated today".
+ * This check used to read the other way round, and was right to: a
+ * directory registration meant a host frozen at its install-day
+ * snapshot, re-reading an unchanged tree and writing a fresh timestamp
+ * over it. Seen at 3.3.0 against 3.3.7 upstream, reporting "Updated
+ * today".
+ *
+ * mise moves the directory now. Where red-dev has a checkout it is the
+ * declared owner of the registration, so a host still pointed at GitHub
+ * is one the standalone installer got to last — it will keep resolving
+ * whatever is published rather than the version this machine pinned.
+ *
+ * With no checkout there is nothing red-dev owns here, and the
+ * standalone registration is the only one on the machine. That is not
+ * drift; it is the supported install mode, and saying otherwise would
+ * send an operator to fix a machine that is working.
  */
 async function checkRedSkillsSource(): Promise<DriftCheck> {
   if (!Bun.which("claude")) {
     return { name: "red-skills", status: "n/a", detail: "claude not installed" };
   }
   try {
-    const { claudeMarketplaceIsGithub } = await import("./agents.ts");
-    const github = await claudeMarketplaceIsGithub();
-    if (github === null) {
+    const { sourceRoot } = await import("./red-skills-ext.ts");
+    const source = sourceRoot();
+    if (source === null) {
+      return { name: "red-skills", status: "n/a", detail: "no managed checkout to register" };
+    }
+
+    const { claudeRegistration, registrationIsOurs } = await import(
+      "./red-skills-registration.ts"
+    );
+    const home = (process.env["HOME"] ?? process.env["USERPROFILE"] ?? "").replace(/\\/g, "/");
+    const registration = await claudeRegistration(home);
+    if (registration === null) {
       return { name: "red-skills", status: "n/a", detail: "no marketplace registered" };
     }
-    return github
-      ? { name: "red-skills", status: "ok", detail: "tracking reddb-io/red-skills" }
-      : {
-          name: "red-skills",
-          status: "drift",
-          detail:
-            "marketplace points at a local directory — it reports updates it cannot receive",
-          fix: "red-dev install core",
-        };
+    if (registrationIsOurs(registration, source)) {
+      return { name: "red-skills", status: "ok", detail: `registered from ${source}` };
+    }
+    return {
+      name: "red-skills",
+      status: "drift",
+      detail:
+        registration.kind === "github"
+          ? "marketplace tracks GitHub — this machine resolves red-skills through mise, and red-dev owns the registration"
+          : `marketplace is registered from ${registration.source}, which nothing advances`,
+      fix: "red-dev install core",
+    };
   } catch (err) {
     return { name: "red-skills", status: "n/a", detail: (err as Error).message };
   }

--- a/src/red-skills-plugins.test.ts
+++ b/src/red-skills-plugins.test.ts
@@ -23,7 +23,6 @@ import { mkdtempSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { repointClaudeMarketplace, repointCodexMarketplace } from "./agents.ts";
 import { TOOLS, type Tool } from "./manifest.ts";
 import { convergeMiseConfig, miseConfigPath, miseEntries, miseToolNames } from "./mise-config.ts";
 import type { Platform } from "./platform.ts";
@@ -33,6 +32,10 @@ import {
   redSkillsPluginNames,
   REDSKILLS_PLUGIN_PREFIX,
 } from "./red-skills-plugins.ts";
+import {
+  REGISTRATION_HOSTS,
+  convergeMarketplaceOwnership,
+} from "./red-skills-registration.ts";
 
 const UBUNTU: Platform = {
   os: "linux",
@@ -155,13 +158,21 @@ describe("the set is derived, not written down", () => {
     // source because the absence of a list is not observable any other
     // way: a second copy would agree with the manifest on the day it was
     // written and drift from it silently afterwards.
-    const src = readFileSync(`${import.meta.dir}/agents.ts`, "utf8");
-    expect(src).not.toContain(`["dev", "memory", "brain"]`);
-    expect(src).toContain("redSkillsPluginNames");
+    //
+    // Both files, because both issue plugin commands: the registration
+    // reinstalls what a re-registration replaced, and the host refresh
+    // updates what is already installed.
+    for (const file of ["agents.ts", "red-skills-registration.ts", "red-skills-hosts.ts"]) {
+      const src = readFileSync(`${import.meta.dir}/${file}`, "utf8");
+      expect(src, file).not.toContain(`["dev", "memory", "brain"]`);
+    }
+    expect(readFileSync(`${import.meta.dir}/red-skills-registration.ts`, "utf8")).toContain(
+      "redSkillsPluginNames",
+    );
   });
 });
 
-/** The `<plugin>@red-skills` arguments a repair asked a host to install. */
+/** The `<plugin>@red-skills` arguments a registration asked a host to install. */
 function installedBy(calls: string[][]): string[] {
   return calls
     .map((cmd) => cmd.find((arg) => arg.endsWith("@red-skills")))
@@ -169,19 +180,40 @@ function installedBy(calls: string[][]): string[] {
     .map((arg) => arg.replace("@red-skills", ""));
 }
 
-async function claudeCalls(tools: readonly Tool[]): Promise<string[][]> {
+/** The source red-dev registers, which never has to exist for this. */
+const SOURCE = "/home/someone/.red-skills/current";
+
+/**
+ * What one host is asked when red-dev declares its registration.
+ *
+ * The host is picked out of the same table the converge walks, so a
+ * spelling that moves there moves here too rather than being asserted
+ * against a copy of it.
+ */
+async function hostCalls(name: string, tools: readonly Tool[]): Promise<string[][]> {
+  const host = REGISTRATION_HOSTS.find((h) => h.name === name);
+  if (!host) throw new Error(`no host named ${name}`);
   const { calls, run } = recorder();
-  await repointClaudeMarketplace(UBUNTU, { run, tools });
+  await convergeMarketplaceOwnership(UBUNTU, {
+    home: mkdtempSync(join(tmpdir(), "red-plugins-registration-")),
+    source: SOURCE,
+    hosts: [host],
+    present: () => true,
+    run,
+    tools,
+  });
   return calls;
 }
 
-async function codexCalls(tools: readonly Tool[]): Promise<string[][]> {
-  const { calls, run } = recorder();
-  await repointCodexMarketplace(UBUNTU, { run, tools });
-  return calls;
+function claudeCalls(tools: readonly Tool[]): Promise<string[][]> {
+  return hostCalls("claude", tools);
 }
 
-describe("the loops that reinstall plugins after a repair", () => {
+function codexCalls(tools: readonly Tool[]): Promise<string[][]> {
+  return hostCalls("codex", tools);
+}
+
+describe("the loops that reinstall the plugins a registration replaced", () => {
   test("Claude installs one plugin per manifest entry, in manifest order", async () => {
     // Order included: the manifest is where the dependency order between
     // plugins is expressed — memory builds on dev — so a repair that
@@ -214,14 +246,14 @@ describe("the loops that reinstall plugins after a repair", () => {
     }
   });
 
-  test("the marketplace itself is still repaired, whatever the plugin set is", async () => {
-    // The plugins are the second half of the repair. Deriving their set
-    // must not quietly drop the first half, which is the re-registration
-    // the whole function exists for.
+  test("the marketplace itself is still registered, whatever the plugin set is", async () => {
+    // The plugins are the second half of the declaration. Deriving their
+    // set must not quietly drop the first half, which is the
+    // re-registration the whole function exists for.
     const calls = await claudeCalls([]);
     expect(calls.map((cmd) => cmd.join(" "))).toEqual([
       "claude plugin marketplace remove red-skills",
-      "claude plugin marketplace add reddb-io/red-skills",
+      `claude plugin marketplace add ${SOURCE}`,
     ]);
   });
 });

--- a/src/red-skills-registration.test.ts
+++ b/src/red-skills-registration.test.ts
@@ -1,0 +1,367 @@
+/**
+ * Which registration wins on a machine that has both installers on it.
+ *
+ * The standalone one-liner registers the marketplace from GitHub and heals
+ * a machine it finds registered from a directory. red-dev registers from
+ * the directory mise advances, because that is the only source on this
+ * machine that is pinned to the version mise resolved. Left to themselves
+ * the two evict each other on every run: silent, endless, and invisible
+ * except as a machine that installs plugins twice a day forever.
+ *
+ * So one of them is the declared owner, and where red-dev is present it is
+ * red-dev. This file pins that half.
+ *
+ * What is asserted is the fact the *other* half reads — the entry the host
+ * itself writes down, in the file the standalone installer's healing looks
+ * at. Asserting an internal flag would let both repos be green about
+ * different things; asserting the recorded registration kind is what makes
+ * the two halves meet on one fact.
+ *
+ * The runner is injected and moves a fake HOME the way the real CLI would,
+ * so all of this holds with no agent, no marketplace and no network.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import type { Platform } from "./platform.ts";
+import {
+  MARKETPLACE_NAME,
+  REGISTRATION_HOSTS,
+  claudeRegistration,
+  claudeRegistrationPath,
+  codexRegistration,
+  codexRegistrationPath,
+  convergeMarketplaceOwnership,
+  type RegistrationOptions,
+} from "./red-skills-registration.ts";
+
+const UBUNTU: Platform = {
+  os: "linux",
+  distro: "ubuntu",
+  version: "24.04",
+  codename: "noble",
+  env: "desktop",
+  arch: "x64",
+  caps: { apt: true, gui: true, systemd: true, winget: false, flatpak: false },
+};
+
+const PLUGINS = ["dev", "memory"];
+
+function home(): string {
+  return mkdtempSync(join(tmpdir(), "red-registration-"));
+}
+
+/** `~/.red-skills/current` — the path red-dev registers, not the version behind it. */
+function currentOf(root: string): string {
+  return `${root}/.red-skills/current`;
+}
+
+/** The entry Claude writes when the standalone one-liner registered from GitHub. */
+function writeGithubRegistration(root: string): void {
+  const path = claudeRegistrationPath(root);
+  mkdirSync(path.slice(0, path.lastIndexOf("/")), { recursive: true });
+  writeFileSync(
+    path,
+    JSON.stringify({
+      [MARKETPLACE_NAME]: {
+        source: { source: "github", repo: "reddb-io/red-skills" },
+        lastUpdated: "2026-08-02T12:35:21.550Z",
+        autoUpdate: true,
+      },
+    }),
+  );
+}
+
+/** The entry Claude writes when a marketplace was added from a path. */
+function writeDirectoryRegistration(root: string, dir: string): void {
+  const path = claudeRegistrationPath(root);
+  mkdirSync(path.slice(0, path.lastIndexOf("/")), { recursive: true });
+  writeFileSync(
+    path,
+    JSON.stringify({
+      [MARKETPLACE_NAME]: {
+        source: { source: "directory", path: dir },
+        lastUpdated: "2026-08-02T12:35:21.550Z",
+        autoUpdate: true,
+      },
+    }),
+  );
+}
+
+/** The table Codex writes under `[marketplaces.red-skills]`. */
+function writeCodexRegistration(root: string, sourceType: string, source: string): void {
+  const path = codexRegistrationPath(root);
+  mkdirSync(path.slice(0, path.lastIndexOf("/")), { recursive: true });
+  writeFileSync(
+    path,
+    [
+      "[marketplaces.red-skills]",
+      'last_updated = "2026-08-02T18:04:00Z"',
+      `source_type = "${sourceType}"`,
+      `source = "${source}"`,
+      "",
+    ].join("\n"),
+  );
+}
+
+/**
+ * A runner that records argv and moves the fake HOME the way the CLI would.
+ *
+ * Recording alone would only pin that red-dev issued an add; the point of
+ * this slice is what the host has written down afterwards, which is the
+ * fact the standalone installer reads. So the simulator writes the entry
+ * an `add` produces and drops the one a `remove` takes away.
+ */
+function hostSim(
+  root: string,
+  code: (cmd: string[]) => number = () => 0,
+): { calls: string[][]; run: (cmd: string[]) => Promise<number> } {
+  const calls: string[][] = [];
+  const run = async (cmd: string[]): Promise<number> => {
+    calls.push(cmd);
+    const exit = code(cmd);
+    const [tool, , sub, verb, arg] = cmd;
+    if (exit === 0 && sub === "marketplace" && verb === "add" && arg !== undefined) {
+      if (tool === "claude") writeDirectoryRegistration(root, arg);
+      else writeCodexRegistration(root, "local", arg);
+    }
+    // A remove really does drop the entry, which is why the add that
+    // follows it is the step allowed to fail the host.
+    if (exit === 0 && sub === "marketplace" && verb === "remove") {
+      const path = tool === "claude" ? claudeRegistrationPath(root) : codexRegistrationPath(root);
+      if (existsSync(path)) writeFileSync(path, tool === "claude" ? "{}" : "");
+    }
+    return exit;
+  };
+  return { calls, run };
+}
+
+/** A machine with both CLI hosts installed and a red-dev checkout on it. */
+function converge(
+  root: string,
+  opts: RegistrationOptions = {},
+): ReturnType<typeof convergeMarketplaceOwnership> {
+  return convergeMarketplaceOwnership(UBUNTU, {
+    home: root,
+    source: currentOf(root),
+    plugins: PLUGINS,
+    present: () => true,
+    ...opts,
+  });
+}
+
+describe("where red-dev is present, the Directory registration wins", () => {
+  test("a machine the standalone installer registered from GitHub ends up on the directory", async () => {
+    const root = home();
+    writeGithubRegistration(root);
+    writeCodexRegistration(root, "git", "https://github.com/reddb-io/red-skills.git");
+
+    const { run } = hostSim(root);
+    const out = await converge(root, { run });
+
+    expect(out.map((o) => o.host)).toEqual(REGISTRATION_HOSTS.map((h) => h.name));
+    expect(out.every((o) => o.registered)).toBe(true);
+
+    // The fact, read back off the host rather than off the outcome.
+    expect(await claudeRegistration(root)).toEqual({
+      kind: "directory",
+      source: currentOf(root),
+    });
+    expect(await codexRegistration(root)).toEqual({
+      kind: "directory",
+      source: currentOf(root),
+    });
+  });
+
+  test("the registration names `current`, which is the path that moves", async () => {
+    // Not the version directory behind it. `current` is what mise repoints
+    // when it advances the core, so a registration pinned to the version
+    // it was made on is the frozen machine this whole spec is about.
+    const root = home();
+    const { calls, run } = hostSim(root);
+    await converge(root, { run });
+
+    const added = calls.filter((c) => c[2] === "marketplace" && c[3] === "add");
+    expect(added.length).toBe(REGISTRATION_HOSTS.length);
+    for (const cmd of added) expect(cmd[4]).toBe(currentOf(root));
+  });
+
+  test("and reinstalls the plugins the manifest declares, in manifest order", async () => {
+    // They were installed from a marketplace that no longer exists under
+    // that name: re-adding the source is not enough on its own.
+    const root = home();
+    const { calls, run } = hostSim(root);
+    await converge(root, { run });
+
+    for (const host of REGISTRATION_HOSTS) {
+      const mine = calls.filter((c) => c[0] === host.cmd);
+      const installed = mine
+        .map((c) => c[c.length - 1] ?? "")
+        .filter((a) => a.endsWith(`@${MARKETPLACE_NAME}`))
+        .map((a) => a.slice(0, a.indexOf("@")));
+      expect(installed, host.name).toEqual(PLUGINS);
+    }
+  });
+
+  test("a host that refuses the add is not claimed as registered", async () => {
+    const root = home();
+    writeGithubRegistration(root);
+    const { run } = hostSim(root, (cmd) => (cmd[3] === "add" ? 1 : 0));
+
+    const out = await converge(root, { run });
+    expect(out.every((o) => !o.registered)).toBe(true);
+    for (const o of out) expect(o.reason, o.host).toContain("add");
+  });
+
+  test("an absent host is a fact about that host, not a failure", async () => {
+    const root = home();
+    const { calls, run } = hostSim(root);
+    const out = await converge(root, { run, present: () => false });
+
+    expect(calls).toEqual([]);
+    expect(out.every((o) => !o.registered)).toBe(true);
+    for (const o of out) expect(o.reason, o.host).toContain("not installed");
+  });
+});
+
+describe("the registration kind, read where the standalone installer reads it", () => {
+  test("Claude records it in known_marketplaces.json", () => {
+    expect(claudeRegistrationPath("/home/x")).toBe(
+      "/home/x/.claude/plugins/known_marketplaces.json",
+    );
+  });
+
+  test("Codex records it in config.toml", () => {
+    expect(codexRegistrationPath("/home/x")).toBe("/home/x/.codex/config.toml");
+  });
+
+  test("a github source and a git source are the same kind", async () => {
+    const root = home();
+    writeGithubRegistration(root);
+    writeCodexRegistration(root, "git", "https://github.com/reddb-io/red-skills.git");
+
+    expect((await claudeRegistration(root))?.kind).toBe("github");
+    expect((await codexRegistration(root))?.kind).toBe("github");
+  });
+
+  test("a directory source and a local source are the same kind", async () => {
+    const root = home();
+    writeDirectoryRegistration(root, currentOf(root));
+    writeCodexRegistration(root, "local", currentOf(root));
+
+    expect((await claudeRegistration(root))?.kind).toBe("directory");
+    expect((await codexRegistration(root))?.kind).toBe("directory");
+  });
+
+  test("no entry is no opinion, not a verdict", async () => {
+    const root = home();
+    expect(await claudeRegistration(root)).toBeNull();
+    expect(await codexRegistration(root)).toBeNull();
+  });
+
+  test("an unreadable file is no opinion either", async () => {
+    // Leaving the machine alone beats re-registering a marketplace on a
+    // guess about a file we could not parse.
+    const root = home();
+    const path = claudeRegistrationPath(root);
+    mkdirSync(path.slice(0, path.lastIndexOf("/")), { recursive: true });
+    writeFileSync(path, "{ not json");
+
+    expect(await claudeRegistration(root)).toBeNull();
+  });
+
+  test("the outcome reports the kind the host has written down", async () => {
+    // Both halves assert against one fact, so the outcome is not allowed
+    // to be an opinion of its own: it is a read of the same boundary.
+    const root = home();
+    const { run } = hostSim(root);
+    const out = await converge(root, { run });
+
+    for (const o of out) expect(o.kind, o.host).toBe("directory");
+    expect((await claudeRegistration(root))?.kind).toBe("directory");
+  });
+
+  test("a host that reports something else afterwards is reported, not assumed", async () => {
+    // The add exited zero and the entry still says github. Trusting the
+    // exit code here is how a machine gets reported as converged while
+    // the standalone installer's registration is still in place.
+    const root = home();
+    const { run } = hostSim(root, () => 0);
+    const out = await converge(root, {
+      run: async (cmd) => {
+        const code = await run(cmd);
+        if (cmd[0] === "claude" && cmd[3] === "add") writeGithubRegistration(root);
+        return code;
+      },
+    });
+
+    const claude = out.find((o) => o.host === "claude");
+    expect(claude?.registered).toBe(false);
+    expect(claude?.kind).toBe("github");
+  });
+});
+
+describe("a converge that has nothing to do", () => {
+  test("issues no commands when the source is already correct", async () => {
+    const root = home();
+    await converge(root, { run: hostSim(root).run });
+
+    const { calls, run } = hostSim(root);
+    const out = await converge(root, { run });
+
+    expect(calls).toEqual([]);
+    expect(out.every((o) => !o.registered)).toBe(true);
+    for (const o of out) {
+      expect(o.kind, o.host).toBe("directory");
+      expect(o.reason, o.host).toContain("already");
+    }
+  });
+
+  test("but a directory registration pinned to a version directory is re-registered", async () => {
+    // The failure mode "directory-sourced" alone cannot see: registered
+    // once against `versions/v3.3.0`, which never moves again.
+    const root = home();
+    writeDirectoryRegistration(root, `${root}/.red-skills/versions/v3.3.0`);
+    writeCodexRegistration(root, "local", `${root}/.red-skills/versions/v3.3.0`);
+
+    const { calls, run } = hostSim(root);
+    await converge(root, { run });
+
+    expect(calls.filter((c) => c[3] === "add").length).toBe(REGISTRATION_HOSTS.length);
+    expect((await claudeRegistration(root))?.source).toBe(currentOf(root));
+  });
+});
+
+describe("a machine without red-dev is left exactly as it is", () => {
+  test("no checkout means no registration to declare, and no commands", async () => {
+    // This is the arbitration seen from the other side. red-dev only owns
+    // the registration where red-dev has put a checkout on the machine;
+    // with none there is nothing to register *from*, and the standalone
+    // installer's GitHub registration is the only one on this machine.
+    const root = home();
+    writeGithubRegistration(root);
+    const before = readFileSync(claudeRegistrationPath(root), "utf8");
+
+    const { calls, run } = hostSim(root);
+    const out = await converge(root, { run, source: null });
+
+    expect(calls).toEqual([]);
+    expect(out).toEqual([]);
+    expect(readFileSync(claudeRegistrationPath(root), "utf8")).toBe(before);
+    expect((await claudeRegistration(root))?.kind).toBe("github");
+  });
+
+  test("and nothing this slice adds writes to a machine it did not converge", async () => {
+    // Not one file: no stamp, no marker, no config left behind on the way
+    // to deciding there was nothing to do.
+    const root = home();
+    await converge(root, { run: hostSim(root).run, source: null });
+
+    expect(existsSync(`${root}/.claude`)).toBe(false);
+    expect(existsSync(`${root}/.codex`)).toBe(false);
+    expect(existsSync(`${root}/.local`)).toBe(false);
+  });
+});

--- a/src/red-skills-registration.ts
+++ b/src/red-skills-registration.ts
@@ -196,6 +196,24 @@ export const REGISTRATION_HOSTS: readonly RegistrationHost[] = [
   },
 ];
 
+/**
+ * Is this the registration red-dev declares, on the path that moves?
+ *
+ * Directory-sourced is not enough on its own. A host registered against
+ * `versions/v3.3.0` is directory-sourced and pinned to a directory that is
+ * correct today and never moves again, which is the original frozen
+ * machine wearing the right kind. Only `current` follows mise.
+ *
+ * One definition, because two callers ask it: the converge, to decide it
+ * has nothing to do, and the drift check, to decide the machine is well.
+ */
+export function registrationIsOurs(
+  registration: MarketplaceRegistration | null,
+  source: string,
+): boolean {
+  return registration?.kind === "directory" && samePath(registration.source, source);
+}
+
 /** What one host was left registered against, or the reason nothing happened. */
 export interface RegistrationOutcome {
   /** The host's name in REGISTRATION_HOSTS. */
@@ -274,7 +292,7 @@ export async function convergeMarketplaceOwnership(
     }
 
     const before = await host.read(home);
-    if (before?.kind === "directory" && samePath(before.source, source)) {
+    if (registrationIsOurs(before, source)) {
       log.skip(`${host.name}: red-skills already registered from ${source}`);
       out.push({
         host: host.name,

--- a/src/red-skills-registration.ts
+++ b/src/red-skills-registration.ts
@@ -1,0 +1,392 @@
+/**
+ * Who owns the marketplace registration on a machine that has both installers.
+ *
+ * The standalone one-liner registers RedSkills from GitHub, and carries a
+ * heal step that re-registers a machine it finds registered from a
+ * directory. It was right to: a directory registration used to mean a
+ * machine frozen at its install-day snapshot, because `marketplace update`
+ * re-reads whatever source was registered and nothing on the machine ever
+ * moved that directory.
+ *
+ * mise is a thing that moves it. Once the core is a manifest entry
+ * resolved at `latest`, `~/.red-skills/current` advances with every other
+ * tool on the machine — so the directory is now the *only* source pinned
+ * to the version this machine actually resolved. Registering from GitHub
+ * instead would put the hosts back on a version nothing here chose.
+ *
+ * Both remain true installers, so both would keep acting. Two installers
+ * evicting each other's registration is silent and endless — each one
+ * finds the other's source, heals it, and reports success — and two
+ * marketplace *names* would be worse still, since every plugin would
+ * install twice. So there is one declared owner rather than a merge, and
+ * where red-dev is present it is red-dev.
+ *
+ * ## The fact both halves assert against
+ *
+ * The other half of this lives in reddb-io/red-skills: the standalone
+ * installer stands down from healing when it detects red-dev. Two repos
+ * cannot share a test, so they share a fact instead — the registration
+ * kind the host itself writes down, in the same file the healing reads:
+ *
+ *   claude  `~/.claude/plugins/known_marketplaces.json`  source.source
+ *   codex   `~/.codex/config.toml`                       source_type
+ *
+ * That is what `claudeRegistration` and `codexRegistration` answer, and
+ * what the converge below re-reads after it registers. An outcome derived
+ * from the exit code instead would let a machine be reported as converged
+ * while the entry on disk still says github — which is precisely the state
+ * the arbitration exists to end.
+ *
+ * ## Registering `current`, not the version behind it
+ *
+ * `~/.red-skills/current` is the path red-dev repoints when mise installs
+ * a newer core. A registration made against `versions/v3.3.0` names a
+ * directory that is correct today and never moves again, so it is treated
+ * as drift here even though it is directory-sourced.
+ *
+ * ## And a machine without red-dev is untouched
+ *
+ * Ownership is claimed from having something to register: with no checkout
+ * under `~/.red-skills/current` this does nothing at all — no commands, no
+ * files, no marker. The standalone one-liner stays first-class on machines
+ * that only have it, which is the whole reason the arbitration is a
+ * declaration rather than a fight.
+ */
+
+import { existsSync, realpathSync } from "node:fs";
+
+import { log } from "./log.ts";
+import type { Platform } from "./platform.ts";
+import type { Tool } from "./manifest.ts";
+
+/** The one name both installers register under. Two names install twice. */
+export const MARKETPLACE_NAME = "red-skills";
+
+/**
+ * What a host says its marketplace came from, in the two spellings that matter.
+ *
+ * Claude's `directory`/`github` and Codex's `local`/`git` are one
+ * distinction recorded in two vocabularies, so they are normalised here:
+ * the arbitration is about which kind wins, and a caller that had to know
+ * which host it was asking would be a caller that can get it wrong.
+ */
+export type RegistrationKind = "directory" | "github";
+
+export interface MarketplaceRegistration {
+  kind: RegistrationKind;
+  /** The directory or repo the host recorded, verbatim. */
+  source: string | null;
+}
+
+function normalise(home: string): string {
+  return home.replace(/\\/g, "/");
+}
+
+/** Where Claude records what it registered. */
+export function claudeRegistrationPath(home: string): string {
+  return `${normalise(home)}/.claude/plugins/known_marketplaces.json`;
+}
+
+/** Where Codex records what it registered. */
+export function codexRegistrationPath(home: string): string {
+  return `${normalise(home)}/.codex/config.toml`;
+}
+
+/**
+ * Claude's entry for the RedSkills marketplace, or null for no opinion.
+ *
+ * Null covers no file, no entry and an unreadable one. Unreadable is not
+ * the same as wrong: re-registering a marketplace on a guess about a file
+ * we could not parse is worse than leaving the machine alone, and the next
+ * converge asks again.
+ */
+export async function claudeRegistration(home: string): Promise<MarketplaceRegistration | null> {
+  const path = claudeRegistrationPath(home);
+  if (!existsSync(path)) return null;
+  try {
+    const known = JSON.parse(await Bun.file(path).text()) as Record<
+      string,
+      { source?: { source?: string; path?: string; repo?: string } }
+    >;
+    const source = known[MARKETPLACE_NAME]?.source;
+    if (source?.source === "directory") return { kind: "directory", source: source.path ?? null };
+    if (source?.source === "github") return { kind: "github", source: source.repo ?? null };
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function tomlStringValue(line: string, key: string): string | null {
+  const match = line.match(new RegExp(`^\\s*${key}\\s*=\\s*"([^"]*)"\\s*$`));
+  return match?.[1] ?? null;
+}
+
+/** Codex's entry for the same marketplace, read out of its config table. */
+export async function codexRegistration(home: string): Promise<MarketplaceRegistration | null> {
+  const path = codexRegistrationPath(home);
+  if (!existsSync(path)) return null;
+  try {
+    let inTable = false;
+    let kind: RegistrationKind | null = null;
+    let source: string | null = null;
+    for (const line of (await Bun.file(path).text()).split(/\r?\n/)) {
+      const table = line.match(/^\s*\[([^\]]+)\]\s*$/);
+      if (table) {
+        if (inTable) break;
+        inTable = table[1] === `marketplaces.${MARKETPLACE_NAME}`;
+        continue;
+      }
+      if (!inTable) continue;
+      const sourceType = tomlStringValue(line, "source_type");
+      if (sourceType !== null) kind = sourceType === "git" ? "github" : "directory";
+      const value = tomlStringValue(line, "source");
+      if (value !== null) source = value;
+    }
+    return kind === null ? null : { kind, source };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * One host whose registration red-dev declares, and how it is declared.
+ *
+ * There is no `marketplace set-source` in either CLI, so re-registering is
+ * remove-then-add — the same steps anyone doing this by hand runs. The
+ * remove is allowed to fail: a machine with nothing registered yet is the
+ * ordinary first converge, not a broken host.
+ *
+ * The plugins are reinstalled because they came from a marketplace that no
+ * longer exists under that name. Which plugins is the manifest's answer,
+ * never this table's: a machine that opted `brain` out has no entry for
+ * it, and naming it here would reinstall exactly what the operator removed.
+ */
+export interface RegistrationHost {
+  /** The name that appears in an outcome and a log line. */
+  name: string;
+  /** The command that has to be on PATH for this host to exist. */
+  cmd: string;
+  /** What this host has written down, read at its own boundary. */
+  read: (home: string) => Promise<MarketplaceRegistration | null>;
+  /** Remove, add from `source`, reinstall `plugins` — in that order. */
+  register: (source: string, plugins: readonly string[]) => string[][];
+}
+
+export const REGISTRATION_HOSTS: readonly RegistrationHost[] = [
+  {
+    name: "claude",
+    cmd: "claude",
+    read: claudeRegistration,
+    register: (source, plugins) => [
+      ["claude", "plugin", "marketplace", "remove", MARKETPLACE_NAME],
+      ["claude", "plugin", "marketplace", "add", source],
+      ...plugins.map((p) => ["claude", "plugin", "install", `${p}@${MARKETPLACE_NAME}`]),
+    ],
+  },
+  {
+    name: "codex",
+    cmd: "codex",
+    read: codexRegistration,
+    register: (source, plugins) => [
+      ["codex", "plugin", "marketplace", "remove", MARKETPLACE_NAME],
+      ["codex", "plugin", "marketplace", "add", source],
+      ...plugins.map((p) => ["codex", "plugin", "add", `${p}@${MARKETPLACE_NAME}`]),
+    ],
+  },
+];
+
+/** What one host was left registered against, or the reason nothing happened. */
+export interface RegistrationOutcome {
+  /** The host's name in REGISTRATION_HOSTS. */
+  host: string;
+  /** True only when this converge re-registered it and the host agrees. */
+  registered: boolean;
+  /** What the host records now, read back rather than assumed. */
+  kind: RegistrationKind | null;
+  /** Why not, present exactly when `registered` is false. */
+  reason?: string;
+}
+
+/**
+ * Everything the converge needs from outside itself.
+ *
+ * All of it has a real default and exists for the tests: registering a
+ * marketplace is a sequence of commands issued to CLIs that may not be
+ * installed, against a checkout that may not exist, and what is worth
+ * pinning is which commands ran and what the host recorded afterwards.
+ */
+export interface RegistrationOptions {
+  /** Defaults to this user's home. The host boundaries live under it. */
+  home?: string;
+  /** The path to register. Defaults to `~/.red-skills/current`, or null. */
+  source?: string | null;
+  /** The plugin set. Defaults to whatever the manifest declares. */
+  plugins?: readonly string[];
+  /** The manifest to derive the plugin set from. Defaults to TOOLS. */
+  tools?: readonly Tool[];
+  /** The hosts to declare against. Defaults to REGISTRATION_HOSTS. */
+  hosts?: readonly RegistrationHost[];
+  /** Is this host's command on PATH? Defaults to `commandPath`. */
+  present?: (cmd: string) => boolean;
+  /** Runs one argv and answers its exit code. Defaults to spawnLogged. */
+  run?: (cmd: string[]) => Promise<number>;
+}
+
+/**
+ * Declare red-dev's registration on every host that has one.
+ *
+ * Answers one outcome per host, including the hosts it left alone:
+ * "absent", "already ours" and "refused" are three different facts, and a
+ * caller reporting them needs to be able to tell them apart.
+ *
+ * With no checkout there is nothing to register from, and that is not a
+ * failure — it is a machine red-dev does not own the wiring of. It answers
+ * with no outcomes at all and touches nothing.
+ */
+export async function convergeMarketplaceOwnership(
+  p: Platform,
+  opts: RegistrationOptions = {},
+): Promise<RegistrationOutcome[]> {
+  const home = opts.home ?? homeOf();
+  const hosts = opts.hosts ?? REGISTRATION_HOSTS;
+
+  const source = opts.source !== undefined ? opts.source : await currentSource();
+  if (source === null) {
+    log.skip("red-skills: no managed checkout, leaving the marketplace registration alone");
+    return [];
+  }
+
+  const plugins = opts.plugins ?? (await declaredPlugins(p, opts.tools));
+  const present = opts.present ?? (await presenceProbe());
+  const run = opts.run ?? (await defaultRunner());
+
+  const out: RegistrationOutcome[] = [];
+  for (const host of hosts) {
+    if (!present(host.cmd)) {
+      out.push({
+        host: host.name,
+        registered: false,
+        kind: null,
+        reason: `${host.cmd} is not installed`,
+      });
+      continue;
+    }
+
+    const before = await host.read(home);
+    if (before?.kind === "directory" && samePath(before.source, source)) {
+      log.skip(`${host.name}: red-skills already registered from ${source}`);
+      out.push({
+        host: host.name,
+        registered: false,
+        kind: "directory",
+        reason: `already registered from ${source}`,
+      });
+      continue;
+    }
+
+    log.step(`${host.name}: registering the red-skills marketplace from ${source}`);
+    if (before?.kind === "github") {
+      log.plain("     red-dev owns this machine's wiring, and the directory it");
+      log.plain("     registers is the version mise resolved. A GitHub source");
+      log.plain("     would put this host back on a version nothing here chose.");
+    }
+
+    const failure = await runSteps(host.register(source, plugins), run);
+    if (failure !== null) {
+      log.warn(`${host.name}: ${failure}`);
+      out.push({
+        host: host.name,
+        registered: false,
+        kind: (await host.read(home))?.kind ?? null,
+        reason: failure,
+      });
+      continue;
+    }
+
+    // Read back, never assumed. The exit code says the command ran; the
+    // entry says what the other half of this arbitration will see.
+    const after = await host.read(home);
+    if (after?.kind !== "directory") {
+      const reason = `registered from ${source}, but the host records ${after?.kind ?? "nothing"}`;
+      log.warn(`${host.name}: ${reason}`);
+      out.push({ host: host.name, registered: false, kind: after?.kind ?? null, reason });
+      continue;
+    }
+
+    log.ok(`${host.name}: red-skills marketplace registered from ${source}`);
+    out.push({ host: host.name, registered: true, kind: "directory" });
+  }
+
+  return out;
+}
+
+/**
+ * Runs one host's steps, and answers the first hard failure or null.
+ *
+ * Only the remove is allowed to fail, and it is the first step, so the
+ * failure this reports is always one that left the host without the
+ * registration it was meant to gain.
+ */
+async function runSteps(
+  steps: readonly string[][],
+  run: (cmd: string[]) => Promise<number>,
+): Promise<string | null> {
+  const [remove, ...rest] = steps;
+  if (remove) {
+    try {
+      await run(remove);
+    } catch (error) {
+      // Nothing registered yet is the ordinary first converge here.
+      log.skip(`${remove.join(" ")} could not be run: ${(error as Error).message}`);
+    }
+  }
+
+  for (const step of rest) {
+    const what = step.join(" ");
+    let code: number;
+    try {
+      code = await run(step);
+    } catch (error) {
+      return `${what} could not be run: ${(error as Error).message}`;
+    }
+    if (code !== 0) return `${what} exited ${code}`;
+  }
+  return null;
+}
+
+/** Two paths naming one directory, whether or not either resolves today. */
+function samePath(a: string | null, b: string): boolean {
+  if (a === null) return false;
+  const trim = (s: string) => normalise(s).replace(/\/+$/, "");
+  if (trim(a) === trim(b)) return true;
+  try {
+    return realpathSync(a) === realpathSync(b);
+  } catch {
+    return false;
+  }
+}
+
+function homeOf(): string {
+  return normalise(process.env["HOME"] ?? process.env["USERPROFILE"] ?? "");
+}
+
+async function currentSource(): Promise<string | null> {
+  const { sourceRoot } = await import("./red-skills-ext.ts");
+  return sourceRoot();
+}
+
+async function declaredPlugins(p: Platform, tools?: readonly Tool[]): Promise<string[]> {
+  const { redSkillsPluginNames } = await import("./red-skills-plugins.ts");
+  return redSkillsPluginNames(p, tools);
+}
+
+async function presenceProbe(): Promise<(cmd: string) => boolean> {
+  const { commandPath } = await import("./agents.ts");
+  return (cmd: string) => commandPath(cmd) !== null;
+}
+
+async function defaultRunner(): Promise<(cmd: string[]) => Promise<number>> {
+  const { spawnLogged } = await import("./providers.ts");
+  return (cmd: string[]) => spawnLogged(cmd);
+}

--- a/src/red-skills.test.ts
+++ b/src/red-skills.test.ts
@@ -17,13 +17,7 @@ import { describe, expect, test } from "bun:test";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { TOOLS, applicableScopes, providerFor } from "./manifest.ts";
-import {
-  AGENTS,
-  SKILL_HOSTS,
-  claudeMarketplaceIsGithub,
-  codexMarketplaceIsGithub,
-  repairCopiedRedSkillsCurrent,
-} from "./agents.ts";
+import { AGENTS, SKILL_HOSTS, repairCopiedRedSkillsCurrent } from "./agents.ts";
 import type { Platform } from "./platform.ts";
 
 function platform(over: Partial<Platform>): Platform {
@@ -160,129 +154,38 @@ describe("how it decides it is already done", () => {
   });
 });
 
-describe("a marketplace that reports updates it cannot receive", () => {
+describe("which registration a converge leaves behind", () => {
   const src = readFileSync("src/agents.ts", "utf8");
 
-  /** A HOME holding one crafted known_marketplaces.json. */
-  function fakeHome(entry: unknown): string {
-    const dir = mkdtempSync(`${tmpdir()}/red-mkt-`);
-    mkdirSync(`${dir}/.claude/plugins`, { recursive: true });
-    if (entry !== undefined) {
-      writeFileSync(
-        `${dir}/.claude/plugins/known_marketplaces.json`,
-        JSON.stringify({ "red-skills": entry }),
-      );
-    }
-    return dir;
-  }
-
-  async function sourceIsGithub(entry: unknown): Promise<boolean | null> {
-    const saved = process.env["HOME"];
-    process.env["HOME"] = fakeHome(entry);
-    try {
-      return await claudeMarketplaceIsGithub();
-    } finally {
-      if (saved === undefined) delete process.env["HOME"];
-      else process.env["HOME"] = saved;
-    }
-  }
-
-  test("a directory source is drift, however recently it says it updated", async () => {
-    // The exact entry off a real machine: autoUpdate on, a timestamp
-    // from today, and a version a week behind. Claude re-reads the
-    // snapshot, finds it unchanged, and records success.
-    expect(
-      await sourceIsGithub({
-        source: { source: "directory", path: "/home/x/.red-skills/current" },
-        lastUpdated: "2026-08-02T12:35:21.550Z",
-        autoUpdate: true,
-      }),
-    ).toBe(false);
-  });
-
-  test("a github source is what a working one looks like", async () => {
-    expect(
-      await sourceIsGithub({ source: { source: "github", repo: "reddb-io/red-skills" } }),
-    ).toBe(true);
-  });
-
-  test("no entry is no opinion, not a verdict", async () => {
-    // Null means leave the machine alone. Repointing a marketplace on a
-    // guess is worse than the drift.
-    expect(await sourceIsGithub(undefined)).toBeNull();
-  });
-
-  /** A HOME holding one crafted Codex config.toml. */
-  function fakeCodexHome(sourceType?: string): string {
-    const dir = mkdtempSync(`${tmpdir()}/red-codex-mkt-`);
-    mkdirSync(`${dir}/.codex`, { recursive: true });
-    if (sourceType !== undefined) {
-      writeFileSync(
-        `${dir}/.codex/config.toml`,
-        [
-          "[marketplaces.red-skills]",
-          'last_updated = "2026-08-02T18:04:00Z"',
-          `source_type = "${sourceType}"`,
-          sourceType === "git"
-            ? 'source = "https://github.com/reddb-io/red-skills.git"'
-            : 'source = "/home/x/.red-skills/versions/v3.3.0"',
-          "",
-        ].join("\n"),
-      );
-    }
-    return dir;
-  }
-
-  async function codexSourceIsGithub(sourceType?: string): Promise<boolean | null> {
-    const saved = process.env["HOME"];
-    process.env["HOME"] = fakeCodexHome(sourceType);
-    try {
-      return await codexMarketplaceIsGithub();
-    } finally {
-      if (saved === undefined) delete process.env["HOME"];
-      else process.env["HOME"] = saved;
-    }
-  }
-
-  test("Codex has the same local-marketplace drift as Claude", async () => {
-    expect(await codexSourceIsGithub("local")).toBe(false);
-  });
-
-  test("Codex git marketplaces can receive RedSkills updates", async () => {
-    expect(await codexSourceIsGithub("git")).toBe(true);
-  });
-
-  test("no Codex marketplace entry is no opinion", async () => {
-    expect(await codexSourceIsGithub(undefined)).toBeNull();
-  });
-
-  test("the name alone cannot tell the two apart", () => {
-    // Which is why the old check could not see this: `red-skills`
-    // appears in `plugin marketplace list` either way.
+  test("the marketplace list cannot tell a directory source from a GitHub one", () => {
+    // `red-skills` is in `plugin marketplace list` either way, which is
+    // why being wired and being registered the way red-dev declares are
+    // two different questions asked in two different places.
     const wired = src.slice(src.indexOf("async function cliNamesRedSkills"));
     expect(wired.slice(0, wired.indexOf("\n}"))).toContain("red-skills");
-    expect(src).toContain("claudeMarketplaceIsGithub");
-    expect(src).toContain("codexMarketplaceIsGithub");
+    expect(src).toContain("convergeMarketplaceOwnership");
   });
 
-  test("the repair reinstalls the plugins it removed", () => {
-    // They came from a marketplace that no longer exists under that
-    // name, so re-adding the source is not enough on its own.
-    //
-    // Which plugins is no longer written here: the set is the manifest's,
-    // and src/red-skills-plugins.test.ts asserts the commands a repair
-    // actually issues against it. What is left to pin at this level is
-    // that the reinstall step still exists at all.
-    const repair = src.slice(src.indexOf("export async function repointClaudeMarketplace"));
-    expect(repair).toContain("redSkillsPluginNames");
-    expect(repair).toContain("@red-skills");
+  test("red-dev declares its registration after the installer, never before", () => {
+    // `install.sh` registers from GitHub wherever it runs, including from
+    // the line above this one. Declaring first would leave the
+    // installer's registration standing until the next converge — which
+    // is the eviction seen from inside a single run.
+    const converge = src.slice(src.indexOf("export async function convergeRedSkills"));
+    const installed = converge.indexOf("await installRedSkills()");
+    const declared = converge.indexOf("convergeMarketplaceOwnership");
+    expect(installed).toBeGreaterThan(-1);
+    expect(declared).toBeGreaterThan(installed);
   });
 
-  test("the Codex repair refreshes the plugins that provide MCPs", () => {
-    const repair = src.slice(src.indexOf("export async function repointCodexMarketplace"));
-    expect(repair).toContain("plugin");
-    expect(repair).toContain("marketplace");
-    expect(repair).toContain("redSkillsPluginNames");
+  test("and nothing here heals a registration back to GitHub", () => {
+    // Both ends of the eviction used to live in this file: one converge
+    // registering the directory mise advances, the next repointing it at
+    // the repo. Where red-dev is present the directory wins, so the
+    // repair is gone rather than merely unused.
+    expect(src).not.toContain("repointClaudeMarketplace");
+    expect(src).not.toContain("repointCodexMarketplace");
+    expect(src).not.toContain('"add", "reddb-io/red-skills"');
   });
 
   test("castle has the repo-local fallback Codex already searches", () => {


### PR DESCRIPTION
Automated AFK landing for #192. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #192

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/199"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789519941&installation_model_id=20659&pr_number=199&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F199&signature=c8dd0e0218d21d1a357eead3a16c382a68a749e2e67c5fbda6e2f2bbc21ba799"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->