### PR TITLE
fix: #202 a core payload that cannot compose a set is refused, and the composed set's generators run

### DIFF
--- a/.red/adr/0011-the-package-set-is-a-self-contained-copy-with-one-identity.md
+++ b/.red/adr/0011-the-package-set-is-a-self-contained-copy-with-one-identity.md
@@ -59,6 +59,12 @@ unknown schema is refused as incompatible metadata.
 
 ## Consequences
 
+- A core payload that cannot compose a set — no marketplace manifests, no generators; the
+  shape of the npm package before 3.19 — is refused, and `current` stays on the tree that
+  works. mise's `minimum_release_age` makes exactly that payload the one it resolves for
+  days after a release (observed on 2026-08-18: `latest` was 3.18.12 while 3.19.5 was
+  published), so this refusal is the ordinary state of a machine right after a RedSkills
+  release, not an edge case.
 - The four mise entries stay as the *acquisition* until #203's mise plugin and
   reddb-io/red-skills#3977's complete set replace them; what changed is that they are no
   longer resolved into the layout independently.

--- a/src/red-skills-hosts.test.ts
+++ b/src/red-skills-hosts.test.ts
@@ -331,6 +331,10 @@ describe("what the hosts are asked", () => {
     const codex = hostNamed("codex");
     const steps = codex.wire(CTX);
     expect(steps[0]?.argv).toEqual(["codex", "plugin", "marketplace", "upgrade", "red-skills"]);
+    // Optional: a Directory marketplace — the one red-dev registers —
+    // is "not configured as a Git marketplace" to `upgrade`, and the
+    // add below reads the tree as it stands.
+    expect(steps[0]?.optional).toBe(true);
     expect(steps.some((s) => s.argv.includes("update"))).toBe(false);
 
     for (const plugin of PLUGINS) {

--- a/src/red-skills-hosts.ts
+++ b/src/red-skills-hosts.ts
@@ -168,7 +168,10 @@ function opencodeCompatible(host: string): SkillHostRefresh {
  * the line above it just upgraded. The remove is optional because a
  * plugin that is not installed yet — the first converge on this machine,
  * or a plugin the operator only just opted in to — makes it exit
- * non-zero, and that is not a broken host.
+ * non-zero, and that is not a broken host. The upgrade is optional too:
+ * `marketplace upgrade` only knows Git marketplaces, and where red-dev
+ * owns the registration the marketplace is a directory — the add reads
+ * the tree as it stands, and there is nothing to upgrade.
  *
  * OpenCode, RedCode and pi are the tree's own generators, invoked with
  * the tree as their source. pi takes `--source-dir` as well as the path,
@@ -194,7 +197,7 @@ export const REFRESH_HOSTS: readonly SkillHostRefresh[] = [
     name: "codex",
     cmd: "codex",
     wire: ({ plugins }) => [
-      must("codex", "plugin", "marketplace", "upgrade", "red-skills"),
+      may("codex", "plugin", "marketplace", "upgrade", "red-skills"),
       ...plugins.flatMap((p) => [
         may("codex", "plugin", "remove", `${p}@red-skills`),
         must("codex", "plugin", "add", `${p}@red-skills`),

--- a/src/red-skills-set.test.ts
+++ b/src/red-skills-set.test.ts
@@ -146,8 +146,9 @@ function fakeInstalls(
     writeFileSync(join(payload, ".claude-plugin", "marketplace.json"), marketplace);
     writeFileSync(join(payload, ".agents", "plugins", "marketplace.json"), marketplace);
     writeFileSync(join(payload, "dist", "opencode-host.bundle.min.mjs"), "// opencode-host\n");
-    writeFileSync(join(payload, "scripts", "install-opencode.sh"), "#!/bin/bash\n");
-    writeFileSync(join(payload, "scripts", "install-pi.sh"), "#!/bin/bash\n");
+    // Mode 0644, exactly as npm unpacks them.
+    writeFileSync(join(payload, "scripts", "install-opencode.sh"), "#!/bin/bash\n", { mode: 0o644 });
+    writeFileSync(join(payload, "scripts", "install-pi.sh"), "#!/bin/bash\n", { mode: 0o644 });
     // A core from before the package set: bins and dist, nothing a host
     // could register or run — the shape mise resolves while a newer
     // release is still under its minimum release age.
@@ -247,6 +248,8 @@ function fakeManifestSet(opts: {
       `${JSON.stringify({ name: "@reddb-io/red-skills", version: opts.version ?? "3.19.5" })}\n`,
     );
     writeFileSync(join(tree, "bin", "red-skills-redskilled.mjs"), "// redskilled\n");
+    mkdirSync(join(tree, "scripts"), { recursive: true });
+    writeFileSync(join(tree, "scripts", "install-opencode.sh"), "#!/bin/bash\n", { mode: 0o644 });
   }
   return dir;
 }
@@ -482,6 +485,11 @@ describe("the composed set", () => {
     expect(existsSync(join(tree, "dist", "opencode-host.bundle.min.mjs"))).toBe(true);
     // The activation config the OpenCode generator dies without.
     expect(readFileSync(join(tree, ".red", "config.yaml"), "utf8")).toBe(hostActivationConfig(PLUGINS));
+    // And the generators runnable: an npm tarball drops the bit, and the
+    // host refresh spawns them by path.
+    for (const script of ["install-opencode.sh", "install-pi.sh"]) {
+      expect(statSync(join(tree, "scripts", script)).mode & 0o111, script).toBe(0o111);
+    }
   });
 
   test("the activation config enables exactly the plugins the set carries", () => {
@@ -818,6 +826,7 @@ describe("activating a published set", () => {
     expect(realpathSync(current)).toBe(realpathSync(result.revisionDir!));
     expect(result.revisionDir).toBe(redSkillsSetDir(home, revisionKey(result.active!)));
     expect(existsSync(join(result.revisionDir!, "plugins", "dev", "skills"))).toBe(true);
+    expect(statSync(join(result.revisionDir!, "scripts", "install-opencode.sh")).mode & 0o111).toBe(0o111);
     expect(readPackageSetState(home).revisions[0]).toMatchObject({ kind: "manifest", trust: "trusted" });
     // A copy into machine-owned storage: the set directory could be a
     // USB stick, and nothing on the machine may keep pointing at it.

--- a/src/red-skills-set.test.ts
+++ b/src/red-skills-set.test.ts
@@ -26,6 +26,7 @@ import {
   readFileSync,
   readlinkSync,
   realpathSync,
+  rmSync,
   statSync,
   symlinkSync,
   writeFileSync,
@@ -41,6 +42,8 @@ import type { Platform } from "./platform.ts";
 import {
   candidateFromMise,
   composeSet,
+  CORE_PAYLOAD_CONTRACT,
+  corePayloadGaps,
   convergeRedSkillsPackageSet,
   convergeSetAfterMise,
   coreInstallsDir,
@@ -122,7 +125,7 @@ const reject: SignatureVerifier = () => ({ ok: false, reason: "test refused it" 
  */
 function fakeInstalls(
   versions: Partial<Record<"core" | (typeof PLUGINS)[number], string[]>>,
-  opts: { selectors?: boolean; content?: Record<string, string>; noBundle?: string[] } = {},
+  opts: { selectors?: boolean; content?: Record<string, string>; noBundle?: string[]; legacyCore?: string[] } = {},
 ): string {
   const root = mkdtempSync(join(tmpdir(), "red-set-installs-"));
   const content = opts.content ?? {};
@@ -130,6 +133,7 @@ function fakeInstalls(
     const payload = payloadDir(coreInstallsDir(root), version, "@reddb-io/red-skills");
     mkdirSync(join(payload, "bin"), { recursive: true });
     mkdirSync(join(payload, ".claude-plugin"), { recursive: true });
+    mkdirSync(join(payload, ".agents", "plugins"), { recursive: true });
     mkdirSync(join(payload, "dist"), { recursive: true });
     mkdirSync(join(payload, "scripts"), { recursive: true });
     writeFileSync(
@@ -138,12 +142,20 @@ function fakeInstalls(
     );
     writeFileSync(join(payload, "bin", "red-skills-redskilled.mjs"), "// redskilled\n");
     writeFileSync(join(payload, "bin", "red-skills-dev.mjs"), "// dev shim\n");
-    writeFileSync(
-      join(payload, ".claude-plugin", "marketplace.json"),
-      `${JSON.stringify({ name: "red-skills", plugins: PLUGINS.map((p) => ({ name: p, source: `./plugins/${p}` })) })}\n`,
-    );
+    const marketplace = `${JSON.stringify({ name: "red-skills", plugins: PLUGINS.map((p) => ({ name: p, source: `./plugins/${p}` })) })}\n`;
+    writeFileSync(join(payload, ".claude-plugin", "marketplace.json"), marketplace);
+    writeFileSync(join(payload, ".agents", "plugins", "marketplace.json"), marketplace);
     writeFileSync(join(payload, "dist", "opencode-host.bundle.min.mjs"), "// opencode-host\n");
     writeFileSync(join(payload, "scripts", "install-opencode.sh"), "#!/bin/bash\n");
+    writeFileSync(join(payload, "scripts", "install-pi.sh"), "#!/bin/bash\n");
+    // A core from before the package set: bins and dist, nothing a host
+    // could register or run — the shape mise resolves while a newer
+    // release is still under its minimum release age.
+    if ((opts.legacyCore ?? []).includes(version)) {
+      rmSync(join(payload, ".claude-plugin"), { recursive: true });
+      rmSync(join(payload, ".agents"), { recursive: true });
+      rmSync(join(payload, "scripts"), { recursive: true });
+    }
   }
   for (const name of PLUGINS) {
     for (const version of versions[name] ?? []) {
@@ -398,6 +410,41 @@ describe("the candidate mise offers, read as one set rather than four tools", ()
     if (c.kind === "incomplete") expect(c.missing).toEqual(["red-skills-dev", "red-skills-memory", "red-skills-brain"]);
   });
 
+  test("a core from before the package set is unusable, and the refusal says what it lacks", () => {
+    // What this machine met on 2026-08-18: mise's minimum release age
+    // resolved 3.18.12 for all four tools, and that core carries no
+    // marketplace manifests and no generators. Composing it produced a
+    // tree every host failed against; refusing keeps `current` on the
+    // tree that works.
+    const root = aligned(["3.18.12"], { legacyCore: ["3.18.12"] });
+    const c = candidateFromMise(root, PLUGINS);
+    expect(c.kind).toBe("unusable");
+    if (c.kind === "unusable") {
+      expect(c.reason).toContain("core 3.18.12 carries no .claude-plugin/marketplace.json, .agents/plugins/marketplace.json, scripts/install-opencode.sh, scripts/install-pi.sh");
+      expect(c.reason).toContain("minimum release age");
+    }
+    expect(corePayloadGaps(payloadDir(coreInstallsDir(root), "3.18.12", "@reddb-io/red-skills"))).toEqual(
+      CORE_PAYLOAD_CONTRACT.filter((r) => r !== "package.json" && r !== "bin"),
+    );
+  });
+
+  test("a legacy core beside a complete one does not count, and the complete one wins", () => {
+    const root = fakeInstalls(
+      { core: ["3.18.12", "3.19.5"], dev: ["3.18.12", "3.19.5"], memory: ["3.18.12", "3.19.5"], brain: ["3.18.12", "3.19.5"] },
+      { legacyCore: ["3.18.12"] },
+    );
+    const c = candidateFromMise(root, PLUGINS);
+    expect(c.kind).toBe("ready");
+    if (c.kind === "ready") expect(c.version).toBe("3.19.5");
+    // And with the plugins only at the legacy version, there is no set
+    // — not a broken one.
+    const skewed = fakeInstalls(
+      { core: ["3.18.12", "3.19.5"], dev: ["3.18.12"], memory: ["3.18.12"], brain: ["3.18.12"] },
+      { legacyCore: ["3.18.12"] },
+    );
+    expect(candidateFromMise(skewed, PLUGINS).kind).toBe("skew");
+  });
+
   test("nothing installed at all is none", () => {
     expect(candidateFromMise(mkdtempSync(join(tmpdir(), "red-set-empty-")), PLUGINS)).toEqual({ kind: "none" });
   });
@@ -488,6 +535,29 @@ describe("the composed set", () => {
     expect(readFileSync(packageSetStatePath(home), "utf8")).not.toBe(beforeState);
     // And a second refusal for the same reason writes nothing more.
     expect(converge(home, skewed).writes).toEqual([]);
+  });
+
+  test("a legacy core is refused with current left where the standalone installer put it", () => {
+    // The tree install.sh materialised is what the hosts read today;
+    // a refused candidate must leave it exactly there, so the
+    // registration that runs next still finds a marketplace to register.
+    const home = fakeHome();
+    const legacy = join(home, ".red-skills", "versions", "v3.19.5");
+    mkdirSync(join(legacy, ".claude-plugin"), { recursive: true });
+    writeFileSync(join(legacy, "package.json"), "{}\n");
+    writeFileSync(join(legacy, ".claude-plugin", "marketplace.json"), "{}\n");
+    mkdirSync(join(home, ".red-skills"), { recursive: true });
+    symlinkSync(legacy, redSkillsCurrentLink(home));
+
+    const result = converge(home, aligned(["3.18.12"], { legacyCore: ["3.18.12"] }));
+
+    expect(result.refused?.failure).toBe("payload");
+    expect(result.active).toBeNull();
+    expect(realpathSync(redSkillsCurrentLink(home))).toBe(realpathSync(legacy));
+    expect(existsSync(join(realpathSync(redSkillsCurrentLink(home)), ".claude-plugin", "marketplace.json"))).toBe(true);
+    expect(existsSync(join(home, ".red-skills", "sets"))).toBe(false);
+    const rows = redSkillsSetRows(redSkillsSetReport(home));
+    expect(rows.at(-1)!.detail).toStartWith("last candidate refused (payload): core 3.18.12 carries no");
   });
 
   test("skew on a machine with no set leaves it with no set, and no current", () => {

--- a/src/red-skills-set.ts
+++ b/src/red-skills-set.ts
@@ -88,6 +88,7 @@
 
 import { spawnSync } from "node:child_process";
 import {
+  chmodSync,
   cpSync,
   existsSync,
   lstatSync,
@@ -798,7 +799,34 @@ export function composeSet(
     mkdirSync(dirname(config), { recursive: true });
     writeFileSync(config, hostActivationConfig(Object.keys(candidate.plugins)), "utf8");
   }
+  restoreScriptModes(dest);
   return { ok: true };
+}
+
+/**
+ * Make the generators runnable again.
+ *
+ * An npm tarball drops the executable bit on `scripts/*.sh`, and the
+ * host refresh spawns `<tree>/scripts/install-opencode.sh` directly —
+ * which is EACCES on a tree copied straight out of a package. The
+ * standalone installer runs them under `bash` for the same reason. This
+ * is red-dev's own copy, so the bit is put back where it belongs; on
+ * Windows the mode is meaningless and the call is harmless.
+ */
+function restoreScriptModes(tree: string): void {
+  const scripts = join(tree, "scripts");
+  for (const name of listing(scripts)) {
+    if (!name.endsWith(".sh")) continue;
+    const path = join(scripts, name);
+    if (statOf(path)?.isFile()) {
+      try {
+        chmodSync(path, 0o755);
+      } catch {
+        // A filesystem that refuses modes gives the same answer it gave
+        // the tarball; the host refresh will say so.
+      }
+    }
+  }
 }
 
 /**
@@ -1281,6 +1309,7 @@ function copyTree(from: string, to: string): void {
   rmSync(staging, { recursive: true, force: true });
   mkdirSync(dirname(to), { recursive: true });
   cpSync(from, staging, { recursive: true, dereference: true });
+  restoreScriptModes(staging);
   renameSync(staging, to);
 }
 

--- a/src/red-skills-set.ts
+++ b/src/red-skills-set.ts
@@ -480,6 +480,7 @@ export type SetFailure =
   | "signature"
   | "tree"
   | "skew"
+  | "payload"
   | "downgrade";
 
 export type SetVerification =
@@ -638,7 +639,36 @@ export type MiseCandidate =
   | { kind: "skew"; versions: Record<string, string[]> }
   /** Some tool has not been installed at all yet — mid-converge, not a fault. */
   | { kind: "incomplete"; missing: string[] }
+  /** Every core mise has is a payload that cannot compose a set. */
+  | { kind: "unusable"; reason: string }
   | { kind: "none" };
+
+/**
+ * What a core payload must carry for the tree composed from it to serve
+ * every consumer: the two marketplace manifests the Claude and Codex
+ * registrations read, the shims, and the generators the OpenCode/RedCode
+ * and Pi refreshes run. Relative to the core package root.
+ *
+ * Checked before anything is composed, because a payload from before
+ * the package set (the npm package carried none of these until 3.19)
+ * composes a tree that *looks* complete and then fails at every host —
+ * and mise's release-age policy makes such a payload the one it
+ * resolves for days after a release. Refusing keeps `current` on the
+ * tree that works.
+ */
+export const CORE_PAYLOAD_CONTRACT: readonly string[] = [
+  "package.json",
+  ".claude-plugin/marketplace.json",
+  ".agents/plugins/marketplace.json",
+  "bin",
+  "scripts/install-opencode.sh",
+  "scripts/install-pi.sh",
+];
+
+/** What a core payload is missing to compose a set, or nothing. PURE over the tree. */
+export function corePayloadGaps(core: string): string[] {
+  return CORE_PAYLOAD_CONTRACT.filter((rel) => !existsSync(join(core, rel)));
+}
 
 /**
  * The one version to compose, or why there is none.
@@ -657,9 +687,28 @@ export function candidateFromMise(installsRoot: string, plugins: readonly string
 
   const versions: Record<string, string[]> = {};
   const missing: string[] = [];
+  const unusable: string[] = [];
   for (const [tool, dir] of Object.entries(dirs)) {
     const pkg = tool === REDSKILLS_CORE_ALIAS ? CORE_PACKAGE : `@reddb-io/${tool}`;
-    const present = installedVersions(dir).filter((v) => existsSync(join(payloadDir(dir, v, pkg), "package.json")));
+    let present = installedVersions(dir).filter((v) => existsSync(join(payloadDir(dir, v, pkg), "package.json")));
+    if (tool === REDSKILLS_CORE_ALIAS) {
+      // Only a core that can compose a set counts as a version of the
+      // core; one that cannot is remembered so the refusal can say why.
+      const usable = present.filter((v) => corePayloadGaps(payloadDir(dir, v, pkg)).length === 0);
+      unusable.push(...present.filter((v) => !usable.includes(v)));
+      if (present.length > 0 && usable.length === 0) {
+        const newest = present.at(-1) as string;
+        const gaps = corePayloadGaps(payloadDir(dir, newest, pkg));
+        return {
+          kind: "unusable",
+          reason:
+            `core ${newest} carries no ${gaps.join(", ")} — a payload from before the ` +
+            "package set cannot compose one (mise resolves a release only after its " +
+            "minimum release age; the newer core is not there yet)",
+        };
+      }
+      present = usable;
+    }
     versions[tool] = present;
     if (present.length === 0) missing.push(tool);
   }
@@ -720,6 +769,10 @@ export function composeSet(
   candidate: Extract<MiseCandidate, { kind: "ready" }>,
   dest: string,
 ): { ok: true } | { ok: false; reason: string } {
+  const gaps = corePayloadGaps(candidate.core);
+  if (gaps.length > 0) {
+    return { ok: false, reason: `core ${candidate.version} carries no ${gaps.join(", ")}` };
+  }
   for (const [name, dir] of Object.entries(candidate.plugins)) {
     const dist = join(dir, "dist");
     if (existsSync(dist) && !existsSync(join(dist, `${name}.bundle.min.mjs`))) {
@@ -1016,6 +1069,7 @@ export function convergeRedSkillsPackageSet(
     // Mid-converge: the rows install one at a time and ask after each.
     return unchanged();
   }
+  if (candidate.kind === "unusable") return refuse("payload", candidate.reason);
   if (candidate.kind === "skew") {
     const detail = Object.entries(candidate.versions)
       .map(([tool, list]) => `${tool} ${list.length > 0 ? list.join(",") : "none"}`)


### PR DESCRIPTION
Follow-up to #216 (Refs #202), from converging the maintainer's machine with 1.0.51.

## What the real converge showed

1. mise's `minimum_release_age` resolved **3.18.12** for all four RedSkills tools (3.19.x published in the last days). That core carries no `.claude-plugin/marketplace.json`, no `.agents/plugins/marketplace.json` and no `scripts/` (the npm package gained them in 3.19). The composed set *looked* complete, `current` moved onto it, and every host failed: Claude "Marketplace file not found", Codex "marketplace root does not contain a supported manifest", opencode/redcode `install-opencode.sh` ENOENT — and the legacy retention, seeing `current` off `versions/`, removed the standalone installer's complete `v3.19.5` tree.
2. On a complete core, `scripts/*.sh` come out of the npm tarball mode 0644 and the host refresh spawns them by path → EACCES.
3. `codex plugin marketplace upgrade` only knows Git marketplaces; where red-dev registers a Directory it always exits 1, so Codex was never stamped and re-added its plugins on every converge.

## Fixes

- `candidateFromMise` only counts a core that carries `CORE_PAYLOAD_CONTRACT` (package.json, both marketplace manifests, `bin/`, `install-opencode.sh`, `install-pi.sh`); a machine whose only cores are legacy gets `unusable` → refused (`payload`) with a reason that names the gaps and mise's release age, and **`current` stays where it was**. A legacy core beside a complete one does not count. `composeSet` re-checks before writing.
- `composeSet` / `copyTree` restore `0755` on `scripts/*.sh` (it is red-dev's own copy).
- Codex's `marketplace upgrade` step is optional (`may`), the add reads the directory as it stands.
- ADR 0011 records the release-age finding.

Tests: 3 new cases (legacy core unusable with the reason; legacy beside complete → complete wins / plugins only legacy → skew; refused with `current` left on the installer's tree), script-mode assertions on both set kinds, codex step optional. `bun test`: 1976 pass.

Verified on this machine: after the fix, `bun run src/main.ts install core --yes` composed `3.19.5+bc45c2f8` (3.19.5 installed explicitly through mise), registered the Directory marketplace in Claude and Codex, installed dev/memory/brain, generated 69 skills into opencode and redcode, stamped all four hosts, and `red-dev doctor` prints the `[red-skills]` block; a rerun writes nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/217"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789666248&installation_model_id=20659&pr_number=217&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F217&signature=795cd6ecf62c087d2eb7880ae097f6dac7c6c1e9e84e5be94afc7137e447b185"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->