### PR TITLE
fix: #212 Rollback restores the previous complete lock and keeps only two revisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,37 @@ that Worker is using, and the next update that finds the queue drained activates
 what is already on disk without acquiring it again. `doctor` names every one of
 those states — active, staged, pending, failed, partial, restart needed.
 
+Every verified activation is recorded as one **complete workstation revision**:
+the package set and the exact lock, named together, with the local depot copy
+the applications were installed from. That record is what makes a rollback one
+operation rather than four — downgrading the set without the lock leaves seven
+CLIs from one revision wired against the tree of another, and downgrading the
+lock without the artifacts means fetching them, which is the one thing the
+machine that most needs a rollback cannot do. So a rollback restores all of it
+out of what is already on disk: no network request, and nothing terminated —
+the hosts are reconciled and the ones that cannot observe the change without a
+fresh process are reported `restart needed`, exactly as an update reports them,
+while running Workers are counted and left completely alone. It does not swap:
+once restored, the revision it left is retained and named, and going forward
+again is an update rather than a second rollback that undoes the first.
+
+Retention is two complete revisions and the host caches either of them needs,
+and it is deliberately conditional on verification. An update that half-applied
+or that a Worker held records its attempt as `pending` and rotates nothing, and
+while anything is pending **nothing at all is pruned** — the last verified state
+stays exactly where it was, because it is the state a rollback restores. On such
+a machine the rollback target is the active record itself rather than the one
+behind it: the machine has already drifted forward into a revision nothing
+vouched for. `doctor` reports both halves — which lock this machine is
+provisioned against, what a rollback would restore, whether all of it is still
+addressable, and how much derived state the retention is holding.
+
+`bun run e2e:rollback-ubuntu24` is the whole of it as a command: three complete
+revisions provisioned onto a network-denied Ubuntu 24.04 target, a prune held
+through an update that did not verify, the workstation rolled back with egress
+blocked, and a second rollback that writes nothing. The same function is what
+`bun test` asserts, so the command and the gate cannot disagree.
+
 `doctor` has an `[agents]` section holding the whole posture: which host is the
 Default agent, how long ago each installed host's copy on PATH last changed, and
 per-provider usage with the reset times the Redwall's one compact line has no

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "build": "bun run build:linux && bun run build:windows",
     "build:debug": "bun build src/main.ts --compile --target=bun-linux-x64 --outfile dist/red-dev-debug",
     "smoke": "bun build scripts/tui-smoke.ts --compile --target=bun-linux-x64 --outfile dist/tui-smoke && ./dist/tui-smoke",
-    "e2e:offline-ubuntu24": "bun run scripts/offline-depot-e2e.ts"
+    "e2e:offline-ubuntu24": "bun run scripts/offline-depot-e2e.ts",
+    "e2e:rollback-ubuntu24": "bun run scripts/rollback-e2e.ts"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/scripts/rollback-e2e.ts
+++ b/scripts/rollback-e2e.ts
@@ -1,0 +1,23 @@
+/**
+ * The Ubuntu 24 rollback journey, as a command.
+ *
+ * `bun run e2e:rollback-ubuntu24` — provision a network-denied Ubuntu
+ * 24.04 x64 target across three complete revisions, hold a prune through
+ * an update that did not verify, roll the whole workstation back to the
+ * previous complete lock with no network and nothing terminated, and
+ * prove a second rollback writes nothing. Every check is printed, and a
+ * failed one exits non-zero, so this is the same claim the test asserts
+ * rather than a second opinion about it.
+ *
+ * `--keep` leaves the machines behind for inspection; without it the
+ * temporary directories go away whether the journey passed or failed.
+ */
+import { rollbackJourneyLines, runUbuntu24RollbackJourney } from "../src/rollback-e2e.ts";
+
+const keep = process.argv.includes("--keep");
+const result = await runUbuntu24RollbackJourney({ keep });
+
+for (const line of rollbackJourneyLines(result)) console.log(line);
+if (result.root !== null) console.log(`kept at ${result.root}`);
+
+process.exit(result.ok ? 0 : 1);

--- a/src/fixtures/offline-depot/rehearsal.ts
+++ b/src/fixtures/offline-depot/rehearsal.ts
@@ -49,7 +49,7 @@ import {
   type ObservedTarget,
   type WorkstationLock,
 } from "../../workstation-lock.ts";
-import { fixtureResolver } from "../workstation-lock/releases.ts";
+import { fixtureResolverAt } from "../workstation-lock/releases.ts";
 
 /** The one target Spec #201's first depot provisions. */
 export const UBUNTU = "ubuntu-24.04-x64";
@@ -70,23 +70,36 @@ export const REHEARSAL_SET_COMMIT = "626a28473edeee992fcf6425dedbca84448343fd";
  * the depot verifies bytes, and a rehearsal that carried twenty-five
  * megabytes would verify the same bytes more slowly.
  */
-export const REHEARSAL_SET_ARTIFACTS: Record<string, string> = {
-  "plugin-dev.payload.tgz": "// dev payload\n",
-  "plugin-memory.payload.tgz": "// memory payload\n",
-  "plugin-brain.payload.tgz": "// brain payload\n",
-  "plugin-internal.payload.tgz": "// internal payload\n",
-  "marketplace-manifests.tgz": "// marketplace manifests\n",
-  "build-gemini-extension.mjs": "// gemini extension generator\n",
-  "install-hermes-skills.mjs": "// hermes skills generator\n",
-  "expand-package-set.mjs": "// package set expander\n",
-  "workstation-package-set.mjs": "// workstation package set\n",
-  "opencode-host.generated.tgz": "// opencode host\n",
-  "gemini-extension.tgz": "// gemini extension\n",
-  "zellij-dashboard.tgz": "// zellij dashboard\n",
-  "herdr-plugin.tgz": "// herdr plugin\n",
-  "dev.bundle.min.mjs": "// dev bundle\n",
-  [`vscode-extension-red-skills-${REHEARSAL_SET_VERSION}.vsix`]: "// vsix\n",
-};
+export const REHEARSAL_SET_ARTIFACTS: Record<string, string> = setArtifacts(REHEARSAL_SET_VERSION);
+
+/**
+ * The same table, for one release of the set. PURE.
+ *
+ * A rollback needs two package sets that differ, and the honest way for
+ * two releases of one set to differ is the version they carry: the
+ * extension's `.vsix` is named after it, `tree/package.json` declares it,
+ * and the whole-set digest is taken over both. So a generation is the
+ * version, and everything else about the layout is deliberately the same.
+ */
+export function setArtifacts(version: string): Record<string, string> {
+  return {
+    "plugin-dev.payload.tgz": "// dev payload\n",
+    "plugin-memory.payload.tgz": "// memory payload\n",
+    "plugin-brain.payload.tgz": "// brain payload\n",
+    "plugin-internal.payload.tgz": "// internal payload\n",
+    "marketplace-manifests.tgz": "// marketplace manifests\n",
+    "build-gemini-extension.mjs": "// gemini extension generator\n",
+    "install-hermes-skills.mjs": "// hermes skills generator\n",
+    "expand-package-set.mjs": "// package set expander\n",
+    "workstation-package-set.mjs": "// workstation package set\n",
+    "opencode-host.generated.tgz": "// opencode host\n",
+    "gemini-extension.tgz": "// gemini extension\n",
+    "zellij-dashboard.tgz": "// zellij dashboard\n",
+    "herdr-plugin.tgz": "// herdr plugin\n",
+    "dev.bundle.min.mjs": "// dev bundle\n",
+    [`vscode-extension-red-skills-${version}.vsix`]: `// vsix ${version}\n`,
+  };
+}
 
 /**
  * A verified manifest set at `dest`, in the layout the verifier reads.
@@ -94,14 +107,21 @@ export const REHEARSAL_SET_ARTIFACTS: Record<string, string> = {
  * Manifest, signature bundle, `artifacts/` and the `tree/` that gets
  * activated — the same four things `verifyPackageSet` walks, so the
  * export's "this set verifies here" gate is a real gate.
+ *
+ * `release` names which one: a rollback rehearsal builds two or three of
+ * these and needs them to be genuinely different sets, which they are —
+ * the version reaches the manifest's artifacts, the tree's package.json
+ * and therefore the whole-set digest the identity is taken from.
  */
-export function rehearsalPackageSet(dest: string): string {
+export function rehearsalPackageSet(dest: string, release: SetRelease = {}): string {
+  const version = release.version ?? REHEARSAL_SET_VERSION;
+  const commit = release.commit ?? REHEARSAL_SET_COMMIT;
   mkdirSync(join(dest, "artifacts"), { recursive: true });
-  const declared = Object.entries(REHEARSAL_SET_ARTIFACTS).map(([name, bytes]) => {
+  const declared = Object.entries(setArtifacts(version)).map(([name, bytes]) => {
     writeFileSync(join(dest, "artifacts", name), bytes);
     return { name, size: Buffer.byteLength(bytes), sha256: sha256Hex(bytes) };
   });
-  const manifest = createPackageSetManifest(REHEARSAL_SET_COMMIT, declared);
+  const manifest = createPackageSetManifest(commit, declared);
   writeFileSync(join(dest, SET_MANIFEST_NAME), encodePackageSet(manifest));
   writeFileSync(
     join(dest, SET_BUNDLE_NAME),
@@ -115,12 +135,18 @@ export function rehearsalPackageSet(dest: string): string {
   mkdirSync(join(tree, ".red"), { recursive: true });
   writeFileSync(
     join(tree, "package.json"),
-    `${JSON.stringify({ name: "@reddb-io/red-skills", version: REHEARSAL_SET_VERSION })}\n`,
+    `${JSON.stringify({ name: "@reddb-io/red-skills", version })}\n`,
   );
   writeFileSync(join(tree, "bin", "red-skills-redskilled.mjs"), "// redskilled\n");
   writeFileSync(join(tree, "plugins", "dev", "skills", "SKILL.md"), "# dev\n");
   writeFileSync(join(tree, "scripts", "install-opencode.sh"), "#!/bin/bash\n", { mode: 0o644 });
   return dest;
+}
+
+/** Which release of the set to build. Defaults to the one the depot carries. */
+export interface SetRelease {
+  version?: string;
+  commit?: string;
 }
 
 /** The exact bytes the lock's checksum for one application was taken over. */
@@ -173,14 +199,28 @@ export const rehearsalVerifier: SignatureVerifier = (manifestPath, bundlePath) =
   return { ok: true, by: "red-dev depot rehearsal" };
 };
 
-/** A lock for the Ubuntu target, resolved through the fixture table. */
+/**
+ * A lock for the Ubuntu target, resolved through the fixture table.
+ *
+ * `generation` is how many revisions back to resolve: 0 is the current
+ * table, and anything `FIXTURE_RELEASE_HISTORY` names is the workstation
+ * as it stood before that. Two generations of one target are what makes a
+ * rollback assertable — the versions that moved are named, and the ones
+ * that did not are identical in both locks.
+ */
 export async function rehearsalLock(
   at: string,
   origin: LockOrigin = "resolved",
+  generation = 0,
 ): Promise<WorkstationLock> {
   const target = workstationTarget(UBUNTU);
   if (target === null) throw new Error(`no such target: ${UBUNTU}`);
-  const resolved = await resolveWorkstationLock(target, at, fixtureResolver, origin);
+  const resolved = await resolveWorkstationLock(
+    target,
+    at,
+    fixtureResolverAt(generation),
+    origin,
+  );
   if (!resolved.ok) throw new Error(`resolution refused: ${resolved.reason}`);
   return resolved.lock;
 }

--- a/src/fixtures/workstation-lock/releases.ts
+++ b/src/fixtures/workstation-lock/releases.ts
@@ -29,7 +29,7 @@ import type {
 } from "../../workstation-lock.ts";
 
 /** One row: the version, and the artifact name on each kind of surface. */
-interface FixtureRelease {
+export interface FixtureRelease {
   version: string;
   /** The artifact a surface takes. Windows differs wherever the shape does. */
   artifact: (surface: LockSurface) => string;
@@ -77,16 +77,80 @@ export function fixtureChecksum(id: string, version: string, artifact: string): 
   return sha256Hex(`fixture:${id}@${version}:${artifact}`);
 }
 
-/** A resolver over the table above, for tests and depot rehearsals. */
-export const fixtureResolver: ReleaseResolver = async (
-  app: WorkstationApp,
-  surface: LockSurface,
-): Promise<ResolvedRelease> => {
-  const release = FIXTURE_RELEASES[app.id];
-  if (release === undefined) throw new Error(`no fixture release for ${app.id}`);
-  const name = release.artifact(surface);
-  return {
-    version: release.version,
-    artifact: { name, sha256: fixtureChecksum(app.id, release.version, name) },
-  };
+/**
+ * What the revisions before the current one shipped, where they differ.
+ *
+ * A rollback needs more than one lock to be a rollback at all, and the
+ * honest shape of "the revision before this one" is not a whole second
+ * table: real workstations move a handful of applications at a time and
+ * leave the rest exactly where they were. So a generation is an override
+ * over the table above — generation 0 is it — and everything a
+ * generation does not name is deliberately identical, which is what
+ * makes a restored version worth asserting: the ones that moved moved
+ * back, and the ones that did not were not touched.
+ *
+ * The artifact names follow the versions, because a publisher's asset
+ * name carries the version wherever the publisher puts one in. That is
+ * also what keeps the fixture checksums distinct per generation, so a
+ * rollback that restored the wrong bytes cannot hash to the right ones.
+ */
+export const FIXTURE_RELEASE_HISTORY: Record<number, Record<string, string>> = {
+  1: {
+    "claude-code": "2.0.35",
+    codex: "0.54.0",
+    "red-dev": "1.0.55",
+    vscode: "1.104.1",
+    zellij: "0.44.3-red.1",
+  },
+  2: {
+    "claude-code": "2.0.34",
+    codex: "0.53.0",
+    "red-dev": "1.0.54",
+    vscode: "1.103.4",
+    zellij: "0.44.2-red.1",
+  },
 };
+
+/**
+ * The release table as it stood `generation` revisions ago. PURE.
+ *
+ * Generation 0 is `FIXTURE_RELEASES` itself, and an unknown generation
+ * is too: a caller asking for a revision nobody wrote down gets the
+ * current one rather than a table with holes in it.
+ */
+export function fixtureReleasesAt(generation: number): Record<string, FixtureRelease> {
+  const overrides = FIXTURE_RELEASE_HISTORY[generation] ?? {};
+  const out: Record<string, FixtureRelease> = {};
+  for (const [id, release] of Object.entries(FIXTURE_RELEASES)) {
+    const version = overrides[id];
+    out[id] =
+      version === undefined
+        ? release
+        : {
+            version,
+            // The publisher's own name, with its version moved back. An
+            // artifact that carries no version is unchanged, and its
+            // checksum still differs because the checksum is taken over
+            // the version as well as the name.
+            artifact: (surface) => release.artifact(surface).split(release.version).join(version),
+          };
+  }
+  return out;
+}
+
+/** A resolver over one generation of the table above. PURE. */
+export function fixtureResolverAt(generation: number): ReleaseResolver {
+  const table = fixtureReleasesAt(generation);
+  return async (app: WorkstationApp, surface: LockSurface): Promise<ResolvedRelease> => {
+    const release = table[app.id];
+    if (release === undefined) throw new Error(`no fixture release for ${app.id}`);
+    const name = release.artifact(surface);
+    return {
+      version: release.version,
+      artifact: { name, sha256: fixtureChecksum(app.id, release.version, name) },
+    };
+  };
+}
+
+/** A resolver over the table above, for tests and depot rehearsals. */
+export const fixtureResolver: ReleaseResolver = fixtureResolverAt(0);

--- a/src/main.ts
+++ b/src/main.ts
@@ -373,6 +373,27 @@ async function cmdDoctor(p: Platform, inv: Invocation): Promise<number> {
     }
   }
 
+  // And what this machine could go back to, which is the one question the
+  // reports above cannot answer between them: which complete revision is
+  // active — the package set and the exact lock, named as one thing —
+  // what a rollback would restore, whether all of it is still on disk,
+  // and how much derived state the retention is holding to keep that
+  // true. An unrestorable rollback target is an error rather than a
+  // warning: the machine still works, and the promise that it can be put
+  // back does not.
+  const { workstationRollbackReport, workstationRollbackRows } = await import(
+    "./workstation-rollback.ts"
+  );
+  for (const row of workstationRollbackRows(workstationRollbackReport(setHome))) {
+    if (row.status === "ok") log.ok(row.detail);
+    else if (row.status === "n/a") log.skip(row.detail);
+    else if (row.status === "warn") log.warn(row.detail);
+    else {
+      log.err(row.detail);
+      setProblems++;
+    }
+  }
+
   // The machine's agent posture, in the one place that already answers
   // "is this machine ready": which host red-dev hands work to, how old
   // each installed host's copy is, and the per-provider allowance detail

--- a/src/red-skills-set.ts
+++ b/src/red-skills-set.ts
@@ -1313,6 +1313,53 @@ export function activateStagedPackageSet(
 }
 
 /**
+ * Activate a revision this machine already retains, acquiring nothing.
+ *
+ * The rollback's half of the move `activateStagedPackageSet` makes
+ * forwards, and it exists for the same reason: the revision was verified
+ * when it arrived, its tree is still under its immutable name, and the
+ * one step left is moving `current`. A rollback that re-acquired the
+ * revision it is rolling back to would need the network — which is the
+ * one thing the machine being rolled back may not have.
+ *
+ * `null` when this machine retains no such revision, which the caller
+ * has to distinguish from a refusal: nothing to roll back to is not the
+ * same fact as a rollback that could not be performed.
+ */
+export function activateRetainedPackageSet(
+  key: string,
+  opts: Pick<PackageSetConvergeOptions, "home" | "platform" | "env"> = {},
+): PackageSetConverge | null {
+  const env = opts.env ?? process.env;
+  const home = opts.home ?? homeOf(env);
+  const platform = opts.platform ?? process.platform;
+  const state = readPackageSetState(home);
+  const revision = state.revisions.find((r) => r.key === key) ?? null;
+  if (revision === null) return null;
+
+  // Recorded and gone: the same failure a staged revision has, and the
+  // same answer. Pointing `current` at a directory that is not there
+  // would break the machine in the act of repairing it.
+  if (!existsSync(revision.path)) {
+    const reason = `the retained revision ${formatPackageSetIdentity(revision)} is recorded but its tree is gone`;
+    log.err(`red-skills package set refused (tree): ${reason}`);
+    const writes = recordRefusal(home, state, { failure: "tree", reason });
+    return {
+      changed: writes.length > 0,
+      writes,
+      active: activeIdentity(state),
+      retained: state.revisions,
+      refused: { failure: "tree", reason },
+      staged: identityOf(state.staged),
+      current: redSkillsCurrentLink(home),
+      revisionDir: activeRevision(state)?.path ?? null,
+    };
+  }
+
+  return activate(home, platform, state, revision, () => {}, false);
+}
+
+/**
  * Point the machine at one verified revision, writing only what differs.
  *
  * Every write is recorded and every one of them is conditional. That is

--- a/src/rollback-e2e.test.ts
+++ b/src/rollback-e2e.test.ts
@@ -1,0 +1,105 @@
+/**
+ * The Ubuntu 24 rollback journey, asserted rather than watched.
+ *
+ * `bun run e2e:rollback-ubuntu24` prints these checks for a person; this
+ * file fails the build when one of them stops holding. Both call the same
+ * function, so there is no second definition of what "the rollback E2E
+ * passes" means — which is the only way the command in the acceptance
+ * criteria and the gate the orchestrator runs can be the same claim.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  rollbackJourneyLines,
+  ROLLBACK_TARGET,
+  runUbuntu24RollbackJourney,
+  SET_RELEASES,
+} from "./rollback-e2e.ts";
+import { FIXTURE_RELEASE_HISTORY, fixtureReleasesAt } from "./fixtures/workstation-lock/releases.ts";
+import type { LockSurface } from "./workstation-lock.ts";
+
+describe("the ubuntu 24.04 rollback journey", () => {
+  test("every criterion of the journey holds", async () => {
+    const result = await runUbuntu24RollbackJourney();
+    const failed = result.checks.filter((c) => !c.ok).map((c) => `${c.name}: ${c.detail}`);
+    expect(failed).toEqual([]);
+    expect(result.ok).toBe(true);
+
+    // Named, so that a journey which quietly stopped making one of these
+    // checks fails here rather than passing with fewer of them.
+    expect(result.checks.map((c) => c.name)).toEqual([
+      "export",
+      "provision",
+      "pending-retains",
+      "pending-target",
+      "retention",
+      "rollback",
+      "versions",
+      "untouched",
+      "package-set",
+      "offline",
+      "uninterrupted",
+      "reconciled",
+      "lock",
+      "idempotent",
+      "doctor",
+    ]);
+    expect(result.root).toBeNull();
+  });
+
+  test("it rolls back the target the spec names, across three distinct revisions", () => {
+    expect(ROLLBACK_TARGET).toBe("ubuntu-24.04-x64");
+    expect(new Set(SET_RELEASES.map((r) => r.version)).size).toBe(3);
+    expect(new Set(SET_RELEASES.map((r) => r.commit)).size).toBe(3);
+  });
+
+  test("each generation moves some applications and leaves the rest alone", () => {
+    const current = fixtureReleasesAt(0);
+    for (const generation of [1, 2]) {
+      const older = fixtureReleasesAt(generation);
+      const moved = Object.keys(current).filter(
+        (id) => current[id]?.version !== older[id]?.version,
+      );
+      // The overrides are the whole of the difference: an application
+      // nobody moved must be identical, or "restored every observed
+      // version" would be true of a rollback that reinstalled the lot.
+      expect(moved.sort()).toEqual(Object.keys(FIXTURE_RELEASE_HISTORY[generation] ?? {}).sort());
+      expect(moved.length).toBeGreaterThan(0);
+      expect(moved.length).toBeLessThan(Object.keys(current).length);
+    }
+  });
+
+  test("an artifact name carries the version it was moved back to", () => {
+    const surface: LockSurface = {
+      id: "ubuntu",
+      os: "linux",
+      distro: "ubuntu",
+      version: "24.04",
+      arch: "x64",
+      env: "desktop",
+      role: "both",
+    };
+    expect(fixtureReleasesAt(0)["vscode"]?.artifact(surface)).toBe("code_1.104.2-1_amd64.deb");
+    expect(fixtureReleasesAt(1)["vscode"]?.artifact(surface)).toBe("code_1.104.1-1_amd64.deb");
+    // And one whose publisher puts no version in the name is unchanged,
+    // which is fine: the checksum is taken over the version as well.
+    expect(fixtureReleasesAt(1)["zellij"]?.artifact(surface)).toBe(
+      fixtureReleasesAt(0)["zellij"]?.artifact(surface),
+    );
+  });
+
+  test("the lines a person reads say which check failed", () => {
+    const lines = rollbackJourneyLines({
+      ok: false,
+      root: null,
+      checks: [
+        { name: "retention", ok: true, detail: "two revisions remain" },
+        { name: "rollback", ok: false, detail: "the retained lock is gone" },
+      ],
+    });
+    expect(lines[0]).toBe("ok   retention — two revisions remain");
+    expect(lines[1]).toBe("FAIL rollback — the retained lock is gone");
+    expect(lines[2]).toContain("1 of 2 checks failed");
+  });
+});

--- a/src/rollback-e2e.ts
+++ b/src/rollback-e2e.ts
@@ -42,14 +42,21 @@
  * matters to a rollback: that a host which cannot observe the change
  * without a fresh process is *reported* rather than restarted.
  *
- * ## Egress is denied, and so is termination
+ * ## Egress is denied, and nothing is stopped
  *
  * The rollback half runs with `globalThis.fetch` replaced by a stub that
- * records the attempt and throws, exactly as the depot journey does. It
- * also runs with a converge that records every host it was asked to
- * reconcile and would record any request to stop one — there is no such
- * request to make, which is the point: the assertion is that the count of
- * terminated sessions and Workers is zero while two Workers are running.
+ * records the attempt and throws, exactly as the depot journey does. If
+ * any code under `rollbackWorkstation` reached for the network the
+ * journey would fail with the URL it asked for, instead of passing on a
+ * laptop that happened to be online.
+ *
+ * Termination is asserted the only way it can honestly be asserted: the
+ * rollback is handed two running Workers and a converge whose hosts all
+ * answer `restart-needed`, and what comes back is a report that counts
+ * both and stops neither. There is no termination hook to spy on because
+ * there is nothing in the module that could call one — so the check is
+ * that every host the rollback reconciled is *owed* a restart rather
+ * than having been given one, and that the two Workers are still two.
  */
 
 import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
@@ -191,8 +198,8 @@ export async function runUbuntu24RollbackJourney(
       packageSet: exported.report.depot.packageSet.active,
     });
   }
-  const [older, previousDepot, currentDepot] = depots;
-  if (older === undefined || previousDepot === undefined || currentDepot === undefined) {
+  const currentDepot = depots[depots.length - 1];
+  if (depots.length !== SET_RELEASES.length || currentDepot === undefined) {
     return finish_(check, finish, "export", "the journey did not build three depots");
   }
   check(
@@ -332,7 +339,6 @@ export async function runUbuntu24RollbackJourney(
   // --------------------------------------------------------------- the rollback
   const before = installed.map((app) => `${app.id}@${app.version}`).sort();
   const reconciled: string[] = [];
-  const terminated: string[] = [];
   const converge = async (): Promise<{ hosts: HostOutcome[]; companions: CompanionOutcome[] }> => {
     // Every host is reconciled on disk and none is stopped. A host whose
     // CLI is running answers `restart-needed`, which is the whole of the
@@ -398,12 +404,13 @@ export async function runUbuntu24RollbackJourney(
       ? "the rollback made no JavaScript network request; every artifact came out of the machine's own depot copy"
       : `the rollback reached for ${egress.attempts.join(", ")}`,
   );
+  const owed = new Set(rolled.restartNeeded);
   check(
     "uninterrupted",
-    terminated.length === 0 && rolled.workers === 2 && rolled.restartNeeded.length > 0,
-    terminated.length === 0
-      ? `${rolled.workers} Worker(s) and every running session were left alone; ${rolled.restartNeeded.length} host(s) are owed a restart`
-      : `${terminated.join(", ")} were terminated`,
+    rolled.workers === 2 && reconciled.every((host) => owed.has(host)),
+    rolled.workers === 2
+      ? `${rolled.workers} Worker(s) were counted and left running, and all ${owed.size} reconciled host(s) are owed a restart rather than having been given one`
+      : `the rollback reported ${rolled.workers} Worker(s) instead of the 2 that were running`,
   );
   check(
     "reconciled",

--- a/src/rollback-e2e.ts
+++ b/src/rollback-e2e.ts
@@ -1,0 +1,483 @@
+/**
+ * The Ubuntu 24 rollback journey, end to end, in one function.
+ *
+ * Spec #201's rollback criteria are five sentences about time rather than
+ * about a machine: a workstation that moved N-2 → N-1 → N has to be able
+ * to go back to N-1 with every version and every digest it had then, out
+ * of what is already on disk, without stopping anything that is running,
+ * without keeping a third copy of everything, and without pruning
+ * anything while an update is still in doubt. None of that is provable
+ * from one activation — the retention only becomes visible on the third,
+ * and the fourth criterion only becomes visible when a run fails. So the
+ * journey is one function that both `bun test` and
+ * `bun run e2e:rollback-ubuntu24` call, and it returns the checks it made
+ * rather than printing them, so the two callers cannot disagree about
+ * what passed.
+ *
+ * ## The three revisions, and the one that failed
+ *
+ * Three generations of the fixture release table
+ * (`FIXTURE_RELEASE_HISTORY`) give three genuinely different complete
+ * workstations: five applications move between each pair and nine stay
+ * exactly where they are, which is what makes "restored every observed
+ * version" worth asserting — a rollback that reinstalled everything
+ * indiscriminately and one that restored the five would both end with the
+ * right versions, and only the second leaves the nine untouched.
+ *
+ * The third activation is deliberately run twice: once unverified, as an
+ * update held behind a running Worker or stopped by a failed surface, and
+ * once verified. The prune that the verified run performs is asserted
+ * *not* to have happened on the unverified one, over the same paths. That
+ * is the fourth criterion, and it is the one that cannot be checked by
+ * looking at a machine — only by looking at two moments of one.
+ *
+ * ## What is real here, and what is rehearsed
+ *
+ * The same split src/offline-depot-e2e.ts draws, for the same reasons:
+ * every line of src/workstation-rollback.ts, src/workstation-lock.ts and
+ * src/red-skills-set.ts the journey touches is real, and the publisher's
+ * bytes, the signature and the installer are the fixture's. What is
+ * additionally rehearsed here is the host and companion converge, which
+ * is injected so the journey can assert the one thing about it that
+ * matters to a rollback: that a host which cannot observe the change
+ * without a fresh process is *reported* rather than restarted.
+ *
+ * ## Egress is denied, and so is termination
+ *
+ * The rollback half runs with `globalThis.fetch` replaced by a stub that
+ * records the attempt and throws, exactly as the depot journey does. It
+ * also runs with a converge that records every host it was asked to
+ * reconcile and would record any request to stop one — there is no such
+ * request to make, which is the point: the assertion is that the count of
+ * terminated sessions and Workers is zero while two Workers are running.
+ */
+
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  cleanUbuntu,
+  rehearsalArtifact,
+  rehearsalFetcher,
+  rehearsalLock,
+  rehearsalPackageSet,
+  rehearsalSigner,
+  rehearsalVerifier,
+  UBUNTU,
+} from "./fixtures/offline-depot/rehearsal.ts";
+import type { JourneyCheck, JourneyResult } from "./offline-depot-e2e.ts";
+import {
+  DEPOT_SET_DIR,
+  exportDepot,
+  importDepot,
+  type DepotInstaller,
+  type DepotRevision,
+} from "./offline-depot.ts";
+import type { CompanionOutcome } from "./red-skills-companions.ts";
+import type { HostOutcome } from "./red-skills-hosts.ts";
+import {
+  convergeRedSkillsPackageSet,
+  readPackageSetState,
+  revisionKey,
+} from "./red-skills-set.ts";
+import {
+  activateWorkstationRevision,
+  planWorkstationRetention,
+  readWorkstationRevisions,
+  retainedLockPath,
+  rollbackWorkstation,
+  workstationRollbackReport,
+  workstationRollbackRows,
+} from "./workstation-rollback.ts";
+import type { ObservedApp, ObservedTarget, WorkstationLock } from "./workstation-lock.ts";
+
+/** The target this journey rolls back, named once. */
+export const ROLLBACK_TARGET = UBUNTU;
+
+/**
+ * The three RedSkills releases the three revisions carry.
+ *
+ * Newest first, so the index is the generation: `SET_RELEASES[1]` is what
+ * the machine was on one revision ago, which is the revision the rollback
+ * restores.
+ */
+export const SET_RELEASES = [
+  { version: "3.20.0", commit: "626a28473edeee992fcf6425dedbca84448343fd" },
+  { version: "3.19.5", commit: "8c3f1d94e21b6a70f5d2c48ab90e7f3612d4a5b8" },
+  { version: "3.19.0", commit: "1f7a90c53be48d21ca6b0e7f4d938265ab71c0e9" },
+] as const;
+
+export interface RollbackJourneyOptions {
+  /** Where the machines are built. Defaults to a temporary directory. */
+  root?: string;
+  /** The export instant. Fixed by default: a journey never reads a clock. */
+  at?: string;
+  /** Leave the directories behind for inspection. */
+  keep?: boolean;
+}
+
+/** A `fetch` that cannot succeed, and remembers being asked. */
+function denyEgress(): { attempts: string[]; restore: () => void } {
+  const attempts: string[] = [];
+  const original = globalThis.fetch;
+  globalThis.fetch = (async (input: unknown) => {
+    const url = typeof input === "string" ? input : String((input as { url?: string })?.url ?? input);
+    attempts.push(url);
+    throw new Error(`network egress is blocked on this target: ${url}`);
+  }) as unknown as typeof fetch;
+  return { attempts, restore: () => { globalThis.fetch = original; } };
+}
+
+/** One provisioned revision, as the journey holds on to it. */
+interface Revision {
+  generation: number;
+  lock: WorkstationLock;
+  depot: string;
+  packageSet: DepotRevision;
+  /** The machine-owned copy the applications were installed from. */
+  owned: string;
+}
+
+/**
+ * Run the whole journey and report what held.
+ *
+ * Every check is recorded rather than thrown, for the reason the depot
+ * journey records rather than throws: an operator reading a red run wants
+ * the whole shape of what broke, not the first fact that stopped being
+ * true.
+ */
+export async function runUbuntu24RollbackJourney(
+  opts: RollbackJourneyOptions = {},
+): Promise<JourneyResult> {
+  const root = opts.root ?? mkdtempSync(join(tmpdir(), "red-rollback-journey-"));
+  const at = opts.at ?? "2026-08-19T00:00:00Z";
+  const home = join(root, "target", "home");
+  const checks: JourneyCheck[] = [];
+  const check = (name: string, ok: boolean, detail: string): boolean => {
+    checks.push({ name, ok, detail });
+    return ok;
+  };
+  const finish = (): JourneyResult => {
+    if (!opts.keep) rmSync(root, { recursive: true, force: true });
+    return { ok: checks.every((c) => c.ok), checks, root: opts.keep ? root : null };
+  };
+
+  // ---------------------------------------------------- the connected machine
+  // Three depots, oldest cut first, each declaring the one before it as
+  // the revision an offline rollback restores.
+  const depots: { generation: number; lock: WorkstationLock; dir: string; packageSet: DepotRevision }[] = [];
+  for (let generation = SET_RELEASES.length - 1; generation >= 0; generation--) {
+    const release = SET_RELEASES[generation];
+    if (release === undefined) continue;
+    const setDir = rehearsalPackageSet(join(root, "connected", `set-${generation}`), release);
+    const lock = await rehearsalLock(at, "resolved", generation);
+    const previous = depots[depots.length - 1]?.packageSet ?? null;
+    const exported = await exportDepot({
+      lock,
+      setDir,
+      dest: join(root, "medium", `depot-${generation}`),
+      exportedAt: at,
+      fetch: rehearsalFetcher,
+      verifier: rehearsalVerifier,
+      sign: rehearsalSigner,
+      previous,
+    });
+    if (!exported.ok) return finish_(check, finish, "export", exported.reason);
+    depots.push({
+      generation,
+      lock,
+      dir: exported.report.dir,
+      packageSet: exported.report.depot.packageSet.active,
+    });
+  }
+  const [older, previousDepot, currentDepot] = depots;
+  if (older === undefined || previousDepot === undefined || currentDepot === undefined) {
+    return finish_(check, finish, "export", "the journey did not build three depots");
+  }
+  check(
+    "export",
+    new Set(depots.map((d) => d.packageSet.digest)).size === 3 &&
+      new Set(depots.map((d) => d.lock.lockDigest)).size === 3,
+    `three complete revisions cut for ${ROLLBACK_TARGET}: ${depots.map((d) => d.packageSet.key).join(" -> ")}`,
+  );
+
+  // ------------------------------------------------- the network-denied target
+  const observed = cleanUbuntu();
+  const installed: ObservedApp[] = [];
+  const install: DepotInstaller = async (step, artifact) => {
+    if (artifact.bytes.toString("utf8") !== rehearsalArtifact(step.app)) {
+      return { ok: false, detail: "the artifact is not the one the lock names" };
+    }
+    const at_ = installed.findIndex((a) => a.id === step.app.id && a.surface === step.app.surface);
+    const entry = { id: step.app.id, surface: step.app.surface, version: step.app.version };
+    if (at_ === -1) installed.push(entry);
+    else installed[at_] = entry;
+    return { ok: true };
+  };
+  const machine = (): ObservedTarget => ({ ...observed, installed: [...installed] });
+
+  const provision = async (depot: (typeof depots)[number]): Promise<Revision | string> => {
+    const imported = await importDepot({
+      depot: depot.dir,
+      home,
+      observed: machine(),
+      verifier: rehearsalVerifier,
+      install,
+    });
+    if (!imported.ok) return imported.reason;
+    const converged = convergeRedSkillsPackageSet({
+      home,
+      source: join(imported.report.path, DEPOT_SET_DIR),
+      verifier: rehearsalVerifier,
+    });
+    if (converged.refused !== null) return converged.refused.reason;
+    return {
+      generation: depot.generation,
+      lock: depot.lock,
+      depot: depot.dir,
+      packageSet: depot.packageSet,
+      owned: imported.report.path,
+    };
+  };
+
+  const provisioned: Revision[] = [];
+  for (const depot of depots) {
+    const revision = await provision(depot);
+    if (typeof revision === "string") return finish_(check, finish, "provision", revision);
+    provisioned.push(revision);
+    // The third revision is recorded twice, and the first of the two is
+    // the failed update: see below.
+    if (depot === currentDepot) break;
+    activateWorkstationRevision({
+      home,
+      lock: revision.lock,
+      packageSet: revision.packageSet,
+      depot: revision.owned,
+      activatedAt: at,
+      verified: true,
+    });
+  }
+  const [oldest, previous, current] = provisioned;
+  if (oldest === undefined || previous === undefined || current === undefined) {
+    return finish_(check, finish, "provision", "the journey did not provision three revisions");
+  }
+  check(
+    "provision",
+    readWorkstationRevisions(home).active?.packageSet.key === previous.packageSet.key,
+    `the target was provisioned ${provisioned.map((r) => r.packageSet.version).join(" -> ")} from three depots`,
+  );
+
+  // ------------------------------------------------------- the failed update
+  // The third revision arrives and does not verify: a surface failed, or
+  // a Worker held the activation. Everything the oldest revision needs
+  // has to still be here afterwards, because a rollback is the remedy.
+  const oldestLock = retainedLockPath(home, oldest.lock.lockDigest);
+  activateWorkstationRevision({
+    home,
+    lock: current.lock,
+    packageSet: current.packageSet,
+    depot: current.owned,
+    activatedAt: at,
+    verified: false,
+  });
+  const held = readWorkstationRevisions(home);
+  const heldPlan = planWorkstationRetention({ home });
+  check(
+    "pending-retains",
+    held.active?.packageSet.key === previous.packageSet.key &&
+      held.previous?.packageSet.key === oldest.packageSet.key &&
+      held.pending?.packageSet.key === current.packageSet.key &&
+      heldPlan.held !== null &&
+      existsSync(oldestLock) &&
+      existsSync(oldest.owned),
+    heldPlan.held === null
+      ? "an unverified activation did not hold the prune"
+      : `the failed update left ${previous.packageSet.key} active and pruned nothing: ${heldPlan.held}`,
+  );
+  // And what a rollback would restore right now is the last state that
+  // verified, not the one behind it: the machine has already drifted
+  // forward into a revision nothing vouched for.
+  const heldReport = workstationRollbackReport(home);
+  check(
+    "pending-target",
+    heldReport.restores?.packageSet.key === previous.packageSet.key && heldReport.restorable,
+    heldReport.restores === null
+      ? "a pending activation left nothing to restore"
+      : `with an activation pending, a rollback restores the last verified state ${heldReport.restores.packageSet.key}`,
+  );
+
+  // ------------------------------------------------------ the verified update
+  const activated = activateWorkstationRevision({
+    home,
+    lock: current.lock,
+    packageSet: current.packageSet,
+    depot: current.owned,
+    activatedAt: at,
+    verified: true,
+  });
+  const after = readWorkstationRevisions(home);
+  check(
+    "retention",
+    after.active?.packageSet.key === current.packageSet.key &&
+      after.previous?.packageSet.key === previous.packageSet.key &&
+      after.pending === null &&
+      !existsSync(oldestLock) &&
+      !existsSync(oldest.owned) &&
+      existsSync(previous.owned) &&
+      existsSync(retainedLockPath(home, previous.lock.lockDigest)),
+    `after verification the two newest revisions remain and ${activated.retention.prunable.length} older derived path(s) went`,
+  );
+
+  // --------------------------------------------------------------- the rollback
+  const before = installed.map((app) => `${app.id}@${app.version}`).sort();
+  const reconciled: string[] = [];
+  const terminated: string[] = [];
+  const converge = async (): Promise<{ hosts: HostOutcome[]; companions: CompanionOutcome[] }> => {
+    // Every host is reconciled on disk and none is stopped. A host whose
+    // CLI is running answers `restart-needed`, which is the whole of the
+    // rule: the session keeps the revision it started with.
+    const hosts: HostOutcome[] = ["claude-code", "codex", "gemini"].map((host) => {
+      reconciled.push(host);
+      return { host, status: "reconciled", reload: "restart-needed" };
+    });
+    const companions: CompanionOutcome[] = [
+      { companion: "redskilled", status: "reconciled", reload: "restart-needed" },
+      { companion: "zellij", status: "current", reload: "current" },
+    ];
+    return { hosts, companions };
+  };
+
+  const egress = denyEgress();
+  let rolled;
+  try {
+    rolled = await rollbackWorkstation({
+      home,
+      observed: machine(),
+      install,
+      converge,
+      workers: async () => 2,
+      at,
+    });
+  } finally {
+    egress.restore();
+  }
+  if (!check("rollback", rolled.code === 0, rolled.reason)) return finish();
+
+  const want = new Map(previous.lock.apps.map((app) => [`${app.id}:${app.surface}`, app.version]));
+  const wrong = installed.filter((app) => want.get(`${app.id}:${app.surface}`) !== app.version);
+  check(
+    "versions",
+    wrong.length === 0 && installed.length === previous.lock.apps.length,
+    wrong.length === 0
+      ? `all ${installed.length} applications are back at the versions ${previous.packageSet.version} locked`
+      : `${wrong.map((a) => `${a.id}@${a.version}`).join(", ")} did not come back`,
+  );
+  const moved = installed
+    .map((app) => `${app.id}@${app.version}`)
+    .sort()
+    .filter((line) => !before.includes(line));
+  check(
+    "untouched",
+    moved.length > 0 && moved.length < installed.length,
+    `${moved.length} of ${installed.length} applications moved, and the rest were left exactly where they were`,
+  );
+
+  const setState = readPackageSetState(home);
+  check(
+    "package-set",
+    setState.active === previous.packageSet.key &&
+      revisionKey(previous.packageSet) === previous.packageSet.key,
+    `the machine resolves package set ${setState.active} again — the whole-set digest ${previous.packageSet.version} was verified under`,
+  );
+
+  check(
+    "offline",
+    egress.attempts.length === 0,
+    egress.attempts.length === 0
+      ? "the rollback made no JavaScript network request; every artifact came out of the machine's own depot copy"
+      : `the rollback reached for ${egress.attempts.join(", ")}`,
+  );
+  check(
+    "uninterrupted",
+    terminated.length === 0 && rolled.workers === 2 && rolled.restartNeeded.length > 0,
+    terminated.length === 0
+      ? `${rolled.workers} Worker(s) and every running session were left alone; ${rolled.restartNeeded.length} host(s) are owed a restart`
+      : `${terminated.join(", ")} were terminated`,
+  );
+  check(
+    "reconciled",
+    reconciled.length > 0 && rolled.surfaces.every((s) => s.state !== "failed"),
+    `${reconciled.length} host(s) and every companion were rebuilt against the restored set`,
+  );
+
+  const lockNow = readFileSync(join(home, ".red-skills", "workstation-lock.json"), "utf8");
+  check(
+    "lock",
+    lockNow === readFileSync(retainedLockPath(home, previous.lock.lockDigest), "utf8"),
+    `the machine's lock is ${previous.lock.lockDigest.slice(0, 12)} again, byte for byte`,
+  );
+
+  // ------------------------------------------------------- the second rollback
+  const secondEgress = denyEgress();
+  let second;
+  try {
+    second = await rollbackWorkstation({
+      home,
+      observed: machine(),
+      install: async () => ({ ok: false, detail: "a rolled-back machine must install nothing" }),
+      converge,
+      workers: async () => 2,
+      at,
+    });
+  } finally {
+    secondEgress.restore();
+  }
+  check(
+    "idempotent",
+    second.outcome === "converged" && second.writes.length === 0 && second.code === 0,
+    second.writes.length === 0
+      ? `a second rollback wrote nothing: ${second.reason}`
+      : `a second rollback wrote ${second.writes.length} path(s)`,
+  );
+
+  const report = workstationRollbackReport(home);
+  const rows = workstationRollbackRows(report);
+  check(
+    "doctor",
+    rows.length > 0 &&
+      rows.every((row) => row.status !== "err") &&
+      report.active?.packageSet.key === previous.packageSet.key &&
+      report.restores === null &&
+      report.rolledBackFrom?.packageSet.key === current.packageSet.key &&
+      rows.some((row) => row.detail.includes("retention holds")) &&
+      rows.some((row) => row.detail.includes(previous.lock.lockDigest.slice(0, 12))),
+    rows.every((row) => row.status !== "err")
+      ? `doctor names the active lock, the revision rolled back from and what retention holds, in ${rows.length} lines`
+      : rows.filter((row) => row.status === "err").map((row) => row.detail).join("; "),
+  );
+
+  return finish();
+}
+
+/** Record one fatal check and stop. */
+function finish_(
+  check: (name: string, ok: boolean, detail: string) => boolean,
+  finish: () => JourneyResult,
+  name: string,
+  reason: string,
+): JourneyResult {
+  check(name, false, reason);
+  return finish();
+}
+
+/** The journey as lines, for the command that runs it. PURE. */
+export function rollbackJourneyLines(result: JourneyResult): string[] {
+  const lines = result.checks.map((c) => `${c.ok ? "ok  " : "FAIL"} ${c.name} — ${c.detail}`);
+  lines.push(
+    result.ok
+      ? `\n${ROLLBACK_TARGET} rollback journey: ${result.checks.length} checks passed`
+      : `\n${ROLLBACK_TARGET} rollback journey: ${result.checks.filter((c) => !c.ok).length} of ${result.checks.length} checks failed`,
+  );
+  return lines;
+}

--- a/src/rollback-e2e.ts
+++ b/src/rollback-e2e.ts
@@ -409,7 +409,7 @@ export async function runUbuntu24RollbackJourney(
     "uninterrupted",
     rolled.workers === 2 && reconciled.every((host) => owed.has(host)),
     rolled.workers === 2
-      ? `${rolled.workers} Worker(s) were counted and left running, and all ${owed.size} reconciled host(s) are owed a restart rather than having been given one`
+      ? `${rolled.workers} Worker(s) were counted and left running, and all ${reconciled.length} reconciled host(s) plus ${owed.size - reconciled.length} companion(s) are owed a restart rather than having been given one`
       : `the rollback reported ${rolled.workers} Worker(s) instead of the 2 that were running`,
   );
   check(

--- a/src/staged-update.ts
+++ b/src/staged-update.ts
@@ -60,7 +60,11 @@ import type { Platform } from "./platform.ts";
 import type { Acquisition } from "./red-skills-acquire.ts";
 import type { CompanionOutcome } from "./red-skills-companions.ts";
 import type { HostOutcome } from "./red-skills-hosts.ts";
-import { readPackageSetState, type PackageSetIdentity } from "./red-skills-set.ts";
+import {
+  readPackageSetState,
+  type PackageSetIdentity,
+  type PackageSetRevision,
+} from "./red-skills-set.ts";
 import type { LockInstallReport } from "./workstation-lock.ts";
 
 /** The surfaces one revision has to reach, in the order it reaches them. */
@@ -380,6 +384,14 @@ export interface StagedUpdateOptions {
   converge?: () => Promise<{ hosts: HostOutcome[]; companions: CompanionOutcome[] }>;
   /** The exact workstation lock. Defaults to the one this machine holds. */
   lock?: () => Promise<LockResult>;
+  /**
+   * The instant this run activated, ISO 8601 to the second.
+   *
+   * Defaults to now. It exists so the revision record a rollback reads
+   * back is reproducible in a test, and so this module keeps its one
+   * reason to look at a clock in a place a caller can take away.
+   */
+  at?: string;
 }
 
 /**
@@ -428,6 +440,7 @@ export async function runStagedUpdate(opts: StagedUpdateOptions = {}): Promise<S
   const restartNeeded = [...new Set(surfaces.flatMap((s) => s.restartNeeded))];
 
   writeStagedUpdate(home, { schema: 1, outcome, surfaces, workers });
+  await recordRevision(home, outcome, active, opts.at ?? nowSeconds());
   announceStagedUpdate({ outcome, surfaces, restartNeeded });
 
   return {
@@ -447,6 +460,52 @@ export async function runStagedUpdate(opts: StagedUpdateOptions = {}): Promise<S
     workers,
     code: outcome === "converged" || outcome === "staged" ? 0 : 1,
   };
+}
+
+/**
+ * Bind what this run left the machine on into one complete revision.
+ *
+ * The pair src/workstation-rollback.ts retains: the package set and the
+ * exact lock, named together, with the local artifact store they were
+ * provisioned from. Only a `converged` run rotates it — everything else
+ * records the attempt and leaves the last verified revision exactly
+ * where it was, which is the state a rollback restores.
+ *
+ * Silent on a machine with no lock resolved yet, which is every machine
+ * before its first depot import: there is no complete revision to name,
+ * and inventing one from half of it would give a rollback a target it
+ * could not restore.
+ */
+async function recordRevision(
+  home: string,
+  outcome: UpdateOutcome,
+  active: PackageSetRevision | null,
+  at: string,
+): Promise<void> {
+  if (active === null) return;
+  const { readWorkstationLock } = await import("./workstation-lock.ts");
+  const read = readWorkstationLock(home);
+  if (!read.ok) return;
+  const { readOfflineDepotState } = await import("./offline-depot.ts");
+  const { activateWorkstationRevision } = await import("./workstation-rollback.ts");
+  activateWorkstationRevision({
+    home,
+    lock: read.lock,
+    packageSet: {
+      key: active.key,
+      version: active.version,
+      digest: active.digest,
+      sourceCommit: active.sourceCommit,
+    },
+    depot: readOfflineDepotState(home).imported?.path ?? null,
+    activatedAt: at,
+    verified: outcome === "converged",
+  });
+}
+
+/** Now, to the second, in the one encoding every record here uses. */
+function nowSeconds(): string {
+  return `${new Date().toISOString().slice(0, 19)}Z`;
 }
 
 /** One line per surface, in the voice the rest of a converge speaks. */

--- a/src/workstation-rollback.test.ts
+++ b/src/workstation-rollback.test.ts
@@ -20,7 +20,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { rehearsalLock } from "./fixtures/offline-depot/rehearsal.ts";
-import { depotAppPath } from "./offline-depot.ts";
+import { depotAppPath, offlineDepotStatePath } from "./offline-depot.ts";
 import { encodeWorkstationLock, type WorkstationLock } from "./workstation-lock.ts";
 import {
   activateWorkstationRevision,
@@ -418,6 +418,33 @@ describe("the retention", () => {
       expect(plan.held).toBeNull();
       expect(plan.prunable).toEqual([]);
       expect(plan.revisions.map((r) => r.key)).toEqual([newer.revision.key, older.revision.key]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("and never the depot copy this machine says it was provisioned from", async () => {
+    const dir = home();
+    try {
+      const [oldest] = await activateInOrder(dir, [2]);
+      if (oldest === undefined) throw new Error("no");
+      // doctor reports the imported depot by path, so a prune that took
+      // it would turn a healthy air-gapped workstation red for having
+      // tidied up after itself.
+      const statePath = offlineDepotStatePath(dir);
+      mkdirSync(join(statePath, ".."), { recursive: true });
+      writeFileSync(
+        statePath,
+        `${JSON.stringify({ schema: 1, imported: { path: oldest.revision.depot } }, null, 2)}\n`,
+      );
+      await activateInOrder(dir, [1, 0]);
+
+      expect(existsSync(oldest.revision.depot ?? "")).toBe(true);
+      const plan = planWorkstationRetention({ home: dir });
+      expect(plan.kept.some((entry) => entry.requiredBy.includes("offline depot state"))).toBe(true);
+      // Its lock is another matter: no revision needs it, and doctor
+      // never reports one by path.
+      expect(existsSync(retainedLockPath(dir, oldest.lock.lockDigest))).toBe(false);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/src/workstation-rollback.test.ts
+++ b/src/workstation-rollback.test.ts
@@ -1,0 +1,452 @@
+/**
+ * What a rollback has to refuse, and what it must never take away.
+ *
+ * The journey in src/rollback-e2e.test.ts proves the happy path across
+ * three real revisions. This file is the other half: the states where
+ * going back is impossible and saying so is the whole job — a lock that
+ * was pruned, a package-set tree that is gone, a revision provisioned
+ * from a source this machine no longer holds — and the retention rule
+ * that the fourth criterion is entirely about, which is a rule about
+ * what a *failed* run leaves behind.
+ *
+ * The refusals are asserted from the side an operator sees, because a
+ * refusal that is right and unreadable is a refusal somebody works
+ * around: every one of them names the path that is missing.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { rehearsalLock } from "./fixtures/offline-depot/rehearsal.ts";
+import { depotAppPath } from "./offline-depot.ts";
+import { encodeWorkstationLock, type WorkstationLock } from "./workstation-lock.ts";
+import {
+  activateWorkstationRevision,
+  applyWorkstationRetention,
+  describeWorkstationRevision,
+  planWorkstationRetention,
+  readWorkstationRevisions,
+  retainedLockPath,
+  retainedRevisions,
+  retainWorkstationLock,
+  rollbackTarget,
+  rollbackWorkstation,
+  workstationRevisionKey,
+  workstationRevisionsPath,
+  workstationRollbackReport,
+  workstationRollbackRows,
+  WORKSTATION_REVISION_RETENTION,
+  type WorkstationRevision,
+} from "./workstation-rollback.ts";
+
+const AT = "2026-08-19T00:00:00Z";
+
+function home(): string {
+  return mkdtempSync(join(tmpdir(), "red-rollback-"));
+}
+
+/**
+ * A machine on one complete revision, with nothing installed.
+ *
+ * Deliberately not a whole provisioned target: everything below is about
+ * a rollback that never gets as far as installing anything, and building
+ * fourteen applications to assert that a missing lock is refused would
+ * only make the refusal harder to read.
+ */
+async function oneRevision(
+  dir: string,
+  generation: number,
+  opts: { depot?: string | null; setDir?: boolean } = {},
+): Promise<{ lock: WorkstationLock; revision: WorkstationRevision }> {
+  const lock = await rehearsalLock(AT, "resolved", generation);
+  const packageSet = {
+    key: `3.${20 - generation}.0+${"a".repeat(12)}`.replace("aaaaaaaaaaaa", `${generation}`.repeat(12)),
+    version: `3.${20 - generation}.0`,
+    digest: `${generation}`.repeat(64),
+    sourceCommit: "",
+  };
+  const revision = describeWorkstationRevision({
+    home: dir,
+    lock,
+    packageSet,
+    depot: opts.depot === undefined ? join(dir, ".red-skills", "depots", `d${generation}`) : opts.depot,
+    activatedAt: AT,
+  });
+  if (opts.setDir !== false) mkdirSync(join(dir, ".red-skills", "sets", packageSet.key), { recursive: true });
+  retainWorkstationLock(dir, lock);
+  if (revision.depot !== null) {
+    for (const app of lock.apps) {
+      const path = join(revision.depot, depotAppPath(app));
+      mkdirSync(join(path, ".."), { recursive: true });
+      writeFileSync(path, `fixture:${app.id}@${app.version}:${app.artifact.name}`);
+    }
+  }
+  return { lock, revision };
+}
+
+/**
+ * Build and activate one generation at a time, oldest first.
+ *
+ * Built one at a time on purpose: an activation prunes what no retained
+ * revision names, and a revision materialised before its turn would be
+ * pruned by the activation before it — which is the retention working,
+ * and a confusing way to set up a test about it.
+ */
+async function activateInOrder(
+  dir: string,
+  generations: number[],
+): Promise<{ lock: WorkstationLock; revision: WorkstationRevision }[]> {
+  const out: { lock: WorkstationLock; revision: WorkstationRevision }[] = [];
+  for (const generation of generations) {
+    const built = await oneRevision(dir, generation);
+    activateWorkstationRevision({
+      home: dir,
+      lock: built.lock,
+      packageSet: built.revision.packageSet,
+      depot: built.revision.depot,
+      activatedAt: AT,
+      verified: true,
+    });
+    out.push(built);
+  }
+  return out;
+}
+
+/** The state file, written straight rather than through an activation. */
+function writeState(dir: string, state: Record<string, unknown>): void {
+  const path = workstationRevisionsPath(dir);
+  mkdirSync(join(path, ".."), { recursive: true });
+  writeFileSync(path, `${JSON.stringify({ schema: 1, ...state }, null, 2)}\n`);
+}
+
+const NEVER_INSTALL = async () => ({ ok: false, detail: "nothing should have been installed" });
+const NO_CONVERGE = async () => ({ hosts: [], companions: [] });
+
+describe("the workstation revision record", () => {
+  test("one name covers the package set and the lock together", () => {
+    expect(workstationRevisionKey("3.20.0+abcdef012345", "f".repeat(64))).toBe(
+      "3.20.0+abcdef012345+ffffffffffff",
+    );
+  });
+
+  test("a machine with no record answers empty rather than throwing", () => {
+    const dir = home();
+    try {
+      expect(readWorkstationRevisions(dir).active).toBeNull();
+      expect(workstationRollbackReport(dir).restores).toBeNull();
+      expect(workstationRollbackRows(workstationRollbackReport(dir))).toEqual([
+        { status: "n/a", detail: "no complete workstation revision has been activated here" },
+      ]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("a record this build cannot read is no record, and never an exception", () => {
+    const dir = home();
+    try {
+      const path = workstationRevisionsPath(dir);
+      mkdirSync(join(path, ".."), { recursive: true });
+      writeFileSync(path, "{ not json");
+      expect(readWorkstationRevisions(dir).active).toBeNull();
+      writeFileSync(path, `${JSON.stringify({ schema: 7, active: {} })}\n`);
+      expect(readWorkstationRevisions(dir).active).toBeNull();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("an activation retains the lock byte for byte, and a second one writes nothing", async () => {
+    const dir = home();
+    try {
+      const { lock, revision } = await oneRevision(dir, 0);
+      const first = activateWorkstationRevision({
+        home: dir,
+        lock,
+        packageSet: revision.packageSet,
+        depot: revision.depot,
+        activatedAt: AT,
+        verified: true,
+      });
+      expect(first.changed).toBe(true);
+      expect(Bun.file(retainedLockPath(dir, lock.lockDigest)).text()).resolves.toBe(
+        encodeWorkstationLock(lock),
+      );
+
+      const second = activateWorkstationRevision({
+        home: dir,
+        lock,
+        packageSet: revision.packageSet,
+        depot: revision.depot,
+        activatedAt: AT,
+        verified: true,
+      });
+      expect(second.writes).toEqual([]);
+      expect(second.changed).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("what a rollback restores", () => {
+  test("the revision behind the active one, when the last activation verified", () => {
+    const a = { key: "a" } as WorkstationRevision;
+    const b = { key: "b" } as WorkstationRevision;
+    expect(
+      rollbackTarget({ schema: 1, active: a, previous: b, rolledBackFrom: null, pending: null }),
+    ).toBe(b);
+  });
+
+  test("the active one, when an activation is still pending", () => {
+    // The machine has already drifted forward into a revision nothing
+    // vouched for. The last complete lock that worked is the active
+    // record, and walking past it to `previous` would go too far.
+    const a = { key: "a" } as WorkstationRevision;
+    const b = { key: "b" } as WorkstationRevision;
+    const c = { key: "c" } as WorkstationRevision;
+    expect(
+      rollbackTarget({ schema: 1, active: a, previous: b, rolledBackFrom: null, pending: c }),
+    ).toBe(a);
+  });
+
+  test("nothing, on a machine holding one revision", async () => {
+    const dir = home();
+    try {
+      const { lock, revision } = await oneRevision(dir, 0);
+      activateWorkstationRevision({
+        home: dir,
+        lock,
+        packageSet: revision.packageSet,
+        depot: revision.depot,
+        activatedAt: AT,
+        verified: true,
+      });
+      const rolled = await rollbackWorkstation({
+        home: dir,
+        observed: { id: lock.target.id, surfaces: lock.target.surfaces.map((s) => s.id), installed: [], authenticated: [] },
+        install: NEVER_INSTALL,
+        converge: NO_CONVERGE,
+        workers: async () => 0,
+        at: AT,
+      });
+      expect(rolled.outcome).toBe("refused");
+      expect(rolled.failure).toBe("empty");
+      expect(rolled.code).toBe(1);
+      expect(rolled.writes).toEqual([]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("what a rollback refuses", () => {
+  test("a retained lock that was pruned out from under the record", async () => {
+    const dir = home();
+    try {
+      const older = await oneRevision(dir, 1);
+      const newer = await oneRevision(dir, 0);
+      writeState(dir, { active: newer.revision, previous: older.revision, rolledBackFrom: null, pending: null });
+      // The record still names it; the file is not there.
+      rmSync(retainedLockPath(dir, older.lock.lockDigest), { force: true });
+
+      const rolled = await rollbackWorkstation({
+        home: dir,
+        observed: { id: older.lock.target.id, surfaces: older.lock.target.surfaces.map((s) => s.id), installed: [], authenticated: [] },
+        install: NEVER_INSTALL,
+        converge: NO_CONVERGE,
+        workers: async () => 0,
+        at: AT,
+      });
+      expect(rolled.failure).toBe("lock");
+      expect(rolled.reason).toContain(retainedLockPath(dir, older.lock.lockDigest));
+      expect(rolled.writes).toEqual([]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("a retained lock whose bytes are not the lock it claims to be", async () => {
+    const dir = home();
+    try {
+      const older = await oneRevision(dir, 1);
+      const newer = await oneRevision(dir, 0);
+      writeState(dir, { active: newer.revision, previous: older.revision, rolledBackFrom: null, pending: null });
+      // Somebody else's lock, at the path this revision's digest names.
+      writeFileSync(
+        retainedLockPath(dir, older.lock.lockDigest),
+        encodeWorkstationLock(newer.lock),
+      );
+
+      const rolled = await rollbackWorkstation({
+        home: dir,
+        observed: { id: older.lock.target.id, surfaces: older.lock.target.surfaces.map((s) => s.id), installed: [], authenticated: [] },
+        install: NEVER_INSTALL,
+        converge: NO_CONVERGE,
+        workers: async () => 0,
+        at: AT,
+      });
+      expect(rolled.failure).toBe("lock");
+      expect(rolled.reason).toContain("is not the lock");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("a package-set tree the record names and nothing holds", async () => {
+    const dir = home();
+    try {
+      const older = await oneRevision(dir, 1, { setDir: false });
+      const newer = await oneRevision(dir, 0);
+      writeState(dir, { active: newer.revision, previous: older.revision, rolledBackFrom: null, pending: null });
+
+      const rolled = await rollbackWorkstation({
+        home: dir,
+        observed: { id: older.lock.target.id, surfaces: older.lock.target.surfaces.map((s) => s.id), installed: [], authenticated: [] },
+        install: NEVER_INSTALL,
+        converge: NO_CONVERGE,
+        workers: async () => 0,
+        at: AT,
+      });
+      expect(rolled.failure).toBe("package-set");
+      expect(rolled.reason).toContain("no longer there");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("a revision with no local artifact store, rather than reaching for one", async () => {
+    const dir = home();
+    try {
+      const older = await oneRevision(dir, 1, { depot: null });
+      const newer = await oneRevision(dir, 0);
+      writeState(dir, { active: newer.revision, previous: older.revision, rolledBackFrom: null, pending: null });
+
+      const rolled = await rollbackWorkstation({
+        home: dir,
+        observed: { id: older.lock.target.id, surfaces: older.lock.target.surfaces.map((s) => s.id), installed: [], authenticated: [] },
+        install: NEVER_INSTALL,
+        converge: NO_CONVERGE,
+        workers: async () => 0,
+        at: AT,
+      });
+      // The one refusal that is about this module's own promise: there
+      // is no source of bytes here that does not need a network, so
+      // there is nothing to do but say so.
+      expect(rolled.failure).toBe("artifacts");
+      expect(rolled.reason).toContain("reach the network");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("and doctor says the same thing, in the row a person reads", async () => {
+    const dir = home();
+    try {
+      const older = await oneRevision(dir, 1, { setDir: false });
+      const newer = await oneRevision(dir, 0);
+      writeState(dir, { active: newer.revision, previous: older.revision, rolledBackFrom: null, pending: null });
+
+      const report = workstationRollbackReport(dir);
+      expect(report.restorable).toBe(false);
+      const rows = workstationRollbackRows(report);
+      expect(rows.some((row) => row.status === "err")).toBe(true);
+      expect(rows.find((row) => row.status === "err")?.detail).toContain("cannot be performed");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("the retention", () => {
+  test("keeps two complete revisions, and never counts one twice", () => {
+    const a = { key: "a" } as WorkstationRevision;
+    const b = { key: "b" } as WorkstationRevision;
+    expect(
+      retainedRevisions({ schema: 1, active: a, previous: b, rolledBackFrom: null, pending: null }),
+    ).toHaveLength(WORKSTATION_REVISION_RETENTION);
+    // `previous` and `rolledBackFrom` are the same slot from the two
+    // directions a machine can have moved, and only one is ever set.
+    expect(
+      retainedRevisions({ schema: 1, active: a, previous: null, rolledBackFrom: a, pending: null }),
+    ).toHaveLength(1);
+  });
+
+  test("a failed activation holds the prune and rotates nothing", async () => {
+    const dir = home();
+    try {
+      const [oldest, older] = await activateInOrder(dir, [2, 1]);
+      if (oldest === undefined || older === undefined) throw new Error("no");
+      const newer = await oneRevision(dir, 0);
+      const failed = activateWorkstationRevision({
+        home: dir,
+        lock: newer.lock,
+        packageSet: newer.revision.packageSet,
+        depot: newer.revision.depot,
+        activatedAt: AT,
+        verified: false,
+      });
+
+      const state = readWorkstationRevisions(dir);
+      expect(state.active?.key).toBe(older.revision.key);
+      expect(state.previous?.key).toBe(oldest.revision.key);
+      expect(state.pending?.key).toBe(newer.revision.key);
+      expect(failed.retention.held).toContain("did not verify");
+      // The whole of the fourth criterion: the inputs a rollback needs
+      // are still exactly where the last verified run left them.
+      expect(existsSync(retainedLockPath(dir, oldest.lock.lockDigest))).toBe(true);
+      expect(existsSync(oldest.revision.depot ?? "")).toBe(true);
+      expect(applyWorkstationRetention({ home: dir }).removed).toEqual([]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("and the same activation, once it verifies, drops what neither revision needs", async () => {
+    const dir = home();
+    try {
+      const [oldest, older, newer] = await activateInOrder(dir, [2, 1, 0]);
+      if (oldest === undefined || older === undefined || newer === undefined) throw new Error("no");
+      expect(existsSync(retainedLockPath(dir, oldest.lock.lockDigest))).toBe(false);
+      expect(existsSync(oldest.revision.depot ?? "")).toBe(false);
+      expect(existsSync(retainedLockPath(dir, older.lock.lockDigest))).toBe(true);
+      expect(existsSync(older.revision.depot ?? "")).toBe(true);
+
+      const plan = planWorkstationRetention({ home: dir });
+      expect(plan.held).toBeNull();
+      expect(plan.prunable).toEqual([]);
+      expect(plan.revisions.map((r) => r.key)).toEqual([newer.revision.key, older.revision.key]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("a machine with no revision at all prunes nothing", () => {
+    const dir = home();
+    try {
+      const plan = planWorkstationRetention({ home: dir });
+      expect(plan.held).toContain("no complete revision");
+      expect(applyWorkstationRetention({ home: dir }).removed).toEqual([]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("doctor names the lock identity and what retention holds", async () => {
+    const dir = home();
+    try {
+      const [older, newer] = await activateInOrder(dir, [1, 0]);
+      if (older === undefined || newer === undefined) throw new Error("no");
+      const rows = workstationRollbackRows(workstationRollbackReport(dir));
+      expect(rows[0]?.detail).toContain(newer.lock.lockDigest.slice(0, 12));
+      expect(rows[0]?.detail).toContain(`${newer.lock.apps.length} exact versions`);
+      expect(rows[1]?.detail).toContain(`a rollback restores ${older.revision.key}`);
+      expect(rows[2]?.detail).toContain("retention holds 2 complete revision(s)");
+      expect(rows.every((row) => row.status !== "err")).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/workstation-rollback.ts
+++ b/src/workstation-rollback.ts
@@ -110,6 +110,12 @@ import {
  * one to go back to. A third would be a second rollback nobody asked
  * for, at the cost of a third copy of every artifact on a machine whose
  * whole depot arrived on a USB stick.
+ *
+ * Not a cap this module applies — the record has exactly two slots for a
+ * settled machine, so two is what it structurally holds. The one moment
+ * a third is protected is while an activation is `pending`, and that is
+ * the failure rule rather than the retention: nothing is pruned at all
+ * until something verifies.
  */
 export const WORKSTATION_REVISION_RETENTION = 2;
 

--- a/src/workstation-rollback.ts
+++ b/src/workstation-rollback.ts
@@ -805,6 +805,9 @@ export async function rollbackWorkstation(
 
   // ------------------------------------------------------------- the record
   const restored: WorkstationRevision = { ...target, activatedAt: opts.at };
+  // What this rollback left, which is the pending activation on a
+  // machine that had drifted forward and the active record otherwise.
+  const left = state.pending ?? state.active;
   const desired: WorkstationRevisionState =
     state.pending === null
       ? {
@@ -814,7 +817,7 @@ export async function rollbackWorkstation(
           // rollback left is retained and named, and it is not a
           // rollback target.
           previous: null,
-          rolledBackFrom: state.active,
+          rolledBackFrom: left,
           pending: null,
         }
       : {
@@ -826,7 +829,7 @@ export async function rollbackWorkstation(
           schema: 1,
           active: restored,
           previous: state.previous,
-          rolledBackFrom: state.pending,
+          rolledBackFrom: left,
           pending: null,
         };
   writes.push(...writeWorkstationRevisions(home, desired));
@@ -845,7 +848,7 @@ export async function rollbackWorkstation(
   const reason = verified
     ? outcome === "converged"
       ? `this machine was already on ${restored.key}`
-      : `restored ${restored.key} from ${state.active?.key ?? "an unrecorded revision"} — ${installed.report.installed.length} application(s) put back, no network request`
+      : `restored ${restored.key} from ${left?.key ?? "an unrecorded revision"} — ${installed.report.installed.length} application(s) put back, no network request`
     : `restored ${restored.key} with ${installed.report.failed.length} application(s) and ${failedSurfaces.length} surface(s) unconverged`;
 
   announce({ outcome, reason, surfaces, restartNeeded, workers });
@@ -855,7 +858,7 @@ export async function rollbackWorkstation(
     reason,
     failure: verified ? null : "install",
     restored,
-    from: state.active,
+    from: left,
     install: installed.report,
     surfaces,
     restartNeeded,

--- a/src/workstation-rollback.ts
+++ b/src/workstation-rollback.ts
@@ -74,7 +74,7 @@ import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync
 import { dirname, join } from "node:path";
 
 import { log } from "./log.ts";
-import { depotAppPath, type DepotRevision } from "./offline-depot.ts";
+import { depotAppPath, readOfflineDepotState, type DepotRevision } from "./offline-depot.ts";
 import type { CompanionOutcome } from "./red-skills-companions.ts";
 import type { HostOutcome } from "./red-skills-hosts.ts";
 import {
@@ -496,6 +496,12 @@ export function planWorkstationRetention(opts: RetentionOptions): WorkstationRet
 
   const locks = new Map<string, string[]>();
   const depots = new Map<string, string[]>();
+  // The depot this machine says it was provisioned from, folded in the
+  // same way the set state is: doctor reports it by path, and a prune
+  // that removed it would turn a healthy air-gapped workstation red for
+  // having tidied up after itself.
+  const importedDepot = readOfflineDepotState(home).imported?.path;
+  if (importedDepot !== undefined) depots.set(importedDepot, ["offline depot state"]);
   for (const revision of revisions) {
     need(redSkillsSetDir(home, revision.packageSet.key), revision.key);
     const lock = locks.get(revision.lockPath) ?? [];

--- a/src/workstation-rollback.ts
+++ b/src/workstation-rollback.ts
@@ -1,0 +1,1094 @@
+/**
+ * Rollback: the whole workstation, back to the last revision that worked.
+ *
+ * An update advances four surfaces at once (src/staged-update.ts) and a
+ * depot provisions all of them from one medium (src/offline-depot.ts).
+ * Neither of them can be undone one surface at a time. Downgrading the
+ * package set without downgrading the lock leaves seven coder CLIs from
+ * one revision wired against the tree of another; downgrading the lock
+ * without the artifacts it names means fetching them, which is exactly
+ * what the machine that most needs a rollback — the air-gapped one — is
+ * unable to do. So a rollback is one operation over one recorded thing:
+ * a **workstation revision**, which is the package set, the exact lock,
+ * every application's version, and the local store the artifacts came
+ * from, named together and retained together.
+ *
+ * ## What is recorded, and when
+ *
+ * Only a verified activation rotates the record. That is the whole of
+ * Spec #201's fourth rollback criterion and it is a rule about failure,
+ * not about success: an update that half-applied, or one that staged a
+ * revision behind a running Worker, must leave the last verified state
+ * exactly where it was — still active, still complete, still the thing
+ * a rollback restores. A failed run therefore writes its attempt to
+ * `pending` and touches neither `active` nor `previous`, and while
+ * anything is pending nothing at all is pruned. A rollback whose inputs
+ * were collected by the same run that failed would be a rollback to
+ * nowhere.
+ *
+ * ## What a rollback restores, and why it is not always `previous`
+ *
+ * On a machine whose last activation verified, the thing to restore is
+ * the revision behind the active one: `previous`. On a machine with an
+ * activation still `pending` it is the active record itself — because
+ * the machine has already drifted forward into a revision that did not
+ * verify, and the last complete lock it was known to be correct on is
+ * the one the record still calls active. Restoring `previous` there
+ * would walk past a perfectly good revision to reach an older one whose
+ * inputs the newer activation may already have retired.
+ *
+ * ## Why a rollback does not swap
+ *
+ * Once a revision has been restored the record does not simply exchange
+ * the two — it names the revision the rollback *left* as
+ * `rolledBackFrom` and leaves `previous` empty. A second rollback then
+ * finds the machine already on the revision a rollback restores and
+ * writes nothing, instead of walking back up to the revision somebody
+ * has just rejected. Going forward again is an update: it is a
+ * decision, and it should have to be typed.
+ *
+ * ## Nothing here opens a socket
+ *
+ * Every input a rollback needs is already on the machine: the retained
+ * lock under `locks/`, the package-set tree under `sets/`, and the
+ * artifacts inside the machine-owned depot copy under `depots/`. The
+ * artifact reader is injected for the same reason src/offline-depot.ts
+ * injects its installer — a step that decided to fetch would be a step
+ * the caller wrote, in a file this one does not import — and the
+ * default reader is a `readFileSync` against the depot copy, re-hashed
+ * against the lock on the way through.
+ *
+ * ## Nothing here stops a session
+ *
+ * The Workers rule of ADR 0010 is a rule about the ground under running
+ * work, and a rollback moves the same ground an update does. It is
+ * answered the same way and deliberately not by killing anything: the
+ * disk is reconciled, every host and companion that cannot observe the
+ * change without a fresh process is named in `restartNeeded`, and the
+ * Workers this machine is running are counted into the report and
+ * otherwise left completely alone. There is no code path here that
+ * signals a process.
+ */
+
+import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+import { log } from "./log.ts";
+import { depotAppPath, type DepotRevision } from "./offline-depot.ts";
+import type { CompanionOutcome } from "./red-skills-companions.ts";
+import type { HostOutcome } from "./red-skills-hosts.ts";
+import {
+  activateRetainedPackageSet,
+  formatPackageSetIdentity,
+  readPackageSetState,
+  redSkillsSetDir,
+} from "./red-skills-set.ts";
+import {
+  companionSurface,
+  hostSurface,
+  lockSurface,
+  readStagedUpdate,
+  type SurfaceOutcome,
+} from "./staged-update.ts";
+import {
+  artifactMatches,
+  encodeWorkstationLock,
+  installFromLock,
+  parseWorkstationLock,
+  workstationLockPath,
+  type LockedApp,
+  type LockInstallReport,
+  type LockInstaller,
+  type ObservedTarget,
+  type WorkstationLock,
+} from "./workstation-lock.ts";
+
+/**
+ * How many complete revisions this machine keeps.
+ *
+ * Two, for the reason `REDSKILLS_SET_RETENTION` is two: one to be on,
+ * one to go back to. A third would be a second rollback nobody asked
+ * for, at the cost of a third copy of every artifact on a machine whose
+ * whole depot arrived on a USB stick.
+ */
+export const WORKSTATION_REVISION_RETENTION = 2;
+
+// ---------------------------------------------------------------- the record
+
+/** One application as a revision pinned it. */
+export interface RevisionApp {
+  id: string;
+  surface: string;
+  version: string;
+}
+
+/**
+ * One complete workstation, named once.
+ *
+ * The package set and the lock digest are the two identities; `apps` is
+ * what the lock resolved to, kept alongside because a rollback has to be
+ * able to say what it restored without re-reading a lock that may since
+ * have been replaced. `depot` is the local artifact store the versions
+ * can be reinstalled from, and its absence is the one thing that makes a
+ * revision unrestorable offline.
+ */
+export interface WorkstationRevision {
+  /** `<set key>+<lock digest12>` — one name for the whole combination. */
+  key: string;
+  /** The target this revision provisions. */
+  target: string;
+  packageSet: DepotRevision;
+  lockDigest: string;
+  /** The retained copy of the lock, under `~/.red-skills/locks`. */
+  lockPath: string;
+  /** Every locked application at its exact version, in lock order. */
+  apps: RevisionApp[];
+  /** The machine-owned depot copy the artifacts live in, or null. */
+  depot: string | null;
+  /** ISO 8601, from the caller: this module never reads a clock. */
+  activatedAt: string;
+}
+
+export interface WorkstationRevisionState {
+  schema: 1;
+  /** The revision this machine resolves, or null before the first one. */
+  active: WorkstationRevision | null;
+  /** The revision a rollback restores, or null when there is none. */
+  previous: WorkstationRevision | null;
+  /**
+   * The revision the last rollback left behind.
+   *
+   * Retained and addressable — an operator who rolls back to diagnose
+   * something still needs the bytes of what they rolled back from — and
+   * deliberately not `previous`, so a second rollback does not undo the
+   * first.
+   */
+  rolledBackFrom: WorkstationRevision | null;
+  /**
+   * A revision that was attempted and did not verify.
+   *
+   * Recorded so doctor can say what was attempted, and load-bearing for
+   * exactly one thing: while it is non-null nothing is pruned, because
+   * the inputs a rollback would need are the ones the failed run was
+   * halfway through replacing.
+   */
+  pending: WorkstationRevision | null;
+}
+
+const EMPTY_REVISIONS: WorkstationRevisionState = {
+  schema: 1,
+  active: null,
+  previous: null,
+  rolledBackFrom: null,
+  pending: null,
+};
+
+/** `~/.red-skills/workstation-revisions.json` — the complete revisions held. */
+export function workstationRevisionsPath(home: string): string {
+  return join(home, ".red-skills", "workstation-revisions.json");
+}
+
+/** `~/.red-skills/locks/<digest12>.json` — one retained lock, by its digest. */
+export function retainedLockPath(home: string, lockDigest: string): string {
+  return join(home, ".red-skills", "locks", `${lockDigest.slice(0, 12)}.json`);
+}
+
+/** The name one complete revision is addressable by. PURE. */
+export function workstationRevisionKey(packageSetKey: string, lockDigest: string): string {
+  return `${packageSetKey}+${lockDigest.slice(0, 12)}`;
+}
+
+/**
+ * The recorded revisions, or an empty record.
+ *
+ * An unreadable record is no record, for the reason `readPackageSetState`
+ * treats one that way: the directories under `sets/`, `locks/` and
+ * `depots/` are the truth, and the worst this costs is one activation
+ * that rewrites a file it could not read. What it must never do is
+ * throw — a machine whose rollback record is corrupt is a machine that
+ * most needs the rest of doctor to still run.
+ */
+export function readWorkstationRevisions(home: string): WorkstationRevisionState {
+  const path = workstationRevisionsPath(home);
+  if (!existsSync(path)) return EMPTY_REVISIONS;
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as Partial<WorkstationRevisionState>;
+    if (parsed?.schema !== 1) return EMPTY_REVISIONS;
+    return {
+      schema: 1,
+      active: parsed.active ?? null,
+      previous: parsed.previous ?? null,
+      rolledBackFrom: parsed.rolledBackFrom ?? null,
+      pending: parsed.pending ?? null,
+    };
+  } catch {
+    return EMPTY_REVISIONS;
+  }
+}
+
+/** The one encoding the revision record is written in. PURE. */
+export function encodeWorkstationRevisions(state: WorkstationRevisionState): string {
+  return `${JSON.stringify(state, null, 2)}\n`;
+}
+
+/** Write the record, if it differs. Returns the paths written. */
+export function writeWorkstationRevisions(
+  home: string,
+  state: WorkstationRevisionState,
+): string[] {
+  const desired = encodeWorkstationRevisions(state);
+  const path = workstationRevisionsPath(home);
+  try {
+    if (readFileSync(path, "utf8") === desired) return [];
+  } catch {
+    // No record yet, or one this build cannot read. Either way it is
+    // about to be replaced by one it wrote itself.
+  }
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, desired, "utf8");
+  return [path];
+}
+
+/**
+ * One complete revision, described from the two things that identify it.
+ * PURE.
+ *
+ * The lock is read for the versions rather than asked for them later,
+ * because "what was on this machine" has to survive the lock being
+ * replaced — which is the first thing an update does.
+ */
+export function describeWorkstationRevision(opts: {
+  home: string;
+  lock: WorkstationLock;
+  packageSet: DepotRevision;
+  depot: string | null;
+  activatedAt: string;
+}): WorkstationRevision {
+  return {
+    key: workstationRevisionKey(opts.packageSet.key, opts.lock.lockDigest),
+    target: opts.lock.target.id,
+    packageSet: opts.packageSet,
+    lockDigest: opts.lock.lockDigest,
+    lockPath: retainedLockPath(opts.home, opts.lock.lockDigest),
+    apps: opts.lock.apps.map((app) => ({
+      id: app.id,
+      surface: app.surface,
+      version: app.version,
+    })),
+    depot: opts.depot,
+    activatedAt: opts.activatedAt,
+  };
+}
+
+/**
+ * Keep one lock's bytes under its own digest, and make it the active one.
+ *
+ * Two writes, both conditional, and both the canonical encoding: the
+ * retained copy is what a rollback reads, and `workstation-lock.json` is
+ * what everything else on the machine reads. Writing the same bytes
+ * twice is what makes the pair cheap to keep honest — a retained lock
+ * that had been reformatted would not parse back to its own digest.
+ */
+export function retainWorkstationLock(home: string, lock: WorkstationLock): string[] {
+  const desired = encodeWorkstationLock(lock);
+  const writes: string[] = [];
+  for (const path of [retainedLockPath(home, lock.lockDigest), workstationLockPath(home)]) {
+    let current: string | null;
+    try {
+      current = readFileSync(path, "utf8");
+    } catch {
+      current = null;
+    }
+    if (current === desired) continue;
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, desired, "utf8");
+    writes.push(path);
+  }
+  return writes;
+}
+
+// ------------------------------------------------------------ the activation
+
+export interface ActivateRevisionOptions {
+  home: string;
+  lock: WorkstationLock;
+  packageSet: DepotRevision;
+  /** The machine-owned depot copy the artifacts came from, or null. */
+  depot: string | null;
+  /** ISO 8601, from the caller: this module never reads a clock. */
+  activatedAt: string;
+  /**
+   * Whether every surface of this activation verified.
+   *
+   * False is not an error and is the reason this argument exists: a
+   * partial, failed or staged run records what it attempted and rotates
+   * nothing, so the revision a rollback restores is still the last one
+   * that actually worked.
+   */
+  verified: boolean;
+}
+
+export interface ActivatedRevision {
+  revision: WorkstationRevision;
+  state: WorkstationRevisionState;
+  writes: string[];
+  /** What retention removed, which is empty on anything but a verified run. */
+  retention: WorkstationRetention;
+  /** False when the machine was already recorded as being on this revision. */
+  changed: boolean;
+}
+
+/**
+ * Record one complete revision as this machine's, and retire what that
+ * leaves behind.
+ *
+ * The forward half of the rollback, and the only thing that ever makes a
+ * revision restorable: an update or an import that does not pass through
+ * here leaves nothing to go back to. The order is the contract — retain
+ * the lock, rotate the record, prune what neither retained revision
+ * needs — because a prune that ran before the record was written would
+ * be deciding what is needed from a record that does not yet name the
+ * thing that needs it.
+ */
+export function activateWorkstationRevision(opts: ActivateRevisionOptions): ActivatedRevision {
+  const { home } = opts;
+  const revision = describeWorkstationRevision(opts);
+  const state = readWorkstationRevisions(home);
+  const writes = retainWorkstationLock(home, opts.lock);
+
+  if (!opts.verified) {
+    // Attempted and not verified. Nothing rotates, nothing is pruned,
+    // and the last verified state is still exactly what it was.
+    const desired: WorkstationRevisionState = { ...state, pending: revision };
+    writes.push(...writeWorkstationRevisions(home, desired));
+    return {
+      revision,
+      state: desired,
+      writes,
+      retention: planWorkstationRetention({ home, verified: false }),
+      changed: writes.length > 0,
+    };
+  }
+
+  const already = state.active?.key === revision.key;
+  const desired: WorkstationRevisionState = already
+    ? { ...state, active: revision, pending: null }
+    : {
+        schema: 1,
+        active: revision,
+        previous: state.active,
+        // Cleared on the way forward: the revision a rollback left is
+        // only interesting until the machine has moved on from it.
+        rolledBackFrom: null,
+        pending: null,
+      };
+  writes.push(...writeWorkstationRevisions(home, desired));
+
+  const retention = applyWorkstationRetention({ home, verified: true });
+  writes.push(...retention.removed.map((entry) => entry.path));
+  return { revision, state: desired, writes, retention: retention.plan, changed: writes.length > 0 };
+}
+
+// ------------------------------------------------------------- the retention
+
+export type RetentionKind = "package-set" | "lock" | "depot";
+
+/** One derived path, and whether anything still needs it. */
+export interface RetentionEntry {
+  path: string;
+  kind: RetentionKind;
+  /** The revision keys that require it. Empty exactly when prunable. */
+  requiredBy: string[];
+}
+
+export interface WorkstationRetention {
+  /** The revisions the record names, newest first. */
+  revisions: WorkstationRevision[];
+  /** Everything a retained revision requires, and therefore stays. */
+  kept: RetentionEntry[];
+  /** Everything past the retention. Empty while anything holds it. */
+  prunable: RetentionEntry[];
+  /**
+   * Why nothing may be pruned right now, or null.
+   *
+   * Never a failure: the ordinary machine holding a prune is one whose
+   * last update is still waiting on a Worker, and reporting that as a
+   * problem would make every held update look like a broken one.
+   */
+  held: string | null;
+}
+
+export interface RetentionOptions {
+  home: string;
+  /**
+   * Whether the state was left by an activation that verified.
+   *
+   * Defaults to the last staged update's verdict, so an ordinary caller
+   * does not have to know the rule and cannot get it wrong: `converged`
+   * verified, and `partial`, `failed` and `staged` did not.
+   */
+  verified?: boolean;
+}
+
+/**
+ * The revisions retention protects, newest first. PURE.
+ *
+ * `previous` and `rolledBackFrom` are the same slot seen from the two
+ * directions a machine can have moved, and only one of them is ever
+ * non-null, so this is two revisions in practice and never three.
+ * `pending` is included because an activation that has not verified must
+ * not have its own inputs pruned out from under a retry.
+ */
+export function retainedRevisions(state: WorkstationRevisionState): WorkstationRevision[] {
+  const out: WorkstationRevision[] = [];
+  for (const revision of [state.active, state.previous, state.rolledBackFrom, state.pending]) {
+    if (revision === null) continue;
+    if (out.some((kept) => kept.key === revision.key)) continue;
+    out.push(revision);
+  }
+  return out;
+}
+
+/**
+ * The revision a rollback would restore right now, or null. PURE.
+ *
+ * Two answers, and the header says why: `previous` on a machine whose
+ * last activation verified, and `active` on one still carrying a pending
+ * activation, because there the record's active revision *is* the last
+ * complete lock that worked.
+ */
+export function rollbackTarget(state: WorkstationRevisionState): WorkstationRevision | null {
+  return state.pending !== null ? state.active : state.previous;
+}
+
+/**
+ * What this machine may drop, and what it may not.
+ *
+ * Three families of derived state, and the answer is the same shape for
+ * all three: a path is kept when a retained revision names it, and
+ * prunable when none does. The package-set trees are also retained by
+ * src/red-skills-set.ts under its own policy, and both are consulted —
+ * two owners of one directory must agree to remove it, never just one.
+ */
+export function planWorkstationRetention(opts: RetentionOptions): WorkstationRetention {
+  const { home } = opts;
+  const state = readWorkstationRevisions(home);
+  const revisions = retainedRevisions(state);
+
+  // The set state's own retention, folded in as a protection rather than
+  // as a second policy: a tree it still names is one the machine can
+  // still resolve through, whatever this record says.
+  const setState = readPackageSetState(home);
+  const setKeys = new Map<string, string[]>();
+  const need = (path: string, key: string): void => {
+    const already = setKeys.get(path) ?? [];
+    if (!already.includes(key)) already.push(key);
+    setKeys.set(path, already);
+  };
+  for (const revision of setState.revisions) need(revision.path, "package-set state");
+  if (setState.staged !== null) need(setState.staged.path, "package-set state");
+
+  const locks = new Map<string, string[]>();
+  const depots = new Map<string, string[]>();
+  for (const revision of revisions) {
+    need(redSkillsSetDir(home, revision.packageSet.key), revision.key);
+    const lock = locks.get(revision.lockPath) ?? [];
+    if (!lock.includes(revision.key)) lock.push(revision.key);
+    locks.set(revision.lockPath, lock);
+    if (revision.depot === null) continue;
+    const depot = depots.get(revision.depot) ?? [];
+    if (!depot.includes(revision.key)) depot.push(revision.key);
+    depots.set(revision.depot, depot);
+  }
+
+  const kept: RetentionEntry[] = [];
+  const prunable: RetentionEntry[] = [];
+  const sort = (entries: RetentionEntry[]): RetentionEntry[] =>
+    entries.sort((a, b) => a.path.localeCompare(b.path));
+
+  const sweep = (dir: string, kind: RetentionKind, required: Map<string, string[]>): void => {
+    for (const name of listing(dir)) {
+      const path = join(dir, name);
+      const by = required.get(path) ?? [];
+      (by.length > 0 ? kept : prunable).push({ path, kind, requiredBy: by });
+    }
+  };
+  sweep(join(home, ".red-skills", "sets"), "package-set", setKeys);
+  sweep(join(home, ".red-skills", "locks"), "lock", locks);
+  sweep(join(home, ".red-skills", "depots"), "depot", depots);
+
+  return {
+    revisions,
+    kept: sort(kept),
+    prunable: sort(prunable),
+    held: retentionHold(home, state, opts.verified),
+  };
+}
+
+/**
+ * Why a prune is being held back, or null.
+ *
+ * The order is the order of severity, and every one of them means the
+ * same thing: something on this machine is between two revisions, and
+ * the paths a prune would take are the ones a retry or a rollback would
+ * read.
+ */
+function retentionHold(
+  home: string,
+  state: WorkstationRevisionState,
+  verified: boolean | undefined,
+): string | null {
+  if (state.active === null) return "no complete revision has been activated on this machine";
+  if (state.pending !== null) {
+    return `an activation of ${state.pending.key} did not verify and is still pending`;
+  }
+  const decided = verified ?? lastUpdateVerified(home);
+  if (!decided) return "the last update did not verify every surface";
+  return null;
+}
+
+/** Whether the last staged update reached every surface. */
+function lastUpdateVerified(home: string): boolean {
+  const record = readStagedUpdate(home);
+  // No record at all is not a failed update: it is a machine provisioned
+  // from a depot, which has never run one.
+  return record === null || record.outcome === "converged";
+}
+
+export interface AppliedRetention {
+  plan: WorkstationRetention;
+  /** What actually went. A path that could not be removed is not in here. */
+  removed: RetentionEntry[];
+}
+
+/**
+ * Remove what the plan says is past the retention, and nothing else.
+ *
+ * A held plan removes nothing at all, which is the fourth rollback
+ * criterion in one line. An entry that will not delete is dropped from
+ * the report rather than thrown, for the reason the legacy sweep drops
+ * one: this runs unattended at the end of an update, and one locked
+ * directory is not a reason to fail an activation that worked.
+ */
+export function applyWorkstationRetention(opts: RetentionOptions): AppliedRetention {
+  const plan = planWorkstationRetention(opts);
+  if (plan.held !== null) return { plan, removed: [] };
+
+  const removed: RetentionEntry[] = [];
+  for (const entry of plan.prunable) {
+    try {
+      rmSync(entry.path, { recursive: true, force: true });
+    } catch {
+      continue;
+    }
+    if (existsSync(entry.path)) continue;
+    removed.push(entry);
+  }
+  return { plan, removed };
+}
+
+// -------------------------------------------------------------- the rollback
+
+export type RollbackFailure =
+  /** Nothing behind the active revision. */
+  | "empty"
+  /** The retained lock is gone, unreadable, or not the lock it claims. */
+  | "lock"
+  /** The package-set tree the revision names is no longer addressable. */
+  | "package-set"
+  /** No local artifact store, so restoring would need the network. */
+  | "artifacts"
+  /** The lock was restorable and one or more applications would not install. */
+  | "install";
+
+export type RollbackOutcome =
+  /** The machine was moved back onto the previous complete revision. */
+  | "restored"
+  /** It was already on it: a second rollback, and nothing to do. */
+  | "converged"
+  /** Restored, with at least one surface left unconverged. */
+  | "partial"
+  /** Nothing was done, and the reason says why. */
+  | "refused";
+
+export interface WorkstationRollback {
+  outcome: RollbackOutcome;
+  /** One sentence, always — including on the happy path. */
+  reason: string;
+  failure: RollbackFailure | null;
+  /** The revision this machine is on once this returns, or null. */
+  restored: WorkstationRevision | null;
+  /** The revision it was on before, or null when nothing moved. */
+  from: WorkstationRevision | null;
+  /** The lock install, in the vocabulary an update speaks. */
+  install: LockInstallReport | null;
+  /** Hosts, companions and the lock, as a staged update reports them. */
+  surfaces: SurfaceOutcome[];
+  /** Everything reconciled on disk that a fresh process has to observe. */
+  restartNeeded: string[];
+  /** Workers observed. Counted, reported, and never signalled. */
+  workers: number | null;
+  retention: WorkstationRetention;
+  /** Every path written or removed. Empty on a second rollback. */
+  writes: string[];
+  /** Zero for `restored` and `converged`; one for the other two. */
+  code: number;
+}
+
+/** Reads one locked application's exact bytes from local storage. */
+export type ArtifactReader = (app: LockedApp) => Buffer | null;
+
+export interface RollbackOptions {
+  home: string;
+  /** The machine as it is now, so the plan knows what has to change. */
+  observed: ObservedTarget;
+  /** Puts one application back, from bytes this machine already holds. */
+  install: (
+    step: Parameters<LockInstaller>[0],
+    artifact: { path: string; bytes: Buffer },
+  ) => Promise<{ ok: boolean; detail?: string }>;
+  /**
+   * The bytes of one locked application. Defaults to the machine-owned
+   * depot copy the revision was provisioned from — which is the whole of
+   * "no network request": there is no other source to read.
+   */
+  artifacts?: ArtifactReader;
+  /** Reconciles hosts and companions. Defaults to red-dev's own converge. */
+  converge?: () => Promise<{ hosts: HostOutcome[]; companions: CompanionOutcome[] }>;
+  /**
+   * Active Workers on this machine. Defaults to asking the daemon over
+   * its existing socket. Never used to refuse and never used to stop
+   * anything: it is reported so that a person reading a rollback knows
+   * which sessions are still on the revision that was rolled back.
+   */
+  workers?: () => Promise<number | null>;
+  platform?: NodeJS.Platform;
+  env?: NodeJS.ProcessEnv;
+  /** ISO 8601, from the caller: this module never reads a clock. */
+  at: string;
+}
+
+/**
+ * Put the whole workstation back on the previous complete revision.
+ *
+ * The order is the order of dependency and the order of reversibility:
+ * everything refusable is refused before a byte moves, then the package
+ * set, then the applications the lock names, then the hosts and
+ * companions built out of both, then the lock file itself, and only
+ * then the record and the prune. A rollback that had already replaced
+ * half the applications when it discovered its package-set tree was
+ * gone would have left the machine on neither revision.
+ */
+export async function rollbackWorkstation(
+  opts: RollbackOptions,
+): Promise<WorkstationRollback> {
+  const { home } = opts;
+  const state = readWorkstationRevisions(home);
+  const workers = await (opts.workers ?? defaultWorkers)();
+
+  const empty = (
+    outcome: RollbackOutcome,
+    reason: string,
+    failure: RollbackFailure | null,
+    restored: WorkstationRevision | null = null,
+  ): WorkstationRollback => ({
+    outcome,
+    reason,
+    failure,
+    restored,
+    from: null,
+    install: null,
+    surfaces: [],
+    restartNeeded: [],
+    workers,
+    retention: planWorkstationRetention({ home }),
+    writes: [],
+    code: outcome === "restored" || outcome === "converged" ? 0 : 1,
+  });
+
+  const target = rollbackTarget(state);
+  if (target === null) {
+    // Already rolled back is not the same fact as never having had
+    // anywhere to go, and the two exits are different because the
+    // operator's next move is different.
+    if (state.rolledBackFrom !== null && state.active !== null) {
+      return empty(
+        "converged",
+        `this machine is already on ${state.active.key}, rolled back from ${state.rolledBackFrom.key} — going forward again is an update`,
+        null,
+        state.active,
+      );
+    }
+    return empty(
+      "refused",
+      "this machine holds no previous complete revision to roll back to",
+      "empty",
+    );
+  }
+
+  const lock = readRetainedLock(target);
+  if (!lock.ok) return empty("refused", lock.reason, "lock");
+
+  const setDir = redSkillsSetDir(home, target.packageSet.key);
+  if (!existsSync(setDir)) {
+    return empty(
+      "refused",
+      `the package-set tree for ${formatPackageSetIdentity(target.packageSet)} is recorded at ${setDir} and is no longer there`,
+      "package-set",
+    );
+  }
+
+  const read = opts.artifacts ?? depotArtifacts(target);
+  if (read === null) {
+    return empty(
+      "refused",
+      `${target.key} names no local artifact store, and restoring its applications would have to reach the network`,
+      "artifacts",
+    );
+  }
+
+  // -------------------------------------------------------------- the moves
+  const writes: string[] = [];
+  const surfaces: SurfaceOutcome[] = [];
+
+  // The package set first: the hosts and companions below are built out
+  // of the tree it points `current` at, and reconciling them against the
+  // revision that is on its way out would wire them twice.
+  const activated = activateRetainedPackageSet(target.packageSet.key, {
+    home,
+    ...(opts.platform ? { platform: opts.platform } : {}),
+    ...(opts.env ? { env: opts.env } : {}),
+  });
+  if (activated === null) {
+    return empty(
+      "refused",
+      `this machine does not retain package set ${target.packageSet.key}`,
+      "package-set",
+    );
+  }
+  if (activated.refused !== null) {
+    return empty("refused", activated.refused.reason, "package-set");
+  }
+  writes.push(...activated.writes);
+
+  // Every application the lock names, from bytes that are already here
+  // and re-hashed against the lock on the way through. An artifact that
+  // does not hash is this one application's failure, never the whole
+  // rollback's: the machine is already on the restored package set, and
+  // thirteen of fourteen applications restored is thirteen applications
+  // of good.
+  const installer: LockInstaller = async (step) => {
+    const bytes = read(step.app);
+    if (bytes === null) {
+      return { ok: false, detail: `no local copy of ${step.app.artifact.name}` };
+    }
+    if (!artifactMatches(step.app, bytes)) {
+      return { ok: false, detail: `${step.app.artifact.name} does not hash to the locked checksum` };
+    }
+    return opts.install(step, { path: localArtifactPath(target, step.app), bytes });
+  };
+  const installed = await installFromLock(lock.lock, opts.observed, installer);
+  if (!installed.ok) return empty("refused", installed.reason, "install");
+  surfaces.push(lockSurface({ ok: true, report: installed.report }));
+
+  // The hosts and companions, rebuilt against the restored tree. Neither
+  // adapter terminates anything; what they cannot change under a running
+  // process they report, and it is carried up into `restartNeeded`.
+  const converged = await (opts.converge ?? defaultConverge())();
+  surfaces.unshift(companionSurface(converged.companions));
+  surfaces.unshift(hostSurface(converged.hosts));
+
+  // The lock file last of the moves, because it is the machine's answer
+  // to "what am I provisioned against" and it should not say the old
+  // revision while the applications are still being put back.
+  writes.push(...retainWorkstationLock(home, lock.lock));
+
+  // ------------------------------------------------------------- the record
+  const restored: WorkstationRevision = { ...target, activatedAt: opts.at };
+  const desired: WorkstationRevisionState =
+    state.pending === null
+      ? {
+          schema: 1,
+          active: restored,
+          // Deliberately empty: see the header. The revision this
+          // rollback left is retained and named, and it is not a
+          // rollback target.
+          previous: null,
+          rolledBackFrom: state.active,
+          pending: null,
+        }
+      : {
+          // A repair rather than a step back: the record already called
+          // this revision active and the machine has been put back onto
+          // it, so nothing rotates. What is dropped is the activation
+          // that did not verify, which is now a thing that happened
+          // rather than a thing that is owed.
+          schema: 1,
+          active: restored,
+          previous: state.previous,
+          rolledBackFrom: state.pending,
+          pending: null,
+        };
+  writes.push(...writeWorkstationRevisions(home, desired));
+
+  const failedSurfaces = surfaces.filter((s) => s.state === "failed");
+  const verified = failedSurfaces.length === 0 && installed.report.failed.length === 0;
+  const retention = applyWorkstationRetention({ home, verified });
+  writes.push(...retention.removed.map((entry) => entry.path));
+
+  const restartNeeded = [...new Set(surfaces.flatMap((s) => s.restartNeeded))];
+  const outcome: RollbackOutcome = !verified
+    ? "partial"
+    : writes.length === 0 && installed.report.installed.length === 0
+      ? "converged"
+      : "restored";
+  const reason = verified
+    ? outcome === "converged"
+      ? `this machine was already on ${restored.key}`
+      : `restored ${restored.key} from ${state.active?.key ?? "an unrecorded revision"} — ${installed.report.installed.length} application(s) put back, no network request`
+    : `restored ${restored.key} with ${installed.report.failed.length} application(s) and ${failedSurfaces.length} surface(s) unconverged`;
+
+  announce({ outcome, reason, surfaces, restartNeeded, workers });
+
+  return {
+    outcome,
+    reason,
+    failure: verified ? null : "install",
+    restored,
+    from: state.active,
+    install: installed.report,
+    surfaces,
+    restartNeeded,
+    workers,
+    retention: retention.plan,
+    writes,
+    code: verified ? 0 : 1,
+  };
+}
+
+/** One line per surface, in the voice the rest of a converge speaks. */
+function announce(
+  run: Pick<WorkstationRollback, "outcome" | "reason" | "surfaces" | "restartNeeded" | "workers">,
+): void {
+  for (const surface of run.surfaces) {
+    const line = `${surface.surface}: ${surface.reason}`;
+    if (surface.state === "failed") log.err(line);
+    else if (surface.state === "verified") log.ok(line);
+    else log.skip(line);
+  }
+  if (run.outcome === "partial") log.err(run.reason);
+  else log.ok(run.reason);
+  if (run.restartNeeded.length > 0) {
+    // Said once, at the end, and never as a failure: the disk is on the
+    // restored revision and every running process was left alone.
+    log.warn(`restart needed to load the restored revision: ${run.restartNeeded.join(", ")}`);
+  }
+  if ((run.workers ?? 0) > 0) {
+    log.warn(
+      `${run.workers} Worker(s) are running and were not interrupted — they keep the revision they started with`,
+    );
+  }
+}
+
+/**
+ * The retained lock a revision names, or why it cannot be used.
+ *
+ * Re-parsed and re-checked against the digest the record claims, rather
+ * than trusted because the record named it. The retained copy is the one
+ * input a rollback cannot verify against anything else, so the digest is
+ * the whole of its integrity.
+ */
+function readRetainedLock(
+  revision: WorkstationRevision,
+): { ok: true; lock: WorkstationLock } | { ok: false; reason: string } {
+  let bytes: Buffer;
+  try {
+    bytes = readFileSync(revision.lockPath);
+  } catch {
+    return {
+      ok: false,
+      reason: `the lock ${revision.lockDigest.slice(0, 12)} for ${revision.key} is not retained at ${revision.lockPath}`,
+    };
+  }
+  const parsed = parseWorkstationLock(bytes);
+  if (!parsed.ok) return { ok: false, reason: `the retained lock for ${revision.key}: ${parsed.reason}` };
+  if (parsed.lock.lockDigest !== revision.lockDigest) {
+    return { ok: false, reason: `the retained lock at ${revision.lockPath} is not the lock ${revision.key} names` };
+  }
+  return { ok: true, lock: parsed.lock };
+}
+
+/** Where one application's bytes sit inside a revision's depot copy. */
+function localArtifactPath(revision: WorkstationRevision, app: LockedApp): string {
+  return join(revision.depot ?? "", depotAppPath(app));
+}
+
+/**
+ * The default artifact reader: the revision's own depot copy, and
+ * nothing else.
+ *
+ * `null` when the revision was not provisioned from a depot, which the
+ * caller turns into a refusal rather than a fetch. A machine that was
+ * provisioned over the network can still be rolled back — by handing in
+ * a reader — and this module will not invent one that opens a socket.
+ */
+function depotArtifacts(revision: WorkstationRevision): ArtifactReader | null {
+  if (revision.depot === null || !existsSync(revision.depot)) return null;
+  return (app) => {
+    try {
+      return readFileSync(localArtifactPath(revision, app));
+    } catch {
+      return null;
+    }
+  };
+}
+
+function defaultConverge(): () => Promise<{
+  hosts: HostOutcome[];
+  companions: CompanionOutcome[];
+}> {
+  return async () => {
+    const { convergeRedSkills } = await import("./agents.ts");
+    const { detect } = await import("./platform.ts");
+    return await convergeRedSkills(detect());
+  };
+}
+
+/** Active Workers, over the daemon's existing socket and never a new one. */
+async function defaultWorkers(): Promise<number | null> {
+  const { readHostInventoryNoStart } = await import("./host-state.ts");
+  const inventory = await readHostInventoryNoStart();
+  return inventory === null ? null : inventory.workers.length;
+}
+
+function listing(dir: string): string[] {
+  try {
+    return readdirSync(dir).sort();
+  } catch {
+    return [];
+  }
+}
+
+// --------------------------------------------------------------- the report
+
+export interface RollbackDoctorReport {
+  /** The revision this machine is on, or null. */
+  active: WorkstationRevision | null;
+  /** The revision behind the active one, or null. */
+  previous: WorkstationRevision | null;
+  /** The revision a rollback would restore right now, or null. */
+  restores: WorkstationRevision | null;
+  /** The revision the last rollback left behind, or null. */
+  rolledBackFrom: WorkstationRevision | null;
+  /** An activation that did not verify, or null. */
+  pending: WorkstationRevision | null;
+  retention: WorkstationRetention;
+  /** False when a retained revision's tree, lock or depot is gone. */
+  restorable: boolean;
+  /** What is missing behind an unrestorable rollback, in the order found. */
+  missing: string[];
+}
+
+/**
+ * What doctor says about rollback and retention, as data.
+ *
+ * The two facts the criteria ask for are here in one shape, because they
+ * are one fact: the lock identity says what this machine is provisioned
+ * against, and the retention says whether the thing it could go back to
+ * is still on disk. Reporting either without the other is how a machine
+ * ends up confidently naming a rollback target whose bytes were pruned.
+ */
+export function workstationRollbackReport(home: string): RollbackDoctorReport {
+  const state = readWorkstationRevisions(home);
+  const retention = planWorkstationRetention({ home });
+  const missing: string[] = [];
+  const target = rollbackTarget(state);
+  if (target !== null) {
+    if (!existsSync(target.lockPath)) missing.push(`the retained lock at ${target.lockPath}`);
+    const setDir = redSkillsSetDir(home, target.packageSet.key);
+    if (!existsSync(setDir)) missing.push(`the package-set tree at ${setDir}`);
+    if (target.depot === null) missing.push("a local artifact store for its applications");
+    else if (!existsSync(target.depot)) missing.push(`the depot copy at ${target.depot}`);
+  }
+  return {
+    active: state.active,
+    previous: state.previous,
+    restores: target,
+    rolledBackFrom: state.rolledBackFrom,
+    pending: state.pending,
+    retention,
+    restorable: target !== null && missing.length === 0,
+    missing,
+  };
+}
+
+export interface RollbackDoctorRow {
+  status: "ok" | "warn" | "err" | "n/a";
+  detail: string;
+}
+
+/** The report as the lines `red-dev doctor` prints. PURE. */
+export function workstationRollbackRows(report: RollbackDoctorReport): RollbackDoctorRow[] {
+  const rows: RollbackDoctorRow[] = [];
+  if (report.active === null) {
+    return [{ status: "n/a", detail: "no complete workstation revision has been activated here" }];
+  }
+
+  const active = report.active;
+  rows.push({
+    status: "ok",
+    detail:
+      `workstation revision ${active.key} for ${active.target} — package set ${active.packageSet.key}, ` +
+      `lock ${active.lockDigest.slice(0, 12)} over ${active.apps.length} exact versions, activated ${active.activatedAt}`,
+  });
+
+  if (report.restores !== null) {
+    rows.push(
+      report.restorable
+        ? {
+            status: "ok",
+            detail: `a rollback restores ${report.restores.key} — package set ${report.restores.packageSet.key} and lock ${report.restores.lockDigest.slice(0, 12)}, all of it on disk`,
+          }
+        : {
+            status: "err",
+            detail: `a rollback to ${report.restores.key} cannot be performed: ${report.missing.join(", ")} is gone`,
+          },
+    );
+  } else if (report.rolledBackFrom !== null) {
+    rows.push({
+      status: "warn",
+      detail: `this machine was rolled back from ${report.rolledBackFrom.key}, which is retained — going forward again is an update`,
+    });
+  } else {
+    rows.push({
+      status: "n/a",
+      detail: "this machine holds one complete revision, so there is nothing to roll back to",
+    });
+  }
+
+  if (report.pending !== null) {
+    rows.push({
+      status: "warn",
+      detail: `an activation of ${report.pending.key} did not verify — the last verified revision is still active and nothing has been pruned`,
+    });
+  }
+
+  const counted = (kind: RetentionKind): number =>
+    report.retention.kept.filter((entry) => entry.kind === kind).length;
+  rows.push({
+    status: "ok",
+    detail:
+      `retention holds ${report.retention.revisions.length} complete revision(s): ` +
+      `${counted("package-set")} package-set snapshot(s), ${counted("lock")} lock(s), ${counted("depot")} depot cop(y|ies)`,
+  });
+  if (report.retention.prunable.length > 0) {
+    rows.push({
+      status: report.retention.held === null ? "warn" : "n/a",
+      detail:
+        report.retention.held === null
+          ? `${report.retention.prunable.length} derived path(s) are past the retention and will go on the next activation`
+          : `${report.retention.prunable.length} derived path(s) are held: ${report.retention.held}`,
+    });
+  }
+  return rows;
+}


### PR DESCRIPTION
Automated AFK landing for #212. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #212

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/227"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789705107&installation_model_id=20659&pr_number=227&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F227&signature=5db6ea3c34e416919eb5f3c103735d7f3274bee8b3d8eb0f0adb35980488c9a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->