### PR TITLE
docs: define the RedSkills workstation package set

### DIFF
--- a/.red/CONTEXT-MAP.md
+++ b/.red/CONTEXT-MAP.md
@@ -9,7 +9,7 @@ Bounded contexts split by **subject** (language boundary), never by OS nor by im
 | `interaction` | Semantic actions: hotkeys, tiling, workspaces, launcher | `.red/contexts/interaction/CONTEXT.md` |
 | `visual` | Visual system: themes, fonts, wallpapers, config ownership | `.red/contexts/visual/CONTEXT.md` |
 | `agents` | Agent hosts, RedSkills, MCPs, and agent accessibility | `.red/contexts/agents/CONTEXT.md` |
-| `lifecycle` | Self-update of the binary, channels, rollback, origin verification | *(no resolved terms yet)* |
+| `lifecycle` | Self-update of the binary, channels, rollback, origin verification | `.red/contexts/lifecycle/CONTEXT.md` |
 
 ## Relationships
 

--- a/.red/adr/0008-red-dev-owns-redskills-wiring-mise-owns-its-version.md
+++ b/.red/adr/0008-red-dev-owns-redskills-wiring-mise-owns-its-version.md
@@ -1,6 +1,6 @@
 # 0008 — red-dev owns RedSkills wiring; mise owns its version
 
-- Status: accepted
+- Status: superseded by ADR 0010
 - Date: 2026-08-16
 - Contexts: `agents`, `lifecycle`
 - Sources: the RedSkills `/start` grilling session of 2026-08-16; red-skills ADR 0146 (what gets published)

--- a/.red/adr/0010-one-redskills-package-set-per-workstation.md
+++ b/.red/adr/0010-one-redskills-package-set-per-workstation.md
@@ -1,0 +1,89 @@
+# 0010 — One RedSkills package set per workstation
+
+- Status: accepted
+- Date: 2026-08-17
+- Contexts: `agents`, `provisioning`, `lifecycle`
+- Supersedes: ADR 0008
+- Sources: the RedSkills `/start` grilling session of 2026-08-17
+
+## Context
+
+RedSkills reaches each agent host through a different marketplace, generator,
+copy, or skills directory. The same revision is consequently cloned and cached
+several times, while the four mise/npm entries can advance independently. The
+current npm runtime package carries bundles and shims rather than the complete
+workstation distribution, and the standalone installer remains a competing
+owner of `~/.red-skills/current`.
+
+The required outcome is one user-global local source for every integration, an
+online update through mise, and a complete offline bootstrap from a directory.
+
+## Decision
+
+**A RedSkills package set is one mise tool.** It contains the complete
+workstation distribution: all four plugin payloads, host manifests and
+generators, shared runtimes, `redskilled`, the Herdr plugin, VS Code extension,
+Zellij integration, and required RedSkills artifacts. Only the `dev` plugin is
+activated in AI coder hosts. Host applications and other third-party tools stay
+separate mise tools, but exact compatible revisions are recorded in the same
+per-target lock.
+
+**A local mise plugin acquires the package set.** Online channels are `stable`,
+`next`, or an exact version/commit. The plugin maintains one local Git mirror,
+creates immutable snapshots, overlays release assets from the same commit,
+verifies a signed manifest and every SHA-256 digest, and invokes red-dev from a
+tool-level postinstall. `mise upgrade red-skills` and `red-dev update` therefore
+reach the same idempotent red-dev reconciliation. The package-set identity is
+its version plus whole-set digest and source commit, never just its path.
+
+A development checkout is a mise `path:` override and is updated explicitly
+through red-dev rather than by `mise upgrade`. It overlays matching release
+assets; assets unavailable for that commit are built into digest-keyed staging
+without mutating the checkout.
+
+**red-dev remains the sole host-wiring owner.** It installs and verifies
+RedSkills for Claude Code, Codex, OpenCode, RedCode, Gemini, Pi, and Hermes,
+using each host's supported extension mechanism and falling back to skills-only
+where richer hooks, MCP, or agent surfaces do not exist. It installs all seven
+hosts on a clean workstation, but activates only `dev`. User configuration is
+preserved through dedicated includes or ownership-aware structural merges.
+Host-owned caches may exist; obsolete revisions are removed only after the new
+source verifies successfully.
+
+**An Offline depot bootstraps a clean workstation without network access.** A
+connected machine creates the private depot with `red-dev depot export`; it
+contains the mise and red-dev bootstrap, local mise plugin, Git snapshot,
+release assets, third-party installers, exact lock, signed manifest, checksums,
+and both the selected and previous revisions. It contains no credentials. An
+import copies versioned state into machine-owned storage, so removable media is
+not a runtime dependency.
+
+The first supported depots are Ubuntu 24.04/26.04 x64 and a combined Windows
+x64 plus WSL2/Ubuntu workstation. On the combined target, all seven coder CLIs,
+Zellij, Herdr, and the one `redskilled` daemon run in WSL; Windows hosts the GUI,
+terminal, and VS Code. One combined depot carries both Windows and Linux
+artifacts. VS Code is installed on a clean machine; the extension is also
+updated in compatible editors already present.
+
+**Convergence is truthful rather than falsely transactional.** Every chosen
+surface must converge before the operation succeeds, but a failed host does not
+roll back hosts already updated. Running coder sessions are never terminated;
+they are reported as `restart needed`. Active Workers cause the complete update
+to stage and remain pending rather than changing the active package set or
+stopping work. Rollback restores the previous complete workstation lock.
+
+The standalone `install.sh` is deprecated and redirects to the mise/red-dev
+bootstrap. Existing installations are adopted and backed up first; Git-sourced
+marketplaces and obsolete caches are removed only after the package-set source
+and all managed surfaces verify.
+
+## Consequences
+
+- The release must publish a complete, commit-correlated workstation asset set;
+  the current runtime-only npm package and partial checkout are insufficient.
+- Gemini's incomplete generated surface and Hermes's missing adapter block a
+  truthful seven-host success and must be completed before this guarantee ships.
+- Offline depots are target-specific, potentially large, and private because
+  they cache third-party distributions rather than republishing them.
+- The machine retains at most the active and previous locked workstation
+  revisions, plus host cache entries still required by those revisions.

--- a/.red/contexts/agents/CONTEXT.md
+++ b/.red/contexts/agents/CONTEXT.md
@@ -4,7 +4,19 @@ Agent hosts, RedSkills, MCPs, and RedDB products' accessibility to agents.
 
 ## Agent host
 
-An agent client program that consumes RedSkills on a provisioned machine. Decided supported set: Claude Code, Codex, RedCode, Gemini, Pi, and Hermes — all six with shared skills and doctor verification. RedCode is the installed OpenCode-compatible host; existing OpenCode installations are retained but are no longer selected or managed. Hermes depends on official upstream RedSkills support.
+An agent client program that consumes RedSkills on a provisioned machine. Decided supported set: Claude Code, Codex, OpenCode, RedCode, Gemini, Pi, and Hermes — all seven with shared skills and doctor verification. OpenCode and RedCode are both managed OpenCode-compatible hosts. Hermes depends on official upstream RedSkills support.
+
+## RedSkills package set
+
+A coherent, versioned unit of the RedSkills workstation distribution: core, all plugin payloads, host manifests and generators, shared runtimes, daemon, companion integrations, and their required artifacts. Releases are the reproducible default; a local source checkout may stand in for the package set during development without becoming a second installation model. AI coder activation is deliberately narrower than its contents: only the `dev` plugin is installed into agent hosts.
+
+_Avoid_: RedSkills install (ambiguous between acquisition and host activation), plugin bundle (only one part of the set)
+
+## User-global installation
+
+An agent-host integration available to one operating-system user in every repository and new session. It is not a system-wide installation shared by other users, and it does not imply that an already-running host has reloaded changed plugins.
+
+_Avoid_: global installation (ambiguous between user-global and system-wide)
 
 ## Default agent
 

--- a/.red/contexts/lifecycle/CONTEXT.md
+++ b/.red/contexts/lifecycle/CONTEXT.md
@@ -1,0 +1,9 @@
+# Context: lifecycle
+
+The identity, movement, and retention of installed product revisions.
+
+## Version channel
+
+A named policy for selecting a revision: `stable` follows production releases, `next` follows prereleases, and a pinned version or commit remains fixed. An offline depot resolves a channel before export and carries that exact revision; it never interprets “latest” without a source it can consult.
+
+_Avoid_: latest version (ambiguous without a channel and source)

--- a/.red/contexts/provisioning/CONTEXT.md
+++ b/.red/contexts/provisioning/CONTEXT.md
@@ -27,3 +27,9 @@ _Avoid_: optional list, extras, pre-installs (Omarchy's word for the same tier)
 ## E2E lane
 
 A clean machine (VM) for one target platform that walks the full journey — install → second convergence with zero drift → theme/font switch → N-1 update → rollback → uninstall. Incremental definition of done: each phase only closes with lanes covering what it shipped; no item is ever declared ready by mere file existence.
+
+## Offline depot
+
+A transportable, integrity-checked directory that carries everything needed to bootstrap a supported clean machine without network access: the RedSkills source, required binaries and dependencies, a lock, and checksums. A source checkout by itself is not an Offline depot.
+
+_Avoid_: offline cache (may be incomplete or disposable), checkout (only one input)


### PR DESCRIPTION
## Summary
- supersede ADR 0008 with the single package-set and offline-depot architecture
- define RedSkills package set, user-global installation, offline depot, and version channels
- restore OpenCode to the managed seven-host set

## Validation
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/200"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789563155&installation_model_id=20659&pr_number=200&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F200&signature=b35775ee7f316d41cf51f013306199bbe97e8e31e403db8ef0a80f064dcefc80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->