### PR TITLE
fix: #210 Update stages one workstation revision without interrupting active work

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,23 @@ host that fails is named and the others still run. `red-dev update` runs it as
 one stage of updating the machine: system packages, RedSkills, mise's tools,
 the agents, then the converge.
 
+The RedSkills half of that stage is one staged reconciliation across four
+surfaces — the package set is acquired, the seven coder hosts are wired against
+it, the companions are built out of it, and the exact workstation lock pins
+everything none of them publishes. `mise upgrade red-skills` reaches the same
+walk through its own postinstall, so the two entry points end on one digest
+rather than two implementations that agree until they do not. It is truthful
+rather than falsely transactional: a surface that fails is named and the ones
+that already verified keep what they got, so the retry only re-attempts the
+failure. Two things it will not do. **A running coder session is never
+terminated** — the host is reconciled on disk and reported `restart needed`
+until a fresh session opens. And **an active Worker holds the activation**: the
+complete new revision is verified and staged under its own immutable name,
+`current`, the daemon, the hosts and the companions all stay on the revision
+that Worker is using, and the next update that finds the queue drained activates
+what is already on disk without acquiring it again. `doctor` names every one of
+those states — active, staged, pending, failed, partial, restart needed.
+
 `doctor` has an `[agents]` section holding the whole posture: which host is the
 Default agent, how long ago each installed host's copy on PATH last changed, and
 per-provider usage with the reset times the Redwall's one compact line has no

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -25,6 +25,8 @@ import {
 import { log, RedError } from "./log.ts";
 import { tlsTrustFailure, unattendedEnvironment } from "./unattended.ts";
 import type { Platform } from "./platform.ts";
+import type { CompanionOutcome } from "./red-skills-companions.ts";
+import type { HostOutcome } from "./red-skills-hosts.ts";
 
 export interface AgentSpec {
   key: string;
@@ -878,18 +880,25 @@ export async function unwiredSkillHosts(): Promise<SkillHost[]> {
  * Skipped loudly with no host installed: red-skills configures agents,
  * and with no agent to configure it has nothing to do.
  */
-export async function convergeRedSkills(p: Platform): Promise<void> {
+export interface RedSkillsConverge {
+  /** One outcome per host in table order, including the ones left alone. */
+  hosts: HostOutcome[];
+  /** The same, per companion. */
+  companions: CompanionOutcome[];
+}
+
+export async function convergeRedSkills(p: Platform): Promise<RedSkillsConverge> {
   // The companions first, and deliberately above the guard below: the
   // runtimes, the daemon, herdr, the editor extension and zellij's
   // dashboard are RedSkills on this workstation whether or not a coding
   // agent is installed on it, and gating them on one would leave a
   // machine with an editor and no coder holding none of them.
-  await convergeRedSkillsCompanions(p);
+  const companions = await convergeRedSkillsCompanions(p);
 
   const present = SKILL_HOSTS.filter((h) => commandPath(h.cmd));
   if (present.length === 0) {
     log.skip("red-skills: no coding agent installed to configure");
-    return;
+    return { hosts: [], companions };
   }
 
   // Ahead of every early return under it. red-dev owns this file, so it
@@ -960,6 +969,11 @@ export async function convergeRedSkills(p: Platform): Promise<void> {
   for (const h of hosts) {
     for (const gap of h.missing ?? []) log.skip(`${h.host}: ${gap}`);
   }
+
+  // Both halves, to whoever asked. The converge is what observed them,
+  // and a caller that has to re-probe to learn what just happened is a
+  // caller that can be told something different from what was done.
+  return { hosts, companions };
 }
 
 /**
@@ -977,7 +991,7 @@ export async function convergeRedSkills(p: Platform): Promise<void> {
  * failure; one that refused is, and is said out loud without taking the
  * artifact the machine was already using with it.
  */
-export async function convergeRedSkillsCompanions(p: Platform): Promise<void> {
+export async function convergeRedSkillsCompanions(p: Platform): Promise<CompanionOutcome[]> {
   const { reconcileCompanions, companionReconciliationFailed } = await import(
     "./red-skills-companions.ts"
   );
@@ -987,4 +1001,5 @@ export async function convergeRedSkillsCompanions(p: Platform): Promise<void> {
     log.warn(`red-skills: companions not converged: ${stuck.map((c) => c.companion).join(", ")}`);
     for (const c of stuck) log.plain(`       ${c.companion}: ${c.reason ?? "no reason given"}`);
   }
+  return companions;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -338,6 +338,23 @@ async function cmdDoctor(p: Platform, inv: Invocation): Promise<number> {
     else log.warn(row.detail);
   }
 
+  // And how the last update across all of them ended. The three reports
+  // above each answer for one surface; this answers for the operation,
+  // which is the only place two facts can be said at all: which surfaces
+  // were held back because a Worker was using the active revision, and
+  // whether a run that failed left this machine between two revisions
+  // rather than on neither.
+  const { stagedUpdateReport, stagedUpdateRows } = await import("./staged-update.ts");
+  for (const row of stagedUpdateRows(stagedUpdateReport(setHome))) {
+    if (row.status === "ok") log.ok(row.detail);
+    else if (row.status === "n/a") log.skip(row.detail);
+    else if (row.status === "warn") log.warn(row.detail);
+    else {
+      log.err(row.detail);
+      setProblems++;
+    }
+  }
+
   // The machine's agent posture, in the one place that already answers
   // "is this machine ready": which host red-dev hands work to, how old
   // each installed host's copy is, and the per-provider allowance detail
@@ -862,15 +879,21 @@ async function cmdUpdate(p: Platform, inv: Invocation): Promise<number> {
     "red-skills": async () => {
       if (inv.dryRun) return;
 
-      // The online acquisition first, and through the same functions the
-      // mise plugin dispatches into — that is what makes `mise upgrade
-      // red-skills` and `red-dev update` reach one active digest instead
-      // of two implementations that agree until they do not. It reports
-      // `unavailable` and changes nothing until red-skills publishes the
-      // complete set (reddb-io/red-skills#3977), so the composed set the
-      // npm entries produce is what the stages below still advance.
-      const { updateRedSkillsPackageSet } = await import("./red-skills-acquire.ts");
-      await updateRedSkillsPackageSet({ manifestPlatform: p });
+      // One staged reconciliation across acquisition, the seven hosts,
+      // the companions and the exact workstation lock — and the same
+      // one `mise upgrade red-skills` reaches through its postinstall.
+      // That is what makes the two entry points end on one active
+      // digest instead of two implementations that agree until they do
+      // not, and it is where ADR 0010's Workers rule is applied: an
+      // update that meets a running Worker stages the complete revision
+      // and leaves this machine on the one that Worker is using.
+      //
+      // Its exit code is deliberately not this stage's. A partial
+      // reconciliation is reported by the converge stage below, which
+      // is the one stage `red-dev update` answers with; a stage that
+      // returned a number here would give the run two verdicts.
+      const { runStagedUpdate } = await import("./staged-update.ts");
+      await runStagedUpdate({ manifestPlatform: p });
 
       const { updateRedSkills } = await import("./agents.ts");
       await updateRedSkills(p);

--- a/src/red-skills-acquire.test.ts
+++ b/src/red-skills-acquire.test.ts
@@ -37,6 +37,7 @@ import { sha256Hex } from "./checksum.ts";
 import { captureTo } from "./log.ts";
 import {
   acquireRedSkills,
+  announce,
   compareVersions,
   directoryAssetProvider,
   ensureMirror,
@@ -55,15 +56,20 @@ import {
   redSkillsSnapshotDir,
   resolveRevision,
   selectorLabel,
-  updateRedSkillsPackageSet,
+  type Acquisition,
+  type AcquireOptions,
   type AssetProvider,
   type CommandRunner,
+  type Reconciliation,
+  type ReconcileOptions,
   type RemoteRevision,
 } from "./red-skills-acquire.ts";
 import { runPluginPhase } from "./red-skills-mise-plugin.ts";
+import { runStagedUpdate } from "./staged-update.ts";
 import {
   createPackageSetManifest,
   encodePackageSet,
+  activateStagedPackageSet,
   readPackageSetState,
   redSkillsCurrentLink,
   SET_BUNDLE_NAME,
@@ -646,14 +652,14 @@ describe("reconciliation runs once per revision that moved", () => {
     const reconcile = () => void reconciled++;
 
     const first = await quiet(() =>
-      updateRedSkillsPackageSet({ ...acquireArgs(home, git, assets), reconcile }),
+      acquireAndReconcile({ ...acquireArgs(home, git, assets), reconcile }),
     );
     expect(first.acquired.outcome).toBe("acquired");
     expect(first.reconciliation.reconciled).toBe(true);
     expect(reconciled).toBe(1);
 
     const second = await quiet(() =>
-      updateRedSkillsPackageSet({ ...acquireArgs(home, git, assets), reconcile }),
+      acquireAndReconcile({ ...acquireArgs(home, git, assets), reconcile }),
     );
     expect(second.acquired.outcome).toBe("current");
     expect(second.acquired.writes).toEqual([]);
@@ -662,7 +668,7 @@ describe("reconciliation runs once per revision that moved", () => {
     expect(reconciled).toBe(1);
 
     const moved = await quiet(() =>
-      updateRedSkillsPackageSet({ ...acquireArgs(home, git, assets), selector: "next", reconcile }),
+      acquireAndReconcile({ ...acquireArgs(home, git, assets), selector: "next", reconcile }),
     );
     expect(moved.acquired.outcome).toBe("acquired");
     expect(reconciled).toBe(2);
@@ -672,9 +678,9 @@ describe("reconciliation runs once per revision that moved", () => {
     const home = fakeHome();
     const git = fakeGit(RELEASES);
     const assets = assetsFor({ [COMMIT_B]: assetsDir(COMMIT_B) });
-    await quiet(() => updateRedSkillsPackageSet({ ...acquireArgs(home, git, assets), reconcile: () => {} }));
+    await quiet(() => acquireAndReconcile({ ...acquireArgs(home, git, assets), reconcile: () => {} }));
     const stamp = readFileSync(reconciledStampPath(home), "utf8");
-    await quiet(() => updateRedSkillsPackageSet({ ...acquireArgs(home, git, assets), reconcile: () => {} }));
+    await quiet(() => acquireAndReconcile({ ...acquireArgs(home, git, assets), reconcile: () => {} }));
     expect(readFileSync(reconciledStampPath(home), "utf8")).toBe(stamp);
     expect(stamp).not.toContain("at");
   });
@@ -694,6 +700,7 @@ describe("both entry points reach the same active digest", () => {
     const viaUpdate = fakeHome();
     const assets = { [COMMIT_B]: assetsDir(COMMIT_B) };
     let reconciled = 0;
+    const idle = async () => 0;
 
     const install = fakeGit(RELEASES);
     const installPath = join(viaPlugin, "mise-install");
@@ -706,6 +713,7 @@ describe("both entry points reach the same active digest", () => {
         plugins: ["dev"],
         platform: "linux",
         url: "https://example.invalid/red-skills.git",
+        workers: idle,
         env: { HOME: viaPlugin, ASDF_INSTALL_VERSION: "stable", ASDF_INSTALL_PATH: installPath },
       }),
     );
@@ -718,11 +726,21 @@ describe("both entry points reach the same active digest", () => {
       }),
     );
 
+    // The other entry point, through the state machine `red-dev update`
+    // runs: same acquisition, same surfaces, same Workers rule.
     const update = fakeGit(RELEASES);
     await quiet(() =>
-      updateRedSkillsPackageSet({
-        ...acquireArgs(viaUpdate, update, assetsFor(assets)),
-        reconcile: () => void reconciled++,
+      runStagedUpdate({
+        home: viaUpdate,
+        env: { HOME: viaUpdate },
+        workers: idle,
+        acquire: (stageOnly) =>
+          acquireRedSkills({ ...acquireArgs(viaUpdate, update, assetsFor(assets)), stageOnly }),
+        converge: async () => {
+          reconciled++;
+          return { hosts: [], companions: [] };
+        },
+        lock: async () => ({ ok: false, present: false, reason: "no workstation lock" }),
       }),
     );
 
@@ -738,6 +756,37 @@ describe("both entry points reach the same active digest", () => {
     const receipt = JSON.parse(readFileSync(join(installPath, "package-set.json"), "utf8"));
     expect(receipt.sourceCommit).toBe(COMMIT_B);
     expect(receipt.digest).toBe(left.revisions[0]?.digest as string);
+  });
+
+  test("mise's own upgrade stages rather than activates while a Worker runs", async () => {
+    // The Workers rule has to hold at the entry point a person did not
+    // type. `mise upgrade red-skills` on a busy machine verifies the
+    // complete revision and leaves `current` where it is.
+    const home = fakeHome();
+    const git = fakeGit(RELEASES);
+    const code = await quiet(() =>
+      runPluginPhase("install", {
+        home,
+        run: git.run,
+        assets: assetsFor({ [COMMIT_B]: assetsDir(COMMIT_B) }),
+        verifier: accept,
+        plugins: ["dev"],
+        platform: "linux",
+        url: "https://example.invalid/red-skills.git",
+        workers: async () => 2,
+        env: { HOME: home, ASDF_INSTALL_VERSION: "stable" },
+      }),
+    );
+    expect(code).toBe(0);
+    const state = readPackageSetState(home);
+    expect(state.active).toBeNull();
+    expect(state.staged?.sourceCommit).toBe(COMMIT_B);
+
+    // And the run that finds the queue drained activates it, acquiring
+    // nothing: the git fake would answer, and it is never asked.
+    const activated = activateStagedPackageSet({ home, platform: "linux", env: { HOME: home } })!;
+    expect(activated.active?.sourceCommit).toBe(COMMIT_B);
+    expect(readPackageSetState(home).active).toBe(state.staged?.key as string);
   });
 
   test("the plugin lists the channels beside the versions, and answers latest-stable", async () => {
@@ -853,6 +902,30 @@ describe("the release assets, over a fake GitHub", () => {
 });
 
 /** The shared arguments of an acquisition, for the tests that spread them. */
+/**
+ * Acquire, then reconcile — the two halves in the order the staged
+ * update walks them.
+ *
+ * A helper here rather than a function in the module, because the
+ * composition itself moved: src/staged-update.ts walks four surfaces
+ * now, and a second acquire-then-reconcile pair beside it would be free
+ * to drift from the one that runs. What is worth pinning is that the
+ * two halves still compose — which is what these tests do.
+ */
+async function acquireAndReconcile(
+  opts: AcquireOptions & { reconcile?: ReconcileOptions["reconcile"] },
+): Promise<{ acquired: Acquisition; reconciliation: Reconciliation }> {
+  const acquired = await acquireRedSkills(opts);
+  announce(acquired);
+  const home = opts.home ?? "";
+  const reconciliation = await reconcileRedSkills({
+    home,
+    ...(opts.reconcile ? { reconcile: opts.reconcile } : {}),
+    ...(opts.env ? { env: opts.env } : {}),
+  });
+  return { acquired, reconciliation };
+}
+
 function acquireArgs(home: string, git: ReturnType<typeof fakeGit>, assets: AssetProvider) {
   return {
     home,

--- a/src/red-skills-acquire.test.ts
+++ b/src/red-skills-acquire.test.ts
@@ -782,6 +782,26 @@ describe("both entry points reach the same active digest", () => {
     expect(state.active).toBeNull();
     expect(state.staged?.sourceCommit).toBe(COMMIT_B);
 
+    // mise's receipt names the revision that was fetched, not the one
+    // the machine is still resolving.
+    const installPath = join(home, "mise-install");
+    await quiet(() =>
+      runPluginPhase("install", {
+        home,
+        run: git.run,
+        assets: assetsFor({ [COMMIT_B]: assetsDir(COMMIT_B) }),
+        verifier: accept,
+        plugins: ["dev"],
+        platform: "linux",
+        url: "https://example.invalid/red-skills.git",
+        workers: async () => 2,
+        env: { HOME: home, ASDF_INSTALL_VERSION: "stable", ASDF_INSTALL_PATH: installPath },
+      }),
+    );
+    const receipt = JSON.parse(readFileSync(join(installPath, "package-set.json"), "utf8"));
+    expect(receipt.sourceCommit).toBe(COMMIT_B);
+    expect(receipt.digest).toBe(state.staged?.digest as string);
+
     // And the run that finds the queue drained activates it, acquiring
     // nothing: the git fake would answer, and it is never asked.
     const activated = activateStagedPackageSet({ home, platform: "linux", env: { HOME: home } })!;

--- a/src/red-skills-acquire.ts
+++ b/src/red-skills-acquire.ts
@@ -819,6 +819,15 @@ export interface Acquisition {
   candidate: string | null;
   /** What `~/.red-skills/current` names once this returns. */
   active: PackageSetIdentity | null;
+  /**
+   * The revision verified and staged rather than activated, or null.
+   *
+   * Non-null exactly when a Worker held the activation. `active` still
+   * names what the machine resolves, so a caller writing down "which
+   * revision is this" — mise's install receipt, most of all — can say
+   * the one that was actually acquired instead of the one it replaced.
+   */
+  staged: PackageSetIdentity | null;
   writes: string[];
 }
 
@@ -871,6 +880,7 @@ export async function acquireRedSkills(opts: AcquireOptions = {}): Promise<Acqui
     snapshot: null,
     candidate: null,
     active: activeIdentityOf(home),
+    staged: null,
     writes:
       outcome === "refused" && failure !== null
         ? recordPackageSetRefusal(home, { failure, reason })
@@ -1025,6 +1035,7 @@ export async function acquireRedSkills(opts: AcquireOptions = {}): Promise<Acqui
     snapshot: { path: snapshot.path, created: snapshot.created },
     candidate,
     active: converged.active,
+    staged: converged.staged,
     writes: converged.writes,
   };
 }

--- a/src/red-skills-acquire.ts
+++ b/src/red-skills-acquire.ts
@@ -1071,8 +1071,17 @@ export interface Reconciliation {
 
 export interface ReconcileOptions {
   home?: string;
-  /** The host wiring. Defaults to red-dev's own converge over every installed host. */
-  reconcile?: () => Promise<void> | void;
+  /**
+   * The host wiring. Defaults to red-dev's own converge over every
+   * installed host.
+   *
+   * Returning `false` means "this did not fully converge, do not stamp
+   * it". Without that, one blocked host would leave a stamp saying the
+   * machine was reconciled against these bytes, and the retry that is
+   * supposed to fix it would be skipped as already done — the surface
+   * would stay broken until the *next* revision moved.
+   */
+  reconcile?: () => Promise<boolean | void> | boolean | void;
   /** Reconcile even when the stamp already names the active revision. */
   force?: boolean;
   env?: NodeJS.ProcessEnv;
@@ -1115,9 +1124,23 @@ export async function reconcileRedSkills(opts: ReconcileOptions = {}): Promise<R
     (async () => {
       const { convergeRedSkills } = await import("./agents.ts");
       const { detect } = await import("./platform.ts");
-      await convergeRedSkills(opts.manifestPlatform ?? detect());
+      const { reconciliationFailed } = await import("./red-skills-hosts.ts");
+      const { companionReconciliationFailed } = await import("./red-skills-companions.ts");
+      const converged = await convergeRedSkills(opts.manifestPlatform ?? detect());
+      return (
+        !reconciliationFailed(converged.hosts) &&
+        !companionReconciliationFailed(converged.companions)
+      );
     });
-  await reconcile();
+  const converged = await reconcile();
+  if (converged === false) {
+    return {
+      reconciled: true,
+      reason: `hosts reconciled against ${key} with surfaces still to converge`,
+      identity: active,
+      writes: [],
+    };
+  }
 
   mkdirSync(dirname(stamp), { recursive: true });
   writeFileSync(stamp, `${JSON.stringify({ schema: 1, key }, null, 2)}\n`, "utf8");

--- a/src/red-skills-acquire.ts
+++ b/src/red-skills-acquire.ts
@@ -1147,29 +1147,15 @@ export async function reconcileRedSkills(opts: ReconcileOptions = {}): Promise<R
   return { reconciled: true, reason: `hosts reconciled against ${key}`, identity: active, writes: [stamp] };
 }
 
-/**
- * Acquire, then reconcile: the whole operation, from either entry point.
- *
- * `mise upgrade red-skills` reaches this through the plugin's install
- * script and the tool's postinstall; `red-dev update` calls it
- * directly. Both therefore end on the same active digest, and neither
- * has an acquisition of its own to drift.
+/*
+ * There used to be an `updateRedSkillsPackageSet` here — acquire, then
+ * reconcile, as the whole operation both entry points ran. It is gone,
+ * and deliberately: the whole operation is now four surfaces rather
+ * than two, and src/staged-update.ts is the one place that walks them.
+ * Keeping a second composition of the same two halves beside it would
+ * be exactly the drift the acquisition was consolidated to end — the
+ * two would agree until one of them learned about Workers.
  */
-export async function updateRedSkillsPackageSet(
-  opts: AcquireOptions & Pick<ReconcileOptions, "reconcile"> = {},
-): Promise<{ acquired: Acquisition; reconciliation: Reconciliation }> {
-  const acquired = await acquireRedSkills(opts);
-  announce(acquired);
-
-  const home = opts.home ?? homeOf(opts.env ?? process.env);
-  const reconciliation = await reconcileRedSkills({
-    home,
-    ...(opts.reconcile ? { reconcile: opts.reconcile } : {}),
-    ...(opts.manifestPlatform ? { manifestPlatform: opts.manifestPlatform } : {}),
-    ...(opts.env ? { env: opts.env } : {}),
-  });
-  return { acquired, reconciliation };
-}
 
 /** One line for each outcome, in the voice the rest of a converge speaks. */
 export function announce(a: Acquisition): void {

--- a/src/red-skills-mise-plugin.ts
+++ b/src/red-skills-mise-plugin.ts
@@ -189,8 +189,17 @@ export function convergeRedSkillsMisePlugin(
 }
 
 export interface PluginPhaseOptions extends AcquireOptions {
-  /** The host wiring `reconcile` invokes. Defaults to red-dev's converge. */
-  reconcile?: () => Promise<void> | void;
+  /**
+   * The host wiring `reconcile` invokes, and the narrow path it selects.
+   *
+   * Given, `reconcile` wires the hosts and nothing else. Absent, the
+   * phase runs the whole staged reconciliation — which is what mise's
+   * postinstall wants and what makes it the same operation as `red-dev
+   * update`.
+   */
+  reconcile?: () => Promise<boolean | void> | boolean | void;
+  /** Active Workers on this machine. Defaults to asking the daemon. */
+  workers?: () => Promise<number | null>;
   /** mise's own variables: ASDF_INSTALL_VERSION, ASDF_INSTALL_PATH. */
   env?: NodeJS.ProcessEnv;
   run?: CommandRunner;
@@ -223,16 +232,38 @@ export async function runPluginPhase(
   const run = opts.run ?? systemRunner;
   const url = opts.url ?? REDSKILLS_GIT_URL;
 
+  // The tool-level postinstall, and the second half of the acceptance
+  // criterion the install phase below carries the first half of: `mise
+  // upgrade red-skills` and `red-dev update` reach the same staged
+  // reconciliation, so they advance the same surfaces under the same
+  // Workers rule and end on the same digest. The acquisition is
+  // `installed` here because mise has just performed it — asking the
+  // remote a second time for one upgrade would be the drift this
+  // consolidation exists to prevent.
+  //
+  // An injected `reconcile` keeps the narrow path: it is what the tests
+  // and `red-skills sync` hand in, and it means "wire the hosts, and
+  // nothing else".
   if (phase === "reconcile") {
-    const result = await reconcileRedSkills({
+    if (opts.reconcile) {
+      const result = await reconcileRedSkills({
+        ...(opts.home ? { home: opts.home } : {}),
+        reconcile: opts.reconcile,
+        ...(opts.manifestPlatform ? { manifestPlatform: opts.manifestPlatform } : {}),
+        env,
+      });
+      if (result.reconciled) log.ok(`red-skills: ${result.reason}`);
+      else log.skip(`red-skills: ${result.reason}`);
+      return 0;
+    }
+    const { runStagedUpdate } = await import("./staged-update.ts");
+    const run = await runStagedUpdate({
+      acquisition: "installed",
       ...(opts.home ? { home: opts.home } : {}),
-      ...(opts.reconcile ? { reconcile: opts.reconcile } : {}),
       ...(opts.manifestPlatform ? { manifestPlatform: opts.manifestPlatform } : {}),
       env,
     });
-    if (result.reconciled) log.ok(`red-skills: ${result.reason}`);
-    else log.skip(`red-skills: ${result.reason}`);
-    return 0;
+    return run.code;
   }
 
   if (phase === "list-all" || phase === "latest-stable") {
@@ -280,8 +311,21 @@ export async function runPluginPhase(
     return 1;
   }
 
-  const acquired = await acquireRedSkills({ ...opts, env, run, url, selector });
+  // ADR 0010's Workers rule reaches the mise entry point too. `mise
+  // upgrade red-skills` on a machine with Workers running verifies and
+  // stages the complete revision and leaves `current` where it is; the
+  // postinstall above then reports every other surface as pending, and
+  // the next update that finds the queue drained activates what is
+  // already on disk.
+  const held = await (opts.workers ?? activeWorkers)();
+  const stageOnly = (held ?? 0) > 0;
+  const acquired = await acquireRedSkills({ ...opts, env, run, url, selector, stageOnly });
   announce(acquired);
+  if (stageOnly) {
+    log.skip(
+      `red-skills: ${held} Worker(s) are running — the revision is staged and activated by the next update that finds none`,
+    );
+  }
   // mise records a version only for an install that produced one. A
   // refusal, a release with no package set, and a remote that could not
   // be read are all "this version is not on this machine".
@@ -331,6 +375,21 @@ function writeReceipt(
     )}\n`,
     "utf8",
   );
+}
+
+/**
+ * Active Workers, over the daemon's existing socket and never a new one.
+ *
+ * Duplicated from src/staged-update.ts rather than imported, for the
+ * reason the postinstall string is duplicated in mise-config.ts: this
+ * module is what mise's scripts dispatch into, and it must not pull the
+ * whole update walk in to answer one number. Both read the same
+ * document through the same function.
+ */
+async function activeWorkers(): Promise<number | null> {
+  const { readHostInventoryNoStart } = await import("./host-state.ts");
+  const inventory = await readHostInventoryNoStart();
+  return inventory === null ? null : inventory.workers.length;
 }
 
 /** Where a plugin script would look for red-dev, for a report that says so. */

--- a/src/red-skills-mise-plugin.ts
+++ b/src/red-skills-mise-plugin.ts
@@ -337,8 +337,13 @@ export async function runPluginPhase(
   // it through `current`. What goes here is the receipt saying which
   // revision this mise version *is* — the identity ADR 0011 defines,
   // rather than a copy of 25 MB that would then have two owners.
+  //
+  // The staged identity first, where there is one: under a running
+  // Worker the machine deliberately stays on its previous revision, and
+  // a receipt naming that one would tell mise it installed the version
+  // it replaced rather than the version it fetched.
   const installPath = env["ASDF_INSTALL_PATH"];
-  if (installPath) writeReceipt(installPath, acquired.active, acquired.commit);
+  if (installPath) writeReceipt(installPath, acquired.staged ?? acquired.active, acquired.commit);
   return 0;
 }
 

--- a/src/red-skills-set.test.ts
+++ b/src/red-skills-set.test.ts
@@ -50,6 +50,7 @@ import {
   composeSet,
   CORE_PAYLOAD_CONTRACT,
   corePayloadGaps,
+  activateStagedPackageSet,
   convergeRedSkillsPackageSet,
   convergeSetAfterMise,
   coreInstallsDir,
@@ -933,15 +934,93 @@ describe("activating a published set", () => {
     const home = fakeHome();
     const before = converge(home, aligned(["3.19.4"]));
     const staged = converge(home, "unused", { source: fakeManifestSet(), verifier: accept, stageOnly: true });
+    const identity = staged.staged!;
     expect(staged.refused).toBeNull();
     expect(staged.active).toEqual(before.active);
-    expect(staged.writes.length).toBe(1);
-    expect(existsSync(staged.writes[0]!)).toBe(true);
+    // The revision's tree, and the record saying it is pending. Nothing
+    // else: `current` still resolves to the set this machine was on.
+    const tree = staged.writes[0]!;
+    expect(staged.writes).toEqual([tree, packageSetStatePath(home)]);
+    expect(existsSync(tree)).toBe(true);
     expect(realpathSync(redSkillsCurrentLink(home))).toBe(realpathSync(before.revisionDir!));
+    expect(readPackageSetState(home).staged?.path).toBe(tree);
+    expect(staged.staged).toEqual(identity);
     // Activating it afterwards is the ordinary path, and finds the copy already there.
     const activated = converge(home, "unused", { source: fakeManifestSet(), verifier: accept });
-    expect(activated.writes).not.toContain(staged.writes[0]);
-    expect(realpathSync(redSkillsCurrentLink(home))).toBe(realpathSync(staged.writes[0]!));
+    expect(activated.writes).not.toContain(tree);
+    expect(activated.staged).toBeNull();
+    expect(readPackageSetState(home).staged).toBeNull();
+    expect(realpathSync(redSkillsCurrentLink(home))).toBe(realpathSync(tree));
+  });
+});
+
+// ------------------------------------------------------- the staged half
+
+/**
+ * What a machine does with a revision it verified and did not activate.
+ *
+ * The Workers rule of ADR 0010 is two operations, not one: an update that
+ * meets a running Worker stages the complete revision, and a later run
+ * activates it. The second must not acquire anything — the bytes were
+ * verified when they were staged, and re-fetching them would make an
+ * offline machine unable to finish an update it had already paid for.
+ */
+describe("activating what was staged", () => {
+  test("nothing staged is not a failure, it is nothing to do", () => {
+    const home = fakeHome();
+    converge(home, aligned(["3.19.4"]));
+    expect(activateStagedPackageSet({ home, platform: "linux" })).toBeNull();
+  });
+
+  test("moves current onto the staged revision without acquiring it again", () => {
+    const home = fakeHome();
+    const before = converge(home, aligned(["3.19.4"]));
+    const staged = converge(home, "unused", { source: fakeManifestSet(), verifier: accept, stageOnly: true });
+    const tree = staged.writes[0]!;
+
+    // Every input the acquisition would need is gone: the source
+    // directory it verified, and any verifier it could ask again.
+    const activated = activateStagedPackageSet({ home, platform: "linux" })!;
+    expect(activated.active).toEqual(staged.staged);
+    expect(activated.staged).toBeNull();
+    expect(activated.writes).not.toContain(tree);
+    expect(realpathSync(redSkillsCurrentLink(home))).toBe(realpathSync(tree));
+    // And the revision it replaced is still the rollback.
+    expect(realpathSync(redSkillsPreviousLink(home))).toBe(realpathSync(before.revisionDir!));
+    expect(readPackageSetState(home).staged).toBeNull();
+  });
+
+  test("a second activation has nothing left to activate", () => {
+    const home = fakeHome();
+    converge(home, aligned(["3.19.4"]));
+    converge(home, "unused", { source: fakeManifestSet(), verifier: accept, stageOnly: true });
+    activateStagedPackageSet({ home, platform: "linux" });
+    expect(activateStagedPackageSet({ home, platform: "linux" })).toBeNull();
+  });
+
+  test("a staged tree that is gone is refused rather than pointed at", () => {
+    const home = fakeHome();
+    const before = converge(home, aligned(["3.19.4"]));
+    const staged = converge(home, "unused", { source: fakeManifestSet(), verifier: accept, stageOnly: true });
+    rmSync(staged.writes[0]!, { recursive: true, force: true });
+
+    const activated = activateStagedPackageSet({ home, platform: "linux" })!;
+    expect(activated.refused?.failure).toBe("tree");
+    expect(activated.active).toEqual(before.active);
+    expect(realpathSync(redSkillsCurrentLink(home))).toBe(realpathSync(before.revisionDir!));
+    // Cleared, so doctor stops promising an activation that cannot happen.
+    expect(readPackageSetState(home).staged).toBeNull();
+  });
+
+  test("doctor names the pending revision beside the active one", () => {
+    const home = fakeHome();
+    converge(home, aligned(["3.19.4"]));
+    converge(home, "unused", { source: fakeManifestSet(), verifier: accept, stageOnly: true });
+    const report = redSkillsSetReport(home);
+    expect(report.active?.version).toBe("3.19.4");
+    expect(report.staged).toMatchObject({ kind: "manifest", trust: "trusted", addressable: true });
+    const row = redSkillsSetRows(report).find((r) => r.detail.includes("staged and pending"))!;
+    expect(row.status).toBe("warn");
   });
 });
 
@@ -1095,7 +1174,7 @@ describe("what doctor says", () => {
 
   test("no set: one line, and no rollback", () => {
     const home = fakeHome();
-    expect(redSkillsSetReport(home)).toEqual({ active: null, retained: [], refused: null });
+    expect(redSkillsSetReport(home)).toEqual({ active: null, retained: [], refused: null, staged: null });
     expect(redSkillsSetRows(redSkillsSetReport(home))).toEqual([
       { status: "n/a", detail: "no RedSkills package set is active on this machine" },
     ]);
@@ -1119,6 +1198,7 @@ describe("what doctor says", () => {
         { key: "3.19.4+<digest12>", version: "3.19.4", digest: "<digest>", sourceCommit: "", kind: "composed", trust: "unsigned", path: "<home>/.red-skills/sets/3.19.4+<digest12>", addressable: true },
       ],
       refused: null,
+      staged: null,
     });
     const rows = redSkillsSetRows(redSkillsSetReport(home));
     expect(rows[0]!.status).toBe("warn");

--- a/src/red-skills-set.ts
+++ b/src/red-skills-set.ts
@@ -938,9 +938,27 @@ export interface PackageSetState {
   /** Newest first, capped at REDSKILLS_SET_RETENTION. */
   revisions: PackageSetRevision[];
   refused: PackageSetRefusal | null;
+  /**
+   * A verified revision on disk that `current` does not name yet.
+   *
+   * ADR 0010's Workers rule: an update that arrives while Workers are
+   * running stages the complete revision and leaves the machine on the
+   * one it is working against. Recorded rather than kept in the process
+   * that staged it, because the activation happens in a later run —
+   * after the Worker finishes — and a staged revision nothing wrote
+   * down would have to be acquired a second time to be activated, which
+   * is the reacquisition the criterion forbids.
+   */
+  staged: PackageSetRevision | null;
 }
 
-const EMPTY_STATE: PackageSetState = { schema: 1, active: null, revisions: [], refused: null };
+const EMPTY_STATE: PackageSetState = {
+  schema: 1,
+  active: null,
+  revisions: [],
+  refused: null,
+  staged: null,
+};
 
 /** `~/.red-skills/package-set.json` — what the machine believes it has. */
 export function packageSetStatePath(home: string): string {
@@ -965,6 +983,10 @@ export function readPackageSetState(home: string): PackageSetState {
       active: typeof parsed.active === "string" ? parsed.active : null,
       revisions: parsed.revisions,
       refused: parsed.refused ?? null,
+      // Absent in every state file written before staging existed, and
+      // that is the same fact as "nothing is staged" rather than a
+      // reason to discard a record this build can otherwise read.
+      staged: parsed.staged ?? null,
     };
   } catch {
     return EMPTY_STATE;
@@ -1076,6 +1098,15 @@ export interface PackageSetConverge {
   retained: PackageSetRevision[];
   /** Why the candidate was refused, or null when it was not. */
   refused: PackageSetRefusal | null;
+  /**
+   * The revision staged and awaiting activation, or null.
+   *
+   * Non-null exactly when this converge verified a revision it was told
+   * not to activate. `active` still names what the machine resolves, so
+   * the two together are the whole answer to "what is this machine on,
+   * and what is it about to be on".
+   */
+  staged: PackageSetIdentity | null;
   current: string;
   /** The immutable directory `current` resolves to, or null. */
   revisionDir: string | null;
@@ -1107,6 +1138,7 @@ export function convergeRedSkillsPackageSet(
     active: activeIdentity(state),
     retained: state.revisions,
     refused: state.refused,
+    staged: identityOf(state.staged),
     current,
     revisionDir: activeRevision(state)?.path ?? null,
   });
@@ -1236,6 +1268,51 @@ export function convergeSetAfterMise(
 }
 
 /**
+ * Activate the revision a previous run staged, acquiring nothing.
+ *
+ * The other half of ADR 0010's Workers rule. The staged revision was
+ * verified when it was staged — the signature was checked, the tree was
+ * copied under its immutable name — and none of that is worth doing
+ * twice. So this reads the record, confirms the directory is still
+ * there, and performs the one step staging left out: moving `current`.
+ *
+ * `null` when nothing is staged, which is the ordinary case and not a
+ * failure: a machine with no pending revision is a machine that is
+ * already on the one it should be on.
+ */
+export function activateStagedPackageSet(
+  opts: Pick<PackageSetConvergeOptions, "home" | "platform" | "env"> = {},
+): PackageSetConverge | null {
+  const env = opts.env ?? process.env;
+  const home = opts.home ?? homeOf(env);
+  const platform = opts.platform ?? process.platform;
+  const state = readPackageSetState(home);
+  const staged = state.staged;
+  if (staged === null) return null;
+
+  // The directory is the revision. One that is gone — retired by a
+  // converge that overtook it, removed by hand — cannot be activated,
+  // and saying so is better than pointing `current` at nothing.
+  if (!existsSync(staged.path)) {
+    const reason = `the staged revision ${formatPackageSetIdentity(staged)} is recorded but its tree is gone`;
+    log.err(`red-skills package set refused (tree): ${reason}`);
+    const writes = writeState(home, { ...state, staged: null, refused: { failure: "tree", reason } });
+    return {
+      changed: writes.length > 0,
+      writes,
+      active: activeIdentity(state),
+      retained: state.revisions,
+      refused: { failure: "tree", reason },
+      staged: null,
+      current: redSkillsCurrentLink(home),
+      revisionDir: activeRevision(state)?.path ?? null,
+    };
+  }
+
+  return activate(home, platform, state, staged, () => {}, false);
+}
+
+/**
  * Point the machine at one verified revision, writing only what differs.
  *
  * Every write is recorded and every one of them is conditional. That is
@@ -1272,13 +1349,30 @@ function activate(
   if (stageOnly) {
     // Staged, and reported as such: the directory is there, the state
     // file does not name it active, and `current` was not touched.
-    log.ok(`red-skills package set ${formatPackageSetIdentity(revision)} staged at ${revision.path}`);
+    //
+    // The one thing that *is* recorded is which revision was staged.
+    // Activation happens in a later process — the run that finds the
+    // Workers finished — and it must not have to acquire the revision
+    // again to perform it. Written through the same conditional write
+    // as everything else, so staging the revision that is already
+    // staged is free.
+    // A revision that is already active is not staged: the machine is
+    // on it, and recording it as pending would make doctor promise an
+    // activation that has nothing to activate.
+    const pending = revision.key === state.active ? null : { ...revision };
+    log.ok(
+      pending === null
+        ? `red-skills package set ${formatPackageSetIdentity(revision)} is already active`
+        : `red-skills package set ${formatPackageSetIdentity(revision)} staged at ${revision.path}`,
+    );
+    writes.push(...writeState(home, { ...state, staged: pending }));
     return {
       changed: writes.length > 0,
       writes,
       active: activeIdentity(state),
       retained: state.revisions,
       refused: state.refused,
+      staged: identityOf(pending),
       current,
       revisionDir: activeRevision(state)?.path ?? null,
     };
@@ -1294,6 +1388,7 @@ function activate(
         active: activeIdentity(state),
         retained: state.revisions,
         refused: state.refused,
+        staged: identityOf(state.staged),
         current,
         revisionDir: null,
       };
@@ -1312,7 +1407,16 @@ function activate(
     if (linkDirectory(rollback.path, previous, platform)) writes.push(previous);
   }
 
-  const desired: PackageSetState = { schema: 1, active: revision.key, revisions: retained, refused: null };
+  // `staged: null`, always. Whatever was pending is either the revision
+  // just activated or one this activation has overtaken, and in both
+  // cases there is no longer an activation waiting on a Worker.
+  const desired: PackageSetState = {
+    schema: 1,
+    active: revision.key,
+    revisions: retained,
+    refused: null,
+    staged: null,
+  };
   writes.push(...writeState(home, desired));
   writes.push(...retire(home, retained));
 
@@ -1328,9 +1432,17 @@ function activate(
     active: { version: revision.version, digest: revision.digest, sourceCommit: revision.sourceCommit },
     retained,
     refused: null,
+    staged: null,
     current,
     revisionDir: revision.path,
   };
+}
+
+/** The identity of a recorded revision, or null. PURE. */
+function identityOf(revision: PackageSetRevision | null): PackageSetIdentity | null {
+  return revision === null
+    ? null
+    : { version: revision.version, digest: revision.digest, sourceCommit: revision.sourceCommit };
 }
 
 /** Write the state file, if it differs. Returns the paths written. */
@@ -1422,6 +1534,16 @@ export interface SetDoctorReport {
     addressable: boolean;
   })[];
   refused: PackageSetRefusal | null;
+  /**
+   * A complete revision on disk that `current` does not name yet.
+   *
+   * Non-null is the whole visible half of the Workers rule: the update
+   * ran, the revision verified, and the machine deliberately stayed
+   * where it was. `addressable` is false when the tree behind the
+   * record is gone, which is the one way a pending activation can
+   * become a thing that will never happen.
+   */
+  staged: (PackageSetRevision & { addressable: boolean }) | null;
 }
 
 /**
@@ -1449,6 +1571,7 @@ export function redSkillsSetReport(home: string): SetDoctorReport {
       : null,
     retained: state.revisions.map((r) => ({ ...r, addressable: existsSync(r.path) })),
     refused: state.refused,
+    staged: state.staged ? { ...state.staged, addressable: existsSync(state.staged.path) } : null,
   };
 }
 
@@ -1492,6 +1615,18 @@ export function redSkillsSetRows(report: SetDoctorReport): SetDoctorRow[] {
           : `rollback revision ${formatPackageSetIdentity(rollback)} is recorded but gone`,
       });
     }
+  }
+  if (report.staged) {
+    // A warning rather than an error: nothing is wrong with a machine
+    // that held an activation back, but "staged" is not "installed" and
+    // a report that said `ok` would read as the latter.
+    rows.push({
+      status: report.staged.addressable ? "warn" : "err",
+      detail: report.staged.addressable
+        ? `${formatPackageSetIdentity(report.staged)} is staged and pending — ` +
+          "activated by the next converge that finds no Worker running"
+        : `staged revision ${formatPackageSetIdentity(report.staged)} is recorded but its tree is gone`,
+    });
   }
   if (report.refused) {
     rows.push({

--- a/src/staged-update.test.ts
+++ b/src/staged-update.test.ts
@@ -233,6 +233,28 @@ describe("a forced failure", () => {
 });
 
 describe("running coder sessions", () => {
+  test("nothing on the update path can signal a process", () => {
+    // Structural, not behavioural, because the guarantee is an absence:
+    // no test that runs the walk can prove that a path it did not take
+    // holds no `kill`. The three modules an update advances surfaces
+    // through are read instead, and none of them may carry one.
+    for (const file of [
+      "./staged-update.ts",
+      "./red-skills-hosts.ts",
+      "./red-skills-companions.ts",
+    ]) {
+      const source = readFileSync(new URL(file, import.meta.url), "utf8")
+        .split("\n")
+        // Prose is allowed to say "never a kill"; code is not allowed to
+        // issue one.
+        .filter((line) => !line.trimStart().startsWith("*") && !line.trimStart().startsWith("//"))
+        .join("\n");
+      expect(source).not.toMatch(/\b(?:pkill|taskkill|SIGKILL|SIGTERM)\b/);
+      expect(source).not.toMatch(/\.kill\(|process\.kill\b/);
+    }
+  });
+
+
   test("are never terminated: the host is reconciled and owed a restart", async () => {
     const home = fakeHome();
     record(home, machine(home));

--- a/src/staged-update.test.ts
+++ b/src/staged-update.test.ts
@@ -1,0 +1,448 @@
+/**
+ * The staged reconciliation, and the two rules that make it one.
+ *
+ * Every assertion here is one sentence of ADR 0010's convergence
+ * paragraph: a failed surface does not roll back the ones that verified,
+ * running coder sessions are never terminated, and an active Worker
+ * stages the complete revision instead of moving the ground under it.
+ *
+ * Walked rather than described, because a rule stated in a comment and a
+ * rule the walk executes are two different things — and the whole point
+ * of this module is that `red-dev update` and `mise upgrade red-skills`
+ * cannot execute two.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+
+import type { Acquisition } from "./red-skills-acquire.ts";
+import type { CompanionOutcome } from "./red-skills-companions.ts";
+import type { HostOutcome } from "./red-skills-hosts.ts";
+import {
+  packageSetStatePath,
+  type PackageSetRevision,
+  type PackageSetState,
+} from "./red-skills-set.ts";
+import {
+  acquisitionSurface,
+  companionSurface,
+  hostSurface,
+  lockSurface,
+  readStagedUpdate,
+  runStagedUpdate,
+  stagedUpdateOutcome,
+  stagedUpdateReport,
+  stagedUpdateRows,
+  UPDATE_SURFACES,
+  type StagedUpdateOptions,
+  type SurfaceOutcome,
+  type UpdateSurface,
+} from "./staged-update.ts";
+
+const fakeHome = (): string => mkdtempSync(`${tmpdir()}/red-staged-`);
+
+/** One acquisition, in whichever of its five endings a case needs. */
+function acquisition(outcome: Acquisition["outcome"], reason = outcome): Acquisition {
+  return {
+    outcome,
+    reason,
+    failure: outcome === "refused" ? "signature" : null,
+    selector: null,
+    commit: null,
+    version: null,
+    mirror: null,
+    snapshot: null,
+    candidate: null,
+    active: null,
+    writes: [],
+  };
+}
+
+function host(name: string, over: Partial<HostOutcome> = {}): HostOutcome {
+  return { host: name, status: "reconciled", reload: "current", ...over };
+}
+
+function companion(name: CompanionOutcome["companion"], over: Partial<CompanionOutcome> = {}): CompanionOutcome {
+  return { companion: name, status: "reconciled", reload: "current", ...over };
+}
+
+const SEVEN = ["claude-code", "codex", "opencode", "redcode", "gemini", "pi", "hermes"];
+
+/** A machine holding one active revision, and nothing staged. */
+function machine(home: string, over: Partial<PackageSetState> = {}): PackageSetState {
+  const active: PackageSetRevision = {
+    key: "3.19.5+0123456789ab",
+    version: "3.19.5",
+    digest: "0123456789ab".repeat(5) + "0123",
+    sourceCommit: "626a28473edeee992fcf6425dedbca84448343fd",
+    kind: "manifest",
+    trust: "trusted",
+    path: `${home}/.red-skills/sets/3.19.5+0123456789ab`,
+  };
+  const state: PackageSetState = {
+    schema: 1,
+    active: active.key,
+    revisions: [active],
+    refused: null,
+    staged: null,
+    ...over,
+  };
+  return state;
+}
+
+/** Put a package-set state on disk, creating its directory. */
+function record(home: string, state: PackageSetState): void {
+  const path = packageSetStatePath(home);
+  mkdirSync(`${home}/.red-skills`, { recursive: true });
+  writeFileSync(path, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+}
+
+/** A run with every surface injected, so the walk is what is under test. */
+function walk(home: string, over: Partial<StagedUpdateOptions> = {}) {
+  return runStagedUpdate({
+    home,
+    env: { HOME: home },
+    workers: async () => 0,
+    acquire: async () => acquisition("acquired", "3.19.6 acquired"),
+    converge: async () => ({
+      hosts: SEVEN.map((h) => host(h)),
+      companions: [companion("redskilled"), companion("herdr")],
+    }),
+    lock: async () => ({ ok: false, present: false, reason: "no workstation lock" }),
+    ...over,
+  });
+}
+
+const stateOf = (run: { surfaces: SurfaceOutcome[] }) =>
+  Object.fromEntries(run.surfaces.map((s) => [s.surface, s.state])) as Record<UpdateSurface, string>;
+
+// --------------------------------------------------------- the translations
+
+describe("one surface's own vocabulary, in the shared one", () => {
+  test("a refused acquisition fails the surface; an unreachable one does not", () => {
+    expect(acquisitionSurface(acquisition("refused")).state).toBe("failed");
+    // A laptop on a train changed nothing and is not a broken machine.
+    expect(acquisitionSurface(acquisition("unreachable")).state).toBe("verified");
+    expect(acquisitionSurface(acquisition("current")).state).toBe("verified");
+    expect(acquisitionSurface(acquisition("unavailable")).state).toBe("skipped");
+  });
+
+  test("a blocked host fails the surface, and an absent one does not", () => {
+    expect(hostSurface(SEVEN.map((h) => host(h))).state).toBe("verified");
+    expect(hostSurface([host("gemini", { status: "absent" })]).state).toBe("verified");
+    const failed = hostSurface([host("pi"), host("hermes", { status: "blocked", reason: "no adapter" })]);
+    expect(failed.state).toBe("failed");
+    expect(failed.reason).toContain("hermes (no adapter)");
+  });
+
+  test("a companion the set does not carry yet is not a failure", () => {
+    expect(companionSurface([companion("vscode", { status: "unavailable" })]).state).toBe("verified");
+    expect(companionSurface([companion("redskilled", { status: "failed" })]).state).toBe("failed");
+  });
+
+  test("a lock nobody resolved is skipped; one that is there and wrong fails", () => {
+    expect(lockSurface({ ok: false, present: false, reason: "none" }).state).toBe("skipped");
+    expect(lockSurface({ ok: false, present: true, reason: "not canonical" }).state).toBe("failed");
+  });
+});
+
+// ----------------------------------------------------------- the verdicts
+
+describe("what the surfaces add up to", () => {
+  const surface = (surfaceName: UpdateSurface, state: SurfaceOutcome["state"]): SurfaceOutcome => ({
+    surface: surfaceName,
+    state,
+    reason: state,
+    restartNeeded: [],
+  });
+
+  test("partial and failed are the same exit code and a different machine", () => {
+    expect(stagedUpdateOutcome([surface("acquisition", "verified"), surface("hosts", "failed")])).toBe("partial");
+    expect(stagedUpdateOutcome([surface("acquisition", "failed"), surface("hosts", "failed")])).toBe("failed");
+    expect(stagedUpdateOutcome([surface("acquisition", "verified"), surface("hosts", "skipped")])).toBe("converged");
+    expect(stagedUpdateOutcome([surface("acquisition", "verified"), surface("hosts", "pending")])).toBe("staged");
+  });
+
+  test("a failure outranks a pending surface", () => {
+    // Acquisition refused under a running Worker: nothing was staged, so
+    // reporting "staged" would name a revision that is not on the disk.
+    expect(stagedUpdateOutcome([surface("acquisition", "failed"), surface("hosts", "pending")])).toBe("failed");
+  });
+});
+
+// --------------------------------------------------------------- the walk
+
+describe("a forced failure", () => {
+  test("returns overall failure and preserves every surface that verified", async () => {
+    const home = fakeHome();
+    record(home, machine(home));
+    const run = await walk(home, {
+      converge: async () => ({
+        hosts: [...SEVEN.slice(0, 6).map((h) => host(h)), host("hermes", { status: "failed", reason: "generator exited 1" })],
+        companions: [companion("redskilled")],
+      }),
+    });
+    expect(run.outcome).toBe("partial");
+    expect(run.code).toBe(1);
+    // The acquisition is not undone by the host that came after it, and
+    // the companions after the failed host still ran.
+    expect(stateOf(run)).toEqual({
+      acquisition: "verified",
+      hosts: "failed",
+      companions: "verified",
+      lock: "skipped",
+    });
+  });
+
+  test("a companion failure is the same shape", async () => {
+    const home = fakeHome();
+    record(home, machine(home));
+    const run = await walk(home, {
+      converge: async () => ({
+        hosts: SEVEN.map((h) => host(h)),
+        companions: [companion("redskilled", { status: "blocked", reason: "daemon is held by another owner" })],
+      }),
+    });
+    expect(run.outcome).toBe("partial");
+    expect(stateOf(run).hosts).toBe("verified");
+    expect(stateOf(run).companions).toBe("failed");
+  });
+
+  test("succeeds on retry, with the failure the only thing left to do", async () => {
+    const home = fakeHome();
+    record(home, machine(home));
+    let attempt = 0;
+    const converge = async () => {
+      attempt += 1;
+      return {
+        hosts:
+          attempt === 1
+            ? [...SEVEN.slice(0, 6).map((h) => host(h)), host("hermes", { status: "failed", reason: "generator exited 1" })]
+            : SEVEN.map((h) => host(h)),
+        companions: [companion("redskilled")],
+      };
+    };
+    expect((await walk(home, { converge })).code).toBe(1);
+    const retry = await walk(home, { converge });
+    expect(retry.outcome).toBe("converged");
+    expect(retry.code).toBe(0);
+    // And the record no longer names a failed surface.
+    expect(stagedUpdateReport(home).failed).toEqual([]);
+  });
+});
+
+describe("running coder sessions", () => {
+  test("are never terminated: the host is reconciled and owed a restart", async () => {
+    const home = fakeHome();
+    record(home, machine(home));
+    const run = await walk(home, {
+      converge: async () => ({
+        hosts: [
+          host("claude-code", { reload: "restart-needed" }),
+          host("codex", { reload: "restart-needed" }),
+          ...SEVEN.slice(2).map((h) => host(h)),
+        ],
+        companions: [companion("herdr", { reload: "restart-needed" })],
+      }),
+    });
+    // Reconciled, not failed: the disk moved and the process was left alone.
+    expect(run.outcome).toBe("converged");
+    expect(run.code).toBe(0);
+    expect(run.restartNeeded).toEqual(["claude-code", "codex", "herdr"]);
+    expect(stagedUpdateReport(home).restartNeeded).toEqual(["claude-code", "codex", "herdr"]);
+  });
+
+  test("stop being owed a restart once a fresh session has observed the revision", async () => {
+    const home = fakeHome();
+    record(home, machine(home));
+    await walk(home, {
+      converge: async () => ({
+        hosts: [host("claude-code", { reload: "restart-needed" }), ...SEVEN.slice(1).map((h) => host(h))],
+        companions: [],
+      }),
+    });
+    expect(stagedUpdateReport(home).restartNeeded).toEqual(["claude-code"]);
+    await walk(home);
+    expect(stagedUpdateReport(home).restartNeeded).toEqual([]);
+  });
+});
+
+describe("an active Worker", () => {
+  test("lets acquisition complete and holds every other surface", async () => {
+    const home = fakeHome();
+    record(home, machine(home));
+    let stagedOnly: boolean | null = null;
+    let converged = false;
+    const run = await walk(home, {
+      workers: async () => 2,
+      acquire: async (stageOnly) => {
+        stagedOnly = stageOnly;
+        return acquisition("acquired", "3.19.6 staged");
+      },
+      converge: async () => {
+        converged = true;
+        return { hosts: [], companions: [] };
+      },
+    });
+    // The acquisition ran, and it was told not to activate what it verified.
+    expect(stagedOnly).toBe(true);
+    expect(run.outcome).toBe("staged");
+    expect(run.code).toBe(0);
+    // Nothing else was even asked: the hosts, the companions and the
+    // daemon stay on the lock the Worker is working against.
+    expect(converged).toBe(false);
+    expect(stateOf(run)).toEqual({
+      acquisition: "verified",
+      hosts: "pending",
+      companions: "pending",
+      lock: "pending",
+    });
+    expect(run.active?.version).toBe("3.19.5");
+  });
+
+  test("is reported as pending, by surface, with the Worker count", async () => {
+    const home = fakeHome();
+    record(home, machine(home));
+    await walk(home, { workers: async () => 3, acquire: async () => acquisition("acquired") });
+    const report = stagedUpdateReport(home);
+    expect(report.outcome).toBe("staged");
+    expect(report.pending).toEqual(["hosts", "companions", "lock"]);
+    expect(report.workers).toBe(3);
+    const row = stagedUpdateRows(report).find((r) => r.detail.includes("pending on 3 active Worker"))!;
+    expect(row.status).toBe("warn");
+  });
+
+  test("an unknown daemon is not a busy one", async () => {
+    // A workstation that runs no daemon has no Workers to protect, and an
+    // update that held its activation on an unanswerable question would
+    // never activate anything there at all.
+    const home = fakeHome();
+    record(home, machine(home));
+    let stagedOnly: boolean | null = null;
+    const run = await walk(home, {
+      workers: async () => null,
+      acquire: async (stageOnly) => {
+        stagedOnly = stageOnly;
+        return acquisition("acquired");
+      },
+    });
+    expect(stagedOnly).toBe(false);
+    expect(run.outcome).toBe("converged");
+  });
+
+  test("a refused acquisition under a Worker is a failure, not a staging", async () => {
+    const home = fakeHome();
+    record(home, machine(home));
+    const run = await walk(home, {
+      workers: async () => 1,
+      acquire: async () => acquisition("refused", "manifest signature is invalid"),
+    });
+    expect(run.outcome).toBe("failed");
+    expect(run.code).toBe(1);
+  });
+});
+
+describe("completing the Worker", () => {
+  test("activates the staged revision without acquiring anything", async () => {
+    const home = fakeHome();
+    const staged: PackageSetRevision = {
+      key: "3.19.6+abcdefabcdef",
+      version: "3.19.6",
+      digest: "abcdefabcdef".repeat(5) + "abcd",
+      sourceCommit: "f".repeat(40),
+      kind: "manifest",
+      trust: "trusted",
+      path: `${home}/.red-skills/sets/3.19.6+abcdefabcdef`,
+    };
+    record(home, machine(home, { staged }));
+
+    // What doctor says while the Worker is still holding it.
+    const held = stagedUpdateReport(home);
+    expect(held.active?.version).toBe("3.19.5");
+    expect(held.staged?.version).toBe("3.19.6");
+
+    // The run that finds the queue drained. The acquisition it is given
+    // is the real default's answer for "the staged revision was
+    // activated" — no selector, no commit resolved, nothing fetched.
+    const run = await walk(home, {
+      workers: async () => 0,
+      acquire: async () => {
+        record(home, machine(home, { active: staged.key, revisions: [staged], staged: null }));
+        return acquisition("acquired", "the staged revision was activated — nothing was acquired");
+      },
+    });
+    expect(run.outcome).toBe("converged");
+    expect(run.active?.version).toBe("3.19.6");
+    expect(run.staged).toBeNull();
+    expect(stagedUpdateReport(home).staged).toBeNull();
+  });
+});
+
+describe("what doctor reads", () => {
+  test("a machine that has never updated says so, and claims nothing", () => {
+    const home = fakeHome();
+    const report = stagedUpdateReport(home);
+    expect(report).toEqual({
+      outcome: null,
+      active: null,
+      staged: null,
+      pending: [],
+      failed: [],
+      restartNeeded: [],
+      workers: null,
+    });
+    expect(stagedUpdateRows(report)).toEqual([
+      { status: "n/a", detail: "no staged update has run on this machine" },
+    ]);
+  });
+
+  test("exposes active, staged, pending, failed, partial and restart-needed", async () => {
+    const home = fakeHome();
+    record(home, machine(home));
+    await walk(home, {
+      converge: async () => ({
+        hosts: [host("claude-code", { reload: "restart-needed" }), host("hermes", { status: "failed", reason: "no adapter" })],
+        companions: [companion("redskilled")],
+      }),
+    });
+    const report = stagedUpdateReport(home);
+    expect(report.outcome).toBe("partial");
+    expect(report.active?.version).toBe("3.19.5");
+    expect(report.failed).toEqual(["hosts"]);
+    expect(report.restartNeeded).toEqual(["claude-code"]);
+    const rows = stagedUpdateRows(report);
+    expect(rows[0]!.status).toBe("err");
+    expect(rows.some((r) => r.detail === "not converged: hosts")).toBe(true);
+    expect(rows.some((r) => r.detail.startsWith("restart needed"))).toBe(true);
+  });
+
+  test("the record is one file, rewritten only when the run differs", async () => {
+    const home = fakeHome();
+    record(home, machine(home));
+    await walk(home);
+    const first = readFileSync(`${home}/.red-skills/update.json`, "utf8");
+    await walk(home);
+    expect(readFileSync(`${home}/.red-skills/update.json`, "utf8")).toBe(first);
+    expect(readStagedUpdate(home)?.outcome).toBe("converged");
+  });
+
+  test("a record this build cannot read is no record rather than an error", () => {
+    const home = fakeHome();
+    record(home, machine(home));
+    mkdirSync(`${home}/.red-skills`, { recursive: true });
+    writeFileSync(`${home}/.red-skills/update.json`, "{ not json", "utf8");
+    expect(readStagedUpdate(home)).toBeNull();
+    expect(stagedUpdateReport(home).outcome).toBeNull();
+  });
+});
+
+describe("the order", () => {
+  test("is acquisition, hosts, companions, lock — and every surface is named once", async () => {
+    const home = fakeHome();
+    record(home, machine(home));
+    const run = await walk(home);
+    expect(run.surfaces.map((s) => s.surface)).toEqual([...UPDATE_SURFACES]);
+    expect(new Set(UPDATE_SURFACES).size).toBe(UPDATE_SURFACES.length);
+  });
+});

--- a/src/staged-update.test.ts
+++ b/src/staged-update.test.ts
@@ -43,7 +43,7 @@ import {
 const fakeHome = (): string => mkdtempSync(`${tmpdir()}/red-staged-`);
 
 /** One acquisition, in whichever of its five endings a case needs. */
-function acquisition(outcome: Acquisition["outcome"], reason = outcome): Acquisition {
+function acquisition(outcome: Acquisition["outcome"], reason: string = outcome): Acquisition {
   return {
     outcome,
     reason,
@@ -272,26 +272,26 @@ describe("an active Worker", () => {
   test("lets acquisition complete and holds every other surface", async () => {
     const home = fakeHome();
     record(home, machine(home));
-    let stagedOnly: boolean | null = null;
-    let converged = false;
+    const told: boolean[] = [];
+    const convergedCalls: string[] = [];
     const run = await walk(home, {
       workers: async () => 2,
       acquire: async (stageOnly) => {
-        stagedOnly = stageOnly;
+        told.push(stageOnly);
         return acquisition("acquired", "3.19.6 staged");
       },
       converge: async () => {
-        converged = true;
+        convergedCalls.push("converge");
         return { hosts: [], companions: [] };
       },
     });
     // The acquisition ran, and it was told not to activate what it verified.
-    expect(stagedOnly).toBe(true);
+    expect(told).toEqual([true]);
     expect(run.outcome).toBe("staged");
     expect(run.code).toBe(0);
     // Nothing else was even asked: the hosts, the companions and the
     // daemon stay on the lock the Worker is working against.
-    expect(converged).toBe(false);
+    expect(convergedCalls).toEqual([]);
     expect(stateOf(run)).toEqual({
       acquisition: "verified",
       hosts: "pending",
@@ -319,15 +319,15 @@ describe("an active Worker", () => {
     // never activate anything there at all.
     const home = fakeHome();
     record(home, machine(home));
-    let stagedOnly: boolean | null = null;
+    const told: boolean[] = [];
     const run = await walk(home, {
       workers: async () => null,
       acquire: async (stageOnly) => {
-        stagedOnly = stageOnly;
+        told.push(stageOnly);
         return acquisition("acquired");
       },
     });
-    expect(stagedOnly).toBe(false);
+    expect(told).toEqual([false]);
     expect(run.outcome).toBe("converged");
   });
 

--- a/src/staged-update.test.ts
+++ b/src/staged-update.test.ts
@@ -55,6 +55,7 @@ function acquisition(outcome: Acquisition["outcome"], reason: string = outcome):
     snapshot: null,
     candidate: null,
     active: null,
+    staged: null,
     writes: [],
   };
 }

--- a/src/staged-update.ts
+++ b/src/staged-update.ts
@@ -359,6 +359,18 @@ export interface StagedUpdateOptions {
    * daemon to ask whether a daemon is busy has changed the answer.
    */
   workers?: () => Promise<number | null>;
+  /** The channel, version or commit to acquire. Defaults to the channel env. */
+  selector?: string;
+  /**
+   * Whether this run has an acquisition to perform at all.
+   *
+   * `installed` is the postinstall's answer: mise has just put the set
+   * on the machine through the plugin's own install phase, and asking
+   * the remote again would be a second acquisition for one upgrade.
+   * The surface is still reported — what it reports is the revision
+   * this machine now resolves.
+   */
+  acquisition?: "acquire" | "installed";
   /**
    * The acquisition, told whether it may activate what it verifies.
    * Defaults to the staged activation, then src/red-skills-acquire.ts.
@@ -498,10 +510,38 @@ function defaultAcquire(
       }
     }
 
+    // mise's postinstall: the set is already on the machine, and the
+    // only honest thing to report is which revision that is.
+    if (opts.acquisition === "installed") {
+      const { readPackageSetState } = await import("./red-skills-set.ts");
+      const { formatPackageSetIdentity } = await import("./red-skills-set.ts");
+      const state = readPackageSetState(home);
+      const active = state.revisions.find((r) => r.key === state.active) ?? null;
+      return {
+        outcome: active === null ? "unavailable" : "current",
+        reason:
+          active === null
+            ? "no package set is active on this machine"
+            : `${formatPackageSetIdentity(active)} was installed by mise`,
+        failure: null,
+        selector: null,
+        commit: active?.sourceCommit ?? null,
+        version: active?.version ?? null,
+        mirror: null,
+        snapshot: null,
+        candidate: null,
+        active: active
+          ? { version: active.version, digest: active.digest, sourceCommit: active.sourceCommit }
+          : null,
+        writes: [],
+      };
+    }
+
     const { acquireRedSkills, announce } = await import("./red-skills-acquire.ts");
     const acquisition = await acquireRedSkills({
       home,
       stageOnly,
+      ...(opts.selector ? { selector: opts.selector } : {}),
       ...(opts.manifestPlatform ? { manifestPlatform: opts.manifestPlatform } : {}),
       ...(opts.env ? { env: opts.env } : {}),
     });

--- a/src/staged-update.ts
+++ b/src/staged-update.ts
@@ -505,6 +505,7 @@ function defaultAcquire(
           snapshot: null,
           candidate: null,
           active: activated.active,
+          staged: activated.staged,
           writes: activated.writes,
         };
       }
@@ -533,6 +534,7 @@ function defaultAcquire(
         active: active
           ? { version: active.version, digest: active.digest, sourceCommit: active.sourceCommit }
           : null,
+        staged: null,
         writes: [],
       };
     }

--- a/src/staged-update.ts
+++ b/src/staged-update.ts
@@ -1,0 +1,669 @@
+/**
+ * One staged reconciliation across every surface an update advances.
+ *
+ * `red-dev update` and `mise upgrade red-skills` both mean the same
+ * thing: put this workstation on one revision. That revision is not one
+ * artifact — it is the package set, the seven coder hosts wired against
+ * it, the companions built out of it, and the exact workstation lock
+ * every external application is pinned by. Four surfaces, four different
+ * mechanisms, no shared transaction between any of them.
+ *
+ * ## Truthful, not falsely transactional
+ *
+ * ADR 0010 settles what to do about that. Every chosen surface must
+ * converge before the operation succeeds, and **a failed surface does
+ * not roll back the ones that already verified**. There is no cross-host
+ * transaction to be had — the plugin managers, the marketplaces and the
+ * editor CLIs offer none — so pretending otherwise would mean uninstall-
+ * ing six good hosts because the seventh refused, at the cost of a
+ * machine that ends up worse than it started. Instead the run answers
+ * with failure and says exactly which side of the line each surface
+ * ended on, so the state is visible and the retry is cheap: everything
+ * verified is already converged, and only the failure is re-attempted.
+ *
+ * ## The Workers rule
+ *
+ * The one thing an update may never do is move the ground under work
+ * that is already running. Two rules follow, and this module is where
+ * they meet:
+ *
+ *   - **Running coder sessions are never terminated.** A host whose CLI
+ *     is running is reconciled on disk and reported `restart needed`;
+ *     the session keeps the revision it started with until somebody
+ *     opens a fresh one. That decision lives in the host and companion
+ *     adapters, which observe it; this module carries it up into the
+ *     report so a person is told once, at the end, what a restart is
+ *     owed.
+ *   - **Active Workers hold the activation.** With a Worker running,
+ *     acquisition still completes — the revision is fetched, verified
+ *     and staged under its immutable name — and nothing else happens at
+ *     all. `current`, the daemon, the hosts and the companions stay on
+ *     the lock the Worker is working against, the complete new revision
+ *     stays staged and pending, and the run reports `staged` rather
+ *     than success or failure. The next run that finds no Worker
+ *     activates what is already on disk, acquiring nothing.
+ *
+ * ## Why the walk is data and the surfaces are injected
+ *
+ * The same reason src/update-order.ts is: the order and the rules are
+ * the load-bearing part, and they are worth pinning without a machine
+ * that has seven coder CLIs, a daemon and a resolved lock on it. Each
+ * surface is a producer returning the vocabulary its own module already
+ * speaks, and the translation into one shared verdict is pure.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+import { log } from "./log.ts";
+import type { Platform } from "./platform.ts";
+import type { Acquisition } from "./red-skills-acquire.ts";
+import type { CompanionOutcome } from "./red-skills-companions.ts";
+import type { HostOutcome } from "./red-skills-hosts.ts";
+import { readPackageSetState, type PackageSetIdentity } from "./red-skills-set.ts";
+import type { LockInstallReport } from "./workstation-lock.ts";
+
+/** The surfaces one revision has to reach, in the order it reaches them. */
+export const UPDATE_SURFACES = ["acquisition", "hosts", "companions", "lock"] as const;
+
+export type UpdateSurface = (typeof UPDATE_SURFACES)[number];
+
+/**
+ * Where one surface ended.
+ *
+ * `verified` covers both "this run converged it" and "it was already
+ * converged": the question a surface answers is whether the machine is
+ * on the revision, not whether work was done to get it there.
+ *
+ * `skipped` is the honest word for a surface this machine does not have
+ * — no coder CLI installed, no lock resolved — and is deliberately not
+ * `verified`: a report that counted an absent surface as converged
+ * would claim a guarantee nothing checked.
+ */
+export type SurfaceState = "verified" | "failed" | "pending" | "skipped";
+
+export interface SurfaceOutcome {
+  surface: UpdateSurface;
+  state: SurfaceState;
+  /** One sentence saying why, always — including on the happy path. */
+  reason: string;
+  /**
+   * What was reconciled on disk and will only be observed by a fresh
+   * session. Empty on every surface that has no such notion.
+   */
+  restartNeeded: string[];
+}
+
+/**
+ * The verdict of one run.
+ *
+ * `staged` is not a failure and not a success: the revision is on the
+ * machine, verified and complete, and the activation is deliberately
+ * owed to a later run. Reporting it as either of the other two would
+ * make an operator either chase a problem that does not exist or
+ * believe an activation that has not happened.
+ */
+export const UPDATE_OUTCOMES = ["converged", "partial", "failed", "staged"] as const;
+
+export type UpdateOutcome = (typeof UPDATE_OUTCOMES)[number];
+
+export interface StagedUpdate {
+  outcome: UpdateOutcome;
+  surfaces: SurfaceOutcome[];
+  /** The identity `current` names once this returns, or null. */
+  active: PackageSetIdentity | null;
+  /** The complete revision staged and pending activation, or null. */
+  staged: PackageSetIdentity | null;
+  /** Every host and companion owed a restart, across all surfaces. */
+  restartNeeded: string[];
+  /** Active Workers observed, or null when the daemon could not be asked. */
+  workers: number | null;
+  /** Zero for `converged` and `staged`; one for everything else. */
+  code: number;
+}
+
+// ------------------------------------------------------- the translations
+
+/**
+ * The acquisition, as one surface. PURE.
+ *
+ * `unreachable` is not a failure and this is the one place that has to
+ * say so out loud: a laptop on a train cannot read the remote, and the
+ * update it runs changes nothing while leaving the machine on the set it
+ * already resolves. Recording that as a failed surface would make every
+ * offline update report a broken workstation.
+ */
+export function acquisitionSurface(a: Acquisition): SurfaceOutcome {
+  const state: SurfaceState =
+    a.outcome === "refused" ? "failed" : a.outcome === "unavailable" ? "skipped" : "verified";
+  return { surface: "acquisition", state, reason: a.reason, restartNeeded: [] };
+}
+
+/**
+ * The seven hosts, as one surface. PURE.
+ *
+ * `blocked` and `failed` are the two ways a host does not converge, and
+ * both fail the surface. Everything else is a host that is on the
+ * revision — including `absent`, which is a host this machine does not
+ * have rather than one it could not wire.
+ *
+ * The restart list is the whole visible half of "running sessions are
+ * never terminated": a host reported here was reconciled on disk with
+ * its process left alone, and the only thing standing between it and
+ * the new revision is a session nobody has opened yet.
+ */
+export function hostSurface(outcomes: readonly HostOutcome[]): SurfaceOutcome {
+  const stuck = outcomes.filter((o) => o.status === "blocked" || o.status === "failed");
+  const restartNeeded = outcomes.filter((o) => o.reload === "restart-needed").map((o) => o.host);
+  if (outcomes.length === 0) {
+    return {
+      surface: "hosts",
+      state: "skipped",
+      reason: "no coding agent is installed to reconcile",
+      restartNeeded,
+    };
+  }
+  if (stuck.length > 0) {
+    return {
+      surface: "hosts",
+      state: "failed",
+      reason: `not reconciled into ${stuck.map((o) => `${o.host} (${o.reason ?? "no reason given"})`).join(", ")}`,
+      restartNeeded,
+    };
+  }
+  return {
+    surface: "hosts",
+    state: "verified",
+    reason: `${outcomes.filter((o) => o.status !== "absent").length} host(s) on the active revision`,
+    restartNeeded,
+  };
+}
+
+/**
+ * The companions, as one surface. PURE.
+ *
+ * `unavailable` is not a failure, for the reason the companion module
+ * gives: a set published before an artifact was part of it is not a
+ * broken machine, and the remedy is a newer set rather than a retry.
+ */
+export function companionSurface(outcomes: readonly CompanionOutcome[]): SurfaceOutcome {
+  const stuck = outcomes.filter((o) => o.status === "blocked" || o.status === "failed");
+  const restartNeeded = outcomes
+    .filter((o) => o.reload === "restart-needed")
+    .map((o) => o.companion as string);
+  if (outcomes.length === 0) {
+    return {
+      surface: "companions",
+      state: "skipped",
+      reason: "no package set to build the companions out of",
+      restartNeeded,
+    };
+  }
+  if (stuck.length > 0) {
+    return {
+      surface: "companions",
+      state: "failed",
+      reason: `not converged: ${stuck.map((o) => `${o.companion} (${o.reason ?? "no reason given"})`).join(", ")}`,
+      restartNeeded,
+    };
+  }
+  return {
+    surface: "companions",
+    state: "verified",
+    reason: `${outcomes.filter((o) => o.status !== "absent").length} companion(s) on the active revision`,
+    restartNeeded,
+  };
+}
+
+/** What the lock surface reports back: a run of it, or why there was none. */
+export type LockResult =
+  | { ok: true; report: LockInstallReport }
+  | { ok: false; present: boolean; reason: string };
+
+/**
+ * The exact workstation lock, as one surface. PURE.
+ *
+ * A machine with no lock resolved yet is `skipped` rather than failed —
+ * that is every machine before its first depot import, and an update
+ * that reported it as broken would be reporting the ordinary case. A
+ * lock that is present and unusable is a failure, because somebody put
+ * it there and it does not describe this machine.
+ */
+export function lockSurface(result: LockResult): SurfaceOutcome {
+  if (!result.ok) {
+    return {
+      surface: "lock",
+      state: result.present ? "failed" : "skipped",
+      reason: result.reason,
+      restartNeeded: [],
+    };
+  }
+  const { report } = result;
+  if (report.failed.length > 0) {
+    return {
+      surface: "lock",
+      state: "failed",
+      reason: `${report.target}: ${report.failed.map((f) => `${f.app} (${f.detail})`).join(", ")}`,
+      restartNeeded: [],
+    };
+  }
+  const total = report.installed.length + report.present.length;
+  return {
+    surface: "lock",
+    state: "verified",
+    reason:
+      `${report.target}: ${total} application(s) at the locked version` +
+      (report.unconfigured.length > 0
+        ? `, ${report.unconfigured.length} awaiting a cloud identity`
+        : ""),
+    restartNeeded: [],
+  };
+}
+
+/** A surface held back because a Worker is using the active revision. PURE. */
+export function pendingSurface(surface: UpdateSurface, workers: number): SurfaceOutcome {
+  return {
+    surface,
+    state: "pending",
+    reason: `held on the active lock: ${workers} Worker(s) are running`,
+    restartNeeded: [],
+  };
+}
+
+/**
+ * The one verdict the surfaces add up to. PURE.
+ *
+ * `partial` earns its own word rather than collapsing into `failed`:
+ * they are the same exit code and a completely different machine. A
+ * partial run left some surfaces on the new revision, and the operator
+ * reading it needs to know that retrying will not start from nothing.
+ */
+export function stagedUpdateOutcome(surfaces: readonly SurfaceOutcome[]): UpdateOutcome {
+  const failed = surfaces.some((s) => s.state === "failed");
+  const verified = surfaces.some((s) => s.state === "verified");
+  if (failed) return verified ? "partial" : "failed";
+  if (surfaces.some((s) => s.state === "pending")) return "staged";
+  return "converged";
+}
+
+// ------------------------------------------------------------- the record
+
+export interface StagedUpdateRecord {
+  schema: 1;
+  outcome: UpdateOutcome;
+  surfaces: SurfaceOutcome[];
+  /** Active Workers when the run started, or null when unknown. */
+  workers: number | null;
+}
+
+/** `~/.red-skills/update.json` — how the last staged reconciliation ended. */
+export function stagedUpdatePath(home: string): string {
+  return join(home, ".red-skills", "update.json");
+}
+
+/**
+ * The last run's record, or null.
+ *
+ * Recorded rather than re-derived because two of the states doctor has
+ * to report cannot be observed after the fact. `pending` is a decision
+ * this run made about surfaces it deliberately did not touch — nothing
+ * on disk distinguishes a companion held back from one that was never
+ * asked — and `partial` is a relation between surfaces rather than a
+ * property of any one of them. An unreadable record is no record, for
+ * the same reason an unreadable package-set state is no state.
+ */
+export function readStagedUpdate(home: string): StagedUpdateRecord | null {
+  const path = stagedUpdatePath(home);
+  if (!existsSync(path)) return null;
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as Partial<StagedUpdateRecord>;
+    if (parsed?.schema !== 1 || !Array.isArray(parsed.surfaces)) return null;
+    const outcome = parsed.outcome;
+    if (outcome === undefined || !UPDATE_OUTCOMES.includes(outcome)) return null;
+    return {
+      schema: 1,
+      outcome,
+      surfaces: parsed.surfaces,
+      workers: typeof parsed.workers === "number" ? parsed.workers : null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** Write the record, if it differs. Returns the paths written. */
+export function writeStagedUpdate(home: string, record: StagedUpdateRecord): string[] {
+  const desired = `${JSON.stringify(record, null, 2)}\n`;
+  const path = stagedUpdatePath(home);
+  try {
+    if (readFileSync(path, "utf8") === desired) return [];
+  } catch {
+    // No record yet, or one this build cannot read. Either way it is
+    // about to be replaced by one it wrote itself.
+  }
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, desired, "utf8");
+  return [path];
+}
+
+// --------------------------------------------------------------- the walk
+
+export interface StagedUpdateOptions {
+  home?: string;
+  env?: NodeJS.ProcessEnv;
+  /** The red-dev platform the host and companion walks need. */
+  manifestPlatform?: Platform;
+  /**
+   * Active Workers on this machine. Defaults to asking the daemon over
+   * its existing socket, and never starting one: an update that births a
+   * daemon to ask whether a daemon is busy has changed the answer.
+   */
+  workers?: () => Promise<number | null>;
+  /**
+   * The acquisition, told whether it may activate what it verifies.
+   * Defaults to the staged activation, then src/red-skills-acquire.ts.
+   */
+  acquire?: (stageOnly: boolean) => Promise<Acquisition>;
+  /** The hosts and companions. Defaults to red-dev's own converge. */
+  converge?: () => Promise<{ hosts: HostOutcome[]; companions: CompanionOutcome[] }>;
+  /** The exact workstation lock. Defaults to the one this machine holds. */
+  lock?: () => Promise<LockResult>;
+}
+
+/**
+ * Advance every surface to one revision, or say which one did not.
+ *
+ * The order is the contract, and it is the order of dependency:
+ * acquisition puts the revision on the machine, the hosts and companions
+ * are built out of it, and the lock pins everything neither of them
+ * publishes. A surface that fails is named and walked past — the ones
+ * after it are still worth advancing, and the ones before it keep what
+ * they already verified.
+ */
+export async function runStagedUpdate(opts: StagedUpdateOptions = {}): Promise<StagedUpdate> {
+  const env = opts.env ?? process.env;
+  const home = opts.home ?? homeOf(env);
+  const workers = await (opts.workers ?? defaultWorkers)();
+
+  // The one question asked before anything is acquired, because its
+  // answer changes what acquisition is allowed to do. Unknown is not
+  // "busy": a machine with no daemon has no Workers to protect, and an
+  // update that refused to activate anything it could not ask about
+  // would never activate on a workstation that runs no daemon at all.
+  const held = (workers ?? 0) > 0;
+
+  const surfaces: SurfaceOutcome[] = [];
+  const acquired = await (opts.acquire ?? defaultAcquire(opts, home))(held);
+  surfaces.push(acquisitionSurface(acquired));
+
+  if (held) {
+    // Everything else, deliberately not done. The Worker is running
+    // against the active lock, and the complete new revision waits on
+    // disk until the run that finds the queue drained.
+    for (const surface of UPDATE_SURFACES.filter((s) => s !== "acquisition")) {
+      surfaces.push(pendingSurface(surface, workers ?? 0));
+    }
+  } else {
+    const converged = await (opts.converge ?? defaultConverge(opts))();
+    surfaces.push(hostSurface(converged.hosts));
+    surfaces.push(companionSurface(converged.companions));
+    surfaces.push(lockSurface(await (opts.lock ?? defaultLock(home))()));
+  }
+
+  const outcome = stagedUpdateOutcome(surfaces);
+  const state = readPackageSetState(home);
+  const active = state.revisions.find((r) => r.key === state.active) ?? null;
+  const restartNeeded = [...new Set(surfaces.flatMap((s) => s.restartNeeded))];
+
+  writeStagedUpdate(home, { schema: 1, outcome, surfaces, workers });
+  announceStagedUpdate({ outcome, surfaces, restartNeeded });
+
+  return {
+    outcome,
+    surfaces,
+    active: active
+      ? { version: active.version, digest: active.digest, sourceCommit: active.sourceCommit }
+      : null,
+    staged: state.staged
+      ? {
+          version: state.staged.version,
+          digest: state.staged.digest,
+          sourceCommit: state.staged.sourceCommit,
+        }
+      : null,
+    restartNeeded,
+    workers,
+    code: outcome === "converged" || outcome === "staged" ? 0 : 1,
+  };
+}
+
+/** One line per surface, in the voice the rest of a converge speaks. */
+function announceStagedUpdate(
+  run: Pick<StagedUpdate, "outcome" | "surfaces" | "restartNeeded">,
+): void {
+  for (const surface of run.surfaces) {
+    const line = `${surface.surface}: ${surface.reason}`;
+    if (surface.state === "failed") log.err(line);
+    else if (surface.state === "pending") log.skip(line);
+    else if (surface.state === "skipped") log.skip(line);
+    else log.ok(line);
+  }
+  if (run.restartNeeded.length > 0) {
+    // Said once, at the end, and never as a failure: the disk is
+    // converged and the process was left alone on purpose.
+    log.warn(`restart needed to load the revision: ${run.restartNeeded.join(", ")}`);
+  }
+  if (run.outcome === "partial") {
+    log.warn("the update was partial — the surfaces that verified are on the new revision");
+  }
+}
+
+// ------------------------------------------------------------ the defaults
+
+/**
+ * The activation a previous run staged, then the ordinary acquisition.
+ *
+ * The order is the criterion: a machine whose Worker has finished
+ * activates the revision that is already on it, and does not go back to
+ * the remote for bytes it verified last week. Only when there is nothing
+ * staged does this reach the network at all.
+ */
+function defaultAcquire(
+  opts: StagedUpdateOptions,
+  home: string,
+): (stageOnly: boolean) => Promise<Acquisition> {
+  return async (stageOnly) => {
+    const { activateStagedPackageSet } = await import("./red-skills-set.ts");
+    if (!stageOnly) {
+      const activated = activateStagedPackageSet({
+        home,
+        ...(opts.env ? { env: opts.env } : {}),
+      });
+      if (activated !== null) {
+        return {
+          outcome: activated.refused ? "refused" : "acquired",
+          reason: activated.refused
+            ? activated.refused.reason
+            : "the staged revision was activated — nothing was acquired",
+          failure: activated.refused?.failure ?? null,
+          selector: null,
+          commit: activated.active?.sourceCommit ?? null,
+          version: activated.active?.version ?? null,
+          mirror: null,
+          snapshot: null,
+          candidate: null,
+          active: activated.active,
+          writes: activated.writes,
+        };
+      }
+    }
+
+    const { acquireRedSkills, announce } = await import("./red-skills-acquire.ts");
+    const acquisition = await acquireRedSkills({
+      home,
+      stageOnly,
+      ...(opts.manifestPlatform ? { manifestPlatform: opts.manifestPlatform } : {}),
+      ...(opts.env ? { env: opts.env } : {}),
+    });
+    announce(acquisition);
+    return acquisition;
+  };
+}
+
+function defaultConverge(
+  opts: StagedUpdateOptions,
+): () => Promise<{ hosts: HostOutcome[]; companions: CompanionOutcome[] }> {
+  return async () => {
+    const { convergeRedSkills } = await import("./agents.ts");
+    const { detect } = await import("./platform.ts");
+    return await convergeRedSkills(opts.manifestPlatform ?? detect());
+  };
+}
+
+/**
+ * The lock surface as this machine can honestly answer it today.
+ *
+ * The lock is read and audited; installing from it is not wired to a
+ * live installer yet (src/workstation-lock.ts owns that half, and it
+ * needs a resolved lock this machine has no publisher for). So a lock
+ * that is present and valid reports the applications it pins as already
+ * planned for, and everything else is `skipped` — which is the truthful
+ * answer rather than a verified surface nothing verified.
+ */
+function defaultLock(home: string): () => Promise<LockResult> {
+  return async () => {
+    const { readWorkstationLock, missingFromLock } = await import("./workstation-lock.ts");
+    const read = readWorkstationLock(home);
+    if (!read.ok) return read;
+    const missing = missingFromLock(read.lock);
+    if (missing.length > 0) {
+      return {
+        ok: false,
+        present: true,
+        reason: `the workstation lock names no version for ${missing.join(", ")}`,
+      };
+    }
+    return {
+      ok: true,
+      report: {
+        target: read.lock.target.id,
+        installed: [],
+        present: read.lock.apps.map((app) => `${app.id} on ${app.surface}`),
+        failed: [],
+        unconfigured: [],
+      },
+    };
+  };
+}
+
+/** Active Workers, over the daemon's existing socket and never a new one. */
+async function defaultWorkers(): Promise<number | null> {
+  const { readHostInventoryNoStart } = await import("./host-state.ts");
+  const inventory = await readHostInventoryNoStart();
+  return inventory === null ? null : inventory.workers.length;
+}
+
+function homeOf(env: NodeJS.ProcessEnv): string {
+  return (env["HOME"] ?? env["USERPROFILE"] ?? "").replace(/\\/g, "/");
+}
+
+// --------------------------------------------------------------- the report
+
+export interface UpdateDoctorReport {
+  /** The verdict of the last run, or null when none has been recorded. */
+  outcome: UpdateOutcome | null;
+  /** The identity `current` names. */
+  active: PackageSetIdentity | null;
+  /** The complete revision staged and waiting on a Worker, or null. */
+  staged: PackageSetIdentity | null;
+  /** Surfaces the last run held back rather than advanced. */
+  pending: UpdateSurface[];
+  /** Surfaces the last run could not converge. */
+  failed: UpdateSurface[];
+  /** Hosts and companions reconciled on disk but not yet observed. */
+  restartNeeded: string[];
+  /** Active Workers when the last run started, or null when unknown. */
+  workers: number | null;
+}
+
+/**
+ * What doctor says about the update, as data.
+ *
+ * The active and staged revisions come off the package-set state — they
+ * are facts about the machine, true whether or not an update has ever
+ * run here — and everything else comes off the last run's record,
+ * because `pending` and `partial` are decisions rather than observable
+ * state. A machine with no record answers `null` and empty lists, which
+ * is exactly what a machine that has never updated should say.
+ */
+export function stagedUpdateReport(home: string): UpdateDoctorReport {
+  const state = readPackageSetState(home);
+  const active = state.revisions.find((r) => r.key === state.active) ?? null;
+  const record = readStagedUpdate(home);
+  return {
+    outcome: record?.outcome ?? null,
+    active: active
+      ? { version: active.version, digest: active.digest, sourceCommit: active.sourceCommit }
+      : null,
+    staged: state.staged
+      ? {
+          version: state.staged.version,
+          digest: state.staged.digest,
+          sourceCommit: state.staged.sourceCommit,
+        }
+      : null,
+    pending: (record?.surfaces ?? []).filter((s) => s.state === "pending").map((s) => s.surface),
+    failed: (record?.surfaces ?? []).filter((s) => s.state === "failed").map((s) => s.surface),
+    restartNeeded: [...new Set((record?.surfaces ?? []).flatMap((s) => s.restartNeeded ?? []))],
+    workers: record?.workers ?? null,
+  };
+}
+
+export interface UpdateDoctorRow {
+  status: "ok" | "warn" | "err" | "n/a";
+  detail: string;
+}
+
+/** The report as the lines `red-dev doctor` prints. PURE. */
+export function stagedUpdateRows(report: UpdateDoctorReport): UpdateDoctorRow[] {
+  const rows: UpdateDoctorRow[] = [];
+  if (report.outcome === null) {
+    rows.push({ status: "n/a", detail: "no staged update has run on this machine" });
+    return rows;
+  }
+  const verdict: Record<UpdateOutcome, UpdateDoctorRow["status"]> = {
+    converged: "ok",
+    staged: "warn",
+    partial: "err",
+    failed: "err",
+  };
+  rows.push({
+    status: verdict[report.outcome],
+    detail: `the last update ${VERDICT_DETAIL[report.outcome]}`,
+  });
+  if (report.pending.length > 0) {
+    rows.push({
+      status: "warn",
+      detail:
+        `pending on ${report.workers ?? 0} active Worker(s): ${report.pending.join(", ")} — ` +
+        "activated by the next update that finds the queue drained",
+    });
+  }
+  if (report.failed.length > 0) {
+    rows.push({ status: "err", detail: `not converged: ${report.failed.join(", ")}` });
+  }
+  if (report.restartNeeded.length > 0) {
+    rows.push({
+      status: "warn",
+      detail: `restart needed before the revision is observed: ${report.restartNeeded.join(", ")}`,
+    });
+  }
+  return rows;
+}
+
+const VERDICT_DETAIL: Record<UpdateOutcome, string> = {
+  converged: "reached every surface of this workstation",
+  staged: "staged a complete revision and left the machine on the one its Workers are using",
+  partial: "left this workstation between two revisions — the surfaces that verified are on the new one",
+  failed: "reached no surface of this workstation",
+};

--- a/src/workstation-lock.ts
+++ b/src/workstation-lock.ts
@@ -72,6 +72,8 @@
  * nobody computed from bytes is not provenance.
  */
 
+import { readFileSync } from "node:fs";
+
 import { sha256Hex } from "./checksum.ts";
 
 export const WORKSTATION_LOCK_SCHEMA = "red.workstation-lock.v1";
@@ -440,6 +442,50 @@ export function missingFromLock(lock: WorkstationLock): string[] {
 export type LockParse =
   | { ok: true; lock: WorkstationLock }
   | { ok: false; reason: string };
+
+/**
+ * `~/.red-skills/workstation-lock.json` — the exact target this machine
+ * is provisioned against.
+ *
+ * One file, beside the package-set state, because the two are the same
+ * fact seen from two sides: the set is what RedSkills is on this
+ * machine, and the lock is what everything RedSkills does not publish is
+ * on it. A machine with no lock is a machine nobody has resolved one for
+ * yet, which is the ordinary state before the first depot import.
+ */
+export function workstationLockPath(home: string): string {
+  return `${home.replace(/\\/g, "/")}/.red-skills/workstation-lock.json`;
+}
+
+/**
+ * The lock this machine holds, or why it holds none. PURE of everything
+ * but the one read.
+ *
+ * Absent and unreadable are different answers: the first is a machine
+ * that was never given a lock, the second is one whose lock cannot be
+ * trusted. Both leave the caller with nothing to install from, and only
+ * the second is worth an operator's attention.
+ */
+export function readWorkstationLock(
+  home: string,
+  read: (path: string) => Uint8Array | null = readIfPresent,
+): { ok: true; lock: WorkstationLock } | { ok: false; present: boolean; reason: string } {
+  const path = workstationLockPath(home);
+  const bytes = read(path);
+  if (bytes === null) {
+    return { ok: false, present: false, reason: `no workstation lock at ${path}` };
+  }
+  const parsed = parseWorkstationLock(bytes);
+  return parsed.ok ? parsed : { ok: false, present: true, reason: parsed.reason };
+}
+
+function readIfPresent(path: string): Uint8Array | null {
+  try {
+    return readFileSync(path);
+  } catch {
+    return null;
+  }
+}
 
 function sameKeys(value: unknown, expected: readonly string[]): value is Record<string, unknown> {
   return (


### PR DESCRIPTION
Automated AFK landing for #210. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #210

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/225"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789694198&installation_model_id=20659&pr_number=225&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F225&signature=20f3a4afe59780a38476d8b2feddac48c800b0963873a8c883ff98d6eba82fac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->