### PR TITLE
fix: #204 Observed reconciliation proves seven hosts and activates only dev

### DIFF
--- a/src/agents.ts
+++ b/src/agents.ts
@@ -921,12 +921,27 @@ export async function convergeRedSkills(p: Platform): Promise<void> {
   await convergeMarketplaceOwnership(p);
 
   // On both paths, and where the early return used to be. Being wired is
-  // not the same as being current: mise advances the version underneath a
-  // machine that was wired months ago, and the hosts read a marketplace
-  // cache that only moves when something tells it to.
+  // not the same as being current: mise advances the set underneath a
+  // machine that was wired months ago, and the hosts read caches and
+  // generated trees that only move when something tells them to.
   //
-  // Free when nothing moved — the walk is gated on the resolved checkout,
-  // so an ordinary converge issues no host commands at all.
-  const { refreshSkillHosts } = await import("./red-skills-hosts.ts");
-  await refreshSkillHosts(p);
+  // Free when nothing moved — a host whose recorded set digest, mode and
+  // observed state all still hold is skipped, so an ordinary converge
+  // issues no host commands at all. It is not free the moment any of them
+  // stops holding, which is the whole difference from the path-only stamp
+  // this replaced: a checkout edited in place keeps its path.
+  const { reconcileSkillHosts, reconciliationFailed } = await import("./red-skills-hosts.ts");
+  const hosts = await reconcileSkillHosts(p);
+
+  // A host that did not converge does not roll back the ones that did —
+  // the plugin managers offer no cross-host transaction, and undoing six
+  // good hosts because the seventh is broken would cost more than it
+  // saves. It is said out loud instead, once, naming them: partial state
+  // is visible and retryable, and silence is what turns it into a machine
+  // nobody knows is half-wired.
+  if (reconciliationFailed(hosts)) {
+    const stuck = hosts.filter((h) => h.status === "blocked" || h.status === "failed");
+    log.warn(`red-skills: not reconciled into ${stuck.map((h) => h.host).join(", ")}`);
+    for (const h of stuck) log.plain(`       ${h.host}: ${h.reason ?? "no reason given"}`);
+  }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -310,6 +310,19 @@ async function cmdDoctor(p: Platform, inv: Invocation): Promise<number> {
     }
   }
 
+  // And what each of the seven hosts was observed to have: the set digest
+  // it was reconciled against, the mechanism it was reached through, the
+  // digest of the state that reconciliation owns, and whether a session
+  // that was up still has to be restarted to load it. Every one of those
+  // was read off the machine at the time it was recorded, which is the
+  // whole difference from the refresh stamp this replaced.
+  const { redSkillsHostReport, redSkillsHostRows } = await import("./red-skills-hosts.ts");
+  for (const row of redSkillsHostRows(redSkillsHostReport(setHome))) {
+    if (row.status === "ok") log.ok(row.detail);
+    else if (row.status === "n/a") log.skip(row.detail);
+    else log.warn(row.detail);
+  }
+
   // The machine's agent posture, in the one place that already answers
   // "is this machine ready": which host red-dev hands work to, how old
   // each installed host's copy is, and the per-provider allowance detail

--- a/src/owned-config.test.ts
+++ b/src/owned-config.test.ts
@@ -1,0 +1,145 @@
+/**
+ * What a field red-dev owns costs the rest of the file: nothing.
+ *
+ * The observable held here is bytes, not values. A merge that keeps every
+ * setting and reflows the document has lost the argument — the operator
+ * still has to re-read a file they wrote, and their dotfiles diff is noise
+ * on every converge. So each case below asserts the exact text outside the
+ * one entry we touched, which is the only assertion that can tell a real
+ * splice from a re-encode that happened to agree this time.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { dropOwnedField, readOwnedField, setOwnedField } from "./owned-config.ts";
+
+/** A settings file with an operator's own hand all over it. */
+const USER = `{
+  "theme": "GitHub Dark",
+  "mcpServers": {
+    "their-own": {
+      "command": "node",
+      "args": ["/home/someone/tools/server.mjs"]
+    }
+  },
+  "autoAccept": false
+}
+`;
+
+const OURS = { command: "bun", args: ["run", "/red-skills/current/bin/mcp.mjs"] };
+
+describe("writing a field we own", () => {
+  test("changes only the bytes of that field", () => {
+    const after = setOwnedField(USER, ["mcpServers", "red-skills"], OURS);
+
+    // Everything the operator wrote is still there, character for
+    // character — including the four lines of the server they added.
+    expect(after).toContain(`  "theme": "GitHub Dark",\n`);
+    expect(after).toContain(`      "args": ["/home/someone/tools/server.mjs"]\n`);
+    expect(after).toContain(`  "autoAccept": false\n`);
+    expect(after.endsWith("}\n")).toBe(true);
+    // And the file is still a file.
+    expect(readOwnedField(after, ["mcpServers", "red-skills"])).toEqual(OURS);
+    expect(readOwnedField(after, ["mcpServers", "their-own", "command"])).toBe("node");
+  });
+
+  test("and puts it back byte for byte when it is removed again", () => {
+    // The property the uninstall contract rests on: adopting RedSkills
+    // and then dropping it leaves the operator with the file they had.
+    const after = setOwnedField(USER, ["mcpServers", "red-skills"], OURS);
+    expect(dropOwnedField(after, ["mcpServers", "red-skills"])).toBe(USER);
+  });
+
+  test("matches the indentation the file already uses", () => {
+    const four = `{\n    "theme": "dark"\n}\n`;
+    const after = setOwnedField(four, ["mcpServers", "red-skills"], { command: "bun" });
+
+    expect(after).toBe(
+      `{\n    "theme": "dark",\n    "mcpServers": {\n        "red-skills": {\n            "command": "bun"\n        }\n    }\n}\n`,
+    );
+    expect(dropOwnedField(after, ["mcpServers"])).toBe(four);
+  });
+
+  test("creates the file's whole shape when there is no file yet", () => {
+    const after = setOwnedField("", ["mcpServers", "red-skills"], { command: "bun" });
+    expect(after).toBe(`{\n  "mcpServers": {\n    "red-skills": {\n      "command": "bun"\n    }\n  }\n}\n`);
+  });
+
+  test("overwrites our own previous value without moving its neighbours", () => {
+    const first = setOwnedField(USER, ["mcpServers", "red-skills"], OURS);
+    const second = setOwnedField(first, ["mcpServers", "red-skills"], { command: "node" });
+
+    expect(readOwnedField(second, ["mcpServers", "red-skills"])).toEqual({ command: "node" });
+    expect(second).toContain(`      "args": ["/home/someone/tools/server.mjs"]\n`);
+    expect(dropOwnedField(second, ["mcpServers", "red-skills"])).toBe(USER);
+  });
+
+  test("refuses a document it cannot read rather than repairing it", () => {
+    // A comment, a trailing comma, a half-finished edit. Splicing into
+    // text we do not understand is how a config the host still loads
+    // becomes one it does not.
+    expect(() => setOwnedField(`{ "a": 1, }`, ["b"], 2)).toThrow();
+    expect(() => setOwnedField(`// mine\n{}`, ["b"], 2)).toThrow();
+  });
+
+  test("refuses a pointer that would bury somebody else's value", () => {
+    expect(() => setOwnedField(`{"mcpServers": 3}`, ["mcpServers", "red-skills"], OURS)).toThrow();
+  });
+});
+
+describe("removing a field we own", () => {
+  test("takes its separator with it, from the middle of an object", () => {
+    const after = dropOwnedField(USER, ["mcpServers"]);
+    expect(after).toBe(`{\n  "theme": "GitHub Dark",\n  "autoAccept": false\n}\n`);
+  });
+
+  test("takes the comma before it, from the end of an object", () => {
+    const after = dropOwnedField(USER, ["autoAccept"]);
+    expect(after).toBe(`{\n  "theme": "GitHub Dark",\n  "mcpServers": {\n    "their-own": {\n      "command": "node",\n      "args": ["/home/someone/tools/server.mjs"]\n    }\n  }\n}\n`);
+  });
+
+  test("collapses the object when what we owned was all it held", () => {
+    const only = `{\n  "mcpServers": {\n    "red-skills": { "command": "bun" }\n  }\n}\n`;
+    expect(dropOwnedField(only, ["mcpServers", "red-skills"])).toBe(`{\n  "mcpServers": {}\n}\n`);
+  });
+
+  test("removes the parent we created, and only while it stays empty", () => {
+    // The two halves of the same question. A `mcpServers` block that
+    // exists to hold our one entry should go when the entry does; one
+    // the operator has since put a server of their own into must not.
+    const made = setOwnedField("", ["mcpServers", "red-skills"], OURS);
+    const emptied = dropOwnedField(made, ["mcpServers", "red-skills"]);
+    expect(dropOwnedField(emptied, ["mcpServers"], { onlyWhenEmpty: true })).toBe(`{}\n`);
+
+    const shared = dropOwnedField(
+      setOwnedField(made, ["mcpServers", "theirs"], { command: "node" }),
+      ["mcpServers", "red-skills"],
+    );
+    expect(dropOwnedField(shared, ["mcpServers"], { onlyWhenEmpty: true })).toBe(shared);
+    expect(readOwnedField(shared, ["mcpServers", "theirs"])).toEqual({ command: "node" });
+  });
+
+  test("a field that is not there leaves the file exactly as it was", () => {
+    expect(dropOwnedField(USER, ["mcpServers", "red-skills"])).toBe(USER);
+    expect(dropOwnedField(USER, ["nothing", "here"])).toBe(USER);
+    expect(dropOwnedField("", ["a"])).toBe("");
+  });
+
+  test("a file we cannot read is handed back untouched", () => {
+    const broken = `{ "a": 1, }`;
+    expect(dropOwnedField(broken, ["a"])).toBe(broken);
+  });
+});
+
+describe("reading a field we own", () => {
+  test("answers undefined for every kind of absence", () => {
+    expect(readOwnedField(USER, ["mcpServers", "red-skills"])).toBeUndefined();
+    expect(readOwnedField(USER, ["theme", "nested"])).toBeUndefined();
+    expect(readOwnedField(`{`, ["theme"])).toBeUndefined();
+  });
+
+  test("and the value itself when it is there", () => {
+    expect(readOwnedField(USER, ["theme"])).toBe("GitHub Dark");
+    expect(readOwnedField(USER, ["autoAccept"])).toBe(false);
+  });
+});

--- a/src/owned-config.ts
+++ b/src/owned-config.ts
@@ -1,0 +1,340 @@
+/**
+ * Owning one field of a file somebody else wrote.
+ *
+ * Adopting RedSkills must not cost an operator the settings they already
+ * had. Every host in the reconciliation registry keeps its configuration
+ * in a file the user is free to edit — MCP servers they added by hand, a
+ * model they pinned, a theme — and red-dev needs exactly one entry inside
+ * some of those files. The obvious way to write it is the way the rest of
+ * this repo has always done it: parse, spread, `JSON.stringify(…, null, 2)`,
+ * write back. That is a rewrite of the whole document.
+ *
+ * A rewrite is not a data loss on the first converge, and it is not one on
+ * the tenth either — the values survive. What does not survive is
+ * everything the encoder has no opinion about: key order, the operator's
+ * four-space indent, the blank line they left between two blocks, the
+ * trailing newline they did not want. A file the user recognises becomes a
+ * file they have to re-read, and a diff in their dotfiles repository stops
+ * being about what changed. Worse, it happens on *every* converge that
+ * reformats differently from the last writer, so the noise is permanent.
+ *
+ * So this module edits the text instead of the value. It finds the span of
+ * the one entry it owns, splices a new one in, and returns the document
+ * with every other byte exactly where it was. Adding a field appends one
+ * line in the indentation its neighbours use; removing it takes that line
+ * and its separator away again. Nothing else in the file is even read as
+ * anything other than characters to keep.
+ *
+ * ## Refusing rather than repairing
+ *
+ * The first thing `setOwnedField` does is `JSON.parse` the document, and
+ * it throws when that fails. A file we cannot read is a file whose author
+ * is doing something we do not understand — a comment, a trailing comma, a
+ * half-finished edit — and splicing into it on a guess is how a config the
+ * host still loads becomes one it does not. The reconciliation above
+ * reports that as a host it could not converge, which is the honest
+ * answer, and leaves the file alone. `dropOwnedField` goes further and
+ * returns the text unchanged: uninstalling is never a reason to hand
+ * somebody back a file we broke.
+ *
+ * ## Pointers, and the parent we may have created
+ *
+ * A field is addressed by a pointer — `["mcpServers", "red-skills"]` — and
+ * a missing intermediate object is created along with it. That matters at
+ * removal time: the `mcpServers` block might be ours, made to hold the one
+ * entry we own, or it might be the operator's with our entry alongside
+ * theirs. `onlyWhenEmpty` is how the caller says "and take the parent too,
+ * but only if nothing else is left in it", which is the only version of
+ * that question with a safe answer.
+ */
+
+/** How a field is addressed: one key per level, outermost first. */
+export type OwnedPointer = readonly string[];
+
+/** What an unindented document is written with when it has no example. */
+const DEFAULT_UNIT = "  ";
+
+/** One `"key": value` pair, and where its parts sit in the text. */
+interface Entry {
+  key: string;
+  /** The opening quote of the key. */
+  entryStart: number;
+  /** One past the last byte of the value. */
+  entryEnd: number;
+  valueStart: number;
+  valueEnd: number;
+}
+
+function isSpace(ch: string): boolean {
+  return ch === " " || ch === "\t" || ch === "\n" || ch === "\r";
+}
+
+function skipSpace(text: string, from: number): number {
+  let i = from;
+  while (i < text.length && isSpace(text.charAt(i))) i++;
+  return i;
+}
+
+/**
+ * The string starting at `i`, and where it ends.
+ *
+ * The raw bytes are collected rather than unescaped by hand, and handed to
+ * `JSON.parse` to decode: `é` and `\\` have exactly one correct
+ * reading and it is not worth a second implementation of it here.
+ */
+function readString(text: string, i: number): { value: string; end: number } {
+  let j = i + 1;
+  let raw = "";
+  while (j < text.length) {
+    const ch = text.charAt(j);
+    if (ch === "\\") {
+      raw += text.slice(j, j + 2);
+      j += 2;
+      continue;
+    }
+    if (ch === '"') return { value: JSON.parse(`"${raw}"`) as string, end: j + 1 };
+    raw += ch;
+    j++;
+  }
+  throw new SyntaxError("unterminated string");
+}
+
+/** One past the end of the value starting at `i`, whatever kind it is. */
+function skipValue(text: string, i: number): number {
+  const ch = text.charAt(i);
+  if (ch === '"') return readString(text, i).end;
+  if (ch === "{" || ch === "[") {
+    let depth = 0;
+    let j = i;
+    while (j < text.length) {
+      const c = text.charAt(j);
+      if (c === '"') {
+        j = readString(text, j).end;
+        continue;
+      }
+      if (c === "{" || c === "[") depth++;
+      else if (c === "}" || c === "]") {
+        depth--;
+        if (depth === 0) return j + 1;
+      }
+      j++;
+    }
+    throw new SyntaxError("unterminated container");
+  }
+  // A number, `true`, `false` or `null`: everything up to the separator.
+  let j = i;
+  while (j < text.length && !isSpace(text.charAt(j)) && !",}]".includes(text.charAt(j))) j++;
+  return j;
+}
+
+/** Every entry of the object opening at `objStart`, and where it closes. */
+function entriesOf(text: string, objStart: number): { entries: Entry[]; objEnd: number } {
+  if (text.charAt(objStart) !== "{") throw new SyntaxError("not an object");
+  const entries: Entry[] = [];
+  let i = objStart + 1;
+  for (;;) {
+    i = skipSpace(text, i);
+    const ch = text.charAt(i);
+    if (ch === "}") return { entries, objEnd: i };
+    if (ch !== '"') throw new SyntaxError("expected a key");
+    const entryStart = i;
+    const key = readString(text, i);
+    i = skipSpace(text, key.end);
+    if (text.charAt(i) !== ":") throw new SyntaxError("expected a colon");
+    i = skipSpace(text, i + 1);
+    const valueStart = i;
+    const valueEnd = skipValue(text, i);
+    entries.push({ key: key.value, entryStart, entryEnd: valueEnd, valueStart, valueEnd });
+    i = skipSpace(text, valueEnd);
+    if (text.charAt(i) === ",") i++;
+  }
+}
+
+/** Where the document's single top-level object opens. */
+function documentStart(text: string): number {
+  const i = skipSpace(text, 0);
+  if (text.charAt(i) !== "{") throw new SyntaxError("the document is not an object");
+  return i;
+}
+
+/** The whitespace this line begins with, which is the indent to match. */
+function indentAt(text: string, i: number): string {
+  const line = text.lastIndexOf("\n", i - 1) + 1;
+  const head = text.slice(line, i);
+  return /^[ \t]*$/.test(head) ? head : "";
+}
+
+/**
+ * The document's own indentation step, so an inserted block matches it.
+ *
+ * Read off the first indented key rather than configured: a file written
+ * with four spaces should keep being written with four, and asking the
+ * caller would be asking them to know something the file already says.
+ */
+function indentUnit(text: string): string {
+  const match = /\n([ \t]+)"/.exec(text);
+  return match?.[1] ?? DEFAULT_UNIT;
+}
+
+/** A value as text, with every line after the first put under `indent`. */
+function render(value: unknown, indent: string, unit: string): string {
+  const raw = JSON.stringify(value, null, unit) ?? "null";
+  return raw.split("\n").map((line, at) => (at === 0 ? line : indent + line)).join("\n");
+}
+
+/** `{a: {b: value}}` out of `["a", "b"]` — the parents a set has to make. */
+function nest(pointer: OwnedPointer, value: unknown): unknown {
+  return pointer.reduceRight<unknown>((acc, key) => ({ [key]: acc }), value);
+}
+
+/** Put a key this object does not have beside the ones it does. */
+function insert(
+  text: string,
+  objStart: number,
+  objEnd: number,
+  entries: readonly Entry[],
+  key: string,
+  value: unknown,
+  unit: string,
+): string {
+  const last = entries[entries.length - 1];
+  if (last) {
+    const indent = indentAt(text, last.entryStart);
+    const entry = `${JSON.stringify(key)}: ${render(value, indent, unit)}`;
+    return `${text.slice(0, last.entryEnd)},\n${indent}${entry}${text.slice(last.entryEnd)}`;
+  }
+  // An empty object carries no example, so the enclosing line supplies it.
+  const outer = indentAt(text, objStart);
+  const indent = outer + unit;
+  const entry = `${JSON.stringify(key)}: ${render(value, indent, unit)}`;
+  return `${text.slice(0, objStart + 1)}\n${indent}${entry}\n${outer}${text.slice(objEnd)}`;
+}
+
+function spliceOwned(
+  text: string,
+  objStart: number,
+  pointer: OwnedPointer,
+  value: unknown,
+  unit: string,
+): string {
+  const [head, ...rest] = pointer;
+  if (head === undefined) throw new Error("an empty pointer owns the whole document");
+  const { entries, objEnd } = entriesOf(text, objStart);
+  const found = entries.find((entry) => entry.key === head);
+
+  if (rest.length === 0) {
+    if (!found) return insert(text, objStart, objEnd, entries, head, value, unit);
+    const indent = indentAt(text, found.entryStart);
+    return text.slice(0, found.valueStart) + render(value, indent, unit) + text.slice(found.valueEnd);
+  }
+
+  if (!found) return insert(text, objStart, objEnd, entries, head, nest(rest, value), unit);
+  if (text.charAt(found.valueStart) !== "{") {
+    throw new SyntaxError(`${head} is not an object, so ${rest.join(".")} cannot live under it`);
+  }
+  // The recursion edits strictly inside this value, so every offset
+  // computed above it stays where it was.
+  return spliceOwned(text, found.valueStart, rest, value, unit);
+}
+
+/**
+ * The value at `pointer`, or undefined when nothing is there.
+ *
+ * Parsed rather than scanned: reading is the one direction where the
+ * document's formatting does not matter, and `JSON.parse` is the reading
+ * the host itself will do.
+ */
+export function readOwnedField(text: string, pointer: OwnedPointer): unknown {
+  let node: unknown;
+  try {
+    node = JSON.parse(text) as unknown;
+  } catch {
+    return undefined;
+  }
+  for (const key of pointer) {
+    if (node === null || typeof node !== "object" || Array.isArray(node)) return undefined;
+    if (!Object.prototype.hasOwnProperty.call(node, key)) return undefined;
+    node = (node as Record<string, unknown>)[key];
+  }
+  return node;
+}
+
+/**
+ * Write one field, leaving every other byte of the document alone.
+ *
+ * An empty document becomes `{ "<key>": … }`; a document that is not JSON
+ * throws, because splicing into text we cannot read is how a config the
+ * host still loads becomes one it does not.
+ */
+export function setOwnedField(text: string, pointer: OwnedPointer, value: unknown): string {
+  const doc = text.trim() === "" ? "{}\n" : text;
+  JSON.parse(doc);
+  return spliceOwned(doc, documentStart(doc), pointer, value, indentUnit(doc));
+}
+
+/** Whether a value is an object with nothing in it. */
+function isEmptyObject(value: unknown): boolean {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    Object.keys(value as Record<string, unknown>).length === 0
+  );
+}
+
+/**
+ * Take one field back out, and nothing else.
+ *
+ * The separator goes with it: an entry with a successor is removed up to
+ * where that successor begins, so the whitespace the file used between
+ * them stays exactly once; an entry that is last gives back the comma
+ * before it instead. The only entry of an object collapses that object to
+ * `{}` rather than leaving a blank line inside it.
+ *
+ * `onlyWhenEmpty` is for the parent object a set had to create: remove it
+ * if the field we owned was all it ever held, and leave it where the
+ * operator has since put something of their own beside ours.
+ */
+export function dropOwnedField(
+  text: string,
+  pointer: OwnedPointer,
+  opts: { onlyWhenEmpty?: boolean } = {},
+): string {
+  if (text.trim() === "") return text;
+  try {
+    JSON.parse(text);
+  } catch {
+    // Uninstalling is never a reason to hand somebody back a broken file.
+    return text;
+  }
+  if (opts.onlyWhenEmpty && !isEmptyObject(readOwnedField(text, pointer))) return text;
+
+  let objStart: number;
+  try {
+    objStart = documentStart(text);
+  } catch {
+    return text;
+  }
+
+  // Walk to the object holding the last key, refusing to guess at any
+  // level that is not there: nothing to remove is already the outcome.
+  const parents = pointer.slice(0, -1);
+  const key = pointer[pointer.length - 1];
+  if (key === undefined) return text;
+  for (const step of parents) {
+    const { entries } = entriesOf(text, objStart);
+    const found = entries.find((entry) => entry.key === step);
+    if (!found || text.charAt(found.valueStart) !== "{") return text;
+    objStart = found.valueStart;
+  }
+
+  const { entries, objEnd } = entriesOf(text, objStart);
+  const at = entries.findIndex((entry) => entry.key === key);
+  if (at < 0) return text;
+  const entry = entries[at] as Entry;
+  const next = entries[at + 1];
+  const previous = entries[at - 1];
+  if (next) return text.slice(0, entry.entryStart) + text.slice(next.entryStart);
+  if (previous) return text.slice(0, previous.entryEnd) + text.slice(entry.entryEnd);
+  return text.slice(0, objStart + 1) + text.slice(objEnd);
+}

--- a/src/red-skills-hosts.test.ts
+++ b/src/red-skills-hosts.test.ts
@@ -1,41 +1,48 @@
 /**
- * What a converge asks the agent hosts to do, and when it asks nothing.
+ * What a converge asks the seven hosts, and what it refuses to write down.
  *
- * A marketplace update plus one plugin update per declared plugin, across
- * every host on the machine, is a walk of several CLIs and a network
- * round trip each. Run on every converge it is pure cost: the overwhelming
- * majority of converges resolve the same red-skills version they resolved
- * last time, and refreshing a host against a tree it already read changes
- * nothing on the machine.
+ * Two observables are held here and nothing else. The first is the command
+ * trace: a reconciliation that "decided" not to run and issued the commands
+ * anyway is the bug, and so is one that reports a host as current after the
+ * host refused. The second is the state on disk afterwards — the generated
+ * trees, the projected extensions, the operator's own settings file — which
+ * is the half the retired stamp never looked at and the half this module
+ * exists to observe.
  *
- * The observable these tests hold is the command trace, never an internal
- * flag. A refresh that "decided" not to run and issued the commands
- * anyway is the bug; so is one that reports a host as current after the
- * host refused the call. So the runner is injected and what is asserted
- * is the argv that reached it — which also means all of this holds with
- * no red-skills, no marketplace and no agent CLI on the machine.
- *
- * Two of those describes go further and actually run a generator, out of
- * a fixture tree with a real script in it. That is the only way to assert
- * the thing the split exists for: a skill added to the tree appears on
- * the machine with nothing here changed, and unwiring removes what the
- * generator's own manifest recorded rather than what this repo guesses.
+ * So the runner is injected and the hosts are fakes, but the package set is
+ * a real tree with real generators in it, and the generators really run.
+ * That is the only way to assert the thing the split exists for: a skill
+ * added to the tree appears on the machine with nothing here changed, and
+ * removal takes back what the generator's own manifest recorded rather than
+ * what this repo guesses.
  */
 
 import { describe, expect, test } from "bun:test";
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import type { Platform } from "./platform.ts";
+import { activatedPlugins } from "./red-skills-plugins.ts";
+import { hostActivationConfig } from "./red-skills-set.ts";
 import {
-  REFRESH_HOSTS,
-  readHostStamp,
-  refreshSkillHosts,
-  unwireSkillHosts,
-  type HostContext,
-  type HostRefreshOptions,
-  type SkillHostRefresh,
+  HOST_ADAPTERS,
+  readHostRegistry,
+  reconcileSkillHosts,
+  redSkillsHostReport,
+  redSkillsHostRows,
+  removeSkillHosts,
+  type HostAdapter,
+  type HostOutcome,
+  type HostReconcileOptions,
 } from "./red-skills-hosts.ts";
 
 const UBUNTU: Platform = {
@@ -48,416 +55,31 @@ const UBUNTU: Platform = {
   caps: { apt: true, gui: true, systemd: true, winget: false, flatpak: false },
 };
 
-/** Two versions of the same checkout: the resolved path is what moves. */
-const OLD = "/home/someone/.red-skills/versions/v3.3.0";
-const NEW = "/home/someone/.red-skills/versions/v3.4.0";
+/** What the set carries, and what red-dev switches on out of it. */
+const CARRIED = ["dev", "memory"];
+const ACTIVATED = ["dev"];
 
-const PLUGINS = ["dev", "memory"];
-
-const CTX: HostContext = { plugins: PLUGINS, source: NEW };
-
-/** The hosts red-dev drives with its own CLI calls. */
-const CLI_HOSTS = ["claude", "codex"];
-/** The hosts wired by the generators inside the installed tree. */
+/** The hosts red-dev drives with an application's own CLI. */
+const MARKETPLACE_HOSTS = ["claude", "codex"];
+/** The hosts a generator inside the set wires. */
 const GENERATOR_HOSTS = ["opencode", "redcode", "pi"];
+/** The hosts red-dev projects itself, because the set ships no generator. */
+const PROJECTED_HOSTS = ["gemini", "hermes"];
 
-function hostNamed(name: string): SkillHostRefresh {
-  const host = REFRESH_HOSTS.find((h) => h.name === name);
-  if (!host) throw new Error(`no host named ${name}`);
-  return host;
-}
+const STAMPED_AT = "2026-08-18T00:00:00.000Z";
 
-function home(): string {
-  return mkdtempSync(join(tmpdir(), "red-hosts-home-"));
-}
-
-/** Collects the argv a refresh issued, and answers with `code`. */
-function recorder(code: (cmd: string[]) => number = () => 0): {
-  calls: string[][];
-  run: (cmd: string[]) => Promise<number>;
-} {
-  const calls: string[][] = [];
-  return {
-    calls,
-    run: async (cmd: string[]) => {
-      calls.push(cmd);
-      return code(cmd);
-    },
-  };
-}
-
-/** A machine with every declared host installed, at `source`. */
-function refresh(
-  opts: HostRefreshOptions & { source: string },
-): ReturnType<typeof refreshSkillHosts> {
-  return refreshSkillHosts(UBUNTU, {
-    plugins: PLUGINS,
-    present: () => true,
-    ...opts,
-  });
-}
-
-/** What one host is asked, as lines, in the order it is asked. */
-function wireOf(host: SkillHostRefresh, ctx: HostContext = CTX): string[] {
-  return host.wire(ctx).map((s) => s.argv.join(" "));
-}
+// ------------------------------------------------------------- the fixtures
 
 /**
- * The commands one host answered for.
+ * A generator, faked down to the two things red-dev knows about it.
  *
- * Matched against that host's own steps rather than against the CLI
- * name: three of the five hosts are wired by a script path, and two of
- * those three are the same script told which host it is working for.
+ * It renders every skill of every plugin the set's activation config
+ * enables, and it records every path it wrote in an uninstall manifest that
+ * its own `--uninstall` reads back. Everything else about the real script
+ * is deliberately on the other side of the fence.
  */
-function forHost(calls: string[][], host: SkillHostRefresh, ctx: HostContext = CTX): string[] {
-  const mine = new Set(wireOf(host, ctx));
-  return calls.map((c) => c.join(" ")).filter((c) => mine.has(c));
-}
-
-describe("the hosts are refreshed when the resolved version moved", () => {
-  test("a first converge refreshes every host once", async () => {
-    // Nothing stamped yet, which is the state of a machine that has never
-    // been refreshed. Unknown is not "current": an empty stamp has to
-    // mean refresh, or a machine gets its first refresh never.
-    const root = home();
-    const { calls, run } = recorder();
-    const out = await refresh({ home: root, source: NEW, run });
-
-    expect(out.every((o) => o.refreshed)).toBe(true);
-    expect(out.map((o) => o.host)).toEqual(REFRESH_HOSTS.map((h) => h.name));
-    expect(calls.map((c) => c.join(" "))).toEqual(REFRESH_HOSTS.flatMap((h) => wireOf(h)));
-  });
-
-  test("and issues them exactly once per host, not once per plugin set", async () => {
-    // The failure this pins is a loop nested one level too deep: the
-    // marketplace refreshed once per plugin rather than once per host.
-    const { calls, run } = recorder();
-    await refresh({ home: home(), source: NEW, run });
-
-    for (const name of CLI_HOSTS) {
-      const host = hostNamed(name);
-      const marketplace = forHost(calls, host).filter((c) => c.includes("marketplace"));
-      expect(marketplace.length, name).toBe(1);
-    }
-    // And the generators are invoked once each, whatever the plugin set:
-    // which plugins to render is the tree's question, not this repo's.
-    for (const name of GENERATOR_HOSTS) {
-      expect(forHost(calls, hostNamed(name)).length, name).toBe(1);
-    }
-  });
-
-  test("a converge whose resolved version is unchanged issues no host commands", async () => {
-    // The whole point of the slice. Not "issues fewer" and not "issues
-    // them and they no-op" — the trace is empty.
-    const root = home();
-    await refresh({ home: root, source: NEW, run: recorder().run });
-
-    const { calls, run } = recorder();
-    const out = await refresh({ home: root, source: NEW, run });
-
-    expect(calls).toEqual([]);
-    expect(out.every((o) => !o.refreshed)).toBe(true);
-    for (const o of out) expect(o.reason, o.host).toContain("v3.4.0");
-  });
-
-  test("a version that moved afterwards refreshes them again", async () => {
-    // Both directions, because a gate that only ever says "skip" is as
-    // broken as one that never does.
-    const root = home();
-    await refresh({ home: root, source: OLD, run: recorder().run });
-
-    const { calls, run } = recorder();
-    const out = await refresh({ home: root, source: NEW, run });
-
-    expect(out.every((o) => o.refreshed)).toBe(true);
-    expect(calls.length).toBeGreaterThan(0);
-    for (const host of REFRESH_HOSTS) {
-      expect(readHostStamp(root)[host.name], host.name).toBe(NEW);
-    }
-  });
-
-  test("red-skills absent from the machine refreshes nothing", async () => {
-    const { calls, run } = recorder();
-    const out = await refreshSkillHosts(UBUNTU, {
-      home: home(),
-      source: null,
-      plugins: PLUGINS,
-      present: () => true,
-      run,
-    });
-
-    expect(calls).toEqual([]);
-    expect(out).toEqual([]);
-  });
-});
-
-describe("a host that is not on the machine", () => {
-  test("is skipped with a reason rather than counted as refreshed", async () => {
-    // The distinction is load-bearing for the stamp below: "we refreshed
-    // it" and "it is not here" are different facts, and collapsing them
-    // is how a host that arrives next week never gets refreshed at all.
-    // Asserted for every host in turn, because the generator hosts are
-    // absent from far more machines than Claude is.
-    for (const skip of REFRESH_HOSTS) {
-      const { calls, run } = recorder();
-      const out = await refresh({
-        home: home(),
-        source: NEW,
-        present: (cmd) => cmd !== skip.cmd,
-        run,
-      });
-
-      const skipped = out.find((o) => o.host === skip.name);
-      expect(skipped?.refreshed, skip.name).toBe(false);
-      expect(skipped?.reason, skip.name).toContain("not installed");
-      expect(forHost(calls, skip), skip.name).toEqual([]);
-      expect(out.filter((o) => o.host !== skip.name).every((o) => o.refreshed), skip.name).toBe(
-        true,
-      );
-    }
-  });
-
-  test("and is refreshed on the converge after it appears", async () => {
-    // Absence must not be stamped. A skipped host recorded as current is
-    // a host installed tomorrow and left on yesterday's tree forever.
-    const first = hostNamed("claude");
-    const root = home();
-    await refresh({ home: root, source: NEW, present: (c) => c !== first.cmd, run: recorder().run });
-    expect(readHostStamp(root)[first.name]).toBeUndefined();
-
-    const { calls, run } = recorder();
-    const out = await refresh({ home: root, source: NEW, run });
-
-    expect(out.find((o) => o.host === first.name)?.refreshed).toBe(true);
-    expect(forHost(calls, first).length).toBeGreaterThan(0);
-    // And only that host: the others were already at this version.
-    expect(calls.every((c) => c[0] === first.cmd)).toBe(true);
-  });
-});
-
-describe("a host that refuses the refresh", () => {
-  test("does not prevent the others", async () => {
-    // One CLI broken for its own reasons — a half-written config, an
-    // expired login — is the ordinary state of a machine with several
-    // agents on it. It cannot be allowed to end the walk.
-    const [first, ...rest] = REFRESH_HOSTS;
-    expect(rest.length).toBeGreaterThan(0);
-
-    const { calls, run } = recorder((cmd) => (cmd[0] === (first as { cmd: string }).cmd ? 1 : 0));
-    const out = await refresh({ home: home(), source: NEW, run });
-
-    expect(out.find((o) => o.host === (first as { name: string }).name)?.refreshed).toBe(false);
-    for (const host of rest) {
-      expect(out.find((o) => o.host === host.name)?.refreshed, host.name).toBe(true);
-      expect(forHost(calls, host), host.name).toEqual(wireOf(host));
-    }
-  });
-
-  test("a runner that throws is a failed host, not a failed converge", async () => {
-    const [first, ...rest] = REFRESH_HOSTS;
-    const calls: string[][] = [];
-    const out = await refresh({
-      home: home(),
-      source: NEW,
-      run: async (cmd) => {
-        if (cmd[0] === (first as { cmd: string }).cmd) throw new Error("spawn failed");
-        calls.push(cmd);
-        return 0;
-      },
-    });
-
-    expect(out.find((o) => o.host === (first as { name: string }).name)?.refreshed).toBe(false);
-    for (const host of rest) {
-      expect(forHost(calls, host).length, host.name).toBeGreaterThan(0);
-    }
-  });
-
-  test("is retried on the next converge, because it was never stamped", async () => {
-    const first = hostNamed("claude");
-    const root = home();
-    const failing = recorder((cmd) => (cmd[0] === first.cmd ? 1 : 0));
-    await refresh({ home: root, source: NEW, run: failing.run });
-    expect(readHostStamp(root)[first.name]).toBeUndefined();
-
-    const { calls, run } = recorder();
-    const out = await refresh({ home: root, source: NEW, run });
-
-    expect(out.find((o) => o.host === first.name)?.refreshed).toBe(true);
-    expect(forHost(calls, first)).toEqual(wireOf(first));
-    expect(readHostStamp(root)[first.name]).toBe(NEW);
-  });
-});
-
-describe("what the hosts are asked", () => {
-  test("the five hosts are the ones the spec settled, by name", () => {
-    expect(REFRESH_HOSTS.map((h) => h.name)).toEqual([...CLI_HOSTS, ...GENERATOR_HOSTS]);
-  });
-
-  test("Claude and Codex are red-dev's own CLI calls", () => {
-    // Not a script, not a generator: the two hosts with a marketplace are
-    // the two red-dev drives itself, and every argv it issues is
-    // addressed to the CLI whose presence gated the call.
-    for (const name of CLI_HOSTS) {
-      const host = hostNamed(name);
-      for (const step of [...host.wire(CTX), ...host.unwire(CTX)]) {
-        expect(step.argv[0], `${name}: ${step.argv.join(" ")}`).toBe(host.cmd);
-      }
-      expect(wireOf(host).some((c) => c.includes("marketplace")), name).toBe(true);
-    }
-  });
-
-  test("every host refreshes each declared plugin", async () => {
-    // Derived from the argument, never a literal here: the plugin set is
-    // the manifest's answer, and a test that wrote one down would be a
-    // second place for it to be declared. Only the CLI hosts take it —
-    // the generators read the tree they ship in.
-    for (const name of CLI_HOSTS) {
-      const host = hostNamed(name);
-      const argv = wireOf(host);
-      for (const plugin of PLUGINS) {
-        expect(
-          argv.some((c) => c.includes(`${plugin}@red-skills`)),
-          `${name}/${plugin}`,
-        ).toBe(true);
-      }
-    }
-  });
-
-  test("Codex removes and re-adds, because it has no plugin update", () => {
-    // Codex's CLI has `marketplace upgrade` and `plugin add`, and no
-    // `plugin update` at all. So the refresh is a remove followed by an
-    // add of the same plugin, in that order, against the marketplace
-    // snapshot the line above them just upgraded.
-    const codex = hostNamed("codex");
-    const steps = codex.wire(CTX);
-    expect(steps[0]?.argv).toEqual(["codex", "plugin", "marketplace", "upgrade", "red-skills"]);
-    // Optional: a Directory marketplace — the one red-dev registers —
-    // is "not configured as a Git marketplace" to `upgrade`, and the
-    // add below reads the tree as it stands.
-    expect(steps[0]?.optional).toBe(true);
-    expect(steps.some((s) => s.argv.includes("update"))).toBe(false);
-
-    for (const plugin of PLUGINS) {
-      const at = steps.findIndex(
-        (s) => s.argv.includes("remove") && s.argv.includes(`${plugin}@red-skills`),
-      );
-      expect(at, plugin).toBeGreaterThan(-1);
-      expect(steps[at + 1]?.argv, plugin).toEqual([
-        "codex",
-        "plugin",
-        "add",
-        `${plugin}@red-skills`,
-      ]);
-      // The remove is the fallback half, not a precondition: a plugin
-      // this machine has never installed makes it exit non-zero, and
-      // that is not a broken host.
-      expect(steps[at]?.optional, plugin).toBe(true);
-      expect(steps[at + 1]?.optional, plugin).toBeUndefined();
-    }
-  });
-
-  test("a plugin Codex has never seen does not fail the host", async () => {
-    // The same fact as above, held at the trace: a non-zero `remove` is
-    // stepped over, the `add` still runs, and the host is stamped.
-    const root = home();
-    const codex = hostNamed("codex");
-    const { calls, run } = recorder((cmd) => (cmd.includes("remove") ? 1 : 0));
-    const out = await refresh({ home: root, source: NEW, hosts: [codex], run });
-
-    expect(out).toEqual([{ host: "codex", refreshed: true }]);
-    expect(calls.map((c) => c.join(" "))).toEqual(wireOf(codex));
-    expect(readHostStamp(root)["codex"]).toBe(NEW);
-  });
-
-  test("an empty plugin set still refreshes the marketplace", async () => {
-    // A machine that opted every plugin out still carries the core, and
-    // the marketplace it registers is what a later opt-in reads.
-    const { calls, run } = recorder();
-    await refresh({ home: home(), source: NEW, plugins: [], run });
-    const empty: HostContext = { plugins: [], source: NEW };
-    expect(calls.map((c) => c.join(" "))).toEqual(REFRESH_HOSTS.flatMap((h) => wireOf(h, empty)));
-    for (const name of CLI_HOSTS) {
-      expect(forHost(calls, hostNamed(name), empty).length, name).toBe(1);
-    }
-  });
-
-  test("the converge reaches the refresh on the already-wired path too", () => {
-    // Asserted against the source because it is not observable any other
-    // way without an agent CLI in the loop, and because the failure it
-    // guards is precise: convergeRedSkills used to return at "already
-    // wired", which is every ordinary converge. A refresh written and
-    // never reached from there would leave the version moving under a
-    // machine whose hosts are never told.
-    const src = readFileSync(`${import.meta.dir}/agents.ts`, "utf8");
-    const converge = src.slice(src.indexOf("export async function convergeRedSkills"));
-    const wired = converge.indexOf("already wired into");
-    expect(wired).toBeGreaterThan(-1);
-    expect(converge.slice(wired)).toContain("refreshSkillHosts");
-  });
-});
-
-describe("the three generator hosts", () => {
-  test("are wired by invoking a script inside the installed tree", async () => {
-    // The split the spec settled, held at the argv. Nothing here spells
-    // out a plugin module, a skill path or an MCP entry: the whole of
-    // red-dev's contribution is naming a script under the checkout.
-    for (const name of GENERATOR_HOSTS) {
-      const host = hostNamed(name);
-      for (const step of [...host.wire(CTX), ...host.unwire(CTX)]) {
-        expect(step.argv[0], `${name}: ${step.argv.join(" ")}`).toStartWith(`${NEW}/scripts/`);
-        expect(step.argv[0], name).toEndWith(".sh");
-      }
-    }
-  });
-
-  test("take the resolved checkout as their source, not a path of our own", async () => {
-    // A generator renders the skills that ship beside it, so the tree it
-    // is invoked out of is the tree it renders. Moving the checkout has
-    // to move every command — a path pinned anywhere in this repo would
-    // render yesterday's tree on a machine mise has already advanced.
-    for (const name of GENERATOR_HOSTS) {
-      const host = hostNamed(name);
-      const old = host.wire({ plugins: PLUGINS, source: OLD });
-      expect(old.every((s) => s.argv.join(" ").includes(OLD)), name).toBe(true);
-      expect(old.some((s) => s.argv.join(" ").includes(NEW)), name).toBe(false);
-    }
-  });
-
-  test("are the same generator for OpenCode and RedCode, told which host", () => {
-    // RedCode is an OpenCode-compatible host: one generator, two config
-    // directories. Two implementations of that would be the drift this
-    // whole split exists to avoid, in miniature.
-    const opencode = hostNamed("opencode").wire(CTX)[0]?.argv ?? [];
-    const redcode = hostNamed("redcode").wire(CTX)[0]?.argv ?? [];
-    expect(opencode[0]).toBe(redcode[0]);
-    expect(opencode.slice(opencode.indexOf("--host"))).toEqual(["--host", "opencode"]);
-    expect(redcode.slice(redcode.indexOf("--host"))).toEqual(["--host", "redcode"]);
-  });
-
-  test("hand pi the checkout explicitly, because it can install from npm instead", () => {
-    const pi = hostNamed("pi").wire(CTX)[0]?.argv ?? [];
-    expect(pi[0]).toBe(`${NEW}/scripts/install-pi.sh`);
-    expect(pi.slice(1)).toEqual(["--source-dir", NEW, "--user"]);
-  });
-});
-
-/**
- * A tree shaped like the installed checkout, with a real generator in it.
- *
- * The script is a stand-in for `scripts/install-opencode.sh` and holds
- * only the part of its contract these tests are about: it renders every
- * skill it finds under the tree it lives in, and it records every path
- * it wrote in an uninstall manifest that its own `--uninstall` reads
- * back. Everything red-dev knows about that contract is the two argv
- * lines above; the rest is deliberately on the other side of the fence.
- */
-function fixtureTree(skills: string[]): string {
-  const tree = mkdtempSync(join(tmpdir(), "red-hosts-tree-"));
-  mkdirSync(join(tree, "scripts"), { recursive: true });
-  const script = join(tree, "scripts", "install-opencode.sh");
-  writeFileSync(
-    script,
-    `#!/usr/bin/env bash
+function opencodeGenerator(): string {
+  return `#!/usr/bin/env bash
 set -euo pipefail
 tree="$(cd "$(dirname "$0")/.." && pwd)"
 action=install
@@ -482,178 +104,782 @@ if [[ "$action" == "uninstall" ]]; then
 fi
 mkdir -p "$config/skills"
 : > "$manifest"
-for skill in "$tree"/plugins/*/skills/*/SKILL.md; do
-  name="$(basename "$(dirname "$skill")")"
-  mkdir -p "$config/skills/$name"
-  cp "$skill" "$config/skills/$name/SKILL.md"
-  printf '%s\\n' "$config/skills/$name" >> "$manifest"
+for plugin in "$tree"/plugins/*/; do
+  name="$(basename "$plugin")"
+  flag="$(awk -v want="  $name:" '$0 == want { found = 1; next } found { print; exit }' "$tree/.red/config.yaml")"
+  case "$flag" in *"enabled: true"*) ;; *) continue ;; esac
+  for skill in "$plugin"skills/*/SKILL.md; do
+    [[ -f "$skill" ]] || continue
+    s="$(basename "$(dirname "$skill")")"
+    mkdir -p "$config/skills/$s"
+    cp "$skill" "$config/skills/$s/SKILL.md"
+    printf '%s\\n' "$config/skills/$s" >> "$manifest"
+  done
 done
-`,
-  );
-  chmodSync(script, 0o755);
-  for (const skill of skills) addSkill(tree, skill);
+`;
+}
+
+/** pi's, which writes under the home rather than under the config root. */
+function piGenerator(): string {
+  return `#!/usr/bin/env bash
+set -euo pipefail
+tree="$(cd "$(dirname "$0")/.." && pwd)"
+action=install
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --uninstall) action=uninstall ;;
+    --source-dir) tree="$2"; shift ;;
+  esac
+  shift
+done
+config="\${HOME:?}/.pi"
+manifest="$config/redskills-install-manifest.txt"
+if [[ "$action" == "uninstall" ]]; then
+  if [[ -f "$manifest" ]]; then
+    while IFS= read -r path || [[ -n "$path" ]]; do
+      if [[ -n "$path" ]]; then rm -rf "$path"; fi
+    done < "$manifest"
+    rm -f "$manifest"
+  fi
+  exit 0
+fi
+mkdir -p "$config/skills"
+: > "$manifest"
+for plugin in "$tree"/plugins/*/; do
+  name="$(basename "$plugin")"
+  flag="$(awk -v want="  $name:" '$0 == want { found = 1; next } found { print; exit }' "$tree/.red/config.yaml")"
+  case "$flag" in *"enabled: true"*) ;; *) continue ;; esac
+  for skill in "$plugin"skills/*/SKILL.md; do
+    [[ -f "$skill" ]] || continue
+    s="$(basename "$(dirname "$skill")")"
+    mkdir -p "$config/skills/$s"
+    cp "$skill" "$config/skills/$s/SKILL.md"
+    printf '%s\\n' "$config/skills/$s" >> "$manifest"
+  done
+done
+`;
+}
+
+interface SetOptions {
+  /** Skills the `dev` plugin carries. */
+  skills?: string[];
+  /** Whether `dev` declares an MCP server for a host to project. */
+  mcp?: boolean;
+  /** Generators to leave out, for the hosts that then have none. */
+  without?: string[];
+}
+
+/** A package set: the shape composeSet produces, small enough to hash. */
+function packageSet(opts: SetOptions = {}): string {
+  const tree = mkdtempSync(join(tmpdir(), "red-hosts-set-"));
+  const without = opts.without ?? [];
+
+  mkdirSync(join(tree, "scripts"), { recursive: true });
+  for (const [name, body] of [
+    ["install-opencode.sh", opencodeGenerator()],
+    ["install-pi.sh", piGenerator()],
+  ] as const) {
+    if (without.includes(name)) continue;
+    const path = join(tree, "scripts", name);
+    writeFileSync(path, body);
+    chmodSync(path, 0o755);
+  }
+
+  for (const skill of opts.skills ?? ["shipped"]) addSkill(tree, "dev", skill);
+  // A payload the set carries and nothing activates. Every assertion about
+  // "only dev" is really an assertion that this one never lands.
+  addSkill(tree, "memory", "memory-only");
+
+  if (opts.mcp !== false) {
+    writeFileSync(
+      join(tree, "plugins", "dev", ".mcp.json"),
+      `${JSON.stringify({ mcpServers: { redskilled: { command: "bun", args: ["run", "d.mjs"] } } }, null, 2)}\n`,
+    );
+  }
+
+  mkdirSync(join(tree, ".red"), { recursive: true });
+  writeFileSync(join(tree, ".red", "config.yaml"), hostActivationConfig(CARRIED, ACTIVATED));
   return tree;
 }
 
-/** One more skill in the tree, which is the only edit these tests make. */
-function addSkill(tree: string, name: string): void {
-  const dir = join(tree, "plugins", "dev", "skills", name);
+/** One more skill in the tree, which is the only edit some tests make. */
+function addSkill(tree: string, plugin: string, name: string): void {
+  const dir = join(tree, "plugins", plugin, "skills", name);
   mkdirSync(dir, { recursive: true });
-  writeFileSync(join(dir, "SKILL.md"), `---\nname: ${name}\n---\n`);
+  writeFileSync(join(dir, "SKILL.md"), `---\nname: ${name}\ndescription: what ${name} does\n---\n`);
 }
 
-/** Runs the argv for real, against a config directory of our own. */
-function spawner(config: string): (cmd: string[]) => Promise<number> {
-  return async (cmd: string[]) => {
-    const proc = Bun.spawn(cmd, {
-      env: { ...process.env, XDG_CONFIG_HOME: config },
-      stdout: "ignore",
-      stderr: "ignore",
-      stdin: "ignore",
-    });
-    return await proc.exited;
+/** Claude's own store, with a marketplace of the operator's beside ours. */
+function knownMarketplaces(current: string): string {
+  return `{
+  "their-marketplace": {
+    "source": { "source": "github", "repo": "someone/theirs" }
+  },
+  "red-skills": {
+    "source": { "source": "directory", "path": "${current}" }
+  }
+}
+`;
+}
+
+/** The same fact in Codex's vocabulary, in the file Codex writes it to. */
+function codexConfig(current: string): string {
+  return `model = "gpt-5"
+
+[marketplaces.red-skills]
+source_type = "local"
+source = "${current}"
+`;
+}
+
+/** A Gemini settings file with the operator's hand all over it. */
+function geminiSettings(): string {
+  return `{
+  "theme": "GitHub Dark",
+  "mcpServers": {
+    "their-own": {
+      "command": "node",
+      "args": ["/home/someone/tools/server.mjs"]
+    }
+  },
+  "autoAccept": false
+}
+`;
+}
+
+interface Machine {
+  home: string;
+  config: string;
+  tree: string;
+  current: string;
+}
+
+/** A machine with all seven hosts, a package set, and settings of its own. */
+function machine(opts: SetOptions = {}): Machine {
+  const home = mkdtempSync(join(tmpdir(), "red-hosts-home-"));
+  const config = join(home, ".config");
+  const tree = packageSet(opts);
+  const current = `${home}/.red-skills/current`;
+
+  mkdirSync(join(home, ".claude", "plugins"), { recursive: true });
+  writeFileSync(join(home, ".claude", "plugins", "known_marketplaces.json"), knownMarketplaces(current));
+  mkdirSync(join(home, ".codex"), { recursive: true });
+  writeFileSync(join(home, ".codex", "config.toml"), codexConfig(current));
+  mkdirSync(join(home, ".gemini"), { recursive: true });
+  writeFileSync(join(home, ".gemini", "settings.json"), geminiSettings());
+
+  return { home, config, tree, current };
+}
+
+/**
+ * Collects the argv a reconciliation issued, and runs the real ones.
+ *
+ * A generator is addressed by absolute path and actually executes; a host
+ * CLI is a name this machine does not have, and is recorded and answered
+ * for. `code` overrides both, which is how a refusing host is expressed.
+ */
+function runner(
+  m: Machine,
+  code: (cmd: string[]) => number = () => 0,
+): { calls: string[][]; run: (cmd: string[]) => Promise<number> } {
+  const calls: string[][] = [];
+  return {
+    calls,
+    run: async (cmd: string[]) => {
+      calls.push(cmd);
+      const forced = code(cmd);
+      if (forced !== 0) return forced;
+      const argv0 = cmd[0] ?? "";
+      if (!argv0.startsWith("/")) return 0;
+      const proc = Bun.spawn(cmd, {
+        env: { ...process.env, HOME: m.home, XDG_CONFIG_HOME: m.config },
+        stdout: "ignore",
+        stderr: "ignore",
+        stdin: "ignore",
+      });
+      return await proc.exited;
+    },
   };
 }
 
-function skillPath(config: string, host: string, name: string): string {
-  return join(config, host, "skills", name, "SKILL.md");
+function reconcile(m: Machine, opts: HostReconcileOptions = {}): Promise<HostOutcome[]> {
+  return reconcileSkillHosts(UBUNTU, {
+    home: m.home,
+    config: m.config,
+    source: m.tree,
+    current: m.current,
+    plugins: ACTIVATED,
+    present: () => true,
+    running: () => false,
+    now: () => STAMPED_AT,
+    ...opts,
+  });
 }
 
-describe("no generator logic is reimplemented here", () => {
-  test("a skill added to the tree lands on the machine with nothing changed here", async () => {
-    // The reason for the whole split, made observable. The only edit
-    // between the two converges below is one directory inside a fixture
-    // tree — no table in this repo names a skill, so none had to grow a
-    // row for `arrived-later` to appear.
-    const tree = fixtureTree(["shipped"]);
-    const config = mkdtempSync(join(tmpdir(), "red-hosts-config-"));
-    const opencode = hostNamed("opencode");
+function statusOf(out: readonly HostOutcome[], host: string): string | undefined {
+  return out.find((o) => o.host === host)?.status;
+}
 
-    const first = await refresh({
-      home: home(),
-      source: tree,
-      hosts: [opencode],
-      run: spawner(config),
-    });
-    expect(first).toEqual([{ host: "opencode", refreshed: true }]);
-    expect(existsSync(skillPath(config, "opencode", "shipped"))).toBe(true);
-    expect(existsSync(skillPath(config, "opencode", "arrived-later"))).toBe(false);
+function adapterNamed(name: string): HostAdapter {
+  const adapter = HOST_ADAPTERS.find((a) => a.name === name);
+  if (!adapter) throw new Error(`no adapter named ${name}`);
+  return adapter;
+}
 
-    addSkill(tree, "arrived-later");
-    // A fresh home so the stamp does not skip: the point is what the
-    // generator renders, not when the walk decides to ask it.
-    const second = await refresh({
-      home: home(),
-      source: tree,
-      hosts: [opencode],
-      run: spawner(config),
-    });
+function lines(calls: readonly string[][]): string[] {
+  return calls.map((c) => c.join(" "));
+}
 
-    expect(second).toEqual([{ host: "opencode", refreshed: true }]);
-    expect(existsSync(skillPath(config, "opencode", "arrived-later"))).toBe(true);
-    expect(existsSync(skillPath(config, "opencode", "shipped"))).toBe(true);
+// -------------------------------------------------------------- the seven
+
+describe("the seven adapters Spec #201 settled", () => {
+  test("are the ones in the table, by name and in walk order", () => {
+    expect(HOST_ADAPTERS.map((a) => a.name)).toEqual([
+      "claude",
+      "codex",
+      "opencode",
+      "redcode",
+      "gemini",
+      "pi",
+      "hermes",
+    ]);
+  });
+
+  test("a first converge reconciles every one of them", async () => {
+    // Nothing recorded yet, which is the state of a machine that has never
+    // been reconciled. Unknown is not "current": an empty registry has to
+    // mean reconcile, or a machine gets its first one never.
+    const m = machine();
+    const { run } = runner(m);
+    const out = await reconcile(m, { run });
+
+    expect(out.map((o) => o.host)).toEqual(HOST_ADAPTERS.map((a) => a.name));
+    for (const o of out) expect(o.status, `${o.host}: ${o.reason ?? ""}`).toBe("reconciled");
+  });
+
+  test("and records the mechanism each one was actually reached through", async () => {
+    // Not a column of the table: for Gemini and Hermes the mode is a fact
+    // about the package set, and the day RedSkills ships a generator for
+    // them the same adapter records `generator` instead.
+    const m = machine();
+    await reconcile(m, { run: runner(m).run });
+    const hosts = readHostRegistry(m.home).hosts;
+
+    for (const name of MARKETPLACE_HOSTS) expect(hosts[name]?.mode, name).toBe("marketplace");
+    for (const name of GENERATOR_HOSTS) expect(hosts[name]?.mode, name).toBe("generator");
+    expect(hosts["gemini"]?.mode).toBe("extension");
+    expect(hosts["hermes"]?.mode).toBe("skills");
+  });
+
+  test("a set that ships a generator for a projected host uses it instead", async () => {
+    const m = machine();
+    const script = join(m.tree, "scripts", "install-gemini.sh");
+    writeFileSync(script, "#!/usr/bin/env bash\nexit 0\n");
+    chmodSync(script, 0o755);
+
+    const { calls, run } = runner(m);
+    const out = await reconcile(m, { run, adapters: [adapterNamed("gemini")] });
+
+    // Blocked rather than reconciled, and deliberately: the script above
+    // records no install manifest, so there is nothing to observe and
+    // nothing that could be removed later. What is asserted here is the
+    // choice — the projection stood down for the tree's own generator.
+    expect(out[0]?.mode).toBe("generator");
+    expect(lines(calls)).toEqual([`${script} --source-dir ${m.tree} --user`]);
+    expect(existsSync(join(m.home, ".gemini", "extensions", "red-skills"))).toBe(false);
   });
 });
 
-describe("unwiring a generator host", () => {
-  test("goes through the same script and removes exactly what the manifest recorded", async () => {
-    // The conservative removal belongs to the generator, because the
-    // manifest is the only record of what it wrote. A second opinion in
-    // this repo would be a list of paths that drifts from the tree —
-    // and the way it fails is by deleting somebody else's file.
-    const tree = fixtureTree(["shipped", "also-shipped"]);
-    const config = mkdtempSync(join(tmpdir(), "red-hosts-config-"));
-    const root = home();
-    const redcode = hostNamed("redcode");
+// -------------------------------------------------------------- only `dev`
 
-    await refresh({ home: root, source: tree, hosts: [redcode], run: spawner(config) });
-    expect(existsSync(skillPath(config, "redcode", "shipped"))).toBe(true);
-    expect(readHostStamp(root)["redcode"]).toBe(tree);
-
-    // Something the generator never wrote, in the directory it writes
-    // into. Nothing recorded it, so nothing may remove it.
-    const mine = join(config, "redcode", "skills", "hand-written");
-    mkdirSync(mine, { recursive: true });
-    writeFileSync(join(mine, "SKILL.md"), "mine\n");
-
-    const calls: string[][] = [];
-    const run = spawner(config);
-    const out = await unwireSkillHosts(UBUNTU, {
-      home: root,
-      source: tree,
-      plugins: PLUGINS,
-      present: () => true,
-      hosts: [redcode],
-      run: (cmd) => {
-        calls.push(cmd);
-        return run(cmd);
-      },
-    });
-
-    expect(out).toEqual([{ host: "redcode", unwired: true }]);
-    expect(calls.map((c) => c.join(" "))).toEqual([
-      `${tree}/scripts/install-opencode.sh --uninstall --global --host redcode`,
-    ]);
-    // What the manifest recorded is gone, and only that.
-    expect(existsSync(skillPath(config, "redcode", "shipped"))).toBe(false);
-    expect(existsSync(skillPath(config, "redcode", "also-shipped"))).toBe(false);
-    expect(existsSync(join(config, "redcode", "redskills-install-manifest.txt"))).toBe(false);
-    expect(existsSync(join(mine, "SKILL.md"))).toBe(true);
-    // And the host is no longer claimed as refreshed against that tree,
-    // so the next converge wires it again rather than skipping it.
-    expect(readHostStamp(root)["redcode"]).toBeUndefined();
+describe("only the dev plugin is activated", () => {
+  test("out of everything the machine carries locally", () => {
+    expect(activatedPlugins(["dev", "memory", "brain"])).toEqual(["dev"]);
+    expect(activatedPlugins(["memory", "brain"])).toEqual([]);
   });
 
-  test("with no checkout on the machine, unwires nothing rather than guessing", async () => {
-    // The scripts live in the tree. With no tree there is no record of
-    // what was written, and this repo does not hold a second copy of it.
-    const { calls, run } = recorder();
-    const out = await unwireSkillHosts(UBUNTU, {
-      home: home(),
+  test("the marketplace hosts are never asked for another one", async () => {
+    const m = machine();
+    const { calls, run } = runner(m);
+    await reconcile(m, { run, plugins: ACTIVATED });
+
+    const issued = lines(calls).join("\n");
+    expect(issued).toContain("dev@red-skills");
+    expect(issued).not.toContain("memory@red-skills");
+    expect(issued).not.toContain("brain@red-skills");
+  });
+
+  test("the projected hosts carry dev's skills and nothing else", async () => {
+    const m = machine({ skills: ["shipped", "also-shipped"] });
+    await reconcile(m, { run: runner(m).run });
+
+    const gemini = join(m.home, ".gemini", "extensions", "red-skills", "skills");
+    const hermes = join(m.home, ".hermes", "skills", "red-skills");
+    for (const root of [gemini, hermes]) {
+      expect(existsSync(join(root, "shipped", "SKILL.md")), root).toBe(true);
+      expect(existsSync(join(root, "also-shipped", "SKILL.md")), root).toBe(true);
+      expect(existsSync(join(root, "memory-only")), root).toBe(false);
+    }
+  });
+
+  test("and the generators render what the set's activation config enables", async () => {
+    // The three hosts red-dev hands no plugin list to. Activation reaches
+    // them through the config composeSet writes beside the tree, which is
+    // why that file names every payload and enables one.
+    const m = machine();
+    await reconcile(m, { run: runner(m).run });
+
+    expect(readFileSync(join(m.tree, ".red", "config.yaml"), "utf8")).toContain(
+      "  dev:\n    enabled: true\n  memory:\n    enabled: false\n",
+    );
+    for (const host of ["opencode", "redcode"]) {
+      expect(existsSync(join(m.config, host, "skills", "shipped", "SKILL.md")), host).toBe(true);
+      expect(existsSync(join(m.config, host, "skills", "memory-only")), host).toBe(false);
+    }
+    expect(existsSync(join(m.home, ".pi", "skills", "shipped", "SKILL.md"))).toBe(true);
+    expect(existsSync(join(m.home, ".pi", "skills", "memory-only"))).toBe(false);
+  });
+});
+
+// ----------------------------------------------------------- the regression
+
+/**
+ * The rule this module replaced, spelled out so the miss can be asserted.
+ *
+ * A host was current when the checkout path it was last refreshed against
+ * was the path resolved now. Nothing else was compared, which is why an
+ * edit that keeps the path is invisible to it.
+ */
+function pathOnlyStampSaysCurrent(stamped: string, resolved: string): boolean {
+  return stamped === resolved;
+}
+
+describe("a source that changed in place", () => {
+  test("is missed by the retired path-only stamp and caught by the record", async () => {
+    // A development checkout, or a set rebuilt from the same version: the
+    // bytes moved and the path did not. This is the case Spec #201 names
+    // as the reason a path stamp cannot be the identity.
+    const m = machine();
+    await reconcile(m, { run: runner(m).run });
+    const before = readHostRegistry(m.home).hosts["opencode"];
+    expect(before?.setDigest).toBeTruthy();
+
+    addSkill(m.tree, "dev", "arrived-later");
+
+    // The old rule, on the same two facts it had: the resolved path is the
+    // stamped path, so it reports a host that has never seen the new skill
+    // as already refreshed.
+    expect(pathOnlyStampSaysCurrent(m.tree, m.tree)).toBe(true);
+
+    const { calls, run } = runner(m);
+    const out = await reconcile(m, { run });
+
+    expect(calls.length).toBeGreaterThan(0);
+    for (const o of out) expect(o.status, `${o.host}: ${o.reason ?? ""}`).toBe("reconciled");
+    const after = readHostRegistry(m.home).hosts["opencode"];
+    expect(after?.setDigest).not.toBe(before?.setDigest);
+    // And the skill is on the machine, with nothing in this repo changed
+    // to let it through: the generator renders the tree it ships in.
+    expect(existsSync(join(m.config, "opencode", "skills", "arrived-later", "SKILL.md"))).toBe(true);
+    expect(existsSync(join(m.home, ".gemini", "extensions", "red-skills", "skills", "arrived-later")))
+      .toBe(true);
+  });
+
+  test("while a converge that changed nothing issues no commands at all", async () => {
+    // The other direction, because a gate that only ever says "reconcile"
+    // is as broken as one that never does. Not "issues fewer" and not
+    // "issues them and they no-op" — the trace is empty.
+    const m = machine();
+    await reconcile(m, { run: runner(m).run });
+
+    const { calls, run } = runner(m);
+    const out = await reconcile(m, { run });
+
+    expect(calls).toEqual([]);
+    for (const o of out) expect(o.status, o.host).toBe("current");
+  });
+
+  test("red-skills absent from the machine reconciles nothing", async () => {
+    const m = machine();
+    const { calls, run } = runner(m);
+    const out = await reconcile(m, { source: null, run });
+
+    expect(calls).toEqual([]);
+    expect(out).toEqual([]);
+  });
+});
+
+describe("state that moved under a host", () => {
+  test("is reconciled again, and only that host is", async () => {
+    // The observation the stamp could never make. Nothing about the set
+    // changed; what changed is that the machine no longer has what the
+    // record says it has.
+    const m = machine();
+    await reconcile(m, { run: runner(m).run });
+    rmSync(join(m.config, "opencode", "skills", "shipped"), { recursive: true, force: true });
+
+    const { calls, run } = runner(m);
+    const out = await reconcile(m, { run });
+
+    expect(statusOf(out, "opencode")).toBe("reconciled");
+    expect(lines(calls)).toEqual([`${m.tree}/scripts/install-opencode.sh --global --host opencode`]);
+    expect(existsSync(join(m.config, "opencode", "skills", "shipped", "SKILL.md"))).toBe(true);
+    for (const other of ["redcode", "gemini", "pi", "hermes", "claude", "codex"]) {
+      expect(statusOf(out, other), other).toBe("current");
+    }
+  });
+
+  test("including one an operator edited by hand", async () => {
+    const m = machine();
+    await reconcile(m, { run: runner(m).run });
+    writeFileSync(
+      join(m.home, ".gemini", "extensions", "red-skills", "REDSKILLS.md"),
+      "somebody rewrote this\n",
+    );
+
+    const out = await reconcile(m, { run: runner(m).run });
+    expect(statusOf(out, "gemini")).toBe("reconciled");
+    expect(readFileSync(join(m.home, ".gemini", "extensions", "red-skills", "REDSKILLS.md"), "utf8"))
+      .toContain("shipped");
+  });
+});
+
+// ---------------------------------------------------------- the verification
+
+describe("nothing short of a verified reconciliation is recorded", () => {
+  test("a host that refuses a required command", async () => {
+    const m = machine();
+    const { run } = runner(m, (cmd) => (cmd[0] === "claude" ? 1 : 0));
+    const out = await reconcile(m, { run });
+
+    expect(statusOf(out, "claude")).toBe("failed");
+    expect(readHostRegistry(m.home).hosts["claude"]).toBeUndefined();
+    // And the others are untouched by it: one CLI broken for its own
+    // reasons is the ordinary state of a machine with several agents.
+    for (const other of HOST_ADAPTERS.filter((a) => a.name !== "claude")) {
+      expect(statusOf(out, other.name), other.name).toBe("reconciled");
+    }
+  });
+
+  test("a runner that throws is a failed host, not a failed converge", async () => {
+    const m = machine();
+    const out = await reconcile(m, {
+      run: async (cmd) => {
+        if (cmd[0] === "codex") throw new Error("spawn failed");
+        return 0;
+      },
+      adapters: [adapterNamed("codex"), adapterNamed("hermes")],
+    });
+
+    expect(statusOf(out, "codex")).toBe("failed");
+    expect(statusOf(out, "hermes")).toBe("reconciled");
+    expect(readHostRegistry(m.home).hosts["codex"]).toBeUndefined();
+  });
+
+  test("a generator that succeeded and recorded no manifest", async () => {
+    // The partial case, and the one that matters most: every command
+    // exited zero, so an exit-code verdict would call this converged. What
+    // is missing is any record of what was written, which means nothing to
+    // observe now and nothing to remove later.
+    const m = machine();
+    const script = join(m.tree, "scripts", "install-opencode.sh");
+    writeFileSync(script, "#!/usr/bin/env bash\nexit 0\n");
+    chmodSync(script, 0o755);
+
+    const out = await reconcile(m, { run: runner(m).run, adapters: [adapterNamed("opencode")] });
+
+    expect(out[0]?.status).toBe("failed");
+    expect(out[0]?.reason).toContain("install manifest");
+    expect(readHostRegistry(m.home).hosts["opencode"]).toBeUndefined();
+  });
+
+  test("a marketplace host whose registration still points somewhere else", async () => {
+    // Told to update, and it did — but what it wrote down says GitHub.
+    // That is exactly the state a record must not describe as converged,
+    // and only reading the host's own file can tell.
+    const m = machine();
+    writeFileSync(
+      join(m.home, ".claude", "plugins", "known_marketplaces.json"),
+      `{\n  "red-skills": {\n    "source": { "source": "github", "repo": "reddb-io/red-skills" }\n  }\n}\n`,
+    );
+
+    const out = await reconcile(m, { run: runner(m).run, adapters: [adapterNamed("claude")] });
+
+    expect(out[0]?.status).toBe("failed");
+    expect(out[0]?.reason).toContain("registered from");
+    expect(readHostRegistry(m.home).hosts["claude"]).toBeUndefined();
+  });
+
+  test("a set with no generator for a host it needs one for", async () => {
+    const m = machine({ without: ["install-opencode.sh", "install-pi.sh"] });
+    const { calls, run } = runner(m);
+    const out = await reconcile(m, { run });
+
+    for (const host of GENERATOR_HOSTS) {
+      expect(statusOf(out, host), host).toBe("blocked");
+      expect(readHostRegistry(m.home).hosts[host], host).toBeUndefined();
+    }
+    expect(lines(calls).some((c) => c.includes("/scripts/"))).toBe(false);
+    // Blocked is a reported failure of the whole walk, not a quiet skip:
+    // seven-host success cannot be claimed while one of them is stuck.
+    for (const host of PROJECTED_HOSTS) expect(statusOf(out, host), host).toBe("reconciled");
+  });
+
+  test("a set with no skills leaves the projected hosts blocked", async () => {
+    const m = machine({ skills: [], mcp: false });
+    const out = await reconcile(m, { run: runner(m).run });
+
+    for (const host of PROJECTED_HOSTS) {
+      expect(statusOf(out, host), host).toBe("blocked");
+      expect(readHostRegistry(m.home).hosts[host], host).toBeUndefined();
+    }
+  });
+
+  test("a host that is not on the machine, until the converge after it appears", async () => {
+    // Absence must not be recorded. A skipped host written down as current
+    // is a host installed tomorrow and left on yesterday's set forever.
+    const m = machine();
+    const first = await reconcile(m, { run: runner(m).run, present: (cmd) => cmd !== "hermes" });
+
+    expect(statusOf(first, "hermes")).toBe("absent");
+    expect(first.find((o) => o.host === "hermes")?.reason).toContain("not installed");
+    expect(readHostRegistry(m.home).hosts["hermes"]).toBeUndefined();
+
+    const second = await reconcile(m, { run: runner(m).run });
+    expect(statusOf(second, "hermes")).toBe("reconciled");
+    expect(existsSync(join(m.home, ".hermes", "skills", "red-skills", "shipped"))).toBe(true);
+  });
+});
+
+// ------------------------------------------------------ the operator's files
+
+describe("configuration the operator owns", () => {
+  test("keeps every byte outside the field red-dev owns", async () => {
+    const m = machine();
+    await reconcile(m, { run: runner(m).run });
+
+    const after = readFileSync(join(m.home, ".gemini", "settings.json"), "utf8");
+    // Their formatting, their key order, their server, their trailing
+    // newline. A parse-and-restringify merge loses all four.
+    expect(after).toContain(`  "theme": "GitHub Dark",\n`);
+    expect(after).toContain(`      "args": ["/home/someone/tools/server.mjs"]\n`);
+    expect(after).toContain(`  "autoAccept": false\n`);
+    expect(after.endsWith("}\n")).toBe(true);
+    // And the one thing that is ours, named so it cannot collide.
+    expect(JSON.parse(after)["mcpServers"]["red-skills-redskilled"]).toEqual({
+      command: "bun",
+      args: ["run", "d.mjs"],
+    });
+  });
+
+  test("and is handed back exactly as it was when RedSkills is removed", async () => {
+    const m = machine();
+    await reconcile(m, { run: runner(m).run });
+    await removeSkillHosts(UBUNTU, {
+      home: m.home,
+      config: m.config,
+      source: m.tree,
+      plugins: ACTIVATED,
+      present: () => true,
+      run: runner(m).run,
+    });
+
+    expect(readFileSync(join(m.home, ".gemini", "settings.json"), "utf8")).toBe(geminiSettings());
+  });
+
+  test("a set that declares no MCP never opens the settings file at all", async () => {
+    const m = machine({ mcp: false });
+    rmSync(join(m.tree, "plugins", "dev", ".mcp.json"), { force: true });
+    await reconcile(m, { run: runner(m).run });
+
+    expect(readFileSync(join(m.home, ".gemini", "settings.json"), "utf8")).toBe(geminiSettings());
+    expect(existsSync(join(m.home, ".gemini", "extensions", "red-skills"))).toBe(true);
+  });
+
+  test("Claude's own store is read and never rewritten", async () => {
+    const m = machine();
+    await reconcile(m, { run: runner(m).run });
+    expect(readFileSync(join(m.home, ".claude", "plugins", "known_marketplaces.json"), "utf8"))
+      .toBe(knownMarketplaces(m.current));
+  });
+});
+
+// -------------------------------------------------------------- the removal
+
+describe("removal is the ownership manifest, replayed", () => {
+  test("takes back what was recorded and nothing beside it", async () => {
+    const m = machine({ skills: ["shipped", "also-shipped"] });
+    await reconcile(m, { run: runner(m).run });
+
+    // Things nobody here wrote, in the directories red-dev writes into.
+    // Nothing recorded them, so nothing may remove them.
+    const theirs = [
+      join(m.config, "opencode", "skills", "hand-written"),
+      join(m.home, ".gemini", "extensions", "their-extension"),
+      join(m.home, ".hermes", "skills", "theirs"),
+      join(m.home, ".pi", "skills", "hand-written"),
+    ];
+    for (const dir of theirs) {
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, "SKILL.md"), "mine\n");
+    }
+
+    const { calls, run } = runner(m);
+    const out = await removeSkillHosts(UBUNTU, {
+      home: m.home,
+      config: m.config,
+      source: m.tree,
+      plugins: ACTIVATED,
+      present: () => true,
+      run,
+    });
+
+    expect(out.every((o) => o.removed)).toBe(true);
+    // The generators were routed back through their own scripts.
+    expect(lines(calls)).toContain(`${m.tree}/scripts/install-opencode.sh --uninstall --global --host opencode`);
+    expect(lines(calls)).toContain(`${m.tree}/scripts/install-pi.sh --uninstall --user`);
+    // What was recorded is gone.
+    expect(existsSync(join(m.config, "opencode", "skills", "shipped"))).toBe(false);
+    expect(existsSync(join(m.config, "redcode", "redskills-install-manifest.txt"))).toBe(false);
+    expect(existsSync(join(m.home, ".gemini", "extensions", "red-skills"))).toBe(false);
+    expect(existsSync(join(m.home, ".hermes", "skills", "red-skills"))).toBe(false);
+    expect(existsSync(join(m.home, ".pi", "skills", "shipped"))).toBe(false);
+    // And what was not is untouched.
+    for (const dir of theirs) expect(existsSync(join(dir, "SKILL.md")), dir).toBe(true);
+    // Including the operator's other marketplace, in the file red-dev
+    // takes only its own entry out of.
+    expect(readFileSync(join(m.home, ".claude", "plugins", "known_marketplaces.json"), "utf8")).toBe(
+      `{\n  "their-marketplace": {\n    "source": { "source": "github", "repo": "someone/theirs" }\n  }\n}\n`,
+    );
+    // The record goes with the state it described.
+    expect(readHostRegistry(m.home).hosts).toEqual({});
+  });
+
+  test("works with the package set already pruned off the machine", async () => {
+    // The record is the manifest, so removal does not need the tree the
+    // way the old unwire did. Only the host's own commands do, and those
+    // are skipped rather than guessed at.
+    const m = machine();
+    await reconcile(m, { run: runner(m).run });
+
+    const { calls, run } = runner(m);
+    const out = await removeSkillHosts(UBUNTU, {
+      home: m.home,
+      config: m.config,
       source: null,
-      plugins: PLUGINS,
+      plugins: ACTIVATED,
       present: () => true,
       run,
     });
 
     expect(calls).toEqual([]);
-    expect(out).toEqual([]);
+    expect(out.every((o) => o.removed)).toBe(true);
+    expect(existsSync(join(m.config, "opencode", "skills", "shipped"))).toBe(false);
+    expect(existsSync(join(m.home, ".gemini", "extensions", "red-skills"))).toBe(false);
+    expect(readHostRegistry(m.home).hosts).toEqual({});
   });
 
-  test("a host that is not installed is skipped with a reason", async () => {
-    const { calls, run } = recorder();
-    const out = await unwireSkillHosts(UBUNTU, {
-      home: home(),
-      source: NEW,
-      plugins: PLUGINS,
-      present: (cmd) => cmd !== "pi",
+  test("a host nothing was recorded for is left alone", async () => {
+    const m = machine();
+    const { calls, run } = runner(m);
+    const out = await removeSkillHosts(UBUNTU, {
+      home: m.home,
+      config: m.config,
+      source: m.tree,
+      plugins: ACTIVATED,
+      present: () => true,
       run,
     });
 
-    const pi = out.find((o) => o.host === "pi");
-    expect(pi?.unwired).toBe(false);
-    expect(pi?.reason).toContain("not installed");
-    expect(calls.some((c) => c.join(" ").includes("install-pi.sh"))).toBe(false);
-    expect(out.filter((o) => o.host !== "pi").every((o) => o.unwired)).toBe(true);
+    expect(calls).toEqual([]);
+    expect(out.every((o) => !o.removed)).toBe(true);
+    for (const o of out) expect(o.reason, o.host).toContain("nothing was recorded");
+  });
+});
+
+// --------------------------------------------------------------- the report
+
+describe("what doctor is told", () => {
+  test("every host's observed digest, mode and reload state, as data", async () => {
+    const m = machine();
+    await reconcile(m, { run: runner(m).run });
+
+    const report = redSkillsHostReport(m.home);
+    expect(report.unrecorded).toEqual([]);
+    expect(report.hosts.map((h) => h.host)).toEqual(HOST_ADAPTERS.map((a) => a.name));
+    for (const row of report.hosts) {
+      expect(row.setDigest, row.host).toMatch(/^[0-9a-f]{64}$/);
+      expect(row.stateDigest, row.host).toMatch(/^[0-9a-f]{64}$/);
+      expect(row.plugins, row.host).toEqual(ACTIVATED);
+      expect(row.reload, row.host).toBe("current");
+      expect(row.verifiedAt, row.host).toBe(STAMPED_AT);
+    }
+    // Two hosts with different state have different state digests: the
+    // number describes the machine rather than the set.
+    const digests = new Set(report.hosts.map((h) => h.stateDigest));
+    expect(digests.size).toBeGreaterThan(1);
   });
 
-  test("every host's removal is the undo of its own wiring", () => {
-    // Held for all five: the CLI hosts hand back their marketplace, the
-    // generator hosts hand back to the script that wired them.
-    for (const host of REFRESH_HOSTS) {
-      const steps = host.unwire(CTX);
-      expect(steps.length, host.name).toBeGreaterThan(0);
-      if (GENERATOR_HOSTS.includes(host.name)) {
-        expect(steps.map((s) => s.argv[0]), host.name).toEqual(
-          host.wire(CTX).map((s) => s.argv[0]),
-        );
-        expect(steps.every((s) => s.argv.includes("--uninstall")), host.name).toBe(true);
-      } else {
-        expect(steps.some((s) => s.argv.includes("marketplace")), host.name).toBe(true);
-        // Removing what may never have been added is allowed to fail: an
-        // uninstall that throws halfway leaves a host part-wired.
-        expect(steps.every((s) => s.optional === true), host.name).toBe(true);
-      }
-    }
+  test("names the hosts it has never observed rather than omitting them", async () => {
+    const m = machine();
+    await reconcile(m, { run: runner(m).run, adapters: [adapterNamed("hermes")] });
+
+    const report = redSkillsHostReport(m.home);
+    expect(report.hosts.map((h) => h.host)).toEqual(["hermes"]);
+    expect(report.unrecorded).toEqual(["claude", "codex", "opencode", "redcode", "gemini", "pi"]);
+    expect(redSkillsHostRows(report).some((r) => r.status === "n/a")).toBe(true);
+  });
+
+  test("a session that was up is reported as needing a restart, never killed", async () => {
+    // Plugin freshness does not justify interrupting somebody's work, so
+    // the only thing that happens to a running host is that it is said so.
+    const m = machine();
+    const { calls, run } = runner(m);
+    const out = await reconcile(m, { run, running: () => true, adapters: [adapterNamed("hermes")] });
+
+    expect(out[0]?.reload).toBe("restart-needed");
+    expect(readHostRegistry(m.home).hosts["hermes"]?.reload).toBe("restart-needed");
+    expect(lines(calls).some((c) => c.includes("kill") || c.includes("pkill"))).toBe(false);
+
+    const rows = redSkillsHostRows(redSkillsHostReport(m.home));
+    expect(rows.find((r) => r.detail.startsWith("hermes"))?.status).toBe("warn");
+    expect(rows.find((r) => r.detail.startsWith("hermes"))?.detail).toContain("restart needed");
+  });
+
+  test("with nothing recorded at all it says so and reads no host", () => {
+    const home = mkdtempSync(join(tmpdir(), "red-hosts-empty-"));
+    const report = redSkillsHostReport(home);
+    expect(report.hosts).toEqual([]);
+    expect(report.unrecorded).toEqual(HOST_ADAPTERS.map((a) => a.name));
+  });
+
+  test("the registry the path-only stamp left behind reads as no record", async () => {
+    // The old file was a bare host-to-path map with no schema. Every host
+    // is reconciled once on the converge after the upgrade, which is
+    // correct: there is nothing in it worth believing.
+    const m = machine();
+    const path = join(m.home, ".local", "share", "red-dev", "red-skills-hosts.json");
+    mkdirSync(join(m.home, ".local", "share", "red-dev"), { recursive: true });
+    writeFileSync(path, `${JSON.stringify({ claude: m.tree, opencode: m.tree }, null, 2)}\n`);
+
+    expect(readHostRegistry(m.home).hosts).toEqual({});
+    const out = await reconcile(m, { run: runner(m).run });
+    for (const o of out) expect(o.status, o.host).toBe("reconciled");
+  });
+});
+
+describe("the converge reaches the reconciliation", () => {
+  test("on the already-wired path too", () => {
+    // Asserted against the source because it is not observable any other
+    // way without an agent CLI in the loop, and because the failure it
+    // guards is precise: convergeRedSkills used to return at "already
+    // wired", which is every ordinary converge. A reconciliation written
+    // and never reached from there would leave the set moving under a
+    // machine whose hosts are never told.
+    const src = readFileSync(`${import.meta.dir}/agents.ts`, "utf8");
+    const converge = src.slice(src.indexOf("export async function convergeRedSkills"));
+    const wired = converge.indexOf("already wired into");
+    expect(wired).toBeGreaterThan(-1);
+    expect(converge.slice(wired)).toContain("reconcileSkillHosts");
   });
 });

--- a/src/red-skills-hosts.ts
+++ b/src/red-skills-hosts.ts
@@ -1,117 +1,107 @@
 /**
- * Refreshing the agent hosts, gated on the version actually having moved.
+ * Reconciling the agent hosts against what they actually have.
  *
- * Once mise owns the RedSkills version, a converge has a fact it never
- * had before: the resolved checkout under `~/.red-skills/current`, which
- * changes exactly when a new package set landed and never otherwise. That
- * fact is what this module spends.
+ * Seven applications on this workstation can be taught RedSkills, and
+ * every one of them learns it differently: Claude Code and Codex own
+ * marketplace caches, OpenCode and RedCode consume a generated tree, Pi
+ * and Hermes read skills off a path, Gemini takes an extension. One
+ * package set has to reach all seven and be provably there afterwards.
  *
- * Refreshing a host is a marketplace update plus one plugin update per
- * declared plugin — several CLI invocations and a network round trip
- * each, per host, across five hosts — and for three of them a generator
- * run that walks the whole skill tree. A converge runs often
- * and the overwhelming majority of them resolve the version they resolved
- * last time, so running the walk unconditionally is a cost paid on every
- * converge for a result identical to doing nothing.
+ * ## Why the stamp had to go
  *
- * ## The stamp is per host, not per machine
+ * The first version of this file recorded, per host, the checkout path it
+ * was last refreshed against, and skipped a host whose recorded path was
+ * the resolved one. That is a correct gate for exactly one kind of change:
+ * a new version installed at a new path. It is blind to every other kind.
  *
- * A single "last refreshed at" would be wrong in both directions. A host
- * installed after the last refresh would be recorded as current on a tree
- * it never read, and a host that refused the call would mark the whole
- * machine as done. So each host records the checkout it was last
- * refreshed against, exactly the way red-skills-ext.ts records the
- * checkout each artifact was last built from — and for the same reason:
- * asking the host what version it has answers a question about the
- * marketplace cache rather than about the tree behind it.
+ * A development checkout is edited in place and never moves. A package set
+ * rebuilt from the same version carries different bytes under the same
+ * name. And a host's own state is not addressed by the stamp at all — an
+ * operator who cleared their plugin cache, an upgrade that dropped a
+ * generated directory, a config a second tool rewrote all leave the stamp
+ * saying "current" about a host that has nothing. The stamp described what
+ * red-dev *attempted*, and reported it as what the machine *has*.
  *
- * Only a host that succeeded is stamped. Absence, refusal and a crash all
- * leave the entry as it was, so the next converge asks again. The cost of
- * being wrong that way is one extra refresh; the cost of the other way is
- * a host frozen on an old tree with nothing anywhere saying so.
+ * So a record here is written from three observations rather than one
+ * assumption: the digest of the package set the host was reconciled
+ * against, the digest of the state that reconciliation is responsible for
+ * as it exists on disk now, and the mode the adapter used to put it there.
+ * A converge re-reconciles a host when any of the three has moved — which
+ * covers the in-place edit, the rebuilt set and the cleared cache, and
+ * still costs nothing on the ordinary converge where all three agree.
  *
- * ## One failure does not end the walk
+ * ## Plan, apply, verify, record — in that order
  *
- * A machine with several agents on it usually has one of them broken for
- * its own reasons — a half-written config, a login that expired. That is
- * a fact about that host, so it is reported against that host and the
- * rest of the walk continues.
+ * Every adapter answers a plan: the commands to issue, the files red-dev
+ * writes itself, the fields it owns inside files somebody else owns, and
+ * the state that has to exist afterwards. Applying it runs that plan;
+ * verifying it reads the result back from disk; and only a verification
+ * that passed writes a record. A host that was absent, blocked, refused a
+ * command or converged only partly leaves whatever record it had — which
+ * means the next converge asks it again, and doctor keeps saying the true
+ * thing about it in the meantime. Being wrong that way costs one extra
+ * reconciliation; being wrong the other way is a host frozen on an old
+ * tree with a file on disk claiming it is current.
  *
- * ## Two kinds of host, and why they are not symmetrical
+ * ## Only `dev` is activated
  *
- * Claude and Codex are CLI calls red-dev makes itself: both expose a
- * marketplace and a plugin cache, and refreshing them is a handful of
- * arguments spelled out here.
+ * The package set carries every plugin payload, and Spec #201 activates
+ * exactly one of them in the coder hosts: `dev` is the global process
+ * surface, and Memory, Brain and the maintainer-only behaviour must not
+ * start acting on a machine because they happened to be in the tarball.
+ * So the activation set is derived from the set rather than from the
+ * manifest's install list — everything is installed locally, one thing is
+ * switched on.
  *
- * OpenCode, RedCode and pi have no marketplace. Their surface is
- * generated — plugin modules, skill trees, MCP and TUI config — by
- * scripts that ship inside the RedSkills tree, beside the skills they
- * render. So this file invokes those scripts and never reimplements
- * them: a generator ported into this repo would be separated from the
- * tree it renders, and a skill added to RedSkills would have to wait for
- * a red-dev release before it could appear on anyone's machine.
+ * ## What red-dev writes, and what it refuses to write
  *
- * The scripts are addressed by path inside the resolved checkout, which
- * is also how each one finds the tree it renders — it resolves its own
- * repo root from `dirname $0/..`. Invoking `<source>/scripts/...` is
- * therefore the whole of "with the tree as their source".
+ * Where the package set carries a generator for a host, that generator is
+ * invoked and nothing here reimplements it: the scripts live beside the
+ * skills they render, so a skill added to RedSkills appears on the machine
+ * with no release of this repo. Where it does not, red-dev projects the
+ * activated plugin itself — but only into state it owns outright, or into
+ * one named field of a user's file through src/owned-config.ts, which
+ * leaves every other byte of that file exactly where it was.
  *
- * ## Unwiring goes back through the same scripts
- *
- * The generators write an uninstall manifest recording every path they
- * created, and their `--uninstall` removes what that manifest names and
- * nothing else. That conservatism is the point: a config directory holds
- * files nobody here put there. So unwiring is the same script with one
- * more flag, exactly as the standalone installer calls it, rather than a
- * second opinion in this repo about what RedSkills left behind.
+ * Everything red-dev owns is written into the record as an ownership
+ * manifest, and removal is that manifest read back. That is the whole of
+ * the uninstall contract: a config directory holds files nobody here put
+ * there, and the only defensible answer to "what did we leave behind" is a
+ * list written at the time rather than a guess made afterwards.
  */
 
-import { existsSync, mkdirSync, readFileSync } from "node:fs";
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
 
+import { sha256Hex } from "./checksum.ts";
 import { log } from "./log.ts";
+import { dropOwnedField, readOwnedField, setOwnedField } from "./owned-config.ts";
 import type { Platform } from "./platform.ts";
 import type { Tool } from "./manifest.ts";
+import { activatedPlugins } from "./red-skills-plugins.ts";
 
 /**
- * One command in a host's wiring.
+ * One command in a host's reconciliation.
  *
  * `optional` is what `try_run … || true` is in the shared installer, and
  * it is load-bearing rather than decorative: removing a plugin that was
- * never installed exits non-zero, and treating that as a failed host
- * would leave a machine permanently unstamped and permanently rewalked.
+ * never installed exits non-zero, and treating that as a failed host would
+ * leave a machine permanently unrecorded and permanently rewalked.
  */
 export interface HostStep {
   /** The command, as argv. */
   argv: string[];
   /** A non-zero exit here is reported, and the host carries on. */
   optional?: boolean;
-}
-
-/**
- * What a host's commands are a function of.
- *
- * The plugin set because which plugins this machine carries is the
- * manifest's answer, and a table that wrote them down would be a second
- * place for that to be declared. The checkout because three of the five
- * hosts are wired by scripts that live inside it.
- */
-export interface HostContext {
-  /** The plugin set this machine declares. */
-  plugins: readonly string[];
-  /** The resolved checkout — `~/.red-skills/versions/v<x>`, resolved. */
-  source: string;
-}
-
-/** One host red-dev wires RedSkills into, and how. */
-export interface SkillHostRefresh {
-  /** Key in the stamp, and the name that appears in a log line. */
-  name: string;
-  /** The command that has to be on PATH for this host to exist. */
-  cmd: string;
-  /** The refresh, in the order it has to be issued. */
-  wire: (ctx: HostContext) => HostStep[];
-  /** The removal, in the order it has to be issued. */
-  unwire: (ctx: HostContext) => HostStep[];
 }
 
 /** A command whose failure fails the host. */
@@ -125,15 +115,164 @@ function may(...argv: string[]): HostStep {
 }
 
 /**
+ * The richest mechanism an adapter found on this machine for its host.
+ *
+ * Recorded rather than declared, because for two of the seven it is a
+ * property of the package set rather than of the host: Gemini and Hermes
+ * are projected by red-dev today and will be `generator` the day RedSkills
+ * ships a script for them. A doctor report that said "extension" about a
+ * machine running a generator would be describing the table instead of the
+ * machine, which is the failure this whole module is a correction to.
+ */
+export type AdapterMode = "marketplace" | "generator" | "extension" | "skills";
+
+/** Whether a running session has yet to see what converged underneath it. */
+export type ReloadState = "current" | "restart-needed";
+
+/** What every adapter is a function of. */
+export interface AdapterContext {
+  /** The plugins to activate — `dev` alone. */
+  plugins: readonly string[];
+  /** The resolved package set: `~/.red-skills/current`, followed. */
+  source: string;
+  /** That set's whole-set digest, which is what a record is keyed on. */
+  setDigest: string;
+  /** Its version, for a line a person reads. */
+  setVersion: string;
+  /** The stable pointer the marketplace hosts are registered against. */
+  current: string;
+  /** This user's home. */
+  home: string;
+  /** `$XDG_CONFIG_HOME`, or `~/.config`. */
+  config: string;
+}
+
+/**
+ * One piece of state a reconciliation owns.
+ *
+ * Three kinds, because there are three ways to be responsible for
+ * something. A `path` is a file or directory red-dev created, and removing
+ * it is removing it. A `field` is one entry inside a file the user owns,
+ * and removing it must leave the rest of that file byte for byte. A `host`
+ * entry is state inside an application's own store — a marketplace
+ * registration in Codex's TOML — which only that application's CLI can
+ * take out, and which red-dev records so it can say what it asked for.
+ */
+export type OwnedEntry =
+  | { kind: "path"; path: string }
+  | { kind: "field"; file: string; pointer: string[]; onlyWhenEmpty?: boolean }
+  | { kind: "host"; what: string };
+
+/** A file red-dev writes in full. */
+export interface OwnedWrite {
+  path: string;
+  bytes: string;
+}
+
+/** A directory red-dev copies out of the package set in full. */
+export interface OwnedCopy {
+  from: string;
+  to: string;
+}
+
+/** One field red-dev owns inside a file the user owns. */
+export interface OwnedMerge {
+  file: string;
+  pointer: string[];
+  value: unknown;
+}
+
+/** Everything an adapter would do, computed before anything is touched. */
+export interface HostPlan {
+  /** How this host is being reached on this machine. */
+  mode: AdapterMode;
+  /** The commands to issue, in the order they have to be issued. */
+  steps: HostStep[];
+  /** Files red-dev writes itself. */
+  writes: OwnedWrite[];
+  /** Trees red-dev copies out of the package set. */
+  copies: OwnedCopy[];
+  /** Fields red-dev owns inside files somebody else owns. */
+  merges: OwnedMerge[];
+  /** State that must exist afterwards for this host to count as done. */
+  expect: OwnedEntry[];
+  /**
+   * Where a generator records what it wrote.
+   *
+   * Read rather than predicted: the generator is the only thing that knows
+   * which paths it created, and a list in this repo would be one that
+   * drifts from the tree — the way it fails being that it deletes
+   * somebody else's file.
+   */
+  manifests: string[];
+  /** Why this adapter cannot act here at all. Reported, never recorded. */
+  blocked?: string;
+}
+
+/** A plan with every empty part spelled out once, here instead of seven times. */
+function plan(partial: Partial<HostPlan> & { mode: AdapterMode }): HostPlan {
+  return {
+    steps: [],
+    writes: [],
+    copies: [],
+    merges: [],
+    expect: [],
+    manifests: [],
+    ...partial,
+  };
+}
+
+/** What a host itself says about the state it holds, after the plan ran. */
+export type HostCheck = { ok: true; witness: string } | { ok: false; reason: string };
+
+/** One host red-dev reconciles RedSkills into, and how. */
+export interface HostAdapter {
+  /** Key in the registry, and the name in a log line. */
+  name: string;
+  /** The command that has to be on PATH for this host to exist. */
+  cmd: string;
+  /** What this adapter would do, given the set and this machine. */
+  plan: (ctx: AdapterContext) => HostPlan;
+  /**
+   * Ground truth only this host can answer for.
+   *
+   * Owned paths and fields are verified generically below; this is for the
+   * facts that live inside an application's own store, where the file
+   * exists either way and only its contents say whether the host agrees.
+   */
+  check?: (ctx: AdapterContext) => Promise<HostCheck>;
+  /** The commands that take this host's own state back out. */
+  remove: (ctx: AdapterContext) => HostStep[];
+}
+
+// ------------------------------------------------------------ the adapters
+
+/** The marketplace name both installers register under. */
+const MARKETPLACE = "red-skills";
+
+/**
  * A generator inside the installed tree, addressed by path.
  *
  * The path is the whole contract. Each script resolves its own repo root
  * from where it sits, so naming it under `source` is what hands it the
- * tree — there is no second flag saying which checkout to render, and
- * inventing one here would be a place for the two to disagree.
+ * tree — there is no second flag saying which set to render, and inventing
+ * one here would be a place for the two to disagree.
  */
 function generator(source: string, script: string): string {
-  return `${source}/scripts/${script}`;
+  return join(source, "scripts", script);
+}
+
+/** Where a generator writes down what it created, in the two usual places. */
+function manifestCandidates(ctx: AdapterContext, host: string): string[] {
+  return [
+    join(ctx.config, host, "redskills-install-manifest.txt"),
+    join(ctx.home, `.${host}`, "redskills-install-manifest.txt"),
+  ];
+}
+
+/** Where the activated plugin's payload sits inside the set. */
+function pluginDir(ctx: AdapterContext, name: string): string {
+  return join(ctx.source, "plugins", name);
 }
 
 /**
@@ -144,118 +283,522 @@ function generator(source: string, script: string): string {
  * function called twice, and so does this — a second table row spelling
  * the same three flags out again is a place for them to drift.
  */
-function opencodeCompatible(host: string): SkillHostRefresh {
+function opencodeCompatible(host: string): HostAdapter {
   const script = (source: string) => generator(source, "install-opencode.sh");
   return {
     name: host,
     cmd: host,
-    wire: ({ source }) => [must(script(source), "--global", "--host", host)],
-    unwire: ({ source }) => [must(script(source), "--uninstall", "--global", "--host", host)],
+    plan: (ctx) => {
+      if (!existsSync(script(ctx.source))) {
+        return plan({ mode: "generator", blocked: "the package set carries no install-opencode.sh" });
+      }
+      return plan({
+        mode: "generator",
+        steps: [must(script(ctx.source), "--global", "--host", host)],
+        manifests: manifestCandidates(ctx, host),
+      });
+    },
+    remove: (ctx) => [must(script(ctx.source), "--uninstall", "--global", "--host", host)],
   };
 }
 
 /**
- * The five hosts, and what each one is asked.
+ * Claude and Codex: the two hosts with a marketplace, driven by their CLIs.
  *
- * Claude and Codex answer in their own currency, and both spellings were
- * read off the installed CLIs rather than assumed:
+ * Both spellings were read off the installed CLIs rather than assumed:
  *
  *   claude  `plugin marketplace update <name>`  then `plugin update <p>`
  *   codex   `plugin marketplace upgrade <name>` then `plugin add <p>`
  *
- * Codex has no `plugin update` at all, so a refresh there is a remove
- * followed by an add: the add reinstalls from the marketplace snapshot
- * the line above it just upgraded. The remove is optional because a
- * plugin that is not installed yet — the first converge on this machine,
- * or a plugin the operator only just opted in to — makes it exit
- * non-zero, and that is not a broken host. The upgrade is optional too:
- * `marketplace upgrade` only knows Git marketplaces, and where red-dev
- * owns the registration the marketplace is a directory — the add reads
- * the tree as it stands, and there is nothing to upgrade.
+ * Codex has no `plugin update` at all, so reconciling there is a remove
+ * followed by an add: the add reinstalls from the marketplace snapshot the
+ * line above it just upgraded. The remove is optional because a plugin
+ * that is not installed yet makes it exit non-zero, and that is not a
+ * broken host. The upgrade is optional too: `marketplace upgrade` only
+ * knows Git marketplaces, and where red-dev owns the registration the
+ * marketplace is a directory — the add reads the tree as it stands.
  *
- * OpenCode, RedCode and pi are the tree's own generators, invoked with
- * the tree as their source. pi takes `--source-dir` as well as the path,
- * because it can install its packages from npm instead and the local
- * checkout is what pins every host on this machine to one version.
+ * Neither is verified by its exit code. What is read back is the entry the
+ * host itself wrote down, in the file the standalone installer's own
+ * healing reads: a machine can be told to update and record a registration
+ * still pointing at GitHub, and that is precisely the state a record must
+ * not describe as converged.
  */
-export const REFRESH_HOSTS: readonly SkillHostRefresh[] = [
-  {
-    name: "claude",
-    cmd: "claude",
-    wire: ({ plugins }) => [
-      must("claude", "plugin", "marketplace", "update", "red-skills"),
-      ...plugins.map((p) => must("claude", "plugin", "update", `${p}@red-skills`)),
-    ],
-    unwire: ({ plugins }) => [
-      // `--keep-data`, matching the shared installer: unwiring a host is
-      // not a request to delete whatever the plugin stored for you.
-      ...plugins.map((p) => may("claude", "plugin", "remove", "--keep-data", p)),
-      may("claude", "plugin", "marketplace", "remove", "red-skills"),
-    ],
+const claude: HostAdapter = {
+  name: "claude",
+  cmd: "claude",
+  plan: (ctx) =>
+    plan({
+      mode: "marketplace",
+      steps: [
+        must("claude", "plugin", "marketplace", "update", MARKETPLACE),
+        ...ctx.plugins.map((p) => must("claude", "plugin", "update", `${p}@${MARKETPLACE}`)),
+      ],
+      // Claude's own store, in JSON, so a registration the CLI failed to
+      // take out can still be removed without rewriting the file.
+      expect: [
+        { kind: "field", file: claudeMarketplaceFile(ctx), pointer: [MARKETPLACE] },
+      ],
+    }),
+  check: async (ctx) => {
+    const { claudeRegistration, registrationIsOurs } = await import("./red-skills-registration.ts");
+    const registration = await claudeRegistration(ctx.home);
+    if (!registrationIsOurs(registration, ctx.current)) {
+      return { ok: false, reason: `the marketplace is registered from ${registration?.source ?? "nothing"}` };
+    }
+    return { ok: true, witness: JSON.stringify(registration) };
   },
-  {
-    name: "codex",
-    cmd: "codex",
-    wire: ({ plugins }) => [
-      may("codex", "plugin", "marketplace", "upgrade", "red-skills"),
-      ...plugins.flatMap((p) => [
-        may("codex", "plugin", "remove", `${p}@red-skills`),
-        must("codex", "plugin", "add", `${p}@red-skills`),
-      ]),
-    ],
-    unwire: ({ plugins }) => [
-      ...plugins.map((p) => may("codex", "plugin", "remove", `${p}@red-skills`)),
-      may("codex", "plugin", "marketplace", "remove", "red-skills"),
-    ],
+  remove: (ctx) => [
+    // `--keep-data`, matching the shared installer: removing a host is not
+    // a request to delete whatever the plugin stored for you.
+    ...ctx.plugins.map((p) => may("claude", "plugin", "remove", "--keep-data", p)),
+    may("claude", "plugin", "marketplace", "remove", MARKETPLACE),
+  ],
+};
+
+function claudeMarketplaceFile(ctx: AdapterContext): string {
+  return join(ctx.home, ".claude", "plugins", "known_marketplaces.json");
+}
+
+const codex: HostAdapter = {
+  name: "codex",
+  cmd: "codex",
+  plan: (ctx) =>
+    plan({
+      mode: "marketplace",
+      steps: [
+        may("codex", "plugin", "marketplace", "upgrade", MARKETPLACE),
+        ...ctx.plugins.flatMap((p) => [
+          may("codex", "plugin", "remove", `${p}@${MARKETPLACE}`),
+          must("codex", "plugin", "add", `${p}@${MARKETPLACE}`),
+        ]),
+      ],
+      // Codex keeps its registration in TOML, which red-dev does not edit:
+      // the CLI that wrote it is the thing that takes it out again, and
+      // the record says so rather than pretending to a path it may remove.
+      expect: [{ kind: "host", what: `codex marketplace ${MARKETPLACE}` }],
+    }),
+  check: async (ctx) => {
+    const { codexRegistration, registrationIsOurs } = await import("./red-skills-registration.ts");
+    const registration = await codexRegistration(ctx.home);
+    if (!registrationIsOurs(registration, ctx.current)) {
+      return { ok: false, reason: `the marketplace is registered from ${registration?.source ?? "nothing"}` };
+    }
+    return { ok: true, witness: JSON.stringify(registration) };
   },
+  remove: (ctx) => [
+    ...ctx.plugins.map((p) => may("codex", "plugin", "remove", `${p}@${MARKETPLACE}`)),
+    may("codex", "plugin", "marketplace", "remove", MARKETPLACE),
+  ],
+};
+
+/**
+ * pi, whose generator ships in the tree like OpenCode's.
+ *
+ * It takes `--source-dir` as well as the path, because it can install its
+ * packages from npm instead and the local set is what pins every host on
+ * this machine to one version.
+ */
+const pi: HostAdapter = {
+  name: "pi",
+  cmd: "pi",
+  plan: (ctx) => {
+    const script = generator(ctx.source, "install-pi.sh");
+    if (!existsSync(script)) {
+      return plan({ mode: "generator", blocked: "the package set carries no install-pi.sh" });
+    }
+    return plan({
+      mode: "generator",
+      steps: [must(script, "--source-dir", ctx.source, "--user")],
+      manifests: manifestCandidates(ctx, "pi"),
+    });
+  },
+  remove: (ctx) => [must(generator(ctx.source, "install-pi.sh"), "--uninstall", "--user")],
+};
+
+/**
+ * One skill of the activated plugin, as the set describes it.
+ *
+ * Name and description come out of the front matter the skill already
+ * carries, because a projection that restated them would be a second place
+ * for a skill's own description to be written down.
+ */
+interface SetSkill {
+  name: string;
+  description: string;
+  path: string;
+}
+
+function frontMatter(text: string, key: string): string | null {
+  const match = new RegExp(`^${key}:\\s*(.+)$`, "m").exec(text.split(/^---\s*$/m)[1] ?? "");
+  return match?.[1]?.trim() ?? null;
+}
+
+/** Every skill the activated plugins carry, in a stable order. */
+function setSkills(ctx: AdapterContext): SetSkill[] {
+  const out: SetSkill[] = [];
+  for (const plugin of ctx.plugins) {
+    const root = join(pluginDir(ctx, plugin), "skills");
+    if (!existsSync(root)) continue;
+    for (const name of listing(root)) {
+      const file = join(root, name, "SKILL.md");
+      if (!existsSync(file)) continue;
+      const text = readFileSync(file, "utf8");
+      out.push({
+        name: frontMatter(text, "name") ?? name,
+        description: frontMatter(text, "description") ?? "",
+        path: join(root, name),
+      });
+    }
+  }
+  return out.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * The MCP the package set declares for a plugin, and never one we invented.
+ *
+ * A Claude-Code plugin declares its servers in `.mcp.json` at its root, and
+ * that file is the only thing consulted here. A set that declares none
+ * gives a host with no MCP surface, which is the honest outcome: a made-up
+ * command would be a server every host fails to start, reported as a
+ * feature every host has.
+ */
+function declaredMcp(ctx: AdapterContext): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const plugin of ctx.plugins) {
+    const file = join(pluginDir(ctx, plugin), ".mcp.json");
+    if (!existsSync(file)) continue;
+    try {
+      const parsed = JSON.parse(readFileSync(file, "utf8")) as Record<string, unknown>;
+      const servers = (parsed["mcpServers"] ?? parsed) as Record<string, unknown>;
+      if (servers === null || typeof servers !== "object" || Array.isArray(servers)) continue;
+      for (const [name, value] of Object.entries(servers)) out[`${MARKETPLACE}-${name}`] = value;
+    } catch {
+      // A payload we cannot read is a payload we do not project. The host
+      // is reported as unconverged rather than given half a config.
+      log.warn(`red-skills: ${file} is not JSON — no MCP projected from it`);
+    }
+  }
+  return out;
+}
+
+/**
+ * Gemini, which takes an extension directory and one field of its settings.
+ *
+ * Gemini has no marketplace and the package set ships no generator for it
+ * yet, so red-dev projects the activated plugin into `~/.gemini/extensions`
+ * — a directory it owns outright, which is the include shape: nothing the
+ * operator wrote is inside it, and removing it removes exactly what was
+ * added. The extension carries its own context file, which is how a skill
+ * the set ships becomes something Gemini reads.
+ *
+ * Its MCP servers are the one thing that cannot live in an owned directory,
+ * because Gemini resolves them from `settings.json`. Those go in as one
+ * named field each, spliced into the operator's file without touching a
+ * byte of the rest of it, and recorded so that removing them leaves the
+ * file they had. A set that declares no MCP touches `settings.json` at all.
+ */
+const gemini: HostAdapter = {
+  name: "gemini",
+  cmd: "gemini",
+  plan: (ctx) => {
+    const script = generator(ctx.source, "install-gemini.sh");
+    if (existsSync(script)) {
+      // The day RedSkills ships one, it wins: a generator lives beside the
+      // skills it renders, and this projection does not.
+      return plan({
+        mode: "generator",
+        steps: [must(script, "--source-dir", ctx.source, "--user")],
+        manifests: manifestCandidates(ctx, "gemini"),
+      });
+    }
+
+    const skills = setSkills(ctx);
+    if (skills.length === 0) {
+      return plan({ mode: "extension", blocked: "the package set carries no skills to project" });
+    }
+
+    const dir = join(ctx.home, ".gemini", "extensions", MARKETPLACE);
+    const mcp = declaredMcp(ctx);
+    const settings = join(ctx.home, ".gemini", "settings.json");
+    return plan({
+      mode: "extension",
+      writes: [
+        {
+          path: join(dir, "gemini-extension.json"),
+          bytes: `${JSON.stringify(
+            { name: MARKETPLACE, version: ctx.setVersion, contextFileName: "REDSKILLS.md" },
+            null,
+            2,
+          )}\n`,
+        },
+        { path: join(dir, "REDSKILLS.md"), bytes: contextFile(ctx, skills) },
+      ],
+      copies: skills.map((skill) => ({ from: skill.path, to: join(dir, "skills", skill.name) })),
+      merges: Object.entries(mcp).map(([name, value]) => ({
+        file: settings,
+        pointer: ["mcpServers", name],
+        value,
+      })),
+      // The directory itself, not only what is in it: red-dev made it, so
+      // removing RedSkills has to leave `~/.gemini/extensions` the way it
+      // found it rather than with our empty shell still sitting in it.
+      expect: [{ kind: "path", path: dir }],
+    });
+  },
+  remove: (ctx) => {
+    const script = generator(ctx.source, "install-gemini.sh");
+    return existsSync(script) ? [must(script, "--uninstall", "--user")] : [];
+  },
+};
+
+/**
+ * Hermes, which has skills and nothing else.
+ *
+ * The skills-only fallback Spec #201 names: no marketplace, no extension
+ * manifest, no MCP surface to project into, so the adapter writes the
+ * activated plugin's skills into a directory of its own under the host's
+ * skills path and stops there. Less than the other six get, and saying so
+ * in the record is the point — a mode of `skills` is how doctor reports a
+ * host that is genuinely converged and genuinely has less.
+ */
+const hermes: HostAdapter = {
+  name: "hermes",
+  cmd: "hermes",
+  plan: (ctx) => {
+    const script = generator(ctx.source, "install-hermes.sh");
+    if (existsSync(script)) {
+      return plan({
+        mode: "generator",
+        steps: [must(script, "--source-dir", ctx.source, "--user")],
+        manifests: manifestCandidates(ctx, "hermes"),
+      });
+    }
+
+    const skills = setSkills(ctx);
+    if (skills.length === 0) {
+      return plan({ mode: "skills", blocked: "the package set carries no skills to project" });
+    }
+    const dir = join(ctx.home, ".hermes", "skills", MARKETPLACE);
+    return plan({
+      mode: "skills",
+      copies: skills.map((skill) => ({ from: skill.path, to: join(dir, skill.name) })),
+      expect: [{ kind: "path", path: dir }],
+    });
+  },
+  remove: (ctx) => {
+    const script = generator(ctx.source, "install-hermes.sh");
+    return existsSync(script) ? [must(script, "--uninstall", "--user")] : [];
+  },
+};
+
+/** What Gemini reads when it loads the extension: the set, as one page. */
+function contextFile(ctx: AdapterContext, skills: readonly SetSkill[]): string {
+  const lines = [
+    `# RedSkills ${ctx.setVersion}`,
+    "",
+    `Projected by red-dev from ${ctx.current}. Do not edit: this file is`,
+    "rewritten whenever the package set moves.",
+    "",
+    ...skills.map((skill) =>
+      skill.description ? `- **${skill.name}** — ${skill.description}` : `- **${skill.name}**`
+    ),
+  ];
+  return `${lines.join("\n")}\n`;
+}
+
+/**
+ * The seven hosts, in the order a converge walks them.
+ *
+ * Spec #201 settles the set: OpenCode stays managed alongside RedCode, and
+ * Gemini and Hermes are required adapters rather than best-effort ones —
+ * seven-host success cannot be reported while either is blocked, which it
+ * cannot be if neither is in the table.
+ */
+export const HOST_ADAPTERS: readonly HostAdapter[] = [
+  claude,
+  codex,
   opencodeCompatible("opencode"),
   opencodeCompatible("redcode"),
-  {
-    name: "pi",
-    cmd: "pi",
-    wire: ({ source }) => [
-      must(generator(source, "install-pi.sh"), "--source-dir", source, "--user"),
-    ],
-    unwire: ({ source }) => [must(generator(source, "install-pi.sh"), "--uninstall", "--user")],
-  },
+  gemini,
+  pi,
+  hermes,
 ];
 
-/** Which checkout each host was last refreshed against. */
-export type HostStamp = Record<string, string>;
+// ------------------------------------------------------------- the registry
 
-/** What one host did, or the reason it did nothing. */
-export interface HostRefreshOutcome {
-  /** The host's name in REFRESH_HOSTS. */
+/** What one host was last observed to have. */
+export interface HostRecord {
+  /** The whole-set digest of the package set it was reconciled against. */
+  setDigest: string;
+  /** That set's version, for a line a person reads. */
+  setVersion: string;
+  /** The mechanism the adapter used. */
+  mode: AdapterMode;
+  /** The plugins activated in this host. */
+  plugins: string[];
+  /** The digest of the owned state, as it was on disk when verified. */
+  stateDigest: string;
+  /** Whether a session running at the time still has to be restarted. */
+  reload: ReloadState;
+  /** Everything this reconciliation is responsible for, for removal. */
+  owned: OwnedEntry[];
+  /** When the verification that wrote this record ran. */
+  verifiedAt: string;
+}
+
+/**
+ * The registry, at the path the stamp used to live at.
+ *
+ * The old file was a bare `host -> path` map with no schema field, so it
+ * reads here as no registry at all and every host is reconciled once on the
+ * converge after the upgrade. That is the correct migration: the old file
+ * recorded an attempt, and there is nothing in it worth believing.
+ */
+export interface HostRegistry {
+  schema: 2;
+  hosts: Record<string, HostRecord>;
+}
+
+/** Computed rather than a constant: the tests move home between cases. */
+export function hostRegistryPath(home: string): string {
+  return `${home.replace(/\\/g, "/")}/.local/share/red-dev/red-skills-hosts.json`;
+}
+
+export function readHostRegistry(home: string): HostRegistry {
+  const path = hostRegistryPath(home);
+  if (!existsSync(path)) return { schema: 2, hosts: {} };
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as Partial<HostRegistry>;
+    if (parsed?.schema !== 2 || typeof parsed.hosts !== "object" || parsed.hosts === null) {
+      return { schema: 2, hosts: {} };
+    }
+    return { schema: 2, hosts: parsed.hosts };
+  } catch {
+    // A registry we cannot read means reconcile, which is the safe way to
+    // be wrong: the cost is one extra walk, not a permanently stale host.
+    return { schema: 2, hosts: {} };
+  }
+}
+
+async function writeHostRegistry(home: string, registry: HostRegistry): Promise<void> {
+  const path = hostRegistryPath(home);
+  mkdirSync(dirname(path), { recursive: true });
+  await Bun.write(path, `${JSON.stringify(registry, null, 2)}\n`);
+}
+
+// ------------------------------------------------------------ the ownership
+
+/** A stable key for one owned entry, so two records can be compared. */
+function ownedKey(entry: OwnedEntry): string {
+  if (entry.kind === "path") return `path:${entry.path}`;
+  if (entry.kind === "field") return `field:${entry.file}#${entry.pointer.join(".")}`;
+  return `host:${entry.what}`;
+}
+
+function dedupe(entries: readonly OwnedEntry[]): OwnedEntry[] {
+  const seen = new Map<string, OwnedEntry>();
+  for (const entry of entries) if (!seen.has(ownedKey(entry))) seen.set(ownedKey(entry), entry);
+  return [...seen.values()];
+}
+
+function listing(dir: string): string[] {
+  try {
+    return readdirSync(dir).sort();
+  } catch {
+    return [];
+  }
+}
+
+/** The digest of one owned entry as it exists now, or `absent`. */
+async function observe(entry: OwnedEntry, witness: string): Promise<string> {
+  if (entry.kind === "host") return sha256Hex(`${entry.what}\0${witness}`);
+  if (entry.kind === "field") {
+    if (!existsSync(entry.file)) return "absent";
+    const value = readOwnedField(readFileSync(entry.file, "utf8"), entry.pointer);
+    return value === undefined ? "absent" : sha256Hex(JSON.stringify(value));
+  }
+  if (!existsSync(entry.path)) return "absent";
+  const stat = statSync(entry.path);
+  if (stat.isDirectory()) {
+    const { treeDigest } = await import("./red-skills-set.ts");
+    return treeDigest(entry.path);
+  }
+  return sha256Hex(readFileSync(entry.path));
+}
+
+/**
+ * The digest of everything this host's reconciliation is responsible for.
+ *
+ * Sorted by owned key, so the same state hashes the same however the plan
+ * happened to order it, and every absence is part of the digest rather than
+ * invisible to it: a generated directory somebody deleted has to move this
+ * number, or the next converge would skip the host that no longer has it.
+ */
+async function stateDigestOf(entries: readonly OwnedEntry[], witness: string): Promise<string> {
+  const lines: string[] = [];
+  for (const entry of entries) lines.push(`${ownedKey(entry)}\0${await observe(entry, witness)}`);
+  lines.sort();
+  return sha256Hex(`${lines.join("\n")}\n`);
+}
+
+// -------------------------------------------------------------- the outcome
+
+/** What happened to one host, in the vocabulary a caller has to distinguish. */
+export type HostStatus = "reconciled" | "current" | "absent" | "blocked" | "failed";
+
+export interface HostOutcome {
+  /** The host's name in HOST_ADAPTERS. */
   host: string;
-  /** True only when every command for this host succeeded. */
-  refreshed: boolean;
-  /** Why not, present exactly when `refreshed` is false. */
+  status: HostStatus;
+  /** The mechanism used, where one was chosen. */
+  mode?: AdapterMode;
+  /** Why, for everything that is not `reconciled`. */
   reason?: string;
+  /** Present when this converge verified the host. */
+  reload?: ReloadState;
+}
+
+/** Whether every required host converged. */
+export function reconciliationFailed(outcomes: readonly HostOutcome[]): boolean {
+  return outcomes.some((o) => o.status === "blocked" || o.status === "failed");
 }
 
 /**
  * Everything the walk needs from outside itself.
  *
- * All of it has a real default and exists for the tests: a refresh is a
- * sequence of commands issued to CLIs that may not be installed, against
- * a checkout that may not exist, and the thing worth pinning is which
- * commands ran and which did not.
+ * All of it has a real default and exists for the tests: reconciling is a
+ * sequence of commands issued to CLIs that may not be installed, against a
+ * set that may not exist, and the thing worth pinning is which commands ran
+ * and what was on disk afterwards.
  */
-export interface HostRefreshOptions {
-  /** Defaults to this user's home. The stamp lives under it. */
+export interface HostReconcileOptions {
+  /** Defaults to this user's home. The registry lives under it. */
   home?: string;
-  /** The resolved checkout. Defaults to `resolvedSource()`. */
+  /** Defaults to `$XDG_CONFIG_HOME`, then `<home>/.config`. */
+  config?: string;
+  /** The resolved package set. Defaults to `resolvedSource()`. */
   source?: string | null;
-  /** The plugin set. Defaults to whatever the manifest declares. */
+  /** The pointer the marketplace hosts register. Defaults to `~/.red-skills/current`. */
+  current?: string;
+  /** The set's whole-set digest. Defaults to the recorded or computed one. */
+  setDigest?: string;
+  /** The set's version. Defaults to the recorded one, or the directory name. */
+  setVersion?: string;
+  /** The activation set. Defaults to `dev`, out of what the manifest declares. */
   plugins?: readonly string[];
   /** The manifest to derive the plugin set from. Defaults to TOOLS. */
   tools?: readonly Tool[];
-  /** The hosts to walk. Defaults to REFRESH_HOSTS. */
-  hosts?: readonly SkillHostRefresh[];
+  /** The hosts to walk. Defaults to HOST_ADAPTERS. */
+  adapters?: readonly HostAdapter[];
   /** Is this host's command on PATH? Defaults to `commandPath`. */
   present?: (cmd: string) => boolean;
+  /** Is a session of it running right now? Defaults to a `pgrep` probe. */
+  running?: (cmd: string) => boolean;
   /** Runs one argv and answers its exit code. Defaults to spawnLogged. */
   run?: (cmd: string[]) => Promise<number>;
+  /** The time a record is stamped with. Defaults to now. */
+  now?: () => string;
 }
 
 function homeOf(): string {
@@ -263,29 +806,9 @@ function homeOf(): string {
   return h.replace(/\\/g, "/");
 }
 
-/** Computed rather than a constant: the tests move home between cases. */
-export function hostStampPath(home: string): string {
-  return `${home}/.local/share/red-dev/red-skills-hosts.json`;
-}
-
-export function readHostStamp(home: string): HostStamp {
-  const path = hostStampPath(home);
-  if (!existsSync(path)) return {};
-  try {
-    const parsed = JSON.parse(readFileSync(path, "utf8")) as unknown;
-    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) return {};
-    return parsed as HostStamp;
-  } catch {
-    // A stamp we cannot read means refresh, which is the safe way to be
-    // wrong: the cost is one extra walk, not a permanently stale host.
-    return {};
-  }
-}
-
-async function writeHostStamp(home: string, stamp: HostStamp): Promise<void> {
-  const path = hostStampPath(home);
-  mkdirSync(path.slice(0, path.lastIndexOf("/")), { recursive: true });
-  await Bun.write(path, `${JSON.stringify(stamp, null, 2)}\n`);
+function configOf(home: string): string {
+  const xdg = process.env["XDG_CONFIG_HOME"];
+  return xdg ? xdg.replace(/\\/g, "/") : `${home}/.config`;
 }
 
 /** `v3.4.0` out of the resolved path, for a log line a person reads. */
@@ -294,70 +817,308 @@ function versionOf(source: string): string {
 }
 
 /**
- * Refresh every host whose recorded checkout is not the one resolved now.
+ * The identity of the set this machine resolves.
  *
- * Answers one outcome per host in table order, including the hosts it
- * left alone — "absent", "already current" and "refused" are three
- * different facts and a caller that wants to report them needs to be able
- * to tell them apart.
- *
- * With no checkout at all there is nothing to refresh against, and that
- * is not a failure: it is the ordinary state of a machine before the mise
- * entry has installed the core. It answers with no outcomes at all.
+ * A revision the converge installed is immutable and already carries a
+ * recorded digest, so it is read rather than recomputed — hashing 25 MB on
+ * every converge to learn what a file already says would be the cost this
+ * gate exists to avoid. Anything else is hashed, and that is the case that
+ * matters: a development checkout is edited in place, keeps its path and
+ * has no recorded identity, so the only way to notice it moved is to look.
  */
-export async function refreshSkillHosts(
+async function setIdentity(home: string, source: string): Promise<{ digest: string; version: string }> {
+  try {
+    const { readPackageSetState } = await import("./red-skills-set.ts");
+    const state = readPackageSetState(home);
+    const active = state.revisions.find((r) => r.key === state.active);
+    if (active && samePath(active.path, source)) {
+      return { digest: active.digest, version: active.version };
+    }
+  } catch {
+    // No state, or one we cannot read: hash the tree and carry on.
+  }
+  const { treeDigest } = await import("./red-skills-set.ts");
+  return { digest: treeDigest(source), version: versionOf(source) };
+}
+
+function samePath(left: string, right: string): boolean {
+  const clean = (p: string) => p.replace(/\\/g, "/").replace(/\/+$/, "");
+  return clean(left) === clean(right);
+}
+
+// ----------------------------------------------------------------- the walk
+
+/**
+ * Reconcile every host whose observed state is not the one the set implies.
+ *
+ * Answers one outcome per host in table order, including the hosts it left
+ * alone — "absent", "already current", "blocked" and "failed" are four
+ * different facts and a caller that wants to report them has to be able to
+ * tell them apart.
+ *
+ * With no set at all there is nothing to reconcile against, and that is not
+ * a failure: it is the ordinary state of a machine before the mise entry
+ * has installed the core. It answers with no outcomes at all.
+ */
+export async function reconcileSkillHosts(
   p: Platform,
-  opts: HostRefreshOptions = {},
-): Promise<HostRefreshOutcome[]> {
+  opts: HostReconcileOptions = {},
+): Promise<HostOutcome[]> {
   const home = opts.home ?? homeOf();
-  const hosts = opts.hosts ?? REFRESH_HOSTS;
+  const adapters = opts.adapters ?? HOST_ADAPTERS;
 
   const source = opts.source !== undefined ? opts.source : await currentSource();
   if (source === null) {
-    log.skip("red-skills: not installed, no host to refresh");
+    log.skip("red-skills: not installed, no host to reconcile");
     return [];
   }
 
-  const plugins = opts.plugins ?? (await declaredPlugins(p, opts.tools));
+  const identity = opts.setDigest !== undefined && opts.setVersion !== undefined
+    ? { digest: opts.setDigest, version: opts.setVersion }
+    : await setIdentity(home, source);
+  const plugins = opts.plugins ?? activatedPlugins(await declaredPlugins(p, opts.tools));
   const present = opts.present ?? (await presenceProbe());
+  const running = opts.running ?? runningProbe;
   const run = opts.run ?? (await defaultRunner());
+  const now = opts.now ?? (() => new Date().toISOString());
 
-  const version = versionOf(source);
-  const stamp = readHostStamp(home);
-  const ctx: HostContext = { plugins, source };
-  const out: HostRefreshOutcome[] = [];
+  const ctx: AdapterContext = {
+    plugins,
+    source,
+    setDigest: opts.setDigest ?? identity.digest,
+    setVersion: opts.setVersion ?? identity.version,
+    current: opts.current ?? `${home}/.red-skills/current`,
+    home,
+    config: opts.config ?? configOf(home),
+  };
 
-  for (const host of hosts) {
-    if (!present(host.cmd)) {
-      // Deliberately not stamped: a host that arrives next week has to be
-      // refreshed then, and recording it now would say it already was.
-      out.push({ host: host.name, refreshed: false, reason: `${host.cmd} is not installed` });
+  const registry = readHostRegistry(home);
+  const out: HostOutcome[] = [];
+
+  for (const adapter of adapters) {
+    if (!present(adapter.cmd)) {
+      // Deliberately not recorded: a host that arrives next week has to be
+      // reconciled then, and recording it now would say it already was.
+      out.push({ host: adapter.name, status: "absent", reason: `${adapter.cmd} is not installed` });
       continue;
     }
 
-    if (stamp[host.name] === source) {
-      log.skip(`${host.name}: red-skills already refreshed at ${version}`);
-      out.push({ host: host.name, refreshed: false, reason: `already refreshed at ${version}` });
+    const desired = adapter.plan(ctx);
+    if (desired.blocked !== undefined) {
+      log.warn(`${adapter.name}: ${desired.blocked}`);
+      out.push({ host: adapter.name, status: "blocked", mode: desired.mode, reason: desired.blocked });
       continue;
     }
 
-    log.step(`${host.name}: refreshing red-skills against ${version}`);
-    const failure = await runSteps(host.wire(ctx), run);
-    if (failure !== null) {
-      // Reported and survived. The stamp keeps whatever it held, so the
+    const recorded = registry.hosts[adapter.name];
+    if (recorded && (await isCurrent(recorded, ctx, desired, adapter))) {
+      log.skip(`${adapter.name}: red-skills already at ${ctx.setVersion}`);
+      out.push({
+        host: adapter.name,
+        status: "current",
+        mode: recorded.mode,
+        reason: `already reconciled at ${ctx.setVersion}`,
+        reload: recorded.reload,
+      });
+      continue;
+    }
+
+    log.step(`${adapter.name}: reconciling red-skills against ${ctx.setVersion}`);
+    const applied = await applyPlan(desired, run);
+    if (applied.failure !== null) {
+      // Reported and survived. The record keeps whatever it held, so the
       // next converge asks this host again.
-      log.warn(`${host.name}: ${failure}`);
-      out.push({ host: host.name, refreshed: false, reason: failure });
+      log.warn(`${adapter.name}: ${applied.failure}`);
+      out.push({ host: adapter.name, status: "failed", mode: desired.mode, reason: applied.failure });
       continue;
     }
 
-    stamp[host.name] = source;
-    await writeHostStamp(home, stamp);
-    log.ok(`${host.name}: red-skills refreshed to ${version}`);
-    out.push({ host: host.name, refreshed: true });
+    const verified = await verifyPlan(adapter, ctx, desired, applied.owned);
+    if (!verified.ok) {
+      log.warn(`${adapter.name}: ${verified.reason}`);
+      out.push({ host: adapter.name, status: "failed", mode: desired.mode, reason: verified.reason });
+      continue;
+    }
+
+    // Never a signal, never a kill: a session that is up keeps its
+    // process and is told, in the record and in doctor, that what is on
+    // disk under it is newer than what it loaded.
+    const reload: ReloadState = running(adapter.cmd) ? "restart-needed" : "current";
+    registry.hosts[adapter.name] = {
+      setDigest: ctx.setDigest,
+      setVersion: ctx.setVersion,
+      mode: desired.mode,
+      plugins: [...plugins],
+      stateDigest: verified.stateDigest,
+      reload,
+      owned: verified.owned,
+      verifiedAt: now(),
+    };
+    await writeHostRegistry(home, registry);
+    log.ok(`${adapter.name}: red-skills reconciled to ${ctx.setVersion}`);
+    out.push({ host: adapter.name, status: "reconciled", mode: desired.mode, reload });
   }
 
   return out;
+}
+
+/**
+ * Whether a recorded host still has what the record says it has.
+ *
+ * Four questions, and any one of them answering no is a reconciliation. The
+ * set's digest, so an in-place edit to a checkout is caught where a path
+ * never moves. The activation set and the mode, so opting a plugin in or a
+ * generator arriving in the tree both take effect. And the observed digest
+ * of the owned state itself, which is the one the stamp could never ask:
+ * a cleared cache, a deleted generated directory or a config a second tool
+ * rewrote all show up here and nowhere else.
+ */
+async function isCurrent(
+  record: HostRecord,
+  ctx: AdapterContext,
+  desired: HostPlan,
+  adapter: HostAdapter,
+): Promise<boolean> {
+  if (record.setDigest !== ctx.setDigest) return false;
+  if (record.mode !== desired.mode) return false;
+  if (record.plugins.join("\0") !== ctx.plugins.join("\0")) return false;
+
+  const witness = adapter.check ? await adapter.check(ctx) : ({ ok: true, witness: "" } as HostCheck);
+  if (!witness.ok) return false;
+  return (await stateDigestOf(record.owned, witness.witness)) === record.stateDigest;
+}
+
+interface Applied {
+  /** The first hard failure, or null. */
+  failure: string | null;
+  /** What the plan turned out to own, discovered as it ran. */
+  owned: OwnedEntry[];
+}
+
+/** Run one host's plan: its commands, its files, then its owned fields. */
+async function applyPlan(desired: HostPlan, run: (cmd: string[]) => Promise<number>): Promise<Applied> {
+  const owned: OwnedEntry[] = [];
+
+  const failure = await runSteps(desired.steps, run);
+  if (failure !== null) return { failure, owned };
+
+  try {
+    for (const write of desired.writes) {
+      mkdirSync(dirname(write.path), { recursive: true });
+      // Compare-then-write: a converge that rewrites an unchanged file is
+      // a converge claiming work, and its mtime is a lie told to whoever
+      // reads it next.
+      if (!existsSync(write.path) || readFileSync(write.path, "utf8") !== write.bytes) {
+        await Bun.write(write.path, write.bytes);
+      }
+      owned.push({ kind: "path", path: write.path });
+    }
+
+    for (const copy of desired.copies) {
+      rmSync(copy.to, { recursive: true, force: true });
+      mkdirSync(dirname(copy.to), { recursive: true });
+      cpSync(copy.from, copy.to, { recursive: true });
+      owned.push({ kind: "path", path: copy.to });
+    }
+
+    for (const merge of desired.merges) {
+      owned.push(...(await applyMerge(merge)));
+    }
+  } catch (error) {
+    return { failure: `${(error as Error).message}`, owned };
+  }
+
+  owned.push(...desired.expect);
+  for (const manifest of desired.manifests) {
+    if (!existsSync(manifest)) continue;
+    owned.push({ kind: "path", path: manifest });
+    for (const path of manifestPaths(manifest)) owned.push({ kind: "path", path });
+  }
+
+  return { failure: null, owned: dedupe(owned) };
+}
+
+/**
+ * Splice one field into a file the user owns, and record what that cost.
+ *
+ * The parent object is recorded too, and only when this call had to create
+ * it: removing `mcpServers` because our entry was all it ever held is
+ * right, and removing it out from under a server the operator added later
+ * is the exact failure the ownership manifest exists to prevent.
+ */
+async function applyMerge(merge: OwnedMerge): Promise<OwnedEntry[]> {
+  const before = existsSync(merge.file) ? readFileSync(merge.file, "utf8") : "";
+  const parent = merge.pointer.slice(0, -1);
+  const madeParent = parent.length > 0 && readOwnedField(before, parent) === undefined;
+  const after = setOwnedField(before, merge.pointer, merge.value);
+  if (after !== before) {
+    mkdirSync(dirname(merge.file), { recursive: true });
+    await Bun.write(merge.file, after);
+  }
+  const entries: OwnedEntry[] = [{ kind: "field", file: merge.file, pointer: [...merge.pointer] }];
+  if (madeParent) entries.push({ kind: "field", file: merge.file, pointer: parent, onlyWhenEmpty: true });
+  return entries;
+}
+
+/** Every path a generator recorded, one per line, blank lines ignored. */
+function manifestPaths(manifest: string): string[] {
+  try {
+    return readFileSync(manifest, "utf8")
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0);
+  } catch {
+    return [];
+  }
+}
+
+interface Verified {
+  ok: boolean;
+  reason?: string;
+  stateDigest: string;
+  owned: OwnedEntry[];
+}
+
+/**
+ * Read the result back, and refuse to record anything less than all of it.
+ *
+ * A generator that recorded no manifest is unverifiable rather than done —
+ * there is no list of what it wrote, so there is nothing to observe now and
+ * nothing to remove later, and a record claiming otherwise would be the
+ * stamp again under a longer name.
+ */
+async function verifyPlan(
+  adapter: HostAdapter,
+  ctx: AdapterContext,
+  desired: HostPlan,
+  owned: readonly OwnedEntry[],
+): Promise<Verified> {
+  const empty = { ok: false, stateDigest: "", owned: [...owned] };
+
+  if (desired.manifests.length > 0 && !desired.manifests.some((m) => existsSync(m))) {
+    return { ...empty, reason: "the generator recorded no install manifest" };
+  }
+
+  const check = adapter.check ? await adapter.check(ctx) : ({ ok: true, witness: "" } as HostCheck);
+  if (!check.ok) return { ...empty, reason: check.reason };
+
+  for (const entry of owned) {
+    if (entry.kind === "path" && !existsSync(entry.path)) {
+      return { ...empty, reason: `${entry.path} was not written` };
+    }
+    if (entry.kind === "field") {
+      const text = existsSync(entry.file) ? readFileSync(entry.file, "utf8") : "";
+      if (readOwnedField(text, entry.pointer) === undefined) {
+        return { ...empty, reason: `${entry.file} has no ${entry.pointer.join(".")}` };
+      }
+    }
+  }
+
+  return {
+    ok: true,
+    stateDigest: await stateDigestOf(owned, check.witness),
+    owned: [...owned],
+  };
 }
 
 /** Runs one host's commands, and answers the first hard failure or null. */
@@ -387,79 +1148,203 @@ async function runSteps(
   return null;
 }
 
+// -------------------------------------------------------------- the removal
+
 /** What one host did on the way out, or the reason it did nothing. */
-export interface HostUnwireOutcome {
-  /** The host's name in REFRESH_HOSTS. */
+export interface HostRemoveOutcome {
+  /** The host's name in HOST_ADAPTERS. */
   host: string;
-  /** True only when every required command for this host succeeded. */
-  unwired: boolean;
-  /** Why not, present exactly when `unwired` is false. */
+  /** True only when every recorded piece of state is gone. */
+  removed: boolean;
+  /** Why not, present exactly when `removed` is false. */
   reason?: string;
+  /** What was taken out, as owned keys, for a caller that wants to say. */
+  took?: string[];
 }
 
 /**
- * Take RedSkills back out of every host on the machine.
+ * Take RedSkills back out of every host, using the record as the manifest.
  *
- * The generator hosts route through the same scripts that wired them,
- * which remove what their own manifest recorded and leave everything
- * else alone — see the header. Claude and Codex are the CLI calls that
- * undo the CLI calls above.
+ * The record is what makes this defensible. A host's config directory holds
+ * files nobody here put there, and the only list of what red-dev added is
+ * the one it wrote when it added them — so removal is that list, replayed,
+ * and never a guess about which paths under `~/.gemini` look like ours.
  *
- * With no checkout there is nothing to unwire *through*: the scripts
- * live in the tree, and this repo deliberately holds no second opinion
- * about which files RedSkills wrote. So a machine with no checkout is
- * left alone and says so, rather than being guessed at.
- *
- * A host that comes out has its stamp entry dropped. The stamp means
- * "this host has been refreshed against that checkout", which stops
- * being true the moment the host is unwired — leaving it would let the
- * next converge skip re-wiring a host that no longer has anything.
+ * The host's own commands run first where the package set is still on the
+ * machine, because a generator's `--uninstall` and a CLI's `marketplace
+ * remove` know things about their own stores that no path list does. But
+ * they are not required: a set that has already been pruned leaves the
+ * record standing, and everything red-dev owns still comes out.
  */
-export async function unwireSkillHosts(
+export async function removeSkillHosts(
   p: Platform,
-  opts: HostRefreshOptions = {},
-): Promise<HostUnwireOutcome[]> {
+  opts: HostReconcileOptions = {},
+): Promise<HostRemoveOutcome[]> {
   const home = opts.home ?? homeOf();
-  const hosts = opts.hosts ?? REFRESH_HOSTS;
-
+  const adapters = opts.adapters ?? HOST_ADAPTERS;
   const source = opts.source !== undefined ? opts.source : await currentSource();
-  if (source === null) {
-    log.skip("red-skills: not installed, no host to unwire");
-    return [];
-  }
-
-  const plugins = opts.plugins ?? (await declaredPlugins(p, opts.tools));
+  const plugins = opts.plugins ?? activatedPlugins(await declaredPlugins(p, opts.tools));
   const present = opts.present ?? (await presenceProbe());
   const run = opts.run ?? (await defaultRunner());
 
-  const ctx: HostContext = { plugins, source };
-  const stamp = readHostStamp(home);
-  const out: HostUnwireOutcome[] = [];
+  const registry = readHostRegistry(home);
+  const out: HostRemoveOutcome[] = [];
 
-  for (const host of hosts) {
-    if (!present(host.cmd)) {
-      out.push({ host: host.name, unwired: false, reason: `${host.cmd} is not installed` });
+  for (const adapter of adapters) {
+    const record = registry.hosts[adapter.name];
+    if (!record) {
+      out.push({ host: adapter.name, removed: false, reason: "nothing was recorded for it" });
       continue;
     }
 
-    log.step(`${host.name}: removing red-skills`);
-    const failure = await runSteps(host.unwire(ctx), run);
-    if (failure !== null) {
-      log.warn(`${host.name}: ${failure}`);
-      out.push({ host: host.name, unwired: false, reason: failure });
-      continue;
+    log.step(`${adapter.name}: removing red-skills`);
+    if (source !== null && present(adapter.cmd)) {
+      const ctx: AdapterContext = {
+        plugins,
+        source,
+        setDigest: record.setDigest,
+        setVersion: record.setVersion,
+        current: opts.current ?? `${home}/.red-skills/current`,
+        home,
+        config: opts.config ?? configOf(home),
+      };
+      const failure = await runSteps(adapter.remove(ctx), run);
+      if (failure !== null) {
+        log.warn(`${adapter.name}: ${failure}`);
+        out.push({ host: adapter.name, removed: false, reason: failure });
+        continue;
+      }
     }
 
-    if (host.name in stamp) {
-      delete stamp[host.name];
-      await writeHostStamp(home, stamp);
-    }
-    log.ok(`${host.name}: red-skills removed`);
-    out.push({ host: host.name, unwired: true });
+    const took = removeOwned(record.owned);
+    delete registry.hosts[adapter.name];
+    await writeHostRegistry(home, registry);
+    log.ok(`${adapter.name}: red-skills removed`);
+    out.push({ host: adapter.name, removed: true, took });
   }
 
   return out;
 }
+
+/**
+ * Remove exactly what a record names, deepest first.
+ *
+ * Fields before their parents, and a parent only while nothing else is left
+ * in it — which is `onlyWhenEmpty`, and the only version of "take the block
+ * we made" with a safe answer. `host` entries name state inside an
+ * application's own store; the commands above are what removes those, and
+ * listing them here is how a caller can say what was asked for.
+ */
+function removeOwned(owned: readonly OwnedEntry[]): string[] {
+  const took: string[] = [];
+  const fields = owned.filter((e) => e.kind === "field");
+  const ordered = [
+    ...owned.filter((e) => e.kind === "path"),
+    ...fields.filter((e) => e.onlyWhenEmpty !== true),
+    ...fields.filter((e) => e.onlyWhenEmpty === true),
+  ];
+
+  for (const entry of ordered) {
+    if (entry.kind === "path") {
+      if (!existsSync(entry.path)) continue;
+      rmSync(entry.path, { recursive: true, force: true });
+      took.push(ownedKey(entry));
+      continue;
+    }
+    if (!existsSync(entry.file)) continue;
+    const before = readFileSync(entry.file, "utf8");
+    const after = dropOwnedField(before, entry.pointer, { onlyWhenEmpty: entry.onlyWhenEmpty === true });
+    if (after === before) continue;
+    mkdirSync(dirname(entry.file), { recursive: true });
+    writeFileSync(entry.file, after);
+    took.push(ownedKey(entry));
+  }
+
+  for (const entry of owned) if (entry.kind === "host") took.push(ownedKey(entry));
+  return took;
+}
+
+// ---------------------------------------------------------------- the report
+
+/** What doctor says about one host, as data. */
+export interface HostDoctorRow {
+  host: string;
+  mode: AdapterMode;
+  /** The package set it was reconciled against. */
+  setDigest: string;
+  setVersion: string;
+  /** The state that reconciliation owns, as observed when it verified. */
+  stateDigest: string;
+  plugins: string[];
+  reload: ReloadState;
+  verifiedAt: string;
+}
+
+export interface HostDoctorReport {
+  hosts: HostDoctorRow[];
+  /** Adapters with no record at all, in table order. */
+  unrecorded: string[];
+}
+
+/**
+ * What the registry says, as JSON rather than as lines.
+ *
+ * The facts a person needs when two machines disagree — which set each host
+ * observed, through which mechanism, over what state, and whether anything
+ * still has to be restarted — are also the facts a script needs, and
+ * rendering them twice is how the two answers start to differ.
+ */
+export function redSkillsHostReport(
+  home: string,
+  adapters: readonly HostAdapter[] = HOST_ADAPTERS,
+): HostDoctorReport {
+  const registry = readHostRegistry(home);
+  const hosts: HostDoctorRow[] = [];
+  const unrecorded: string[] = [];
+  for (const adapter of adapters) {
+    const record = registry.hosts[adapter.name];
+    if (!record) {
+      unrecorded.push(adapter.name);
+      continue;
+    }
+    hosts.push({
+      host: adapter.name,
+      mode: record.mode,
+      setDigest: record.setDigest,
+      setVersion: record.setVersion,
+      stateDigest: record.stateDigest,
+      plugins: record.plugins,
+      reload: record.reload,
+      verifiedAt: record.verifiedAt,
+    });
+  }
+  return { hosts, unrecorded };
+}
+
+export interface HostDoctorLine {
+  status: "ok" | "warn" | "n/a";
+  detail: string;
+}
+
+/** The report as the lines doctor prints. */
+export function redSkillsHostRows(report: HostDoctorReport): HostDoctorLine[] {
+  const rows: HostDoctorLine[] = report.hosts.map((row) => ({
+    status: row.reload === "restart-needed" ? "warn" : "ok",
+    detail:
+      `${row.host} (${row.mode}) — ${row.setVersion} ${row.setDigest.slice(0, 12)}, ` +
+      `state ${row.stateDigest.slice(0, 12)}, ${row.plugins.join(", ") || "no plugin"} activated` +
+      (row.reload === "restart-needed" ? " — restart needed to load it" : ""),
+  }));
+  if (report.unrecorded.length > 0) {
+    rows.push({
+      status: "n/a",
+      detail: `no observed record yet: ${report.unrecorded.join(", ")}`,
+    });
+  }
+  return rows;
+}
+
+// ------------------------------------------------------------- the defaults
 
 async function currentSource(): Promise<string | null> {
   const { resolvedSource } = await import("./red-skills-ext.ts");
@@ -479,4 +1364,22 @@ async function presenceProbe(): Promise<(cmd: string) => boolean> {
 async function defaultRunner(): Promise<(cmd: string[]) => Promise<number>> {
   const { spawnLogged } = await import("./providers.ts");
   return (cmd: string[]) => spawnLogged(cmd);
+}
+
+/**
+ * Is a session of this host up right now?
+ *
+ * Only ever used to say "restart needed" — nothing here signals or waits
+ * for anything, because plugin freshness does not justify interrupting
+ * somebody's work. A probe that cannot run answers no, which reports one
+ * fewer restart than the machine needs rather than inventing one it does
+ * not.
+ */
+function runningProbe(cmd: string): boolean {
+  try {
+    const probe = Bun.spawnSync(["pgrep", "-x", cmd], { stdout: "ignore", stderr: "ignore" });
+    return probe.exitCode === 0;
+  } catch {
+    return false;
+  }
 }

--- a/src/red-skills-plugins.ts
+++ b/src/red-skills-plugins.ts
@@ -69,3 +69,25 @@ export function redSkillsPluginEntries(
 export function redSkillsPluginNames(p: Platform, tools: readonly Tool[] = TOOLS): string[] {
   return redSkillsPluginEntries(p, tools).map((e) => e.spec.slice(REDSKILLS_PLUGIN_PREFIX.length));
 }
+
+/**
+ * The one plugin switched on in the coder hosts.
+ *
+ * Spec #201 draws the line here: the package set carries every payload, so
+ * that activating another one later is a flag rather than a download, and
+ * exactly one of them is switched on. `dev` is the global process surface
+ * everybody wants; Memory, Brain and the maintainer-only behaviour must not
+ * start acting on a machine because they happened to be in the tarball.
+ *
+ * It lives beside the manifest projection rather than beside the host
+ * adapters because both sides need it and neither may own it: the set is
+ * composed with an activation config that says which plugins the
+ * generators render, and the hosts are handed the same set to install. Two
+ * spellings of "only dev" is one more pair that can disagree.
+ */
+export const ACTIVATED_PLUGIN = "dev";
+
+/** The activation set, out of everything the machine carries locally. */
+export function activatedPlugins(declared: readonly string[]): string[] {
+  return declared.filter((name) => name === ACTIVATED_PLUGIN);
+}

--- a/src/red-skills-set.test.ts
+++ b/src/red-skills-set.test.ts
@@ -39,6 +39,7 @@ import { sha256Hex } from "./checksum.ts";
 import { providerFor, TOOLS } from "./manifest.ts";
 import { miseEntries, miseToolNames, renderMiseConfig } from "./mise-config.ts";
 import type { Platform } from "./platform.ts";
+import { activatedPlugins } from "./red-skills-plugins.ts";
 import {
   candidateFromMise,
   composeSet,
@@ -254,15 +255,35 @@ function fakeManifestSet(opts: {
   return dir;
 }
 
-/** The cosign binary, wherever this machine keeps it. */
+/**
+ * The cosign binary, wherever this machine keeps it.
+ *
+ * A mise shim is resolved to the executable behind it while the resolving
+ * still works. The signing case below hands cosign a HOME of its own so
+ * the throwaway key lands in a temporary directory — and a HOME with no
+ * mise config in it is a HOME where the shim answers "cosign is not a
+ * valid shim" instead of signing anything. Asking mise now, with the real
+ * environment still in place, is the difference between a test that
+ * exercises cosign and one that reports the machine as broken.
+ */
 function findCosign(): string {
   const onPath = Bun.which("cosign");
+  if (onPath && !onPath.includes("/mise/shims/")) return onPath;
+  const resolved = miseWhich("cosign");
+  if (resolved) return resolved;
   if (onPath) return onPath;
   const shim = join(homedir(), ".local", "share", "mise", "shims", "cosign");
   if (existsSync(shim)) return shim;
   throw new Error(
     "cosign is required for these tests: `mise use -g cosign` (it is a core manifest entry, and CI installs it)",
   );
+}
+
+/** What mise says a shimmed tool actually is, or null when it cannot say. */
+function miseWhich(tool: string): string | null {
+  const answer = spawnSync("mise", ["which", tool], { encoding: "utf8" });
+  const path = answer.status === 0 ? answer.stdout.trim() : "";
+  return path.length > 0 && existsSync(path) ? path : null;
 }
 
 // ------------------------------------------------------------- the entries
@@ -483,8 +504,12 @@ describe("the composed set", () => {
     // And the asset the memory bundle lazily loads beside itself.
     expect(existsSync(join(tree, "dist", "memory-tokenizer.asset.cjs"))).toBe(true);
     expect(existsSync(join(tree, "dist", "opencode-host.bundle.min.mjs"))).toBe(true);
-    // The activation config the OpenCode generator dies without.
-    expect(readFileSync(join(tree, ".red", "config.yaml"), "utf8")).toBe(hostActivationConfig(PLUGINS));
+    // The activation config the OpenCode generator dies without, naming
+    // every payload the set carries and enabling the one Spec #201
+    // activates.
+    expect(readFileSync(join(tree, ".red", "config.yaml"), "utf8")).toBe(
+      hostActivationConfig(PLUGINS, activatedPlugins(PLUGINS)),
+    );
     // And the generators runnable: an npm tarball drops the bit, and the
     // host refresh spawns them by path.
     for (const script of ["install-opencode.sh", "install-pi.sh"]) {
@@ -492,9 +517,17 @@ describe("the composed set", () => {
     }
   });
 
-  test("the activation config enables exactly the plugins the set carries", () => {
-    expect(hostActivationConfig(["dev", "memory"])).toContain("plugins:\n  dev:\n    enabled: true\n  memory:\n    enabled: true\n");
-    expect(hostActivationConfig(["dev"])).not.toContain("memory");
+  test("the activation config names every payload and enables only dev", () => {
+    // Both halves are load-bearing. Naming a payload the set carries is
+    // what makes switching it on later a flag rather than a download;
+    // enabling only `dev` is what stops Memory and Brain acting on a
+    // machine because they happened to be in the tarball.
+    const carried = ["dev", "memory"];
+    expect(hostActivationConfig(carried, activatedPlugins(carried))).toContain(
+      "plugins:\n  dev:\n    enabled: true\n  memory:\n    enabled: false\n",
+    );
+    expect(hostActivationConfig(["dev"], ["dev"])).not.toContain("memory");
+    expect(activatedPlugins(["dev", "memory", "brain"])).toEqual(["dev"]);
   });
 
   test("nothing inside the set is a link into mise's tree", () => {

--- a/src/red-skills-set.ts
+++ b/src/red-skills-set.ts
@@ -113,7 +113,11 @@ import { sha256Hex } from "./checksum.ts";
 import { log } from "./log.ts";
 import { miseInstallRoot } from "./mise-config.ts";
 import type { Platform } from "./platform.ts";
-import { REDSKILLS_PLUGIN_PREFIX, redSkillsPluginNames } from "./red-skills-plugins.ts";
+import {
+  activatedPlugins,
+  REDSKILLS_PLUGIN_PREFIX,
+  redSkillsPluginNames,
+} from "./red-skills-plugins.ts";
 
 // ------------------------------------------------------------- the names
 
@@ -741,8 +745,20 @@ export function candidateFromMise(installsRoot: string, plugins: readonly string
  * enables nothing inside any project. It is the ADR 0067 opt-in gate
  * for the plugins the composed set carries, written once beside the
  * tree, exactly as the standalone installer writes it. PURE.
+ *
+ * Every plugin the set carries gets a row, and only the activated ones
+ * get a true. That distinction is the whole of Spec #201's "every payload
+ * is installed, `dev` is activated": omitting the others would make
+ * switching one on a download again, and enabling them would start Memory
+ * and Brain acting on a machine because they were in the tarball. The
+ * generators read these flags, which is how the three hosts red-dev does
+ * not hand a plugin list to are held to the same activation as the four
+ * it does.
  */
-export function hostActivationConfig(plugins: readonly string[]): string {
+export function hostActivationConfig(
+  plugins: readonly string[],
+  activated: readonly string[] = plugins,
+): string {
   const lines = [
     "# Written by red-dev: activation flags for the host-install generator",
     "# (opencode-host) over the composed RedSkills package set. Not a",
@@ -750,7 +766,9 @@ export function hostActivationConfig(plugins: readonly string[]): string {
     "# nothing inside any project.",
     "plugins:",
   ];
-  for (const name of plugins) lines.push(`  ${name}:`, "    enabled: true");
+  for (const name of plugins) {
+    lines.push(`  ${name}:`, `    enabled: ${activated.includes(name)}`);
+  }
   return `${lines.join("\n")}\n`;
 }
 
@@ -797,7 +815,8 @@ export function composeSet(
   const config = join(dest, ".red", "config.yaml");
   if (!existsSync(config)) {
     mkdirSync(dirname(config), { recursive: true });
-    writeFileSync(config, hostActivationConfig(Object.keys(candidate.plugins)), "utf8");
+    const carried = Object.keys(candidate.plugins);
+    writeFileSync(config, hostActivationConfig(carried, activatedPlugins(carried)), "utf8");
   }
   restoreScriptModes(dest);
   return { ok: true };


### PR DESCRIPTION
Automated AFK landing for #204. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #204

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/218"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789681541&installation_model_id=20659&pr_number=218&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F218&signature=25ca16ebd6f85eb370a714275c93a183362fc2589c64be501b2a73a7d51c0319"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->