### PR TITLE
fix: #207 Gemini converges the local dev projection and proves installed state

### DIFF
--- a/src/agents.ts
+++ b/src/agents.ts
@@ -944,4 +944,14 @@ export async function convergeRedSkills(p: Platform): Promise<void> {
     log.warn(`red-skills: not reconciled into ${stuck.map((h) => h.host).join(", ")}`);
     for (const h of stuck) log.plain(`       ${h.host}: ${h.reason ?? "no reason given"}`);
   }
+
+  // A host can converge and still have less than the one beside it —
+  // Gemini has no hook runner, and a set may declare no MCP for anybody.
+  // Said out loud on the converge that observed it, not only in doctor:
+  // "seven hosts reconciled" read without this is a claim that all seven
+  // got the same thing, which is the misdescription the record exists to
+  // prevent. Skipped hosts say it too, out of what they recorded.
+  for (const h of hosts) {
+    for (const gap of h.missing ?? []) log.skip(`${h.host}: ${gap}`);
+  }
 }

--- a/src/red-skills-hosts.test.ts
+++ b/src/red-skills-hosts.test.ts
@@ -24,7 +24,9 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  readdirSync,
   rmSync,
+  statSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -40,6 +42,7 @@ import {
   redSkillsHostReport,
   redSkillsHostRows,
   removeSkillHosts,
+  type AdapterContext,
   type HostAdapter,
   type HostOutcome,
   type HostReconcileOptions,
@@ -163,8 +166,15 @@ done
 interface SetOptions {
   /** Skills the `dev` plugin carries. */
   skills?: string[];
-  /** Whether `dev` declares an MCP server for a host to project. */
-  mcp?: boolean;
+  /**
+   * Whether `dev` declares an MCP server for a host to project.
+   *
+   * `"dangling"` declares one whose script is not in the set — the shape a
+   * half-composed package set has, and the one a host must refuse.
+   */
+  mcp?: boolean | "dangling";
+  /** Whether `dev` declares hooks, and whether their scripts are there. */
+  hooks?: "declared" | "dangling";
   /** Generators to leave out, for the hosts that then have none. */
   without?: string[];
 }
@@ -191,10 +201,41 @@ function packageSet(opts: SetOptions = {}): string {
   addSkill(tree, "memory", "memory-only");
 
   if (opts.mcp !== false) {
+    // The dangling variant names a script by path, which is the only kind
+    // of declaration a host can check: `bun run d.mjs` resolves against a
+    // cwd nothing here owns, and pretending to verify it would be a check
+    // that fails on every correct set.
+    const server = opts.mcp === "dangling"
+      ? { command: "bun", args: ["run", "${CLAUDE_PLUGIN_ROOT}/servers/redskilled.mjs"] }
+      : { command: "bun", args: ["run", "d.mjs"] };
     writeFileSync(
       join(tree, "plugins", "dev", ".mcp.json"),
-      `${JSON.stringify({ mcpServers: { redskilled: { command: "bun", args: ["run", "d.mjs"] } } }, null, 2)}\n`,
+      `${JSON.stringify({ mcpServers: { redskilled: server } }, null, 2)}\n`,
     );
+  }
+
+  if (opts.hooks !== undefined) {
+    const dir = join(tree, "plugins", "dev", "hooks");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "hooks.json"),
+      `${JSON.stringify(
+        {
+          hooks: {
+            PreToolUse: [
+              { matcher: "Bash", hooks: [{ type: "command", command: "${CLAUDE_PLUGIN_ROOT}/hooks/castle.sh" }] },
+            ],
+          },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    if (opts.hooks === "declared") {
+      const script = join(dir, "castle.sh");
+      writeFileSync(script, "#!/usr/bin/env bash\nexit 0\n");
+      chmodSync(script, 0o755);
+    }
   }
 
   mkdirSync(join(tree, ".red"), { recursive: true });
@@ -704,6 +745,235 @@ describe("configuration the operator owns", () => {
   });
 });
 
+// ------------------------------------------------------------- the Gemini
+
+/** What the Gemini adapter is a function of, for the checks called directly. */
+function geminiContext(m: Machine): AdapterContext {
+  return {
+    plugins: ACTIVATED,
+    source: m.tree,
+    setDigest: "0".repeat(64),
+    setVersion: "v9.9.9",
+    current: m.current,
+    home: m.home,
+    config: m.config,
+  };
+}
+
+const GEMINI_EXTENSION = ["extensions", "red-skills"] as const;
+
+function geminiDir(m: Machine): string {
+  return join(m.home, ".gemini", ...GEMINI_EXTENSION);
+}
+
+function geminiSettingsFile(m: Machine): string {
+  return join(m.home, ".gemini", "settings.json");
+}
+
+/** Every file under a tree, with the bytes and the mtime that prove no rewrite. */
+function snapshot(root: string, base = root): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const name of readdirSync(root).sort()) {
+    const path = join(root, name);
+    if (statSync(path).isDirectory()) {
+      Object.assign(out, snapshot(path, base));
+      continue;
+    }
+    out[path.slice(base.length)] = `${statSync(path).mtimeMs}\0${readFileSync(path, "utf8")}`;
+  }
+  return out;
+}
+
+async function geminiCheck(m: Machine): Promise<{ ok: boolean; reason?: string }> {
+  const adapter = adapterNamed("gemini");
+  const ctx = geminiContext(m);
+  const checked = await adapter.check?.(ctx, adapter.plan(ctx));
+  if (!checked) throw new Error("the Gemini adapter answers no check");
+  return checked.ok ? { ok: true } : { ok: false, reason: checked.reason };
+}
+
+function geminiOnly(m: Machine, opts: HostReconcileOptions = {}): Promise<HostOutcome[]> {
+  return reconcile(m, { run: runner(m).run, adapters: [adapterNamed("gemini")], ...opts });
+}
+
+describe("the Gemini projection of the local dev set", () => {
+  test("a set whose declared hook script is not in it never reaches the disk", async () => {
+    // The fixture the acceptance criteria ask for: a projection that names
+    // a path nothing carries. Refused at plan time, so `~/.gemini` is
+    // exactly as it was and there is no half-installed extension to find.
+    const m = machine({ hooks: "dangling" });
+    const { calls, run } = runner(m);
+    const out = await geminiOnly(m, { run });
+
+    expect(out[0]?.status).toBe("blocked");
+    expect(out[0]?.reason).toContain("hooks/castle.sh");
+    expect(calls).toEqual([]);
+    expect(existsSync(geminiDir(m))).toBe(false);
+    expect(readFileSync(geminiSettingsFile(m), "utf8")).toBe(geminiSettings());
+    expect(readHostRegistry(m.home).hosts["gemini"]).toBeUndefined();
+  });
+
+  test("and neither does one whose declared MCP server points at nothing", async () => {
+    const m = machine({ mcp: "dangling" });
+    const out = await geminiOnly(m);
+
+    expect(out[0]?.status).toBe("blocked");
+    expect(out[0]?.reason).toContain("servers/redskilled.mjs");
+    expect(existsSync(geminiDir(m))).toBe(false);
+    expect(readFileSync(geminiSettingsFile(m), "utf8")).toBe(geminiSettings());
+    expect(readHostRegistry(m.home).hosts["gemini"]).toBeUndefined();
+  });
+
+  test("a valid set installs into a clean Gemini home with nothing spawned", async () => {
+    // No `~/.gemini` at all, and no command issued: the projection is
+    // files red-dev writes itself, so it needs no CLI and no network.
+    const m = machine({ hooks: "declared" });
+    rmSync(join(m.home, ".gemini"), { recursive: true, force: true });
+
+    const { calls, run } = runner(m);
+    const out = await geminiOnly(m, { run });
+
+    expect(out[0]?.status).toBe("reconciled");
+    expect(out[0]?.mode).toBe("extension");
+    expect(calls).toEqual([]);
+
+    expect(JSON.parse(readFileSync(join(geminiDir(m), "gemini-extension.json"), "utf8"))).toMatchObject({
+      name: "red-skills",
+      contextFileName: "REDSKILLS.md",
+    });
+    expect(readFileSync(join(geminiDir(m), "REDSKILLS.md"), "utf8")).toContain("shipped");
+    expect(existsSync(join(geminiDir(m), "skills", "shipped", "SKILL.md"))).toBe(true);
+    expect(JSON.parse(readFileSync(geminiSettingsFile(m), "utf8"))["mcpServers"]).toEqual({
+      "red-skills-redskilled": { command: "bun", args: ["run", "d.mjs"] },
+    });
+    expect(readHostRegistry(m.home).hosts["gemini"]?.mode).toBe("extension");
+  });
+
+  test("verification reads Gemini's own state back, not the exit code", async () => {
+    const m = machine({ hooks: "declared" });
+
+    // Nothing projected yet: there is no extension for Gemini to load.
+    expect(await geminiCheck(m)).toMatchObject({ ok: false });
+
+    await geminiOnly(m);
+    expect(await geminiCheck(m)).toEqual({ ok: true });
+
+    // Every declared surface, one at a time. The manifest Gemini reads
+    // first, the skills path it resolves out of it, and the server it
+    // starts from a file red-dev owns one field of.
+    const manifest = join(geminiDir(m), "gemini-extension.json");
+    const kept = readFileSync(manifest, "utf8");
+    writeFileSync(manifest, "{ not json\n");
+    expect((await geminiCheck(m)).reason).toContain("Gemini can load");
+    writeFileSync(manifest, kept);
+
+    rmSync(join(geminiDir(m), "skills", "shipped"), { recursive: true, force: true });
+    expect((await geminiCheck(m)).reason).toContain("skills/shipped");
+    mkdirSync(join(geminiDir(m), "skills", "shipped"), { recursive: true });
+    writeFileSync(join(geminiDir(m), "skills", "shipped", "SKILL.md"), "---\nname: shipped\n---\n");
+
+    writeFileSync(geminiSettingsFile(m), geminiSettings());
+    expect((await geminiCheck(m)).reason).toContain("mcpServers.red-skills-redskilled");
+  });
+
+  test("and a state that moved under it is reconciled again rather than skipped", async () => {
+    const m = machine({ hooks: "declared" });
+    await geminiOnly(m);
+
+    // A second tool rewrote the settings file, taking our server with it.
+    writeFileSync(geminiSettingsFile(m), geminiSettings());
+    const out = await geminiOnly(m);
+
+    expect(out[0]?.status).toBe("reconciled");
+    expect(JSON.parse(readFileSync(geminiSettingsFile(m), "utf8"))["mcpServers"]["red-skills-redskilled"])
+      .toEqual({ command: "bun", args: ["run", "d.mjs"] });
+  });
+
+  test("re-running the install produces no drift at all", async () => {
+    const m = machine({ hooks: "declared" });
+    expect((await geminiOnly(m))[0]?.status).toBe("reconciled");
+    const before = snapshot(join(m.home, ".gemini"));
+
+    const { calls, run } = runner(m);
+    const out = await geminiOnly(m, { run });
+
+    expect(out[0]?.status).toBe("current");
+    expect(calls).toEqual([]);
+    // Byte for byte and mtime for mtime: a converge that rewrote an
+    // unchanged file would be claiming work it did not do.
+    expect(snapshot(join(m.home, ".gemini"))).toEqual(before);
+  });
+
+  test("uninstall removes what it owns and leaves the rest of ~/.gemini", async () => {
+    const m = machine({ hooks: "declared" });
+    await geminiOnly(m);
+
+    const theirs = join(m.home, ".gemini", "extensions", "their-extension");
+    mkdirSync(theirs, { recursive: true });
+    writeFileSync(join(theirs, "gemini-extension.json"), "{ \"name\": \"theirs\" }\n");
+
+    const out = await removeSkillHosts(UBUNTU, {
+      home: m.home,
+      config: m.config,
+      source: m.tree,
+      plugins: ACTIVATED,
+      present: () => true,
+      run: runner(m).run,
+      adapters: [adapterNamed("gemini")],
+    });
+
+    expect(out[0]?.removed).toBe(true);
+    expect(existsSync(geminiDir(m))).toBe(false);
+    expect(readFileSync(join(theirs, "gemini-extension.json"), "utf8")).toContain("theirs");
+    expect(readFileSync(geminiSettingsFile(m), "utf8")).toBe(geminiSettings());
+    expect(readHostRegistry(m.home).hosts["gemini"]).toBeUndefined();
+  });
+
+  test("what Gemini cannot be given is said in the outcome and in doctor", async () => {
+    // Hooks are the rich capability the set carries and this host has no
+    // runner for. Saying so is the point: a converge that reported seven
+    // identical hosts would be describing the table, not the machine.
+    const m = machine({ hooks: "declared" });
+    const first = await geminiOnly(m);
+
+    expect(first[0]?.status).toBe("reconciled");
+    expect(first[0]?.missing?.join(" ")).toContain("hooks");
+
+    // And it survives into the record, so the converge that skips the host
+    // still says what the host does not have.
+    const second = await geminiOnly(m);
+    expect(second[0]?.status).toBe("current");
+    expect(second[0]?.missing?.join(" ")).toContain("hooks");
+
+    const row = redSkillsHostRows(redSkillsHostReport(m.home)).find((r) => r.detail.startsWith("gemini"));
+    expect(row?.detail).toContain("hooks");
+    expect(redSkillsHostReport(m.home).hosts[0]?.capabilities).toContainEqual(
+      expect.objectContaining({ name: "hooks", state: "unsupported" }),
+    );
+  });
+
+  test("a set that declares no MCP is reported as carrying none, not as broken", async () => {
+    const m = machine({ mcp: false });
+    const out = await geminiOnly(m);
+
+    expect(out[0]?.status).toBe("reconciled");
+    expect(out[0]?.missing?.join(" ")).toContain("mcp");
+    expect(readFileSync(geminiSettingsFile(m), "utf8")).toBe(geminiSettings());
+  });
+
+  test("a Gemini session that was up is told to restart, never killed", async () => {
+    const m = machine({ hooks: "declared" });
+    const { calls, run } = runner(m);
+    const out = await geminiOnly(m, { run, running: () => true });
+
+    expect(out[0]?.reload).toBe("restart-needed");
+    expect(calls).toEqual([]);
+    const row = redSkillsHostRows(redSkillsHostReport(m.home)).find((r) => r.detail.startsWith("gemini"));
+    expect(row?.status).toBe("warn");
+    expect(row?.detail).toContain("restart needed");
+  });
+});
+
 // -------------------------------------------------------------- the removal
 
 describe("removal is the ownership manifest, replayed", () => {
@@ -881,5 +1151,8 @@ describe("the converge reaches the reconciliation", () => {
     const wired = converge.indexOf("already wired into");
     expect(wired).toBeGreaterThan(-1);
     expect(converge.slice(wired)).toContain("reconcileSkillHosts");
+    // And what a host did not get is on the converge itself rather than
+    // only in a doctor run nobody is obliged to make.
+    expect(converge.slice(wired)).toContain("h.missing");
   });
 });

--- a/src/red-skills-hosts.ts
+++ b/src/red-skills-hosts.ts
@@ -63,6 +63,19 @@
  * one named field of a user's file through src/owned-config.ts, which
  * leaves every other byte of that file exactly where it was.
  *
+ * ## Converged is not the same as equal
+ *
+ * Seven hosts do not have seven equal surfaces. Gemini takes skills and
+ * MCP and has no hook runner at all, so a set that ships hooks reaches it
+ * without them; a set may declare no MCP for anybody. Both leave a host
+ * that is genuinely converged and genuinely poorer than its neighbour, and
+ * a walk that answered "reconciled" and stopped would be reporting the
+ * table rather than the machine. So each plan says what became of every
+ * capability the set carries, the record keeps it, and the converge and
+ * doctor both name what a host did not get — with `absent` (the set
+ * carried none) kept apart from `unsupported` (the host cannot take it),
+ * because only one of the two is fixed by shipping a better set.
+ *
  * Everything red-dev owns is written into the record as an ownership
  * manifest, and removal is that manifest read back. That is the whole of
  * the uninstall contract: a config directory holds files nobody here put
@@ -80,7 +93,7 @@ import {
   statSync,
   writeFileSync,
 } from "node:fs";
-import { dirname, join } from "node:path";
+import { dirname, isAbsolute, join } from "node:path";
 
 import { sha256Hex } from "./checksum.ts";
 import { log } from "./log.ts";
@@ -128,6 +141,34 @@ export type AdapterMode = "marketplace" | "generator" | "extension" | "skills";
 
 /** Whether a running session has yet to see what converged underneath it. */
 export type ReloadState = "current" | "restart-needed";
+
+/**
+ * One thing the package set carries, and what became of it in this host.
+ *
+ * Seven hosts do not have seven equal surfaces. Gemini takes skills and
+ * MCP and has no hook runner at all; a set may declare no MCP for anyone.
+ * Both of those produce a host that is genuinely converged and genuinely
+ * has less than its neighbour, and the two reasons are not the same fact:
+ * `absent` is something the set never carried, `unsupported` is something
+ * the host cannot be given. A converge that reported seven identical rows
+ * would be describing the table instead of the machine, which is the
+ * failure this whole module is a correction to.
+ */
+export interface HostCapability {
+  /** `skills`, `mcp`, `hooks`. */
+  name: string;
+  /** Projected into the host, absent from the set, or beyond the host. */
+  state: "projected" | "absent" | "unsupported";
+  /** Why it is not projected. Present exactly when it is not. */
+  reason?: string;
+}
+
+/** The capabilities a host did not get, as the lines a person reads. */
+export function missingCapabilities(capabilities: readonly HostCapability[] = []): string[] {
+  return capabilities
+    .filter((c) => c.state !== "projected")
+    .map((c) => `no ${c.name}: ${c.reason ?? c.state}`);
+}
 
 /** What every adapter is a function of. */
 export interface AdapterContext {
@@ -196,6 +237,8 @@ export interface HostPlan {
   merges: OwnedMerge[];
   /** State that must exist afterwards for this host to count as done. */
   expect: OwnedEntry[];
+  /** What the set carries, and what this host does with each of it. */
+  capabilities: HostCapability[];
   /**
    * Where a generator records what it wrote.
    *
@@ -217,6 +260,7 @@ function plan(partial: Partial<HostPlan> & { mode: AdapterMode }): HostPlan {
     copies: [],
     merges: [],
     expect: [],
+    capabilities: [],
     manifests: [],
     ...partial,
   };
@@ -240,7 +284,7 @@ export interface HostAdapter {
    * facts that live inside an application's own store, where the file
    * exists either way and only its contents say whether the host agrees.
    */
-  check?: (ctx: AdapterContext) => Promise<HostCheck>;
+  check?: (ctx: AdapterContext, plan: HostPlan) => Promise<HostCheck>;
   /** The commands that take this host's own state back out. */
   remove: (ctx: AdapterContext) => HostStep[];
 }
@@ -466,20 +510,126 @@ function setSkills(ctx: AdapterContext): SetSkill[] {
 function declaredMcp(ctx: AdapterContext): Record<string, unknown> {
   const out: Record<string, unknown> = {};
   for (const plugin of ctx.plugins) {
-    const file = join(pluginDir(ctx, plugin), ".mcp.json");
-    if (!existsSync(file)) continue;
-    try {
-      const parsed = JSON.parse(readFileSync(file, "utf8")) as Record<string, unknown>;
-      const servers = (parsed["mcpServers"] ?? parsed) as Record<string, unknown>;
-      if (servers === null || typeof servers !== "object" || Array.isArray(servers)) continue;
-      for (const [name, value] of Object.entries(servers)) out[`${MARKETPLACE}-${name}`] = value;
-    } catch {
-      // A payload we cannot read is a payload we do not project. The host
-      // is reported as unconverged rather than given half a config.
-      log.warn(`red-skills: ${file} is not JSON — no MCP projected from it`);
+    for (const [name, value] of Object.entries(pluginMcp(pluginDir(ctx, plugin)))) {
+      out[`${MARKETPLACE}-${name}`] = value;
     }
   }
   return out;
+}
+
+/** One plugin's servers, under the names the plugin itself gave them. */
+function pluginMcp(root: string): Record<string, unknown> {
+  const file = join(root, ".mcp.json");
+  if (!existsSync(file)) return {};
+  try {
+    const parsed = JSON.parse(readFileSync(file, "utf8")) as Record<string, unknown>;
+    const servers = (parsed["mcpServers"] ?? parsed) as Record<string, unknown>;
+    if (servers === null || typeof servers !== "object" || Array.isArray(servers)) return {};
+    return servers;
+  } catch {
+    // A payload we cannot read is a payload we do not project. The host
+    // is reported as unconverged rather than given half a config.
+    log.warn(`red-skills: ${file} is not JSON — no MCP projected from it`);
+    return {};
+  }
+}
+
+/**
+ * The commands one plugin's `hooks/hooks.json` declares, flattened.
+ *
+ * Shape rather than schema: the file nests matchers inside event names and
+ * hooks inside matchers, and everything read out of it here is the one
+ * field that names something on disk. A file this cannot parse declares no
+ * hook, which is the same answer as a plugin that ships none — the host
+ * that has no hook runner is told the truth either way.
+ */
+function pluginHooks(root: string): string[] {
+  const file = join(root, "hooks", "hooks.json");
+  if (!existsSync(file)) return [];
+  const out: string[] = [];
+  const walk = (node: unknown): void => {
+    if (Array.isArray(node)) {
+      for (const item of node) walk(item);
+      return;
+    }
+    if (node === null || typeof node !== "object") return;
+    const record = node as Record<string, unknown>;
+    const command = record["command"];
+    if (typeof command === "string") out.push(command);
+    for (const value of Object.values(record)) walk(value);
+  };
+  try {
+    walk(JSON.parse(readFileSync(file, "utf8")));
+  } catch {
+    log.warn(`red-skills: ${file} is not JSON — no hook read out of it`);
+    return [];
+  }
+  return out;
+}
+
+/** One file the activated payload names, and what named it. */
+interface DeclaredPath {
+  /** The declaration it came out of, for the sentence a person reads. */
+  what: string;
+  /** Where it resolves to inside the package set. */
+  path: string;
+}
+
+/**
+ * The file a token in a declared command names, or null if it names none.
+ *
+ * A command is `bun`, `node`, a plugin-root path or an argument that is
+ * not a path at all, and only the third of those is checkable: a bare
+ * program name resolves off PATH and a bare filename resolves against a
+ * cwd nothing here owns, so treating either as a dangling path would be a
+ * check that fails on every correct set. A token still carrying a
+ * variable after expansion belongs to the host that expands it.
+ */
+function declaredPathIn(root: string, token: string): string | null {
+  // A function replacement, so a `$&` in the resolved path stays literal.
+  const expanded = token.replace(/\$\{(?:CLAUDE|CODEX)_PLUGIN_ROOT\}/g, () => root);
+  if (expanded.includes("$")) return null;
+  if (!expanded.includes("/") && !expanded.includes("\\")) return null;
+  return isAbsolute(expanded) ? expanded : join(root, expanded);
+}
+
+/**
+ * Every file the activated payload names, so a dangling one can be caught.
+ *
+ * A package set composed halfway declares a server and a hook whose
+ * scripts are not in the tarball. Installing that projects a config whose
+ * every entry fails the moment the host tries to use it — an MCP server
+ * that dies at launch, a hook that is not there — and a host recorded as
+ * converged against it is the worst of the two ways to be wrong. So the
+ * declarations are resolved against the set before anything is written.
+ */
+function declaredPaths(ctx: AdapterContext): DeclaredPath[] {
+  const out: DeclaredPath[] = [];
+  for (const plugin of ctx.plugins) {
+    const root = pluginDir(ctx, plugin);
+    for (const command of pluginHooks(root)) {
+      for (const token of command.split(/\s+/)) {
+        const path = declaredPathIn(root, token);
+        if (path !== null) out.push({ what: `${plugin} hook`, path });
+      }
+    }
+    for (const [name, server] of Object.entries(pluginMcp(root))) {
+      for (const token of serverTokens(server)) {
+        const path = declaredPathIn(root, token);
+        if (path !== null) out.push({ what: `${plugin} MCP server ${name}`, path });
+      }
+    }
+  }
+  return out;
+}
+
+/** The command and arguments of one declared server, as flat strings. */
+function serverTokens(server: unknown): string[] {
+  if (server === null || typeof server !== "object") return [];
+  const record = server as Record<string, unknown>;
+  const command = typeof record["command"] === "string" ? [record["command"]] : [];
+  const args = Array.isArray(record["args"]) ? record["args"].filter((a) => typeof a === "string") : [];
+  return [...command, ...(args as string[])];
 }
 
 /**
@@ -518,9 +668,21 @@ const gemini: HostAdapter = {
       return plan({ mode: "extension", blocked: "the package set carries no skills to project" });
     }
 
-    const dir = join(ctx.home, ".gemini", "extensions", MARKETPLACE);
+    // Before a byte is written, because the alternative is a config whose
+    // every entry fails the first time Gemini uses it and a home directory
+    // holding half an extension nothing recorded.
+    const dangling = declaredPaths(ctx).find((declared) => !existsSync(declared.path));
+    if (dangling !== undefined) {
+      return plan({
+        mode: "extension",
+        blocked: `the ${dangling.what} names ${dangling.path}, which the package set does not carry`,
+      });
+    }
+
+    const dir = geminiExtensionDir(ctx);
     const mcp = declaredMcp(ctx);
-    const settings = join(ctx.home, ".gemini", "settings.json");
+    const hooks = ctx.plugins.flatMap((p) => pluginHooks(pluginDir(ctx, p)));
+    const settings = geminiSettingsFile(ctx);
     return plan({
       mode: "extension",
       writes: [
@@ -532,7 +694,7 @@ const gemini: HostAdapter = {
             2,
           )}\n`,
         },
-        { path: join(dir, "REDSKILLS.md"), bytes: contextFile(ctx, skills) },
+        { path: join(dir, "REDSKILLS.md"), bytes: contextFile(ctx, skills, mcp, hooks) },
       ],
       copies: skills.map((skill) => ({ from: skill.path, to: join(dir, "skills", skill.name) })),
       merges: Object.entries(mcp).map(([name, value]) => ({
@@ -544,13 +706,105 @@ const gemini: HostAdapter = {
       // removing RedSkills has to leave `~/.gemini/extensions` the way it
       // found it rather than with our empty shell still sitting in it.
       expect: [{ kind: "path", path: dir }],
+      capabilities: [
+        { name: "skills", state: "projected" },
+        Object.keys(mcp).length > 0
+          ? { name: "mcp", state: "projected" }
+          : { name: "mcp", state: "absent", reason: "the package set declares no MCP server" },
+        // Not a gap in the projection: Gemini has no hook runner to give
+        // them to, so a set that carries hooks reaches this host without
+        // them and doctor says which capability was left behind.
+        hooks.length > 0
+          ? {
+              name: "hooks",
+              state: "unsupported",
+              reason: `Gemini runs no hook of its own, so the ${hooks.length} the set declares are not projected`,
+            }
+          : { name: "hooks", state: "absent", reason: "the package set declares no hook" },
+      ],
     });
   },
+  check: (ctx, desired) => geminiCheck(ctx, desired),
   remove: (ctx) => {
     const script = generator(ctx.source, "install-gemini.sh");
     return existsSync(script) ? [must(script, "--uninstall", "--user")] : [];
   },
 };
+
+/** The directory red-dev owns outright under Gemini's extensions. */
+function geminiExtensionDir(ctx: AdapterContext): string {
+  return join(ctx.home, ".gemini", "extensions", MARKETPLACE);
+}
+
+/** The file Gemini resolves its MCP servers from, and the operator owns. */
+function geminiSettingsFile(ctx: AdapterContext): string {
+  return join(ctx.home, ".gemini", "settings.json");
+}
+
+/**
+ * What Gemini itself says it has, read back the way Gemini reads it.
+ *
+ * The exit code proves nothing here — nothing was spawned. What can be
+ * wrong is everything between the plan and the load: a manifest Gemini's
+ * parser rejects, a `contextFileName` pointing at a file that is not
+ * beside it, a skills directory that was copied and then emptied, a server
+ * a second tool took back out of `settings.json`. Each of those leaves a
+ * host that looks installed from the outside and loads nothing, and each
+ * of them is a reason to reconcile rather than a reason to record.
+ *
+ * The declared paths are resolved again at the end rather than only at
+ * plan time, because this is also what a skipped converge asks: a set
+ * edited in place under a recorded host can lose the script its server
+ * runs, and the host has to stop being current the moment it does.
+ *
+ * A generator in the tree answers for its own tree — its install manifest
+ * is what verification reads, generically — so this stands down for it.
+ */
+async function geminiCheck(ctx: AdapterContext, desired: HostPlan): Promise<HostCheck> {
+  if (desired.mode !== "extension") return { ok: true, witness: "" };
+
+  const dir = geminiExtensionDir(ctx);
+  const manifest = join(dir, "gemini-extension.json");
+  if (!existsSync(manifest)) return { ok: false, reason: `${manifest} is not there` };
+
+  let loaded: Record<string, unknown>;
+  try {
+    loaded = JSON.parse(readFileSync(manifest, "utf8")) as Record<string, unknown>;
+  } catch {
+    return { ok: false, reason: `${manifest} is not JSON Gemini can load` };
+  }
+  if (loaded["name"] !== MARKETPLACE) {
+    return { ok: false, reason: `${manifest} declares the extension as ${String(loaded["name"])}` };
+  }
+  const contextFileName = loaded["contextFileName"];
+  if (typeof contextFileName !== "string" || !existsSync(join(dir, contextFileName))) {
+    return { ok: false, reason: `${manifest} names a context file Gemini cannot read` };
+  }
+
+  for (const skill of setSkills(ctx)) {
+    const projected = join(dir, "skills", skill.name, "SKILL.md");
+    if (!existsSync(projected)) return { ok: false, reason: `${projected} is not there` };
+  }
+
+  const settings = geminiSettingsFile(ctx);
+  const text = existsSync(settings) ? readFileSync(settings, "utf8") : "";
+  const servers = declaredMcp(ctx);
+  for (const [name, value] of Object.entries(servers)) {
+    const seen = readOwnedField(text, ["mcpServers", name]);
+    if (seen === undefined) return { ok: false, reason: `${settings} declares no mcpServers.${name}` };
+    if (JSON.stringify(seen) !== JSON.stringify(value)) {
+      return { ok: false, reason: `mcpServers.${name} in ${settings} is not the server the set declares` };
+    }
+  }
+
+  for (const declared of declaredPaths(ctx)) {
+    if (!existsSync(declared.path)) {
+      return { ok: false, reason: `the ${declared.what} names ${declared.path}, which is not there` };
+    }
+  }
+
+  return { ok: true, witness: JSON.stringify({ loaded, servers: Object.keys(servers).sort() }) };
+}
 
 /**
  * Hermes, which has skills and nothing else.
@@ -592,17 +846,44 @@ const hermes: HostAdapter = {
   },
 };
 
-/** What Gemini reads when it loads the extension: the set, as one page. */
-function contextFile(ctx: AdapterContext, skills: readonly SetSkill[]): string {
+/**
+ * What Gemini reads when it loads the extension: the set, as one page.
+ *
+ * The servers and the missing hook runner are on it as well as the skills,
+ * because a model told what it has is also being told what it does not:
+ * a session that believes a hook fires on its behalf is a session waiting
+ * for something nothing on this host will ever run.
+ */
+function contextFile(
+  ctx: AdapterContext,
+  skills: readonly SetSkill[],
+  servers: Readonly<Record<string, unknown>>,
+  hooks: readonly string[],
+): string {
+  const names = Object.keys(servers).sort();
   const lines = [
     `# RedSkills ${ctx.setVersion}`,
     "",
     `Projected by red-dev from ${ctx.current}. Do not edit: this file is`,
     "rewritten whenever the package set moves.",
     "",
+    "## Skills",
+    "",
     ...skills.map((skill) =>
       skill.description ? `- **${skill.name}** — ${skill.description}` : `- **${skill.name}**`
     ),
+    "",
+    "## MCP servers",
+    "",
+    ...(names.length > 0
+      ? names.map((name) => `- \`${name}\`, started by Gemini from \`settings.json\`.`)
+      : ["The package set declares none."]),
+    "",
+    "## Hooks",
+    "",
+    hooks.length > 0
+      ? `The set declares ${hooks.length}, and Gemini runs no hook of its own: none of them fires here.`
+      : "The package set declares none.",
   ];
   return `${lines.join("\n")}\n`;
 }
@@ -637,6 +918,15 @@ export interface HostRecord {
   mode: AdapterMode;
   /** The plugins activated in this host. */
   plugins: string[];
+  /**
+   * What the set carried and what this host got of it.
+   *
+   * Optional because it arrived after schema 2 shipped, and a record
+   * written before it is not wrong — it is a record from a converge that
+   * did not have the vocabulary. It reads as no capability reported, and
+   * the next converge that touches the host writes the real answer.
+   */
+  capabilities?: HostCapability[];
   /** The digest of the owned state, as it was on disk when verified. */
   stateDigest: string;
   /** Whether a session running at the time still has to be restarted. */
@@ -757,6 +1047,13 @@ export interface HostOutcome {
   reason?: string;
   /** Present when this converge verified the host. */
   reload?: ReloadState;
+  /**
+   * What the set carries and this host did not get, in sentences.
+   *
+   * Reported on the skipped converge as well as the reconciling one, out
+   * of the record — a host is no richer on the day nothing happened to it.
+   */
+  missing?: string[];
 }
 
 /** Whether every required host converged. */
@@ -919,6 +1216,7 @@ export async function reconcileSkillHosts(
         mode: recorded.mode,
         reason: `already reconciled at ${ctx.setVersion}`,
         reload: recorded.reload,
+        missing: missingCapabilities(recorded.capabilities),
       });
       continue;
     }
@@ -949,6 +1247,7 @@ export async function reconcileSkillHosts(
       setVersion: ctx.setVersion,
       mode: desired.mode,
       plugins: [...plugins],
+      capabilities: desired.capabilities,
       stateDigest: verified.stateDigest,
       reload,
       owned: verified.owned,
@@ -956,7 +1255,13 @@ export async function reconcileSkillHosts(
     };
     await writeHostRegistry(home, registry);
     log.ok(`${adapter.name}: red-skills reconciled to ${ctx.setVersion}`);
-    out.push({ host: adapter.name, status: "reconciled", mode: desired.mode, reload });
+    out.push({
+      host: adapter.name,
+      status: "reconciled",
+      mode: desired.mode,
+      reload,
+      missing: missingCapabilities(desired.capabilities),
+    });
   }
 
   return out;
@@ -983,7 +1288,7 @@ async function isCurrent(
   if (record.mode !== desired.mode) return false;
   if (record.plugins.join("\0") !== ctx.plugins.join("\0")) return false;
 
-  const witness = adapter.check ? await adapter.check(ctx) : ({ ok: true, witness: "" } as HostCheck);
+  const witness = adapter.check ? await adapter.check(ctx, desired) : ({ ok: true, witness: "" } as HostCheck);
   if (!witness.ok) return false;
   return (await stateDigestOf(record.owned, witness.witness)) === record.stateDigest;
 }
@@ -1099,7 +1404,7 @@ async function verifyPlan(
     return { ...empty, reason: "the generator recorded no install manifest" };
   }
 
-  const check = adapter.check ? await adapter.check(ctx) : ({ ok: true, witness: "" } as HostCheck);
+  const check = adapter.check ? await adapter.check(ctx, desired) : ({ ok: true, witness: "" } as HostCheck);
   if (!check.ok) return { ...empty, reason: check.reason };
 
   for (const entry of owned) {
@@ -1276,6 +1581,8 @@ export interface HostDoctorRow {
   /** The state that reconciliation owns, as observed when it verified. */
   stateDigest: string;
   plugins: string[];
+  /** What the set carried and what this host got of it. */
+  capabilities: HostCapability[];
   reload: ReloadState;
   verifiedAt: string;
 }
@@ -1314,6 +1621,7 @@ export function redSkillsHostReport(
       setVersion: record.setVersion,
       stateDigest: record.stateDigest,
       plugins: record.plugins,
+      capabilities: record.capabilities ?? [],
       reload: record.reload,
       verifiedAt: record.verifiedAt,
     });
@@ -1328,13 +1636,20 @@ export interface HostDoctorLine {
 
 /** The report as the lines doctor prints. */
 export function redSkillsHostRows(report: HostDoctorReport): HostDoctorLine[] {
-  const rows: HostDoctorLine[] = report.hosts.map((row) => ({
-    status: row.reload === "restart-needed" ? "warn" : "ok",
-    detail:
-      `${row.host} (${row.mode}) — ${row.setVersion} ${row.setDigest.slice(0, 12)}, ` +
-      `state ${row.stateDigest.slice(0, 12)}, ${row.plugins.join(", ") || "no plugin"} activated` +
-      (row.reload === "restart-needed" ? " — restart needed to load it" : ""),
-  }));
+  const rows: HostDoctorLine[] = report.hosts.map((row) => {
+    // Said on the same line as the digests, because "converged" and "has
+    // less than its neighbour" are both true of this host at once and
+    // reading one without the other is how a machine is misdescribed.
+    const missing = missingCapabilities(row.capabilities);
+    return {
+      status: row.reload === "restart-needed" ? "warn" : "ok",
+      detail:
+        `${row.host} (${row.mode}) — ${row.setVersion} ${row.setDigest.slice(0, 12)}, ` +
+        `state ${row.stateDigest.slice(0, 12)}, ${row.plugins.join(", ") || "no plugin"} activated` +
+        (missing.length > 0 ? ` — ${missing.join("; ")}` : "") +
+        (row.reload === "restart-needed" ? " — restart needed to load it" : ""),
+    };
+  });
   if (report.unrecorded.length > 0) {
     rows.push({
       status: "n/a",


### PR DESCRIPTION
Automated AFK landing for #207. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #207

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789690229&installation_model_id=20659&pr_number=221&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F221&signature=f50d815009a3302c46b1d9509d90b309c3acba4b8c5cf42666692b336df551a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->