### PR TITLE
fix: #209 Hermes converges complete dev skills and explicit capability limits

### DIFF
--- a/src/red-skills-hosts.test.ts
+++ b/src/red-skills-hosts.test.ts
@@ -27,6 +27,7 @@ import {
   readdirSync,
   rmSync,
   statSync,
+  symlinkSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -175,6 +176,17 @@ interface SetOptions {
   mcp?: boolean | "dangling";
   /** Whether `dev` declares hooks, and whether their scripts are there. */
   hooks?: "declared" | "dangling";
+  /**
+   * Whether the first `dev` skill carries a payload beside its `SKILL.md`.
+   *
+   * A skill is a directory: the references it cites and the scripts it runs
+   * are as much of it as the entry point. `"dangling"` cites one the set
+   * does not carry — the shape a half-composed set has, and the one a
+   * skills-only host must refuse before it writes anything.
+   */
+  assets?: boolean | "dangling";
+  /** Whether `dev` carries agent definitions, which no skills-only host loads. */
+  agents?: boolean;
   /** Generators to leave out, for the hosts that then have none. */
   without?: string[];
 }
@@ -195,7 +207,14 @@ function packageSet(opts: SetOptions = {}): string {
     chmodSync(path, 0o755);
   }
 
-  for (const skill of opts.skills ?? ["shipped"]) addSkill(tree, "dev", skill);
+  const carried = opts.skills ?? ["shipped"];
+  for (const skill of carried) addSkill(tree, "dev", skill);
+  if (opts.assets !== undefined && carried[0] !== undefined) addAssets(tree, carried[0], opts.assets);
+  if (opts.agents === true) {
+    const dir = join(tree, "plugins", "dev", "agents");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "reviewer.md"), "---\nname: reviewer\n---\n");
+  }
   // A payload the set carries and nothing activates. Every assertion about
   // "only dev" is really an assertion that this one never lands.
   addSkill(tree, "memory", "memory-only");
@@ -248,6 +267,25 @@ function addSkill(tree: string, plugin: string, name: string): void {
   const dir = join(tree, "plugins", plugin, "skills", name);
   mkdirSync(dir, { recursive: true });
   writeFileSync(join(dir, "SKILL.md"), `---\nname: ${name}\ndescription: what ${name} does\n---\n`);
+}
+
+/**
+ * The payload one skill carries beside its entry point.
+ *
+ * The dangling variant is a link with nothing behind it, which is what a
+ * set composed against a tree that moved leaves: the copy still puts it on
+ * the machine, still pointing at nothing, and the skill that cites it fails
+ * in the middle of somebody's session rather than at install time.
+ */
+function addAssets(tree: string, skill: string, kind: boolean | "dangling"): void {
+  const root = join(tree, "plugins", "dev", "skills", skill);
+  mkdirSync(join(root, "references"), { recursive: true });
+  writeFileSync(join(root, "references", "guide.md"), "# the long form of it\n");
+  mkdirSync(join(root, "scripts"), { recursive: true });
+  const script = join(root, "scripts", "run.sh");
+  writeFileSync(script, "#!/usr/bin/env bash\nexit 0\n");
+  chmodSync(script, 0o755);
+  if (kind === "dangling") symlinkSync("./gone.md", join(root, "references", "cited.md"));
 }
 
 /** Claude's own store, with a marketplace of the operator's beside ours. */
@@ -747,8 +785,8 @@ describe("configuration the operator owns", () => {
 
 // ------------------------------------------------------------- the Gemini
 
-/** What the Gemini adapter is a function of, for the checks called directly. */
-function geminiContext(m: Machine): AdapterContext {
+/** What an adapter is a function of, for the plans and checks called directly. */
+function hostContext(m: Machine): AdapterContext {
   return {
     plugins: ACTIVATED,
     source: m.tree,
@@ -786,7 +824,7 @@ function snapshot(root: string, base = root): Record<string, string> {
 
 async function geminiCheck(m: Machine): Promise<{ ok: boolean; reason?: string }> {
   const adapter = adapterNamed("gemini");
-  const ctx = geminiContext(m);
+  const ctx = hostContext(m);
   const checked = await adapter.check?.(ctx, adapter.plan(ctx));
   if (!checked) throw new Error("the Gemini adapter answers no check");
   return checked.ok ? { ok: true } : { ok: false, reason: checked.reason };
@@ -971,6 +1009,251 @@ describe("the Gemini projection of the local dev set", () => {
     const row = redSkillsHostRows(redSkillsHostReport(m.home)).find((r) => r.detail.startsWith("gemini"));
     expect(row?.status).toBe("warn");
     expect(row?.detail).toContain("restart needed");
+  });
+});
+
+// ------------------------------------------------------------- the Hermes
+
+const HERMES_SKILLS = ["skills", "red-skills"] as const;
+
+function hermesDir(m: Machine): string {
+  return join(m.home, ".hermes", ...HERMES_SKILLS);
+}
+
+async function hermesCheck(m: Machine): Promise<{ ok: boolean; reason?: string }> {
+  const adapter = adapterNamed("hermes");
+  const ctx = hostContext(m);
+  const checked = await adapter.check?.(ctx, adapter.plan(ctx));
+  if (!checked) throw new Error("the Hermes adapter answers no check");
+  return checked.ok ? { ok: true } : { ok: false, reason: checked.reason };
+}
+
+function hermesOnly(m: Machine, opts: HostReconcileOptions = {}): Promise<HostOutcome[]> {
+  return reconcile(m, { run: runner(m).run, adapters: [adapterNamed("hermes")], ...opts });
+}
+
+describe("the user-global surface Hermes supports", () => {
+  test("is a skills tree of its own, and no command and no config file", () => {
+    // The contract, read off the plan rather than off the disk: everything
+    // this host is given lands under one directory red-dev made, nothing is
+    // spawned to put it there, and no field of anybody's file is ours.
+    const m = machine({ hooks: "declared", assets: true, agents: true });
+    const adapter = adapterNamed("hermes");
+    const desired = adapter.plan(hostContext(m));
+
+    expect(adapter.cmd).toBe("hermes");
+    expect(desired.mode).toBe("skills");
+    expect(desired.steps).toEqual([]);
+    expect(desired.merges).toEqual([]);
+    expect(desired.manifests).toEqual([]);
+
+    const owned = [
+      ...desired.writes.map((w) => w.path),
+      ...desired.copies.map((c) => c.to),
+      ...desired.expect.flatMap((e) => (e.kind === "path" ? [e.path] : [])),
+    ];
+    expect(owned.length).toBeGreaterThan(0);
+    for (const path of owned) expect(path, path).toStartWith(hermesDir(m));
+
+    // And the limits, named rather than left to be inferred from what is
+    // missing: three capabilities the set carries that this host has no
+    // mechanism for, in one list beside the one it does.
+    expect(desired.capabilities.map((c) => `${c.name}:${c.state}`)).toEqual([
+      "skills:projected",
+      "mcp:unsupported",
+      "hooks:unsupported",
+      "agents:unsupported",
+    ]);
+  });
+
+  test("a set that ships a generator for it stands the projection down", () => {
+    const m = machine();
+    const script = join(m.tree, "scripts", "install-hermes.sh");
+    writeFileSync(script, "#!/usr/bin/env bash\nexit 0\n");
+    chmodSync(script, 0o755);
+
+    const desired = adapterNamed("hermes").plan(hostContext(m));
+    expect(desired.mode).toBe("generator");
+    expect(lines(desired.steps.map((s) => s.argv))).toEqual([`${script} --source-dir ${m.tree} --user`]);
+    expect(desired.copies).toEqual([]);
+  });
+});
+
+describe("the Hermes projection of the local dev set", () => {
+  test("a valid set installs complete skills and their payload, with nothing spawned", async () => {
+    // A clean machine: no `~/.hermes` at all, and no command issued. The
+    // projection is a tree red-dev copies out of the set it already has,
+    // so it needs no CLI, no marketplace and no network.
+    const m = machine({ hooks: "declared", assets: true, agents: true });
+    expect(existsSync(join(m.home, ".hermes"))).toBe(false);
+
+    const { calls, run } = runner(m);
+    const out = await hermesOnly(m, { run });
+
+    expect(out[0]?.status).toBe("reconciled");
+    expect(out[0]?.mode).toBe("skills");
+    expect(calls).toEqual([]);
+
+    const shipped = join(hermesDir(m), "shipped");
+    expect(readFileSync(join(shipped, "SKILL.md"), "utf8")).toContain("name: shipped");
+    // The whole skill, not its entry point: a reference the model is sent
+    // to read and a script it is told to run are the skill as much as the
+    // page naming them.
+    expect(readFileSync(join(shipped, "references", "guide.md"), "utf8")).toContain("the long form");
+    expect(statSync(join(shipped, "scripts", "run.sh")).mode & 0o111).not.toBe(0);
+    // And nothing the set carries but nobody activated.
+    expect(existsSync(join(hermesDir(m), "memory-only"))).toBe(false);
+
+    expect(readFileSync(join(hermesDir(m), "REDSKILLS.md"), "utf8")).toContain("shipped");
+    expect(readHostRegistry(m.home).hosts["hermes"]?.mode).toBe("skills");
+  });
+
+  test("a skill citing a file the set does not carry never reaches the disk", async () => {
+    const m = machine({ assets: "dangling" });
+    const { calls, run } = runner(m);
+    const out = await hermesOnly(m, { run });
+
+    expect(out[0]?.status).toBe("blocked");
+    expect(out[0]?.reason).toContain("references/cited.md");
+    expect(calls).toEqual([]);
+    expect(existsSync(join(m.home, ".hermes"))).toBe(false);
+    expect(readHostRegistry(m.home).hosts["hermes"]).toBeUndefined();
+  });
+
+  test("verification reads the projected tree back, not the exit code", async () => {
+    const m = machine({ assets: true });
+
+    // Nothing projected yet: there is no skill for Hermes to read.
+    expect(await hermesCheck(m)).toMatchObject({ ok: false });
+
+    await hermesOnly(m);
+    expect(await hermesCheck(m)).toEqual({ ok: true });
+
+    // Every part of the surface, one at a time: the payload beside the
+    // entry point, the entry point itself, and the page that says what
+    // this host has and has not.
+    const asset = join(hermesDir(m), "shipped", "references", "guide.md");
+    rmSync(asset);
+    expect((await hermesCheck(m)).reason).toContain("references/guide.md");
+    writeFileSync(asset, "# the long form of it\n");
+
+    rmSync(join(hermesDir(m), "shipped"), { recursive: true, force: true });
+    expect((await hermesCheck(m)).reason).toContain("shipped/SKILL.md");
+
+    rmSync(join(hermesDir(m), "REDSKILLS.md"));
+    expect((await hermesCheck(m)).reason).toContain("REDSKILLS.md");
+  });
+
+  test("a projection that lost part of a skill is reconciled again, not skipped", async () => {
+    const m = machine({ assets: true });
+    await hermesOnly(m);
+
+    // The state the record described is not the state on disk any more.
+    rmSync(join(hermesDir(m), "shipped", "scripts"), { recursive: true, force: true });
+    const out = await hermesOnly(m);
+
+    expect(out[0]?.status).toBe("reconciled");
+    expect(existsSync(join(hermesDir(m), "shipped", "scripts", "run.sh"))).toBe(true);
+  });
+
+  test("and one that could not be written at all is recorded as nothing", async () => {
+    // An operator's stray file where the skills path has to be. The plan
+    // fails partway, which is the state a success record must never
+    // describe: the next converge has to ask this host again.
+    const m = machine({ assets: true });
+    mkdirSync(join(m.home, ".hermes"), { recursive: true });
+    writeFileSync(join(m.home, ".hermes", "skills"), "not a directory\n");
+
+    const out = await hermesOnly(m);
+
+    expect(out[0]?.status).toBe("failed");
+    expect(readHostRegistry(m.home).hosts["hermes"]).toBeUndefined();
+  });
+
+  test("re-running the install produces no drift at all", async () => {
+    const m = machine({ assets: true, hooks: "declared" });
+    expect((await hermesOnly(m))[0]?.status).toBe("reconciled");
+    const before = snapshot(join(m.home, ".hermes"));
+
+    const { calls, run } = runner(m);
+    const out = await hermesOnly(m, { run });
+
+    expect(out[0]?.status).toBe("current");
+    expect(calls).toEqual([]);
+    // Byte for byte and mtime for mtime: a converge that recopied an
+    // unchanged tree would be claiming work it did not do.
+    expect(snapshot(join(m.home, ".hermes"))).toEqual(before);
+  });
+
+  test("uninstall removes what it owns and leaves the rest of ~/.hermes", async () => {
+    const m = machine({ assets: true });
+    await hermesOnly(m);
+
+    const theirs = join(m.home, ".hermes", "skills", "hand-written");
+    mkdirSync(theirs, { recursive: true });
+    writeFileSync(join(theirs, "SKILL.md"), "---\nname: hand-written\n---\n");
+    const settings = join(m.home, ".hermes", "settings.json");
+    writeFileSync(settings, `{ "theme": "theirs" }\n`);
+
+    const out = await removeSkillHosts(UBUNTU, {
+      home: m.home,
+      config: m.config,
+      source: m.tree,
+      plugins: ACTIVATED,
+      present: () => true,
+      run: runner(m).run,
+      adapters: [adapterNamed("hermes")],
+    });
+
+    expect(out[0]?.removed).toBe(true);
+    expect(existsSync(hermesDir(m))).toBe(false);
+    expect(readFileSync(join(theirs, "SKILL.md"), "utf8")).toContain("hand-written");
+    expect(readFileSync(settings, "utf8")).toBe(`{ "theme": "theirs" }\n`);
+    expect(readHostRegistry(m.home).hosts["hermes"]).toBeUndefined();
+  });
+
+  test("what Hermes cannot be given is said, and its skills are installed anyway", async () => {
+    // The whole point of the capability vocabulary: a set carrying hooks,
+    // servers and agents is not a broken set for this host, and a host
+    // that takes none of the three is not a host with worse skills.
+    const m = machine({ hooks: "declared", agents: true, assets: true });
+    const first = await hermesOnly(m);
+
+    expect(first[0]?.status).toBe("reconciled");
+    const said = first[0]?.missing?.join("\n") ?? "";
+    for (const name of ["mcp", "hooks", "agents"]) expect(said, name).toContain(`no ${name}`);
+    expect(existsSync(join(hermesDir(m), "shipped", "SKILL.md"))).toBe(true);
+
+    // It survives into the record, so the converge that skips the host
+    // still says what the host does not have.
+    const second = await hermesOnly(m);
+    expect(second[0]?.status).toBe("current");
+    expect(second[0]?.missing?.join("\n")).toContain("no agents");
+
+    const report = redSkillsHostReport(m.home);
+    expect(report.hosts[0]?.capabilities).toContainEqual(
+      expect.objectContaining({ name: "agents", state: "unsupported" }),
+    );
+    const row = redSkillsHostRows(report).find((r) => r.detail.startsWith("hermes"));
+    // Converged, and poorer than its neighbour: both on the same line, and
+    // neither of them a warning about the host being broken.
+    expect(row?.status).toBe("ok");
+    expect(row?.detail).toContain("no hooks");
+    // And the same sentences on the page Hermes itself reads, so a model
+    // waiting for a hook to fire here is told nothing ever will.
+    expect(readFileSync(join(hermesDir(m), "REDSKILLS.md"), "utf8")).toContain("no hooks");
+  });
+
+  test("a set carrying none of them is reported as carrying none, not as refused", async () => {
+    const m = machine({ mcp: false });
+    const out = await hermesOnly(m);
+
+    expect(out[0]?.status).toBe("reconciled");
+    const said = out[0]?.missing?.join("\n") ?? "";
+    expect(said).toContain("the package set declares no MCP server");
+    expect(said).toContain("the package set declares no hook");
+    expect(said).toContain("the package set carries no agent");
+    expect(said).not.toContain("Hermes");
   });
 });
 

--- a/src/red-skills-hosts.ts
+++ b/src/red-skills-hosts.ts
@@ -83,7 +83,7 @@
  * list written at the time rather than a guess made afterwards.
  */
 
-import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { dirname, isAbsolute, join } from "node:path";
 
 import { log } from "./log.ts";
@@ -767,11 +767,26 @@ async function geminiCheck(ctx: AdapterContext, desired: HostPlan): Promise<Host
  * Hermes, which has skills and nothing else.
  *
  * The skills-only fallback Spec #201 names: no marketplace, no extension
- * manifest, no MCP surface to project into, so the adapter writes the
- * activated plugin's skills into a directory of its own under the host's
- * skills path and stops there. Less than the other six get, and saying so
- * in the record is the point — a mode of `skills` is how doctor reports a
- * host that is genuinely converged and genuinely has less.
+ * manifest, no MCP surface, no hook runner and no agent loader, so the
+ * adapter writes the activated plugin's skills into a directory of its own
+ * under the host's skills path and stops there. Less than the other six
+ * get, and saying so is the point — a mode of `skills` and three
+ * `unsupported` capabilities are how doctor reports a host that is
+ * genuinely converged and genuinely has less.
+ *
+ * A skill is a directory rather than a file, and the whole of it is what
+ * makes it work: the references a skill cites, the scripts it runs, the
+ * templates it renders. So the projection is the tree, verification is
+ * every file of that tree read back, and the plan stands down before it
+ * writes anything when the set carries a skill whose own payload does not
+ * resolve — a half-composed set installs nothing here rather than a skill
+ * Hermes loads and then fails partway through.
+ *
+ * What it cannot take is reported and never blocks. A set that ships hooks,
+ * MCP servers or agent definitions is not a broken set for this host and
+ * does not make its skills any less installed: those capabilities are named
+ * as `unsupported` in the outcome, in the record, in doctor and in the page
+ * Hermes itself reads, and the skills are verified on their own terms.
  */
 const hermes: HostAdapter = {
   name: "hermes",
@@ -779,6 +794,8 @@ const hermes: HostAdapter = {
   plan: (ctx) => {
     const script = generator(ctx.source, "install-hermes.sh");
     if (existsSync(script)) {
+      // The day RedSkills ships one, it wins, for the reason Gemini's does:
+      // a generator lives beside the skills it renders, and this does not.
       return plan({
         mode: "generator",
         steps: [must(script, "--source-dir", ctx.source, "--user")],
@@ -790,18 +807,205 @@ const hermes: HostAdapter = {
     if (skills.length === 0) {
       return plan({ mode: "skills", blocked: "the package set carries no skills to project" });
     }
-    const dir = join(ctx.home, ".hermes", "skills", MARKETPLACE);
+
+    // Before a byte is written: a skill missing the file it tells the model
+    // to read is a skill that fails in the middle of somebody's session,
+    // and a home holding half of one is worse than a host left unwired.
+    const dangling = danglingAsset(skills);
+    if (dangling !== undefined) {
+      return plan({
+        mode: "skills",
+        blocked: `the ${dangling.what} names ${dangling.path}, which the package set does not carry`,
+      });
+    }
+
+    const dir = hermesSkillsDir(ctx);
+    const capabilities = hermesCapabilities(ctx);
     return plan({
       mode: "skills",
+      // The one file red-dev writes rather than copies: what this host has
+      // and, as importantly, what it does not. A model told it has skills
+      // and nothing else stops waiting for a hook that will never fire.
+      writes: [{ path: join(dir, "REDSKILLS.md"), bytes: hermesContext(ctx, skills, capabilities) }],
       copies: skills.map((skill) => ({ from: skill.path, to: join(dir, skill.name) })),
+      // The directory itself, not only what is in it: red-dev made it, so
+      // removing RedSkills has to leave `~/.hermes/skills` the way it found
+      // it rather than with our empty shell still sitting in it.
       expect: [{ kind: "path", path: dir }],
+      capabilities,
     });
   },
+  check: (ctx, desired) => hermesCheck(ctx, desired),
   remove: (ctx) => {
     const script = generator(ctx.source, "install-hermes.sh");
     return existsSync(script) ? [must(script, "--uninstall", "--user")] : [];
   },
 };
+
+/** The directory red-dev owns outright under Hermes's skills path. */
+function hermesSkillsDir(ctx: AdapterContext): string {
+  return join(ctx.home, ".hermes", "skills", MARKETPLACE);
+}
+
+/**
+ * What the set carries, and what a skills-only host does with each of it.
+ *
+ * Three of the four are the same shape — carried by the set, refused by the
+ * host — and the distinction that matters in every one of them is between
+ * a capability this host cannot be given and one nobody was given, because
+ * only the second is fixed by shipping a better set.
+ */
+function hermesCapabilities(ctx: AdapterContext): HostCapability[] {
+  return [
+    { name: "skills", state: "projected" },
+    beyondHermes(
+      "mcp",
+      Object.keys(declaredMcp(ctx)).length,
+      "Hermes starts no MCP server of its own",
+      "the package set declares no MCP server",
+    ),
+    beyondHermes(
+      "hooks",
+      ctx.plugins.flatMap((p) => pluginHooks(pluginDir(ctx, p))).length,
+      "Hermes runs no hook of its own",
+      "the package set declares no hook",
+    ),
+    beyondHermes(
+      "agents",
+      setAgents(ctx).length,
+      "Hermes loads no agent of its own",
+      "the package set carries no agent",
+    ),
+  ];
+}
+
+/** One capability this host cannot take: unsupported if carried, absent if not. */
+function beyondHermes(name: string, carried: number, cannot: string, none: string): HostCapability {
+  if (carried === 0) return { name, state: "absent", reason: none };
+  const what = carried === 1 ? "the one the set carries is" : `the ${carried} the set carries are`;
+  return { name, state: "unsupported", reason: `${cannot}, so ${what} not projected` };
+}
+
+/** Every agent definition the activated plugins carry, in a stable order. */
+function setAgents(ctx: AdapterContext): string[] {
+  const out: string[] = [];
+  for (const plugin of ctx.plugins) {
+    for (const name of listing(join(pluginDir(ctx, plugin), "agents"))) {
+      if (name.endsWith(".md")) out.push(`${plugin}/${name}`);
+    }
+  }
+  return out.sort();
+}
+
+/**
+ * Every file one skill carries, relative to it, in a stable order.
+ *
+ * A skill is its whole directory: `SKILL.md` is the entry point and the
+ * references, scripts and templates beside it are what the entry point
+ * sends a model to. Listing them is how a projection can be checked for
+ * being complete rather than for having started.
+ *
+ * A link with nothing behind it is listed rather than followed. It is a
+ * file as far as the copy is concerned — it arrives on the machine, still
+ * pointing at nothing — and that is exactly the thing worth catching.
+ */
+function carriedAssets(root: string, prefix = ""): string[] {
+  const out: string[] = [];
+  for (const name of listing(root)) {
+    const path = join(root, name);
+    const relative = prefix === "" ? name : `${prefix}/${name}`;
+    if (existsSync(path) && statSync(path).isDirectory()) {
+      out.push(...carriedAssets(path, relative));
+      continue;
+    }
+    out.push(relative);
+  }
+  return out;
+}
+
+/** The first file an activated skill carries that resolves to nothing. */
+function danglingAsset(skills: readonly SetSkill[]): DeclaredPath | undefined {
+  for (const skill of skills) {
+    for (const asset of carriedAssets(skill.path)) {
+      const path = join(skill.path, asset);
+      if (!existsSync(path)) return { what: `${skill.name} skill`, path };
+    }
+  }
+  return undefined;
+}
+
+/**
+ * What Hermes has, read back the way Hermes reads it.
+ *
+ * Nothing was spawned, so there is no exit code to believe. What can be
+ * wrong is everything between the plan and the load: a copy that ran out
+ * of disk partway through a tree, a skill an operator deleted out of the
+ * projected directory, a reference the set carries that never arrived.
+ * Each of those is a skill Hermes lists and cannot complete, and each is a
+ * reason to reconcile rather than a reason to record — which is also what
+ * a skipped converge asks, so a projection that lost a file stops being
+ * current the moment it does.
+ *
+ * A generator in the tree answers for its own tree, so this stands down
+ * for it: its install manifest is what verification reads, generically.
+ */
+async function hermesCheck(ctx: AdapterContext, desired: HostPlan): Promise<HostCheck> {
+  if (desired.mode !== "skills") return { ok: true, witness: "" };
+
+  const dir = hermesSkillsDir(ctx);
+  const index = join(dir, "REDSKILLS.md");
+  if (!existsSync(index)) return { ok: false, reason: `${index} is not there` };
+
+  const projected: string[] = [];
+  for (const skill of setSkills(ctx)) {
+    const into = join(dir, skill.name);
+    const entry = join(into, "SKILL.md");
+    if (!existsSync(entry)) return { ok: false, reason: `${entry} is not there` };
+    for (const asset of carriedAssets(skill.path)) {
+      const path = join(into, asset);
+      if (!existsSync(path)) {
+        return { ok: false, reason: `${path} is not there, and the ${skill.name} skill carries it` };
+      }
+    }
+    projected.push(skill.name);
+  }
+
+  return { ok: true, witness: JSON.stringify({ skills: projected }) };
+}
+
+/**
+ * The page Hermes reads beside the skills: the set, and this host's limits.
+ *
+ * The limits are the record's own sentences rather than a second wording of
+ * them, because a host describing itself one way to a person and another
+ * way to the model reading its skills path is two answers to one question.
+ */
+function hermesContext(
+  ctx: AdapterContext,
+  skills: readonly SetSkill[],
+  capabilities: readonly HostCapability[],
+): string {
+  const limits = missingCapabilities(capabilities);
+  const lines = [
+    `# RedSkills ${ctx.setVersion}`,
+    "",
+    `Projected by red-dev from ${ctx.current}. Do not edit: this file is`,
+    "rewritten whenever the package set moves.",
+    "",
+    "## Skills",
+    "",
+    ...skills.map((skill) =>
+      skill.description ? `- **${skill.name}** — ${skill.description}` : `- **${skill.name}**`
+    ),
+    "",
+    "## What this host does not have",
+    "",
+    ...(limits.length > 0
+      ? limits.map((limit) => `- ${limit}`)
+      : ["Everything the package set carries reached this host."]),
+  ];
+  return `${lines.join("\n")}\n`;
+}
 
 /**
  * What Gemini reads when it loads the extension: the set, as one page.


### PR DESCRIPTION
Automated AFK landing for #209. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #209

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789691321&installation_model_id=20659&pr_number=223&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F223&signature=b2a593005ff70ad5c4900276c898dfa8653d8e372c79bc6e0c46879b3d06f87b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->