### PR TITLE
fix: #206 A checkout override builds missing assets into immutable staging

### DIFF
--- a/.red/adr/0013-a-development-checkout-is-a-content-identity-not-a-release.md
+++ b/.red/adr/0013-a-development-checkout-is-a-content-identity-not-a-release.md
@@ -1,0 +1,117 @@
+# 0013 — A development checkout is a content identity, not a release
+
+- Status: accepted
+- Date: 2026-08-18
+- Contexts: `agents`, `provisioning`, `lifecycle`
+- Refines: ADR 0010 (the local mise plugin), ADR 0011 (what a package set is), ADR 0012 (one acquisition, dispatched into)
+- Sources: red-dev #206; Spec #201; mise's `path:` tool selector
+
+## Context
+
+ADR 0012 gives this machine exactly one acquisition: a channel resolves to a
+commit, the commit is archived into an immutable snapshot, that commit's release
+assets are overlaid, the signed manifest is verified, and only then does
+`current` move. Every one of those steps is a statement about something somebody
+published.
+
+None of them is true of the tree a person is editing. A working checkout has no
+release to resolve, frequently no tag, usually uncommitted edits, and never a
+signature — so the acquisition would refuse it four times over. Yet the tree a
+person is editing is precisely what they need this machine to resolve while they
+edit it, and the alternative they reach for otherwise is a symlink into
+`~/.red-skills/current`, which puts a mutable directory behind a pointer the
+whole machine treats as immutable.
+
+The other half of the context is what a checkout must not cost. The bytes belong
+to Git and to the package manager: a build that writes `dist/` into the working
+tree makes the developer's `git status` dirty because red-dev ran, and a sync
+that touched `node_modules` would be red-dev acting inside a directory it does
+not own.
+
+## Decision
+
+**A checkout is admitted through its own door, and the door is narrow.** It is
+spelled `path:<dir>` — mise's own word for the same thing — and it is refused
+unless spelled that way, because a bare directory name and a channel name are
+both just words and a selector that guessed between them would install a release
+for a typo'd path.
+
+**The identity is the content, and never the path.** A revision key is
+`<version>-dev.<content8>+<content12>`, where the content is a sha256 over the
+checkout's source: the same walk and the same relative paths a composed set is
+digested with, minus `.git` and `node_modules`. Two directories holding the same
+bytes are therefore one revision, and a machine that synced one has nothing to do
+for the other. A key derived from where a directory happens to sit would change
+when somebody moved it, and every downstream comparison — is this active, is it
+staged, were the hosts reconciled against it — would silently be answering about
+a path.
+
+`.git` is excluded because it is version-control state rather than content: a
+`git status` writes an index, and an identity that moved when you *looked* at the
+repository would be no identity. `node_modules` is excluded because it belongs to
+the package manager.
+
+**The version says `dev`, everywhere a version is printed.** `3.20.0` becomes
+`3.20.0-dev.4f2c81ae`. A checkout that borrowed the bare version would be
+indistinguishable, in the state file and in `red-dev doctor`, from the release it
+was branched from — and the point of the override is to run something that is not
+that release. The revision is recorded as `kind: "checkout"`, `trust: "unsigned"`,
+and doctor prints it as a development checkout rather than as a published set.
+
+**Same commit, or built here.** A checkout that is clean at a commit reuses that
+commit's published bundles: they describe exactly these bytes, and reusing them
+is one download instead of a build. A checkout with uncommitted edits reuses
+nothing — those bundles describe bytes that are no longer there, and overlaying
+them would produce a tree whose source says one thing and whose bundles say
+another, which is the cross-commit failure ADR 0012 refuses under a different
+name. Assets declaring some *other* commit are refused outright, exactly as they
+are online, and the refusal is recorded in `~/.red-skills/package-set.json` so
+doctor can say why hours later.
+
+**The build runs in the staging, so the checkout never moves.** The source is
+copied into `~/.red-skills/checkouts/<key>/tree` and the checkout's own `build`
+script runs *there*. Its own script rather than one red-dev knows how to perform:
+red-dev has no opinion about how RedSkills is bundled, and one written here would
+be a second build to keep in step with the repository's. The content digest is
+recomputed when the staging is finished and the sync refuses if it moved, which
+makes "the checkout is byte-for-byte unchanged" a property of the code rather
+than a promise about it.
+
+**Staging is keyed by the digest, so a second sync with no edits does nothing.**
+A staging directory carries a receipt naming its own key, written last and
+renamed into place, so an interrupted build is a directory with no receipt and is
+rebuilt rather than activated. A staging whose key matches is reused whole: no
+copy, no download, no build — and the activation then writes nothing, because
+`current` already resolves to that revision and the reconciliation stamp already
+names it.
+
+**Only an explicit `red-dev red-skills sync <path>` advances a checkout.** The
+mise plugin's install phase recognises a `path:` override and acquires nothing:
+mise's job is to record which version a tool is on, and a working tree moves for
+reasons mise has no way to see, so a `mise upgrade` that "advanced" one would be
+advancing it to whatever it already was while reporting an install. `red-dev
+update` leaves it too — an unpinned update on a machine resolving a checkout
+returns before it reaches the remote. Naming a revision explicitly
+(`red-dev red-skills install 3.19.5`) still leaves the override, because that is
+a person asking to go back.
+
+## Consequences
+
+- `red-dev doctor` gains a third kind of active revision, and a machine on a
+  checkout reads as a warning rather than as an error: unsigned is the accurate
+  thing to say about a tree nobody published, and the verified revision it
+  displaced stays retained as the rollback.
+- The downgrade guard — an unsigned composed set may not replace a verified one —
+  deliberately does not apply here. That guard exists so a set nobody asked for
+  cannot displace a verified one; a checkout is the one candidate somebody asked
+  for by name.
+- `~/.red-skills/checkouts/` grows with what a developer edits rather than with
+  what is released, so it is held to the same retention the revisions are: the
+  active staging and its rollback.
+- A checkout that carries no `build` script, or whose build produces no bundles,
+  is refused with that sentence. That is a one-line fix in the tree rather than a
+  mystery about a missing bundle at the first host launch.
+- The sync costs one full content walk of the checkout on every invocation, twice
+  when it stages. That is what buys a path-independent identity and the
+  unchanged-checkout proof; a mtime-based shortcut would be faster and would be
+  wrong the first time two machines disagreed.

--- a/README.md
+++ b/README.md
@@ -479,6 +479,7 @@ red-dev agents default codex # change it
 red-dev agents run           # start the Default agent
 red-dev agents update        # refresh each host by its publisher's mechanism
 red-dev red-skills install [selector] # acquire the package set: stable | next | version | commit
+red-dev red-skills sync <path> # run a development checkout, built into staging, never a release
 red-dev red-skills reconcile # wire the hosts against the active package set, once
 red-dev share [path]         # one directory both WSL and Windows read
 red-dev share adopt <tool>   # move that tool's configuration into it

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -210,16 +210,17 @@ export function buildCli(): CLI {
         // rather than `scope`, which would reject `install` as an
         // invalid scope and print the wrong list of words.
         description:
-          "acquire the RedSkills package set: list-all, latest-stable, install [selector], reconcile",
+          "acquire the RedSkills package set: list-all, latest-stable, install [selector], sync <path>, reconcile",
         positional: [
           {
             name: "phase",
-            description: "list-all, latest-stable, install, reconcile",
+            description: "list-all, latest-stable, install, sync, reconcile",
             required: false,
           },
           {
             name: "selector",
-            description: "with `install`: stable, next, a version, or a commit",
+            description:
+              "with `install`: stable, next, a version, or a commit; with `sync`: a development checkout",
             required: false,
           },
         ],

--- a/src/main.ts
+++ b/src/main.ts
@@ -781,14 +781,48 @@ async function cmdPrivileged(p: Platform, inv: Invocation): Promise<number> {
 async function cmdRedSkills(p: Platform, inv: Invocation): Promise<number> {
   const { isPluginPhase, PLUGIN_PHASES, runPluginPhase } = await import("./red-skills-mise-plugin.ts");
   const phase = inv.redSkillsPhase ?? "install";
+
+  // `sync` is red-dev's own, and is not one of the plugin's scripts on
+  // purpose: a development checkout moves for reasons mise cannot see,
+  // so nothing mise runs may advance one. See src/red-skills-checkout.ts.
+  if (phase === "sync") return await cmdRedSkillsSync(p, inv);
+
   if (!isPluginPhase(phase)) {
-    log.err(`unknown phase '${phase}' (expected: ${PLUGIN_PHASES.join(", ")})`);
+    log.err(`unknown phase '${phase}' (expected: ${[...PLUGIN_PHASES, "sync"].join(", ")})`);
     return 1;
   }
   return await runPluginPhase(phase, {
     manifestPlatform: p,
     ...(inv.redSkillsSelector ? { selector: inv.redSkillsSelector } : {}),
   });
+}
+
+/**
+ * Sync one development checkout, and reconcile the hosts against it.
+ *
+ * The explicit operation the override requires: a content identity read
+ * off the checkout, a digest-keyed staging built once and reused after,
+ * and the same reconciliation stamp every other acquisition is gated on
+ * — so a second sync with no edits in between writes nothing at all.
+ */
+async function cmdRedSkillsSync(p: Platform, inv: Invocation): Promise<number> {
+  const dir = inv.redSkillsSelector;
+  if (!dir) {
+    log.err("red-skills sync needs the checkout to sync: `red-dev red-skills sync <path>`");
+    return 1;
+  }
+
+  const { announceCheckout, syncRedSkillsCheckout } = await import("./red-skills-checkout.ts");
+  const { reconcileRedSkills } = await import("./red-skills-acquire.ts");
+
+  const synced = await syncRedSkillsCheckout({ dir, manifestPlatform: p });
+  announceCheckout(synced);
+  if (synced.outcome === "refused") return 1;
+
+  const reconciled = await reconcileRedSkills({ manifestPlatform: p });
+  if (reconciled.reconciled) log.ok(`red-skills: ${reconciled.reason}`);
+  else log.skip(`red-skills: ${reconciled.reason}`);
+  return 0;
 }
 
 /**

--- a/src/red-skills-acquire.ts
+++ b/src/red-skills-acquire.ts
@@ -837,6 +837,12 @@ export async function acquireRedSkills(opts: AcquireOptions = {}): Promise<Acqui
   const run = opts.run ?? systemRunner;
   const url = opts.url ?? REDSKILLS_GIT_URL;
   const raw = opts.selector ?? env[CHANNEL_ENV] ?? DEFAULT_CHANNEL;
+  // Whether a revision was *asked* for, as against defaulted to. The
+  // difference decides what happens on a machine resolving a
+  // development checkout: `red-dev red-skills install 3.19.5` is a
+  // person leaving the override, and an unpinned `red-dev update` is
+  // not — see the checkout short-cut below.
+  const pinned = opts.selector !== undefined || env[CHANNEL_ENV] !== undefined;
 
   /**
    * Every ending that is not an activation, in one shape.
@@ -879,6 +885,24 @@ export async function acquireRedSkills(opts: AcquireOptions = {}): Promise<Acqui
       `'${raw}' is not a channel (${CHANNELS.join(", ")}), a version, or a 40-character commit`,
       "manifest",
     );
+  }
+
+  // Before the network, because a machine on a development checkout has
+  // nothing to ask the remote. `red-dev update` runs this on every run
+  // with no selector, and an update that replaced somebody's working
+  // tree with `stable` would be an update that undid the override it was
+  // never told about. Naming a revision explicitly still leaves it.
+  if (!pinned) {
+    const override = activeCheckoutRevision(home);
+    if (override) {
+      return nothing(
+        "current",
+        `this machine resolves the development checkout ${override.key} — ` +
+          "`red-dev red-skills sync <path>` advances it",
+        null,
+        { selector, active: activeIdentityOf(home) },
+      );
+    }
   }
 
   const listed = listRemoteRevisions(run, url);
@@ -1150,6 +1174,19 @@ export function announce(a: Acquisition): void {
 }
 
 // ------------------------------------------------------------------ details
+
+/**
+ * The active revision when it is a development checkout, or null.
+ *
+ * Read from the state file rather than tracked here, because the
+ * override is a fact about what this machine resolves and the state
+ * file is where that fact already lives.
+ */
+function activeCheckoutRevision(home: string): { key: string } | null {
+  const state = readPackageSetState(home);
+  const active = state.revisions.find((r) => r.key === state.active);
+  return active && active.kind === "checkout" ? { key: active.key } : null;
+}
 
 function activeIdentityOf(home: string): PackageSetIdentity | null {
   const state = readPackageSetState(home);

--- a/src/red-skills-checkout.test.ts
+++ b/src/red-skills-checkout.test.ts
@@ -1,0 +1,551 @@
+/**
+ * A development checkout: what identifies it, what it reuses, what it
+ * builds, and what it is never allowed to touch.
+ *
+ * The fixtures are real directories, because every property here is a
+ * property of bytes on disk. Two copies of one checkout in two temp
+ * directories prove the identity is content and not path; a checkout
+ * whose digest is taken before and after a sync proves the acceptance
+ * criterion the whole design exists for — a build that writes into the
+ * tree somebody is editing would pass every other test in this file.
+ *
+ * `git` is faked for the identity's two questions (`rev-parse`, `status
+ * --porcelain`) so a fixture can be dirty, clean, or not a repository at
+ * all without a repository being created for each; the build is faked
+ * the same way and writes the bundles a real `bun run build` would, so
+ * the sequence — reuse what the commit published, build only the rest —
+ * is exercised rather than short-circuited.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { sha256Hex } from "./checksum.ts";
+import { captureTo } from "./log.ts";
+import { directoryAssetProvider, type AssetProvider, type CommandRunner } from "./red-skills-acquire.ts";
+import {
+  checkoutAssetGaps,
+  checkoutDigest,
+  checkoutExcludes,
+  checkoutIdentity,
+  checkoutLabel,
+  checkoutPathOf,
+  readCheckoutReceipt,
+  redSkillsCheckoutDir,
+  syncRedSkillsCheckout,
+  type AssetBuilder,
+} from "./red-skills-checkout.ts";
+import { runPluginPhase } from "./red-skills-mise-plugin.ts";
+import {
+  createPackageSetManifest,
+  encodePackageSet,
+  readPackageSetState,
+  redSkillsCurrentLink,
+  redSkillsSetReport,
+  redSkillsSetRows,
+  SET_BUNDLE_NAME,
+  SET_MANIFEST_NAME,
+  treeDigest,
+} from "./red-skills-set.ts";
+
+const COMMIT_A = "a".repeat(40);
+const COMMIT_B = "b".repeat(40);
+
+/** Run something with the log redirected into nothing. */
+async function quiet<T>(fn: () => T | Promise<T>): Promise<T> {
+  const release = captureTo(() => {});
+  try {
+    return await fn();
+  } finally {
+    release();
+  }
+}
+
+// ------------------------------------------------------------- the fixtures
+
+/**
+ * A RedSkills checkout on disk: the payload contract every set must
+ * carry, plus whatever the test wants to differ.
+ */
+function checkout(extra: Record<string, string> = {}, version = "3.20.0"): string {
+  const dir = mkdtempSync(join(tmpdir(), "red-checkout-"));
+  const files: Record<string, string> = {
+    "package.json": `${JSON.stringify({ name: "@reddb-io/red-skills", version, scripts: { build: "bun run bundle" } }, null, 2)}\n`,
+    ".claude-plugin/marketplace.json": `${JSON.stringify({ name: "red-skills", plugins: [] })}\n`,
+    ".agents/plugins/marketplace.json": `${JSON.stringify({ name: "red-skills", plugins: [] })}\n`,
+    "bin/red-skills.mjs": "// shim\n",
+    "scripts/install-opencode.sh": "#!/bin/bash\n",
+    "scripts/install-pi.sh": "#!/bin/bash\n",
+    "src/dev.ts": "export const dev = 1;\n",
+    ...extra,
+  };
+  for (const [rel, contents] of Object.entries(files)) {
+    mkdirSync(join(dir, rel, ".."), { recursive: true });
+    writeFileSync(join(dir, rel), contents);
+  }
+  return dir;
+}
+
+/** A `git` that answers the two questions the identity asks, and nothing else. */
+function fakeGit(opts: { commit?: string | null; dirty?: boolean } = {}): CommandRunner {
+  const commit = opts.commit === undefined ? COMMIT_A : opts.commit;
+  return (argv) => {
+    if (argv[0] === "git" && argv[3] === "rev-parse") {
+      return commit === null
+        ? { code: 128, stdout: "", stderr: "fatal: not a git repository" }
+        : { code: 0, stdout: `${commit}\n`, stderr: "" };
+    }
+    if (argv[0] === "git" && argv[3] === "status") {
+      return { code: 0, stdout: opts.dirty ? " M src/dev.ts\n" : "", stderr: "" };
+    }
+    return { code: 1, stdout: "", stderr: `unexpected command: ${argv.join(" ")}` };
+  };
+}
+
+/** A build that writes the bundles the checkout's own `bun run build` would. */
+function fakeBuild(): { build: AssetBuilder; calls: BuildCall[] } {
+  const calls: BuildCall[] = [];
+  const build: AssetBuilder = (req) => {
+    calls.push({ tree: req.tree, missing: [...req.missing] });
+    mkdirSync(join(req.tree, "dist"), { recursive: true });
+    for (const name of req.missing) writeFileSync(join(req.tree, "dist", name), `// built ${name}\n`);
+    return { ok: true, built: [...req.missing] };
+  };
+  return { build, calls };
+}
+
+interface BuildCall {
+  tree: string;
+  missing: string[];
+}
+
+/** A published release's assets on disk, exactly as a release directory has them. */
+function assetsDir(commit: string, artifacts: Record<string, string>): string {
+  const dir = mkdtempSync(join(tmpdir(), "red-checkout-assets-"));
+  mkdirSync(join(dir, "artifacts"), { recursive: true });
+  const declared = Object.entries(artifacts).map(([name, bytes]) => {
+    writeFileSync(join(dir, "artifacts", name), bytes);
+    return { name, size: Buffer.byteLength(bytes), sha256: sha256Hex(bytes) };
+  });
+  writeFileSync(join(dir, SET_MANIFEST_NAME), encodePackageSet(createPackageSetManifest(commit, declared)));
+  writeFileSync(join(dir, SET_BUNDLE_NAME), "{}\n");
+  return dir;
+}
+
+function assetsFor(map: Record<string, string>): AssetProvider {
+  return async (req) => {
+    const dir = map[req.commit];
+    if (!dir) return { kind: "unavailable", reason: `nothing published for ${req.commit.slice(0, 12)}` };
+    return directoryAssetProvider(dir)(req);
+  };
+}
+
+function fakeHome(): string {
+  return mkdtempSync(join(tmpdir(), "red-checkout-home-"));
+}
+
+/** Everything a sync needs with no network, no cosign and no real build. */
+function sync(
+  home: string,
+  dir: string,
+  extra: Partial<Parameters<typeof syncRedSkillsCheckout>[0]> = {},
+) {
+  const built = fakeBuild();
+  return syncRedSkillsCheckout({
+    home,
+    dir,
+    run: fakeGit(),
+    build: built.build,
+    plugins: ["dev"],
+    platform: "linux",
+    env: { HOME: home },
+    ...extra,
+  });
+}
+
+// ------------------------------------------------------------- the selector
+
+describe("how a checkout is spelled where a version would go", () => {
+  test("`path:` and nothing else, so a typo cannot resolve to a release", () => {
+    expect(checkoutPathOf("path:/srv/red-skills")).toBe("/srv/red-skills");
+    expect(checkoutPathOf("  path:/srv/red-skills  ")).toBe("/srv/red-skills");
+    expect(checkoutPathOf("stable")).toBeNull();
+    expect(checkoutPathOf("3.19.5")).toBeNull();
+    expect(checkoutPathOf("/srv/red-skills")).toBeNull();
+    expect(checkoutPathOf("path:")).toBeNull();
+  });
+
+  test("a relative path is resolved, so the selector names one directory", () => {
+    expect(checkoutPathOf("path:.")).toBe(process.cwd());
+  });
+
+  test("a checkout reads back the way it was written", () => {
+    expect(checkoutLabel("/srv/red-skills")).toBe("path:/srv/red-skills");
+  });
+});
+
+// ------------------------------------------------------------- the identity
+
+describe("the identity of a checkout is its content, not its path", () => {
+  test("two directories holding the same bytes are one revision", async () => {
+    const left = checkout();
+    const right = mkdtempSync(join(tmpdir(), "red-checkout-elsewhere-"));
+    rmSync(right, { recursive: true, force: true });
+    cpSync(left, right, { recursive: true });
+
+    const a = checkoutIdentity(left, { run: fakeGit() });
+    const b = checkoutIdentity(right, { run: fakeGit() });
+    expect(a.ok && b.ok).toBe(true);
+    if (!a.ok || !b.ok) return;
+    expect(a.identity.content).toBe(b.identity.content);
+    expect(a.identity.key).toBe(b.identity.key);
+    expect(a.identity.dir).not.toBe(b.identity.dir);
+  });
+
+  test("one edited byte is a different revision", () => {
+    const dir = checkout();
+    const before = checkoutIdentity(dir, { run: fakeGit() });
+    writeFileSync(join(dir, "src", "dev.ts"), "export const dev = 2;\n");
+    const after = checkoutIdentity(dir, { run: fakeGit() });
+    expect(before.ok && after.ok).toBe(true);
+    if (!before.ok || !after.ok) return;
+    expect(after.identity.content).not.toBe(before.identity.content);
+  });
+
+  test("`.git` and `node_modules` are not content", () => {
+    expect(checkoutExcludes(".git/index")).toBe(true);
+    expect(checkoutExcludes("plugins/dev/node_modules/x/index.js")).toBe(true);
+    expect(checkoutExcludes("src/dev.ts")).toBe(false);
+
+    const dir = checkout();
+    const bare = checkoutDigest(dir);
+    mkdirSync(join(dir, ".git"), { recursive: true });
+    writeFileSync(join(dir, ".git", "index"), "whatever\n");
+    mkdirSync(join(dir, "node_modules", "left-pad"), { recursive: true });
+    writeFileSync(join(dir, "node_modules", "left-pad", "index.js"), "// dep\n");
+    expect(checkoutDigest(dir)).toBe(bare);
+  });
+
+  test("the version says dev, so a checkout is never mistaken for its release", () => {
+    const read = checkoutIdentity(checkout({}, "3.20.0"), { run: fakeGit() });
+    expect(read.ok).toBe(true);
+    if (!read.ok) return;
+    expect(read.identity.version).toMatch(/^3\.20\.0-dev\.[0-9a-f]{8}$/);
+    expect(read.identity.key).toBe(`${read.identity.version}+${read.identity.content.slice(0, 12)}`);
+  });
+
+  test("a dirty checkout claims no commit, a clean one claims its own", () => {
+    const dir = checkout();
+    const clean = checkoutIdentity(dir, { run: fakeGit({ dirty: false }) });
+    const dirty = checkoutIdentity(dir, { run: fakeGit({ dirty: true }) });
+    expect(clean.ok && dirty.ok).toBe(true);
+    if (!clean.ok || !dirty.ok) return;
+    expect(clean.identity.sourceCommit).toBe(COMMIT_A);
+    expect(dirty.identity.commit).toBe(COMMIT_A);
+    expect(dirty.identity.dirty).toBe(true);
+    expect(dirty.identity.sourceCommit).toBe("");
+    // The identity itself is the content either way: dirtiness decides
+    // what may be reused, never what this revision is called.
+    expect(dirty.identity.key).toBe(clean.identity.key);
+  });
+
+  test("an unreleased checkout with no repository at all still has one", () => {
+    const read = checkoutIdentity(checkout(), { run: fakeGit({ commit: null }) });
+    expect(read.ok).toBe(true);
+    if (!read.ok) return;
+    expect(read.identity.commit).toBeNull();
+    expect(read.identity.sourceCommit).toBe("");
+    expect(read.identity.content).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  test("a directory that is not a checkout is refused rather than guessed at", () => {
+    const empty = mkdtempSync(join(tmpdir(), "red-checkout-empty-"));
+    expect(checkoutIdentity(empty, { run: fakeGit() }).ok).toBe(false);
+    expect(checkoutIdentity(join(empty, "nope"), { run: fakeGit() }).ok).toBe(false);
+
+    const unversioned = checkout({ "package.json": `${JSON.stringify({ name: "x" })}\n` });
+    expect(checkoutIdentity(unversioned, { run: fakeGit() }).ok).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------- the sync
+
+describe("what a sync builds, and what it leaves alone", () => {
+  test("the checkout is byte-for-byte unchanged, `.git` included", async () => {
+    const home = fakeHome();
+    const dir = checkout();
+    mkdirSync(join(dir, ".git"), { recursive: true });
+    writeFileSync(join(dir, ".git", "HEAD"), "ref: refs/heads/main\n");
+    mkdirSync(join(dir, "node_modules", "left-pad"), { recursive: true });
+    writeFileSync(join(dir, "node_modules", "left-pad", "index.js"), "// dep\n");
+    const before = treeDigest(dir);
+
+    const result = await quiet(() => sync(home, dir));
+    expect(result.outcome).toBe("synced");
+    expect(treeDigest(dir)).toBe(before);
+    expect(existsSync(join(dir, "dist"))).toBe(false);
+  });
+
+  test("missing assets are built into digest-keyed staging", async () => {
+    const home = fakeHome();
+    const dir = checkout();
+    const built = fakeBuild();
+
+    const result = await quiet(() => sync(home, dir, { build: built.build }));
+    expect(result.outcome).toBe("synced");
+    expect(result.built).toEqual(["dev.bundle.min.mjs"]);
+    expect(result.reused).toEqual([]);
+    expect(result.staging).toBe(redSkillsCheckoutDir(home, result.identity?.key ?? ""));
+    // Built inside the staging that is renamed into place, and never
+    // inside the checkout — the whole reason the source is copied first.
+    expect(built.calls[0]?.tree).toBe(
+      join(redSkillsCheckoutDir(home, `.staging-${result.identity?.key ?? ""}`), "tree"),
+    );
+    expect(existsSync(join(result.staging ?? "", "tree", "dist", "dev.bundle.min.mjs"))).toBe(true);
+
+    const receipt = readCheckoutReceipt(result.staging ?? "");
+    expect(receipt?.key).toBe(result.identity?.key ?? "");
+    expect(receipt?.built).toEqual(["dev.bundle.min.mjs"]);
+  });
+
+  test("the machine ends on the checkout, recorded as a checkout and unsigned", async () => {
+    const home = fakeHome();
+    const result = await quiet(() => sync(home, checkout()));
+    expect(result.outcome).toBe("synced");
+
+    const state = readPackageSetState(home);
+    expect(state.active).toBe(result.identity?.key ?? "");
+    expect(state.revisions[0]?.kind).toBe("checkout");
+    expect(state.revisions[0]?.trust).toBe("unsigned");
+    expect(existsSync(redSkillsCurrentLink(home))).toBe(true);
+    expect(existsSync(join(redSkillsCurrentLink(home), "dist", "dev.bundle.min.mjs"))).toBe(true);
+
+    const rows = redSkillsSetRows(redSkillsSetReport(home));
+    expect(rows[0]?.status).toBe("warn");
+    expect(rows[0]?.detail).toContain("development checkout");
+  });
+
+  test("a checkout that cannot serve the hosts is refused before anything moves", async () => {
+    const home = fakeHome();
+    const dir = checkout();
+    rmSync(join(dir, "scripts", "install-pi.sh"));
+
+    const result = await quiet(() => sync(home, dir));
+    expect(result.outcome).toBe("refused");
+    expect(result.failure).toBe("payload");
+    expect(readPackageSetState(home).active).toBeNull();
+    expect(existsSync(redSkillsCurrentLink(home))).toBe(false);
+  });
+
+  test("a build that produces nothing is a refusal, not a half-staged revision", async () => {
+    const home = fakeHome();
+    const refuse: AssetBuilder = () => ({ ok: false, reason: "the checkout's build produced no dev.bundle.min.mjs" });
+
+    const result = await quiet(() => sync(home, checkout(), { build: refuse }));
+    expect(result.outcome).toBe("refused");
+    expect(result.failure).toBe("artifact");
+    expect(result.staging === null || !existsSync(result.staging)).toBe(true);
+    expect(readPackageSetState(home).active).toBeNull();
+  });
+
+  test("only the assets a set carries are asked for", () => {
+    const tree = checkout();
+    expect(checkoutAssetGaps(tree, ["dev", "memory"])).toEqual([
+      "dev.bundle.min.mjs",
+      "memory.bundle.min.mjs",
+    ]);
+    mkdirSync(join(tree, "dist"), { recursive: true });
+    writeFileSync(join(tree, "dist", "dev.bundle.min.mjs"), "// there\n");
+    expect(checkoutAssetGaps(tree, ["dev", "memory"])).toEqual(["memory.bundle.min.mjs"]);
+  });
+});
+
+// -------------------------------------------------------------- the assets
+
+describe("same commit, or built here", () => {
+  test("a clean checkout reuses what its own commit published", async () => {
+    const home = fakeHome();
+    const dir = checkout();
+    const built = fakeBuild();
+    const assets = assetsFor({
+      [COMMIT_A]: assetsDir(COMMIT_A, {
+        "dev.bundle.min.mjs": "// published dev\n",
+        "verify-package-set.mjs": "// verifier\n",
+      }),
+    });
+
+    const result = await quiet(() =>
+      sync(home, dir, { run: fakeGit({ dirty: false }), assets, build: built.build }),
+    );
+    expect(result.outcome).toBe("synced");
+    expect(result.reused).toEqual(["dev.bundle.min.mjs"]);
+    expect(result.built).toEqual([]);
+    // Nothing to build, and the builder is told so rather than skipped.
+    expect(built.calls[0]?.missing).toEqual([]);
+    expect(readFileSync(join(result.staging ?? "", "tree", "dist", "dev.bundle.min.mjs"), "utf8")).toBe(
+      "// published dev\n",
+    );
+    // Only the bundles overlay; the rest of the release is not the tree's.
+    expect(existsSync(join(result.staging ?? "", "tree", "dist", "verify-package-set.mjs"))).toBe(false);
+  });
+
+  test("assets declaring another commit are refused, and nothing is staged", async () => {
+    const home = fakeHome();
+    const assets: AssetProvider = async (req) =>
+      directoryAssetProvider(assetsDir(COMMIT_B, { "dev.bundle.min.mjs": "// other\n" }))(req);
+
+    const result = await quiet(() => sync(home, checkout(), { run: fakeGit({ dirty: false }), assets }));
+    expect(result.outcome).toBe("refused");
+    expect(result.failure).toBe("cross-commit");
+    expect(readPackageSetState(home).active).toBeNull();
+    expect(readPackageSetState(home).refused?.failure).toBe("cross-commit");
+  });
+
+  test("a dirty checkout reuses nothing, because the release is not these bytes", async () => {
+    const home = fakeHome();
+    const built = fakeBuild();
+    const assets = assetsFor({
+      [COMMIT_A]: assetsDir(COMMIT_A, { "dev.bundle.min.mjs": "// published dev\n" }),
+    });
+
+    const result = await quiet(() =>
+      sync(home, checkout(), { run: fakeGit({ dirty: true }), assets, build: built.build }),
+    );
+    expect(result.outcome).toBe("synced");
+    expect(result.reused).toEqual([]);
+    expect(result.built).toEqual(["dev.bundle.min.mjs"]);
+    expect(readFileSync(join(result.staging ?? "", "tree", "dist", "dev.bundle.min.mjs"), "utf8")).toBe(
+      "// built dev.bundle.min.mjs\n",
+    );
+  });
+
+  test("a release with no package set is not a refusal — the assets are simply built", async () => {
+    const home = fakeHome();
+    const result = await quiet(() =>
+      sync(home, checkout(), { run: fakeGit({ dirty: false }), assets: assetsFor({}) }),
+    );
+    expect(result.outcome).toBe("synced");
+    expect(result.built).toEqual(["dev.bundle.min.mjs"]);
+    expect(readPackageSetState(home).refused).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------- the second run
+
+describe("a sync with nothing to do does nothing", () => {
+  test("the staging is reused and no host state is written", async () => {
+    const home = fakeHome();
+    const dir = checkout();
+    const first = await quiet(() => sync(home, dir));
+    expect(first.outcome).toBe("synced");
+    expect(first.staged).toBe(true);
+
+    const built = fakeBuild();
+    const stateBefore = readFileSync(join(home, ".red-skills", "package-set.json"), "utf8");
+    const stagingBefore = treeDigest(first.staging ?? "");
+
+    const second = await quiet(() => sync(home, dir, { build: built.build }));
+    expect(second.outcome).toBe("current");
+    expect(second.staged).toBe(false);
+    expect(second.writes).toEqual([]);
+    expect(built.calls).toEqual([]);
+    expect(second.staging).toBe(first.staging);
+    expect(treeDigest(second.staging ?? "")).toBe(stagingBefore);
+    expect(readFileSync(join(home, ".red-skills", "package-set.json"), "utf8")).toBe(stateBefore);
+    expect(second.reused).toEqual(first.reused);
+    expect(second.built).toEqual(first.built);
+  });
+
+  test("an edit is a new staging, and the previous revision is the rollback", async () => {
+    const home = fakeHome();
+    const dir = checkout();
+    const first = await quiet(() => sync(home, dir));
+    writeFileSync(join(dir, "src", "dev.ts"), "export const dev = 2;\n");
+    const second = await quiet(() => sync(home, dir));
+
+    expect(second.outcome).toBe("synced");
+    expect(second.identity?.key).not.toBe(first.identity?.key);
+    const state = readPackageSetState(home);
+    expect(state.active).toBe(second.identity?.key ?? "");
+    expect(state.revisions[1]?.key).toBe(first.identity?.key ?? "");
+    // The staging past the retention is collected, so a day of editing
+    // does not leave a directory per keystroke.
+    expect(existsSync(second.staging ?? "")).toBe(true);
+  });
+
+  test("an interrupted staging is rebuilt rather than activated", async () => {
+    const home = fakeHome();
+    const dir = checkout();
+    const read = checkoutIdentity(dir, { run: fakeGit() });
+    expect(read.ok).toBe(true);
+    if (!read.ok) return;
+
+    // A directory with the right name and no receipt: what a sync killed
+    // halfway through would leave if it staged in place.
+    const staging = redSkillsCheckoutDir(home, read.identity.key);
+    mkdirSync(join(staging, "tree"), { recursive: true });
+    writeFileSync(join(staging, "tree", "package.json"), "{}\n");
+
+    const built = fakeBuild();
+    const result = await quiet(() => sync(home, dir, { build: built.build }));
+    expect(result.outcome).toBe("synced");
+    expect(result.staged).toBe(true);
+    expect(built.calls).toHaveLength(1);
+    expect(readCheckoutReceipt(staging)?.key).toBe(read.identity.key);
+  });
+});
+
+// ------------------------------------------------------------ the override
+
+describe("only an explicit sync advances a checkout", () => {
+  test("`mise upgrade` on a path override acquires nothing", async () => {
+    const home = fakeHome();
+    const dir = checkout();
+    const installPath = join(fakeHome(), "installs", "red-skills-set", "path");
+
+    const code = await quiet(() =>
+      runPluginPhase("install", {
+        home,
+        selector: `path:${dir}`,
+        env: { HOME: home, ASDF_INSTALL_PATH: installPath },
+        // Anything reaching a git or a network here is the bug: a path
+        // override must be decided before either is consulted.
+        run: () => {
+          throw new Error("mise must not acquire a path override");
+        },
+      }),
+    );
+
+    expect(code).toBe(0);
+    expect(readPackageSetState(home).active).toBeNull();
+    expect(existsSync(redSkillsCurrentLink(home))).toBe(false);
+    const receipt = JSON.parse(readFileSync(join(installPath, "package-set.json"), "utf8")) as {
+      checkout?: string;
+    };
+    expect(receipt.checkout).toBe(dir);
+  });
+
+  test("an unpinned update leaves a machine on its checkout", async () => {
+    const home = fakeHome();
+    const dir = checkout();
+    await quiet(() => sync(home, dir));
+    const before = readFileSync(join(home, ".red-skills", "package-set.json"), "utf8");
+
+    const { acquireRedSkills } = await import("./red-skills-acquire.ts");
+    const result = await quiet(() =>
+      acquireRedSkills({
+        home,
+        env: { HOME: home },
+        run: () => {
+          throw new Error("an unpinned update must not reach the remote");
+        },
+      }),
+    );
+
+    expect(result.outcome).toBe("current");
+    expect(result.reason).toContain("development checkout");
+    expect(readFileSync(join(home, ".red-skills", "package-set.json"), "utf8")).toBe(before);
+  });
+});

--- a/src/red-skills-checkout.ts
+++ b/src/red-skills-checkout.ts
@@ -1,0 +1,763 @@
+/**
+ * A development checkout as a package set, without calling it a release.
+ *
+ * ADR 0010 and ADR 0012 give this machine one acquisition: a channel
+ * resolves to a commit, the commit is archived into an immutable
+ * snapshot, the release's assets are overlaid from *that* commit, the
+ * signed manifest is verified, and only then does `current` move. That
+ * is the right shape for something somebody published. It is the wrong
+ * shape for the tree a person is editing: a working checkout has no
+ * release, frequently no tag, usually uncommitted edits, and never a
+ * signature — and the four properties above would each refuse it.
+ *
+ * So a checkout is admitted through its own door, and the door is
+ * narrow on purpose.
+ *
+ * ## The identity is the content, never the path
+ *
+ * `~/src/red-skills` and `/tmp/wt/red-skills` holding the same bytes are
+ * the same revision, and a machine that synced one has nothing to do for
+ * the other. That is what makes a checkout addressable at all: a
+ * revision key derived from where a directory happens to sit would
+ * change when somebody moved it, and every downstream comparison — is
+ * this active, is it staged, were the hosts reconciled against it —
+ * would silently answer about a path rather than about a tree.
+ *
+ * The digest is taken over the source and only the source. `.git` is
+ * excluded because it is version-control state rather than content: a
+ * `git status` writes an index, and an identity that moved when you
+ * *looked* at the repository would be no identity. `node_modules` is
+ * excluded because it is the package manager's, and the acceptance
+ * criterion this file carries says neither sync nor build may treat
+ * package-manager-owned files as ours.
+ *
+ * ## The version says `dev`, in every place a version is printed
+ *
+ * The identity's version is the checkout's own with `-dev.<content8>`
+ * appended, so `3.20.0` becomes `3.20.0-dev.4f2c81ae`. A checkout that
+ * borrowed the bare version would be indistinguishable, in the state
+ * file and in `red-dev doctor`, from the release it was branched from —
+ * and the whole point of the override is to run something that is *not*
+ * that release.
+ *
+ * ## Same commit, or build it here
+ *
+ * A checkout is source; the bundles the hosts load are built. Where the
+ * checkout is clean at a commit, that commit's published assets describe
+ * exactly these bytes and are reused — one download instead of a build.
+ * Where it is dirty, they describe bytes that are no longer there, so
+ * they are not reused at all: overlaying them would produce a tree whose
+ * source says one thing and whose bundles say another, which is the
+ * cross-commit failure ADR 0012 refuses under a different name. Assets
+ * declared for some *other* commit are refused outright, exactly as they
+ * are online.
+ *
+ * ## The build runs in the staging, so the checkout never moves
+ *
+ * The source is copied into `~/.red-skills/checkouts/<key>/tree` first
+ * and the build runs there. A build in the checkout would write `dist/`
+ * into a directory Git is tracking, which is the other half of the
+ * acceptance criterion — and it would also change the content the
+ * identity was just computed over, so the sync would be naming a
+ * revision that no longer exists by the time it activated it. The digest
+ * is recomputed at the end and the sync refuses if it moved, which makes
+ * "the checkout is byte-for-byte unchanged" a property of this code
+ * rather than a promise about it.
+ *
+ * ## Explicitly, or not at all
+ *
+ * `red-dev red-skills sync <path>` is the only thing that advances a
+ * checkout. `mise upgrade` cannot: the plugin's install phase recognises
+ * a `path:` override and declines it without acquiring anything, because
+ * mise's job is to record which version a tool is on and a working tree
+ * moves for reasons mise has no way to see. `red-dev update` cannot
+ * either, for the same reason — an unpinned update leaves a machine on
+ * its checkout instead of quietly replacing it with `stable`.
+ */
+
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, relative, resolve } from "node:path";
+
+import { log } from "./log.ts";
+import type { Platform } from "./platform.ts";
+import { redSkillsPluginNames } from "./red-skills-plugins.ts";
+import {
+  overlaysIntoTree,
+  redSkillsRoot,
+  systemRunner,
+  type AssetProvider,
+  type CommandRunner,
+} from "./red-skills-acquire.ts";
+import {
+  convergeRedSkillsPackageSet,
+  corePayloadGaps,
+  hostActivationConfig,
+  parsePackageSetManifest,
+  readPackageSetState,
+  recordPackageSetRefusal,
+  revisionKey,
+  SET_MANIFEST_NAME,
+  setArtifactsDir,
+  treeDigest,
+  type PackageSetIdentity,
+  type SetFailure,
+} from "./red-skills-set.ts";
+
+// ------------------------------------------------------------- the selector
+
+/**
+ * How a checkout is spelled where a version would go.
+ *
+ * mise's own word for the same thing, so a `[tools]` entry reading
+ * `red-skills-set = "path:/home/me/src/red-skills"` says to mise and to
+ * red-dev what it appears to say. Nothing bare is accepted: a directory
+ * name and a channel name are both just words, and a selector that
+ * guessed between them would install a release for a typo'd path.
+ */
+export const CHECKOUT_PREFIX = "path:";
+
+/** The checkout a selector names, absolute, or null. PURE. */
+export function checkoutPathOf(raw: string): string | null {
+  const value = raw.trim();
+  if (!value.startsWith(CHECKOUT_PREFIX)) return null;
+  const path = value.slice(CHECKOUT_PREFIX.length).trim();
+  return path === "" ? null : resolve(path);
+}
+
+/** How a checkout selector is written back into a log line. PURE. */
+export function checkoutLabel(dir: string): string {
+  return `${CHECKOUT_PREFIX}${dir}`;
+}
+
+// ------------------------------------------------------------- the identity
+
+/**
+ * What a checkout carries that is not its content.
+ *
+ * A path segment rather than a prefix, so a nested `node_modules` and a
+ * submodule's `.git` are excluded wherever they sit — which is where
+ * they actually are in a workspace repository.
+ */
+export const CHECKOUT_EXCLUDED: readonly string[] = [".git", "node_modules"];
+
+/** Whether a path relative to the checkout root is content. PURE. */
+export function checkoutExcludes(rel: string): boolean {
+  return rel.split(/[\\/]/).some((segment) => CHECKOUT_EXCLUDED.includes(segment));
+}
+
+/**
+ * The content digest of one checkout: every source file's path and bytes.
+ *
+ * The same digest the package set uses for a composed tree, over the
+ * same relative paths, so two checkouts of the same content in two
+ * directories — a worktree and its origin, a copy on another machine —
+ * produce one identity.
+ */
+export function checkoutDigest(dir: string): string {
+  return treeDigest(dir, { skip: checkoutExcludes });
+}
+
+/** One development checkout, as everything downstream refers to it. */
+export interface CheckoutIdentity {
+  /** Where it was read from. Deliberately not an input to anything below. */
+  dir: string;
+  /** sha256 over the source content. The same content anywhere is this. */
+  content: string;
+  /** `HEAD`, or null for a checkout with no commit at all. */
+  commit: string | null;
+  /** Whether the worktree differs from `HEAD`. False when there is no HEAD. */
+  dirty: boolean;
+  /** The checkout's own version with `-dev.<content8>`, never a release's. */
+  version: string;
+  /** `<version>+<content12>` — the revision key and the staging directory. */
+  key: string;
+  /**
+   * The commit the staged tree may claim, which is `HEAD` only when the
+   * worktree matches it. A dirty checkout is not its commit, and a
+   * revision that named one would print `@<commit>` about bytes that
+   * commit never had.
+   */
+  sourceCommit: string;
+}
+
+const CHECKOUT_VERSION = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/;
+const HEX40 = /^[0-9a-f]{40}$/;
+
+export type CheckoutRead =
+  | { ok: true; identity: CheckoutIdentity }
+  | { ok: false; reason: string };
+
+/**
+ * Read one checkout's identity, without writing a byte into it.
+ *
+ * `git rev-parse` and `git status --porcelain` are the only two
+ * questions asked of Git, and neither is required to succeed: a
+ * directory exported from an archive, or one whose Git is not installed,
+ * is an unreleased checkout with no commit rather than an error. What is
+ * required is a `package.json` carrying a version, because that is the
+ * one field the set's identity cannot be invented for.
+ */
+export function checkoutIdentity(dir: string, opts: { run?: CommandRunner } = {}): CheckoutRead {
+  const root = resolve(dir);
+  if (!existsSync(root)) return { ok: false, reason: `${root} is not there` };
+  const pkg = join(root, "package.json");
+  if (!existsSync(pkg)) {
+    return { ok: false, reason: `${root} carries no package.json, so it is not a RedSkills checkout` };
+  }
+
+  let version: string;
+  try {
+    const parsed = JSON.parse(readFileSync(pkg, "utf8")) as { version?: unknown };
+    if (typeof parsed.version !== "string" || !CHECKOUT_VERSION.test(parsed.version)) {
+      return { ok: false, reason: `${root}/package.json declares no usable version` };
+    }
+    version = parsed.version;
+  } catch {
+    return { ok: false, reason: `${root}/package.json is not readable JSON` };
+  }
+
+  const run = opts.run ?? systemRunner;
+  const head = run(["git", "-C", root, "rev-parse", "HEAD"]);
+  const commit = head.code === 0 && HEX40.test(head.stdout.trim()) ? head.stdout.trim() : null;
+  const status = commit === null ? null : run(["git", "-C", root, "status", "--porcelain"]);
+  const dirty = status !== null && (status.code !== 0 || status.stdout.trim() !== "");
+
+  const content = checkoutDigest(root);
+  const devVersion = `${version}-dev.${content.slice(0, 8)}`;
+  const identity: CheckoutIdentity = {
+    dir: root,
+    content,
+    commit,
+    dirty,
+    version: devVersion,
+    key: revisionKey({ version: devVersion, digest: content, sourceCommit: "" }),
+    sourceCommit: commit !== null && !dirty ? commit : "",
+  };
+  return { ok: true, identity };
+}
+
+/** The identity the package set records for one checkout. PURE. */
+export function checkoutPackageIdentity(identity: CheckoutIdentity): PackageSetIdentity {
+  return { version: identity.version, digest: identity.content, sourceCommit: identity.sourceCommit };
+}
+
+// -------------------------------------------------------------- the staging
+
+/** `~/.red-skills/checkouts` — where a checkout's built trees are keyed by digest. */
+export function redSkillsCheckoutRoot(home: string): string {
+  return join(redSkillsRoot(home), "checkouts");
+}
+
+/** `~/.red-skills/checkouts/<version>+<content12>` — one staged checkout. */
+export function redSkillsCheckoutDir(home: string, key: string): string {
+  return join(redSkillsCheckoutRoot(home), key);
+}
+
+/** The one file that says a staging directory is finished, and of what. */
+export function checkoutReceiptPath(staging: string): string {
+  return join(staging, "checkout.json");
+}
+
+/**
+ * What a finished staging directory records about itself.
+ *
+ * Written last and named by the same key as its directory, so a staging
+ * interrupted halfway is a directory with no receipt — indistinguishable
+ * from one that was never started, and therefore rebuilt rather than
+ * activated.
+ */
+export interface CheckoutReceipt {
+  schema: 1;
+  key: string;
+  content: string;
+  commit: string | null;
+  dirty: boolean;
+  /** Asset basenames overlaid from the release published for `commit`. */
+  reused: string[];
+  /** Asset basenames this machine built, because nothing published them. */
+  built: string[];
+}
+
+/** The receipt a finished staging carries, or null. */
+export function readCheckoutReceipt(staging: string): CheckoutReceipt | null {
+  const path = checkoutReceiptPath(staging);
+  if (!existsSync(path)) return null;
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as Partial<CheckoutReceipt>;
+    if (parsed.schema !== 1 || typeof parsed.key !== "string" || typeof parsed.content !== "string") {
+      return null;
+    }
+    return {
+      schema: 1,
+      key: parsed.key,
+      content: parsed.content,
+      commit: typeof parsed.commit === "string" ? parsed.commit : null,
+      dirty: parsed.dirty === true,
+      reused: Array.isArray(parsed.reused) ? parsed.reused.filter((n): n is string => typeof n === "string") : [],
+      built: Array.isArray(parsed.built) ? parsed.built.filter((n): n is string => typeof n === "string") : [],
+    };
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------- the build
+
+export interface BuildRequest {
+  /** The staged copy of the checkout. The build runs here and writes here. */
+  tree: string;
+  /** The asset basenames `tree/dist` still has to carry, in order. */
+  missing: readonly string[];
+}
+
+export type BuildOutcome = { ok: true; built: string[] } | { ok: false; reason: string };
+
+export type AssetBuilder = (req: BuildRequest) => BuildOutcome;
+
+/** Which of the assets a set must carry are not in the staged tree yet. PURE over the tree. */
+export function checkoutAssetGaps(tree: string, plugins: readonly string[]): string[] {
+  return plugins
+    .map((name) => `${name}.bundle.min.mjs`)
+    .filter((name) => !existsSync(join(tree, "dist", name)));
+}
+
+/**
+ * Build the missing assets with the checkout's own build script.
+ *
+ * The checkout's script rather than a build red-dev knows how to
+ * perform: red-dev has no opinion about how RedSkills is bundled, and
+ * one written here would be a second build to keep in step with the
+ * repository's own. A checkout that declares no `build` is refused with
+ * that sentence, which is a one-line fix in the tree rather than a
+ * mystery about a missing bundle.
+ */
+export function checkoutAssetBuilder(opts: { run?: CommandRunner } = {}): AssetBuilder {
+  const run = opts.run ?? systemRunner;
+  return (req) => {
+    if (req.missing.length === 0) return { ok: true, built: [] };
+
+    let scripts: Record<string, unknown> = {};
+    try {
+      const parsed = JSON.parse(readFileSync(join(req.tree, "package.json"), "utf8")) as {
+        scripts?: Record<string, unknown>;
+      };
+      scripts = parsed.scripts ?? {};
+    } catch {
+      return { ok: false, reason: "the staged checkout carries no readable package.json" };
+    }
+    if (typeof scripts["build"] !== "string") {
+      return {
+        ok: false,
+        reason: `the checkout declares no build script, and ${req.missing.join(", ")} is not in its dist/`,
+      };
+    }
+
+    const built = run(["bun", "run", "build"], { cwd: req.tree });
+    if (built.code !== 0) {
+      return { ok: false, reason: `bun run build exited ${built.code}: ${firstLine(built.stderr)}` };
+    }
+    const still = req.missing.filter((name) => !existsSync(join(req.tree, "dist", name)));
+    if (still.length > 0) {
+      return { ok: false, reason: `the checkout's build produced no ${still.join(", ")}` };
+    }
+    return { ok: true, built: [...req.missing] };
+  };
+}
+
+// ----------------------------------------------------------------- the sync
+
+export interface CheckoutSyncOptions {
+  home?: string;
+  /** The checkout, as a path or as a `path:` selector. */
+  dir: string;
+  run?: CommandRunner;
+  /** Where a released commit's assets come from. Defaults to none. */
+  assets?: AssetProvider;
+  /** Defaults to the checkout's own `bun run build`. */
+  build?: AssetBuilder;
+  plugins?: readonly string[];
+  platform?: NodeJS.Platform;
+  manifestPlatform?: Platform;
+  env?: NodeJS.ProcessEnv;
+  /** Stage the revision but leave `current` where it is. */
+  stageOnly?: boolean;
+}
+
+export interface CheckoutSync {
+  /**
+   * `synced` moved the machine onto the checkout; `current` found it
+   * already there, with the staging reused and nothing written;
+   * `refused` found something and would not have it.
+   */
+  outcome: "synced" | "current" | "refused";
+  reason: string;
+  failure: SetFailure | null;
+  identity: CheckoutIdentity | null;
+  /** The digest-keyed staging directory, once there is one. */
+  staging: string | null;
+  /** Asset basenames overlaid from the release published for the commit. */
+  reused: string[];
+  /** Asset basenames built here, because nothing published them. */
+  built: string[];
+  /** Whether this sync built or copied anything, as against reusing a staging. */
+  staged: boolean;
+  active: PackageSetIdentity | null;
+  writes: string[];
+}
+
+/**
+ * Sync one development checkout onto this machine.
+ *
+ * The order is the same one the online acquisition uses and for the same
+ * reason: the cheap question first, and nothing expensive after an
+ * answer that ends the run. The identity is read (two `git` calls and
+ * one walk), the staging is looked for by that identity's key, and a
+ * staging that is already there is reused whole — no copy, no download,
+ * no build. Only then is anything assembled.
+ */
+export async function syncRedSkillsCheckout(opts: CheckoutSyncOptions): Promise<CheckoutSync> {
+  const env = opts.env ?? process.env;
+  const home = opts.home ?? homeOf(env);
+  const run = opts.run ?? systemRunner;
+  const dir = checkoutPathOf(opts.dir) ?? resolve(opts.dir);
+
+  /**
+   * Every ending that is not an activation, in one shape.
+   *
+   * A refusal writes the one line ADR 0012 has the online acquisition
+   * write — the failure and the reason, into the package-set state — so
+   * "why is this machine not on the checkout I synced" is answerable by
+   * `red-dev doctor` hours later rather than only by the log line that
+   * scrolled past. Nothing else writes.
+   */
+  const nothing = (
+    outcome: CheckoutSync["outcome"],
+    reason: string,
+    failure: SetFailure | null = null,
+    extra: Partial<CheckoutSync> = {},
+  ): CheckoutSync => ({
+    outcome,
+    reason,
+    failure,
+    identity: null,
+    staging: null,
+    reused: [],
+    built: [],
+    staged: false,
+    active: null,
+    writes:
+      outcome === "refused" && failure !== null
+        ? recordPackageSetRefusal(home, { failure, reason })
+        : [],
+    ...extra,
+  });
+
+  const read = checkoutIdentity(dir, { run });
+  if (!read.ok) return nothing("refused", read.reason, "tree");
+  const identity = read.identity;
+
+  const plugins =
+    opts.plugins ?? redSkillsPluginNames(opts.manifestPlatform ?? manifestPlatformOf(opts.platform));
+  const staging = redSkillsCheckoutDir(home, identity.key);
+
+  // The short-cut. A staging keyed by this content is this content:
+  // there is nothing to copy, nothing to download and nothing to build,
+  // and the converge below writes nothing when `current` already
+  // resolves to it.
+  const receipt = readCheckoutReceipt(staging);
+  const assembled =
+    receipt !== null && receipt.key === identity.key
+      ? { ok: true as const, reused: receipt.reused, built: receipt.built, staged: false }
+      : await assemble({
+          home,
+          identity,
+          staging,
+          plugins,
+          run,
+          ...(opts.assets ? { assets: opts.assets } : {}),
+          ...(opts.build ? { build: opts.build } : {}),
+        });
+
+  if (!assembled.ok) {
+    return nothing("refused", assembled.reason, assembled.failure, { identity, staging });
+  }
+
+  // The acceptance criterion, checked rather than asserted: a sync that
+  // wrote into the checkout would have changed the very content its
+  // identity was computed over, and would be activating a revision that
+  // no longer describes anything on this machine.
+  const after = checkoutDigest(dir);
+  if (after !== identity.content) {
+    return nothing(
+      "refused",
+      `${dir} changed while it was being synced — the checkout must be byte-for-byte unchanged`,
+      "tree",
+      { identity, staging },
+    );
+  }
+
+  const converged = convergeRedSkillsPackageSet({
+    home,
+    checkout: { tree: join(staging, "tree"), identity: checkoutPackageIdentity(identity) },
+    ...(opts.platform ? { platform: opts.platform } : {}),
+    ...(opts.stageOnly === true ? { stageOnly: true } : {}),
+    env,
+  });
+  if (converged.refused) {
+    return nothing("refused", converged.refused.reason, converged.refused.failure, {
+      identity,
+      staging,
+      reused: assembled.reused,
+      built: assembled.built,
+      staged: assembled.staged,
+      active: converged.active,
+      writes: converged.writes,
+    });
+  }
+
+  retainCheckouts(home, converged.retained.map((r) => r.key));
+
+  return {
+    outcome: converged.changed ? "synced" : "current",
+    reason: converged.changed
+      ? `${identity.key} from ${dir}${identity.dirty ? " (dirty)" : ""}`
+      : `already on ${identity.key} (${checkoutLabel(dir)})`,
+    failure: null,
+    identity,
+    staging,
+    reused: assembled.reused,
+    built: assembled.built,
+    staged: assembled.staged,
+    active: converged.active,
+    writes: converged.writes,
+  };
+}
+
+type Assembly =
+  | { ok: true; reused: string[]; built: string[]; staged: true }
+  | { ok: false; reason: string; failure: SetFailure };
+
+/**
+ * Copy the source, overlay what the commit published, build the rest.
+ *
+ * Assembled under a `.staging-` name and renamed at the end, so a
+ * directory under `checkouts/` either carries a receipt naming its own
+ * key or is not a staging at all. An interrupted build can therefore
+ * never be reused as a finished one, which is what makes the short-cut
+ * above safe to take on nothing but a directory's name.
+ */
+async function assemble(req: {
+  home: string;
+  identity: CheckoutIdentity;
+  staging: string;
+  plugins: readonly string[];
+  run: CommandRunner;
+  assets?: AssetProvider;
+  build?: AssetBuilder;
+}): Promise<Assembly> {
+  const { identity, staging, plugins } = req;
+  const work = redSkillsCheckoutDir(req.home, `.staging-${identity.key}`);
+  rmSync(work, { recursive: true, force: true });
+  mkdirSync(work, { recursive: true });
+
+  const tree = join(work, "tree");
+  cpSync(identity.dir, tree, {
+    recursive: true,
+    dereference: true,
+    filter: (src) => {
+      const rel = relative(identity.dir, src);
+      return rel === "" || !checkoutExcludes(rel);
+    },
+  });
+
+  const reused: string[] = [];
+  if (identity.sourceCommit !== "" && req.assets) {
+    // Clean, at a commit: what that release published describes exactly
+    // these bytes. A dirty checkout skips this entirely — its bundles
+    // would be the commit's and its source would not.
+    const dest = join(work, "assets");
+    const outcome = await req.assets({
+      commit: identity.sourceCommit,
+      version: null,
+      tag: null,
+      dest,
+    });
+    if (outcome.kind === "refused") {
+      rmSync(work, { recursive: true, force: true });
+      const failure: SetFailure = outcome.failure === "network" ? "network" : outcome.failure;
+      return { ok: false, reason: outcome.reason, failure };
+    }
+    if (outcome.kind === "ready") {
+      const manifest = parsePackageSetManifest(readFileSync(join(outcome.dir, SET_MANIFEST_NAME)));
+      if (!manifest.ok) {
+        rmSync(work, { recursive: true, force: true });
+        return { ok: false, reason: manifest.reason, failure: "manifest" };
+      }
+      if (manifest.manifest.sourceCommit !== identity.sourceCommit) {
+        rmSync(work, { recursive: true, force: true });
+        return {
+          ok: false,
+          failure: "cross-commit",
+          reason:
+            `the assets declare commit ${manifest.manifest.sourceCommit.slice(0, 12)} but ` +
+            `${identity.dir} is at ${identity.sourceCommit.slice(0, 12)}`,
+        };
+      }
+      const dist = join(tree, "dist");
+      mkdirSync(dist, { recursive: true });
+      for (const artifact of manifest.manifest.artifacts) {
+        if (!overlaysIntoTree(artifact.name)) continue;
+        const from = join(setArtifactsDir(outcome.dir), artifact.name);
+        if (!existsSync(from)) {
+          rmSync(work, { recursive: true, force: true });
+          return { ok: false, reason: `declared artifact is missing: ${artifact.name}`, failure: "artifact" };
+        }
+        cpSync(from, join(dist, artifact.name), { dereference: true });
+        reused.push(artifact.name);
+      }
+    }
+  }
+
+  const missing = checkoutAssetGaps(tree, plugins);
+  const builder = req.build ?? checkoutAssetBuilder({ run: req.run });
+  const built = builder({ tree, missing });
+  if (!built.ok) {
+    rmSync(work, { recursive: true, force: true });
+    return { ok: false, reason: built.reason, failure: "artifact" };
+  }
+
+  const gaps = corePayloadGaps(tree);
+  if (gaps.length > 0) {
+    rmSync(work, { recursive: true, force: true });
+    return {
+      ok: false,
+      reason: `${identity.dir} carries no ${gaps.join(", ")}, so it cannot serve the hosts`,
+      failure: "payload",
+    };
+  }
+
+  // The opt-in gate the host generators read, written beside the tree
+  // exactly as a composed set writes it, and never over one the checkout
+  // already carries — that file is the developer's to decide.
+  const config = join(tree, ".red", "config.yaml");
+  if (!existsSync(config)) {
+    mkdirSync(dirname(config), { recursive: true });
+    writeFileSync(config, hostActivationConfig(plugins), "utf8");
+  }
+
+  const record: CheckoutReceipt = {
+    schema: 1,
+    key: identity.key,
+    content: identity.content,
+    commit: identity.commit,
+    dirty: identity.dirty,
+    reused: [...reused].sort((a, b) => a.localeCompare(b, "en")),
+    built: [...built.built].sort((a, b) => a.localeCompare(b, "en")),
+  };
+  writeFileSync(checkoutReceiptPath(work), `${JSON.stringify(record, null, 2)}\n`, "utf8");
+
+  rmSync(staging, { recursive: true, force: true });
+  mkdirSync(dirname(staging), { recursive: true });
+  renameSync(work, staging);
+  return { ok: true, reused: record.reused, built: record.built, staged: true };
+}
+
+/**
+ * Drop the staged checkouts no retained revision names.
+ *
+ * The same retention the revisions have, applied to what they were built
+ * from: a directory keyed by content grows with every edit somebody
+ * syncs, and a developer edits all day. Nothing is removed when the
+ * machine retains no revision at all, which is what an interrupted first
+ * sync looks like from here.
+ */
+export function retainCheckouts(home: string, keep: readonly string[]): string[] {
+  const root = redSkillsCheckoutRoot(home);
+  if (keep.length === 0 || !existsSync(root)) return [];
+  const removed: string[] = [];
+  for (const name of listing(root)) {
+    if (keep.includes(name) || name.startsWith(".staging-")) continue;
+    rmSync(join(root, name), { recursive: true, force: true });
+    removed.push(join(root, name));
+  }
+  return removed;
+}
+
+/** The checkout this machine currently resolves, or null. */
+export function activeCheckoutKey(home: string): string | null {
+  const state = readPackageSetState(home);
+  const active = state.revisions.find((r) => r.key === state.active);
+  return active && active.kind === "checkout" ? active.key : null;
+}
+
+/** One line for each outcome, in the voice the rest of a converge speaks. */
+export function announceCheckout(sync: CheckoutSync): void {
+  switch (sync.outcome) {
+    case "synced": {
+      const from =
+        sync.reused.length > 0 && sync.built.length > 0
+          ? ` (${sync.reused.length} reused, ${sync.built.length} built)`
+          : sync.built.length > 0
+            ? ` (${sync.built.length} built)`
+            : sync.reused.length > 0
+              ? ` (${sync.reused.length} reused)`
+              : "";
+      log.ok(`red-skills checkout: ${sync.reason}${from}`);
+      return;
+    }
+    case "current":
+      log.skip(`red-skills checkout: ${sync.reason}`);
+      return;
+    case "refused":
+      log.err(`red-skills checkout refused (${sync.failure ?? "unknown"}): ${sync.reason}`);
+      log.plain("       current is unchanged — the machine keeps the set it already resolves");
+      return;
+  }
+}
+
+// ------------------------------------------------------------------ details
+
+function listing(dir: string): string[] {
+  try {
+    // Sorted, so a retention pass removes in the same order everywhere.
+    return readdirSync(dir).sort();
+  } catch {
+    return [];
+  }
+}
+
+function firstLine(text: string): string {
+  return text.split("\n").find((l) => l.trim() !== "")?.trim() ?? "";
+}
+
+/** The same spelling red-skills-set.ts uses, so the two agree on one home. */
+function homeOf(env: NodeJS.ProcessEnv): string {
+  return (env["HOME"] ?? env["USERPROFILE"] ?? homedir()).replace(/\\/g, "/");
+}
+
+/**
+ * Enough of a Platform to derive the plugin set, for a caller that was
+ * handed nothing but a path.
+ */
+function manifestPlatformOf(platform?: NodeJS.Platform): Platform {
+  const windows = (platform ?? process.platform) === "win32";
+  return {
+    os: windows ? "windows" : "linux",
+    distro: null,
+    version: null,
+    codename: null,
+    env: windows ? "windows" : "desktop",
+    arch: process.arch === "arm64" ? "arm64" : "x64",
+    caps: { apt: false, gui: false, systemd: false, winget: false, flatpak: false },
+  };
+}

--- a/src/red-skills-mise-plugin.ts
+++ b/src/red-skills-mise-plugin.ts
@@ -58,6 +58,7 @@ import {
   type AcquireOptions,
   type CommandRunner,
 } from "./red-skills-acquire.ts";
+import { checkoutLabel, checkoutPathOf } from "./red-skills-checkout.ts";
 
 /**
  * The plugin's directory name, which is also the tool name mise knows.
@@ -257,6 +258,23 @@ export async function runPluginPhase(
   // it; a selector on the command line wins, because that is how a
   // person asks for one revision without editing their config.
   const selector = opts.selector ?? env["ASDF_INSTALL_VERSION"] ?? DEFAULT_CHANNEL;
+
+  // A `path:` override is a working tree, and mise has no way to see
+  // that one moved: there is no version to compare, no tag to resolve
+  // and no release to fetch. So `mise upgrade` records the pin and
+  // acquires nothing — the checkout is advanced by the one explicit
+  // command that reads its content, and by nothing else.
+  const checkout = checkoutPathOf(selector);
+  if (checkout !== null) {
+    log.skip(
+      `red-skills: ${checkoutLabel(checkout)} is a development checkout — ` +
+        `advanced by \`red-dev red-skills sync ${checkout}\`, not by mise`,
+    );
+    const pinPath = env["ASDF_INSTALL_PATH"];
+    if (pinPath) writeReceipt(pinPath, null, null, checkout);
+    return 0;
+  }
+
   if (!parseSelector(selector)) {
     log.err(`red-skills: '${selector}' is not a channel, a version, or a commit`);
     return 1;
@@ -289,6 +307,7 @@ function writeReceipt(
   installPath: string,
   active: { version: string; digest: string; sourceCommit: string } | null,
   commit: string | null,
+  checkout: string | null = null,
 ): void {
   mkdirSync(installPath, { recursive: true });
   writeFileSync(
@@ -300,6 +319,11 @@ function writeReceipt(
         version: active?.version ?? null,
         digest: active?.digest ?? null,
         sourceCommit: active?.sourceCommit ?? commit ?? null,
+        // Present only for a `path:` override, and the reason this
+        // directory is not empty: mise reads an empty install as a
+        // failed one, and what it installed here is a pin naming a
+        // working tree rather than a revision anybody published.
+        ...(checkout === null ? {} : { checkout }),
         postinstall: REDSKILLS_RECONCILE_POSTINSTALL,
       },
       null,

--- a/src/red-skills-set.ts
+++ b/src/red-skills-set.ts
@@ -879,13 +879,19 @@ function restoreScriptModes(tree: string): void {
  * different one. Symlinks are hashed by their target text; there should
  * be none in a composed set, and one that appears is part of the
  * identity rather than invisible to it.
+ *
+ * `skip` is how a development checkout leaves out what is not its
+ * content — its `.git`, its `node_modules` — without a second walk that
+ * would be free to hash a tree differently from this one.
  */
-export function treeDigest(root: string): string {
+export function treeDigest(root: string, opts: { skip?: (rel: string) => boolean } = {}): string {
   const lines: string[] = [];
+  const skip = opts.skip ?? (() => false);
   const walk = (dir: string, rel: string): void => {
     for (const name of listing(dir)) {
       const path = join(dir, name);
       const relPath = rel ? `${rel}/${name}` : name;
+      if (skip(relPath)) continue;
       const stat = statOf(path);
       if (!stat) continue;
       if (stat.isSymbolicLink()) {
@@ -910,9 +916,10 @@ export interface PackageSetRevision {
   key: string;
   version: string;
   digest: string;
-  /** Empty for a composed set. */
+  /** Empty for a composed set, and for a checkout that is not clean at a commit. */
   sourceCommit: string;
-  kind: "composed" | "manifest";
+  /** `checkout` is a development tree staged by red-dev, never a release. */
+  kind: "composed" | "manifest" | "checkout";
   trust: "trusted" | "unsigned";
   /** The immutable directory this revision is addressable through. */
   path: string;
@@ -1026,6 +1033,14 @@ export interface PackageSetConvergeOptions {
    * consulted — this is what a depot import or a fixture hands in.
    */
   source?: string;
+  /**
+   * A development checkout's staged tree, activated as an unsigned
+   * `checkout` revision. There is no manifest and no signature to verify
+   * — a working tree publishes neither — so the caller
+   * (src/red-skills-checkout.ts) has already established the identity
+   * from the content, and this is only the activation.
+   */
+  checkout?: { tree: string; identity: PackageSetIdentity };
   /** Defaults to mise's installs root. */
   installsRoot?: string;
   /** The plugins the composed set must carry. Defaults to the manifest's. */
@@ -1104,6 +1119,28 @@ export function convergeRedSkillsPackageSet(
   };
 
   const activeTrusted = activeRevision(state)?.trust === "trusted";
+
+  // A checkout, before the two acquisitions, and deliberately not
+  // subject to the downgrade guard below: that guard exists so an
+  // unsigned set nobody asked for cannot displace a verified one, and a
+  // checkout is the one candidate somebody asked for by name. The
+  // verified revision it displaces stays retained as the rollback.
+  if (opts.checkout !== undefined) {
+    const { tree, identity } = opts.checkout;
+    if (!existsSync(join(tree, "package.json"))) {
+      return refuse("tree", `the staged checkout at ${tree} carries no workstation tree`);
+    }
+    const key = revisionKey(identity);
+    const path = redSkillsSetDir(home, key);
+    return activate(
+      home,
+      platform,
+      state,
+      { key, ...identity, kind: "checkout", trust: "unsigned", path },
+      () => copyTree(tree, path),
+      opts.stageOnly === true,
+    );
+  }
 
   if (opts.source !== undefined) {
     const verifier = opts.verifier ?? cosignVerifier({ home });
@@ -1375,7 +1412,7 @@ export interface SetDoctorReport {
     version: string;
     digest: string;
     sourceCommit: string;
-    kind: "composed" | "manifest";
+    kind: "composed" | "manifest" | "checkout";
     trust: "trusted" | "unsigned";
     path: string;
   } | null;
@@ -1420,6 +1457,13 @@ export interface SetDoctorRow {
   detail: string;
 }
 
+/** How each kind of revision is named in a report. PURE. */
+const SET_KIND_LABEL: Record<PackageSetRevision["kind"], string> = {
+  composed: "composed from mise",
+  manifest: "published set",
+  checkout: "development checkout",
+};
+
 /** The report as the lines `red-dev doctor` prints. PURE. */
 export function redSkillsSetRows(report: SetDoctorReport): SetDoctorRow[] {
   const rows: SetDoctorRow[] = [];
@@ -1430,10 +1474,12 @@ export function redSkillsSetRows(report: SetDoctorReport): SetDoctorRow[] {
     rows.push({
       status: a.trust === "trusted" ? "ok" : "warn",
       detail:
-        `${formatPackageSetIdentity(a)} — ${a.kind === "composed" ? "composed from mise" : "published set"}, ` +
+        `${formatPackageSetIdentity(a)} — ${SET_KIND_LABEL[a.kind]}, ` +
         (a.trust === "trusted"
           ? "signature verified over the declared artifacts"
-          : "unsigned (nothing published signs a composed set yet)"),
+          : a.kind === "checkout"
+            ? "unsigned (a development checkout is not a release, and `red-dev red-skills sync` advances it)"
+            : "unsigned (nothing published signs a composed set yet)"),
     });
     const rollback = report.retained[1];
     if (!rollback) {


### PR DESCRIPTION
Automated AFK landing for #206. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #206

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/220"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789688370&installation_model_id=20659&pr_number=220&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F220&signature=d593d11b97f940541d3ab355a05c64029d373b665088838f394aec4d3054a9d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->