### PR TITLE
feat: contain WSL workloads and protect host disk

### DIFF
--- a/config/bash/rc.sh
+++ b/config/bash/rc.sh
@@ -203,14 +203,14 @@ else
   unset RED_SHARE
 fi
 
-# zellij sits between shared and init on purpose: after shared, which
-# exports ZELLIJ_CONFIG_DIR, and before init, whose tool activations are
-# the expensive part and would be paid twice — once by the shell zellij
-# replaces, once by the shell inside the pane.
+# Workload policy sits before zellij and init on purpose. It gives the zellij
+# server its protected control slice, then moves each pane into the bounded work
+# plane before init's expensive tool activations run. The scoped pane starts one
+# replacement shell, marked so this ordering does not recurse.
 # red-skills-watch is last of the sourced parts and after `path`, which
 # is what puts red-dev on PATH: it spawns nothing if the command cannot
 # be found, and finding it is the whole point of running after path.
-for _red_part in path shared zellij init aliases functions prompt red-skills-watch; do
+for _red_part in path shared build-resources zellij init aliases functions prompt red-skills-watch; do
   _red_file="$RED_ROOT/config/bash/${_red_part}.sh"
   if [ -r "$_red_file" ]; then
     # shellcheck disable=SC1090

--- a/config/bash/zellij.sh
+++ b/config/bash/zellij.sh
@@ -95,8 +95,17 @@ fi
 # the prune skip this whole tree.
 _red_zellij_log="${XDG_STATE_HOME:-$HOME/.local/state}/red-dev/zellij/crash-$$.log"
 mkdir -p "${_red_zellij_log%/*}" 2>/dev/null
-RED_IN_ZELLIJ=1 zellij 2>"$_red_zellij_log"
-_red_zellij_status=$?
+if declare -F _red_dev_run_control >/dev/null 2>&1; then
+  RED_IN_ZELLIJ=1 _red_dev_run_control zellij 2>"$_red_zellij_log"
+  _red_zellij_status=$?
+elif [ "${RED_ENV:-server}" = "windows" ]; then
+  RED_IN_ZELLIJ=1 zellij 2>"$_red_zellij_log"
+  _red_zellij_status=$?
+else
+  printf 'red-dev: control-plane guard is unavailable; refusing uncontained zellij\n' \
+    >"$_red_zellij_log"
+  _red_zellij_status=125
+fi
 
 if [ "$_red_zellij_status" -eq 0 ]; then
   rm -f "$_red_zellij_log"

--- a/src/agent-launch.ts
+++ b/src/agent-launch.ts
@@ -28,6 +28,8 @@
 import { AGENTS, npmArgv, type AgentSpec } from "./agents.ts";
 import { isDefaultAgentCandidate, readDefaultAgent, reportDefaultAgent } from "./default-agent.ts";
 import { RedError } from "./log.ts";
+import { detect, type Platform } from "./platform.ts";
+import { workloadPolicy } from "./workload-policy.ts";
 
 /**
  * What a permission bypass looks like across the hosts red-dev
@@ -212,8 +214,8 @@ export function resolveLaunch(
  * UNATTENDED_ENV exists to tell package managers that nobody is
  * watching, and here somebody is.
  */
-export async function runLaunchTarget(target: LaunchTarget): Promise<number> {
-  const child = Bun.spawn(target.argv, {
+export async function runLaunchTarget(target: LaunchTarget, p: Platform = detect()): Promise<number> {
+  const child = Bun.spawn(workloadPolicy().launch("agent", target.argv, p), {
     stdin: "inherit",
     stdout: "inherit",
     stderr: "inherit",

--- a/src/build-resources.test.ts
+++ b/src/build-resources.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, test } from "bun:test";
+import type { Platform } from "./platform.ts";
+import {
+  buildResourcePolicy,
+  assessBuildResources,
+  cargoHomeConfigPlan,
+  renderCargoDefaults,
+  parseWindowsLogicalCpus,
+  parseWindowsPhysicalMemory,
+  hostDiskThresholds,
+  recommendedWslMemoryMiB,
+  recommendedWslProcessors,
+  wslHostConfigPlan,
+} from "./build-resources.ts";
+import { workloadPolicy } from "./workload-policy.ts";
+
+const GIB = 1024 ** 3;
+
+const LINUX_SYSTEMD: Platform = {
+  os: "linux",
+  distro: "ubuntu",
+  version: "24.04",
+  codename: "noble",
+  env: "wsl",
+  arch: "x64",
+  caps: { apt: true, gui: false, systemd: true, winget: true, flatpak: false },
+};
+
+describe("build resource policy", () => {
+  test("bounds this 16 GiB / 12-thread WSL host", () => {
+    expect(buildResourcePolicy({ totalMemoryBytes: 16 * GIB, logicalCpus: 12 })).toEqual({
+      cargoJobs: 4,
+      rustTestThreads: 2,
+      nextestThreads: 4,
+    });
+    // WSL reports slightly less than the configured nominal capacity.
+    expect(buildResourcePolicy({ totalMemoryBytes: 15.5 * GIB, logicalCpus: 12 })).toEqual({
+      cargoJobs: 4,
+      rustTestThreads: 2,
+      nextestThreads: 4,
+    });
+  });
+
+  test("scales down on a small host and stops scaling at safe ceilings", () => {
+    expect(buildResourcePolicy({ totalMemoryBytes: 8 * GIB, logicalCpus: 4 })).toEqual({
+      cargoJobs: 2,
+      rustTestThreads: 1,
+      nextestThreads: 2,
+    });
+    expect(buildResourcePolicy({ totalMemoryBytes: 64 * GIB, logicalCpus: 32 })).toEqual({
+      cargoJobs: 8,
+      rustTestThreads: 4,
+      nextestThreads: 8,
+    });
+  });
+
+  test("renders low-priority Cargo defaults without changing profiles or target dirs", () => {
+    const rendered = renderCargoDefaults({ cargoJobs: 4, rustTestThreads: 2, nextestThreads: 4 });
+    expect(rendered).toContain("[build]");
+    expect(rendered).toContain("jobs = 4");
+    expect(rendered).toContain("RUST_TEST_THREADS = { value = \"2\", force = false }");
+    expect(rendered).not.toMatch(/^target-dir\s*=/m);
+    expect(rendered).not.toMatch(/^incremental\s*=/m);
+    expect(rendered).not.toMatch(/^rustflags\s*=/m);
+  });
+});
+describe("Cargo user layer", () => {
+  test("creates an including config on a fresh machine", () => {
+    const plan = cargoHomeConfigPlan(null);
+    expect(plan.action).toBe("write");
+    expect(plan.content).toContain("../.config/red-dev/cargo.toml");
+    expect(plan.content).toContain('include = ["../.config/red-dev/cargo.toml"]');
+  });
+
+  test("prepends the include while preserving an existing user config", () => {
+    const existing = "[build]\njobs = 7\n";
+    const plan = cargoHomeConfigPlan(existing);
+    expect(plan.action).toBe("write");
+    expect(plan.content).toEndWith(existing);
+    expect(plan.content).toContain("../.config/red-dev/cargo.toml");
+  });
+
+  test("does not rewrite an include graph it cannot safely merge", () => {
+    const existing = "include = [\"company.toml\"]\n";
+    expect(cargoHomeConfigPlan(existing)).toEqual({
+      action: "blocked",
+      content: existing,
+      reason: "Cargo config already declares include; add ../.config/red-dev/cargo.toml to that list",
+    });
+  });
+
+  test("migrates red-dev's newer table include for stable Cargo compatibility", () => {
+    const existing = "# red-dev:build-resources begin\ninclude = [{ path = \"../.config/red-dev/cargo.toml\", optional = true }]\n# red-dev:build-resources end\n";
+    const plan = cargoHomeConfigPlan(existing);
+    expect(plan.action).toBe("write");
+    expect(plan.content).toContain('include = ["../.config/red-dev/cargo.toml"]');
+    expect(plan.content).not.toContain("optional = true");
+  });
+});
+
+describe("workload isolation", () => {
+  test("doctor reports both layers from the same expected bytes", () => {
+    const policy = { cargoJobs: 5, rustTestThreads: 2, nextestThreads: 5 };
+    const isolation = workloadPolicy({ totalMemoryBytes: 20 * GIB, logicalCpus: 10 });
+    expect(assessBuildResources(LINUX_SYSTEMD, policy, {
+      cargoDefaults: renderCargoDefaults(policy),
+      cargoHome: "include = [{ path = \"../.config/red-dev/cargo.toml\", optional = true }]\n",
+      workloadShell: isolation.shell,
+      diskGuardian: isolation.diskGuardian,
+      systemd: Object.entries(isolation.systemd).map(([path, content]) => ({ path, content })),
+      totalMemoryBytes: 20 * GIB,
+      logicalCpus: 10,
+      windowsLogicalCpus: 12,
+      wslConfig: "[wsl2]\nmemory=19660MB\nprocessors=10\nswap=4GB\nmaxCrashDumpCount=1\n[experimental]\nautoMemoryReclaim=dropCache\n",
+      windowsPhysicalMemoryBytes: 32 * GIB,
+      hostDiskGuard: {
+        totalKiB: 900 * 1024 ** 2,
+        freeKiB: 35 * 1024 ** 2,
+        timerEnabled: true,
+        timerActive: true,
+        serviceResult: "success",
+        serviceExitStatus: 0,
+        buildFreezerState: "running",
+        agentFreezerState: "running",
+        frozenMarker: null,
+        lastEvent: "at=2026-08-25T10:00:00Z action=thawed reason=host-disk-recovered",
+      },
+    })).toEqual([
+      { name: "Cargo resources", status: "ok", detail: "5 compiler job(s), 2 libtest thread(s)" },
+      { name: "workload isolation", status: "ok", detail: "dynamic 80% wall (16G memory, 800% CPU); protected Zellij and bounded panes, agents and builds" },
+      { name: "host disk guard", status: "ok", detail: "35 GiB free; 72 GiB build reserve (admission blocked); 20 GiB freeze / 30 GiB resume; timer enabled/active; workloads running; last event action=thawed reason=host-disk-recovered" },
+      { name: "WSL host resources", status: "ok", detail: "60% host RAM, CPU headroom, 4 GiB swap, one retained crash dump, cache reclaim" },
+    ]);
+  });
+
+  test("doctor reports a disabled disk guardian as drift", () => {
+    const policy = { cargoJobs: 5, rustTestThreads: 2, nextestThreads: 5 };
+    const isolation = workloadPolicy({ totalMemoryBytes: 20 * GIB, logicalCpus: 10 });
+    const findings = assessBuildResources(LINUX_SYSTEMD, policy, {
+      cargoDefaults: renderCargoDefaults(policy),
+      cargoHome: `include = ["../.config/red-dev/cargo.toml"]\n`,
+      workloadShell: isolation.shell,
+      diskGuardian: isolation.diskGuardian,
+      systemd: Object.entries(isolation.systemd).map(([path, content]) => ({ path, content })),
+      totalMemoryBytes: 20 * GIB,
+      logicalCpus: 10,
+      hostDiskGuard: {
+        totalKiB: 900 * 1024 ** 2,
+        freeKiB: 100 * 1024 ** 2,
+        timerEnabled: false,
+        timerActive: false,
+        serviceResult: "success",
+        serviceExitStatus: 0,
+        buildFreezerState: "running",
+        agentFreezerState: "running",
+        frozenMarker: null,
+        lastEvent: null,
+      },
+    });
+
+    expect(findings).toContainEqual({
+      name: "host disk guard",
+      status: "drift",
+      detail: "disk guardian timer is disabled/inactive",
+      fix: "red-dev install core",
+    });
+  });
+});
+
+test("host disk thresholds share the admission reserve and guardian hysteresis", () => {
+  expect(hostDiskThresholds(900 * 1024 ** 2)).toEqual({
+    reserveKiB: 72 * 1024 ** 2,
+    floorKiB: 20 * 1024 ** 2,
+    resumeKiB: 30 * 1024 ** 2,
+  });
+});
+
+describe("WSL host config", () => {
+  test("derives 60% of physical RAM in whole MiB", () => {
+    expect(parseWindowsPhysicalMemory("34279841792\r\n")).toBe(34279841792);
+    expect(parseWindowsPhysicalMemory("not memory")).toBeNull();
+    expect(recommendedWslMemoryMiB(34279841792)).toBe(19615);
+    expect(parseWindowsLogicalCpus("12\r\n")).toBe(12);
+    expect(parseWindowsLogicalCpus("not cpus")).toBeNull();
+  });
+
+  test("leaves two logical CPUs for Windows and preserves operator values", () => {
+    expect(recommendedWslProcessors(12)).toBe(10);
+    const existing = "[wsl2]\nmemory=16GB\nswap=6GB\n\n[experimental]\nnetworkingMode=mirrored\n";
+    const plan = wslHostConfigPlan(existing, 12, 34279841792);
+    expect(plan.action).toBe("write");
+    expect(plan.content).toContain("memory=19615MB");
+    expect(plan.content).toContain("swap=6GB");
+    expect(plan.content).toContain("processors=10");
+    expect(plan.content).toContain("maxCrashDumpCount=1");
+    expect(plan.content).toContain("networkingMode=mirrored");
+    expect(plan.content).toContain("autoMemoryReclaim=dropCache");
+  });
+
+  test("does not touch an ambiguous duplicate-section file", () => {
+    expect(wslHostConfigPlan("[wsl2]\nswap=4GB\n[wsl2]\nmemory=8GB\n", 8).action).toBe("blocked");
+  });
+});

--- a/src/build-resources.ts
+++ b/src/build-resources.ts
@@ -1,0 +1,726 @@
+import { totalmem } from "node:os";
+import { chmodSync, existsSync, mkdirSync } from "node:fs";
+import { log } from "./log.ts";
+import type { Platform } from "./platform.ts";
+import { localPath } from "./shared-root.ts";
+import { powershellBin, windowsUserProfile } from "./wsl.ts";
+import {
+  hostDiskThresholds,
+  workloadLogicalCpuCount,
+  workloadPolicy,
+} from "./workload-policy.ts";
+
+const file = Bun.file;
+const spawn = Bun.spawn;
+const write = Bun.write;
+const readStreamText = async (stream: ReadableStream<Uint8Array> | null): Promise<string> =>
+  stream === null ? "" : await new Response(stream).text();
+
+export { hostDiskThresholds } from "./workload-policy.ts";
+
+const GIB = 1024 ** 3;
+const MIB = 1024 ** 2;
+const CARGO_INCLUDE = "../.config/red-dev/cargo.toml";
+const CARGO_INCLUDE_MARKER = "# red-dev:build-resources begin";
+const CARGO_INCLUDE_LINE = `include = ["${CARGO_INCLUDE}"]`;
+
+export interface BuildResourcePolicy {
+  /** Maximum concurrent rustc processes. */
+  cargoJobs: number;
+  /** Standard libtest concurrency. */
+  rustTestThreads: number;
+  /** Recommended nextest process pool; repositories may override it. */
+  nextestThreads: number;
+}
+
+/**
+ * A memory-first default for compilation and test execution. PURE.
+ *
+ * Rust compilation commonly has several large rustc/linker processes alive at
+ * once, so logical CPUs are an unsafe default on a development workstation.
+ * One compile slot per 4 GiB and one libtest thread per 8 GiB leave room for
+ * the editor and coding agent. The ceilings keep a large host useful without
+ * turning one build into the machine's only tenant.
+ */
+export function buildResourcePolicy(input: {
+  totalMemoryBytes: number;
+  logicalCpus: number;
+}): BuildResourcePolicy {
+  // Hypervisors reserve a small amount, so a configured 16 GiB guest reports
+  // roughly 15.5 GiB. Round to the nominal capacity before deriving slots.
+  const memoryGiB = Math.max(1, Math.round(input.totalMemoryBytes / GIB));
+  const cpus = Math.max(1, Math.floor(input.logicalCpus));
+  const cpuHalf = Math.max(1, Math.floor(cpus / 2));
+  const cargoJobs = Math.max(1, Math.min(8, cpuHalf, Math.max(1, Math.floor(memoryGiB / 4))));
+  const rustTestThreads = Math.max(
+    1,
+    Math.min(4, cargoJobs, Math.max(1, Math.floor(memoryGiB / 8))),
+  );
+  return { cargoJobs, rustTestThreads, nextestThreads: cargoJobs };
+}
+
+/** The low-priority Cargo layer; repository config and the user's env win. */
+export function renderCargoDefaults(policy: BuildResourcePolicy): string {
+  return `# Managed by red-dev. Loaded from ~/.cargo/config.toml at Cargo's
+# lowest (home) precedence; a repository's .cargo/config.toml wins.
+# Do not put target-dir, incremental or rustflags here: those are project policy.
+
+[build]
+jobs = ${policy.cargoJobs}
+
+[env]
+# libtest still recognises this compatibility variable. An explicitly exported
+# value wins because force=false; projects may also override it in deeper config.
+RUST_TEST_THREADS = { value = "${policy.rustTestThreads}", force = false }
+`;
+}
+
+export type CargoHomeConfigPlan =
+  | { action: "write"; content: string }
+  | { action: "current"; content: string }
+  | { action: "blocked"; content: string; reason: string };
+
+/**
+ * Put red-dev below the person's Cargo config without parsing or rewriting it.
+ *
+ * Cargo merges includes first and the including file second, so values already
+ * in ~/.cargo/config.toml keep the last word. A pre-existing include graph is
+ * left alone because inserting into arbitrary TOML arrays without a parser is
+ * not an ownership-safe edit.
+ */
+export function cargoHomeConfigPlan(existing: string | null): CargoHomeConfigPlan {
+  if (existing?.includes(CARGO_INCLUDE_MARKER)) {
+    // Cargo releases before table-form includes accept strings only. Migrate
+    // the short-lived red-dev table form in place; this is our marked block.
+    const migrated = existing.replace(
+      /^include\s*=\s*\[\{\s*path\s*=\s*"\.\.\/\.config\/red-dev\/cargo\.toml"[^\n]*$/m,
+      CARGO_INCLUDE_LINE,
+    );
+    return migrated === existing
+      ? { action: "current", content: existing }
+      : { action: "write", content: migrated };
+  }
+  if (existing?.includes(CARGO_INCLUDE)) {
+    return { action: "current", content: existing };
+  }
+  if (existing !== null && /^\s*include\s*=/m.test(existing)) {
+    return {
+      action: "blocked",
+      content: existing,
+      reason: `Cargo config already declares include; add ${CARGO_INCLUDE} to that list`,
+    };
+  }
+
+  const block = `${CARGO_INCLUDE_MARKER}
+# Your settings in this file are merged afterwards and therefore win.
+${CARGO_INCLUDE_LINE}
+# red-dev:build-resources end
+
+`;
+  if (existing === null) return { action: "write", content: block };
+  if (existing.startsWith("\uFEFF")) {
+    return { action: "write", content: `\uFEFF${block}${existing.slice(1)}` };
+  }
+  return { action: "write", content: block + existing };
+}
+
+export type WslHostConfigPlan =
+  | { action: "write"; content: string; added: string[] }
+  | { action: "current"; content: string; added: string[] }
+  | { action: "blocked"; content: string; added: string[]; reason: string };
+
+export function recommendedWslProcessors(logicalCpus: number): number {
+  const cpus = Math.max(1, Math.floor(logicalCpus));
+  return cpus <= 2 ? cpus : cpus - 2;
+}
+
+export function parseWindowsPhysicalMemory(value: string): number | null {
+  const trimmed = value.trim();
+  if (!/^\d+$/.test(trimmed)) return null;
+  const bytes = Number(trimmed);
+  return Number.isSafeInteger(bytes) && bytes > 0 ? bytes : null;
+}
+
+export function parseWindowsLogicalCpus(value: string): number | null {
+  const trimmed = value.trim();
+  if (!/^\d+$/.test(trimmed)) return null;
+  const count = Number(trimmed);
+  return Number.isSafeInteger(count) && count > 0 ? count : null;
+}
+
+/** WSL receives 60% of physical RAM, rounded down to an integral MiB. */
+export function recommendedWslMemoryMiB(physicalMemoryBytes: number): number {
+  return Math.max(1024, Math.floor((physicalMemoryBytes * 60) / 100 / MIB));
+}
+
+async function windowsPhysicalMemoryBytes(): Promise<number | null> {
+  const proc = spawn([
+    powershellBin(),
+    "-NoProfile",
+    "-NonInteractive",
+    "-Command",
+    "[int64](Get-CimInstance Win32_ComputerSystem).TotalPhysicalMemory",
+  ], { stdin: "ignore", stdout: "pipe", stderr: "ignore" });
+  const output = await readStreamText(proc.stdout);
+  return (await proc.exited) === 0 ? parseWindowsPhysicalMemory(output) : null;
+}
+
+async function windowsLogicalCpuCount(): Promise<number | null> {
+  const proc = spawn([
+    powershellBin(),
+    "-NoProfile",
+    "-NonInteractive",
+    "-Command",
+    "[int](Get-CimInstance Win32_ComputerSystem).NumberOfLogicalProcessors",
+  ], { stdin: "ignore", stdout: "pipe", stderr: "ignore" });
+  const output = await readStreamText(proc.stdout);
+  return (await proc.exited) === 0 ? parseWindowsLogicalCpus(output) : null;
+}
+
+async function commandOutput(argv: readonly string[]): Promise<{ code: number; output: string } | null> {
+  try {
+    const proc = spawn([...argv], { stdin: "ignore", stdout: "pipe", stderr: "ignore" });
+    const output = await readStreamText(proc.stdout);
+    return { code: await proc.exited, output: output.trim() };
+  } catch {
+    return null;
+  }
+}
+
+export function parseHostDiskDf(output: string): { totalKiB: number; freeKiB: number } | null {
+  const line = output.trim().split(/\r?\n/).at(-1)?.trim() ?? "";
+  const fields = line.split(/\s+/);
+  const totalKiB = Number(fields[1]);
+  const freeKiB = Number(fields[3]);
+  if (
+    fields.length < 6 || !Number.isSafeInteger(totalKiB) || totalKiB <= 0 ||
+    !Number.isSafeInteger(freeKiB) || freeKiB < 0
+  ) return null;
+  return { totalKiB, freeKiB };
+}
+
+/** Preserve unrelated WSL settings while enforcing the workstation memory cap. PURE. */
+export function wslHostConfigPlan(
+  existing: string | null,
+  logicalCpus: number,
+  physicalMemoryBytes?: number,
+): WslHostConfigPlan {
+  let content = existing ?? "";
+  content = content
+    .split("# Added by red-dev; existing operator values are never replaced.")
+    .join("# Added by red-dev; unrelated operator values are preserved.");
+  const added: string[] = [];
+  const duplicate = (name: string): boolean => {
+    const matches = content.match(new RegExp(`^\\s*\\[${name}\\]\\s*$`, "gim"));
+    return (matches?.length ?? 0) > 1;
+  };
+  if (duplicate("wsl2") || duplicate("experimental")) {
+    return {
+      action: "blocked",
+      content,
+      added: [],
+      reason: ".wslconfig declares a section more than once; red-dev left it untouched",
+    };
+  }
+
+  const ensure = (section: string, entries: Readonly<Record<string, string>>): void => {
+    const lines = content.replace(/\r\n/g, "\n").split("\n");
+    const start = lines.findIndex((line) =>
+      line.trim().toLowerCase() === `[${section.toLowerCase()}]`
+    );
+    if (start < 0) {
+      const suffix = content.trimEnd();
+      const body = Object.entries(entries).map(([key, value]) => `${key}=${value}`);
+      content = `${suffix}${suffix ? "\n\n" : ""}[${section}]\n${body.join("\n")}\n`;
+      added.push(...Object.keys(entries).map((key) => `${section}.${key}`));
+      return;
+    }
+    let end = lines.findIndex((line, index) => index > start && /^\s*\[.+\]\s*$/.test(line));
+    if (end < 0) end = lines.length;
+    const present = new Set(
+      lines.slice(start + 1, end).flatMap((line) => {
+        const match = /^\s*([A-Za-z][A-Za-z0-9]*)\s*=/.exec(line);
+        return match?.[1] ? [match[1].toLowerCase()] : [];
+      }),
+    );
+    const missing = Object.entries(entries).filter(([key]) => !present.has(key.toLowerCase()));
+    if (missing.length === 0) return;
+    const inserted = [
+      "# Added by red-dev; unrelated operator values are preserved.",
+      ...missing.map(([key, value]) => `${key}=${value}`),
+    ];
+    content = `${[...lines.slice(0, end), ...inserted, ...lines.slice(end)].join("\n").trimEnd()}\n`;
+    added.push(...missing.map(([key]) => `${section}.${key}`));
+  };
+
+  const memory = physicalMemoryBytes === undefined
+    ? undefined
+    : `${recommendedWslMemoryMiB(physicalMemoryBytes)}MB`;
+  if (memory !== undefined && /^\s*memory\s*=/im.test(content)) {
+    const current = /^\s*memory\s*=\s*([^\r\n#;]+)/im.exec(content)?.[1]?.trim();
+    if (current !== memory) {
+      content = content.replace(/^(\s*memory\s*=\s*)[^\r\n#;]+/im, `$1${memory}`);
+      added.push("wsl2.memory");
+    }
+  }
+
+  const wsl2: Record<string, string> = {};
+  if (memory !== undefined) wsl2["memory"] = memory;
+  wsl2["processors"] = String(recommendedWslProcessors(logicalCpus));
+  wsl2["swap"] = "4GB";
+  wsl2["maxCrashDumpCount"] = "1";
+  ensure("wsl2", wsl2);
+  ensure("experimental", { autoMemoryReclaim: "dropCache" });
+  return added.length === 0
+    ? { action: "current", content, added: [] }
+    : { action: "write", content, added };
+}
+
+function userHome(): string {
+  const value = process.env["HOME"] ?? process.env["USERPROFILE"];
+  if (!value) throw new Error("neither HOME nor USERPROFILE is set");
+  return value.replace(/\\/g, "/");
+}
+
+async function writeIfChanged(path: string, content: string): Promise<boolean> {
+  if (existsSync(path) && (await file(path).text()) === content) return false;
+  await write(path, content);
+  return true;
+}
+
+export interface BuildResourceFinding {
+  name: string;
+  status: "ok" | "drift" | "n/a";
+  detail: string;
+  fix?: string;
+}
+
+export interface HostDiskGuardObservation {
+  totalKiB: number | null;
+  freeKiB: number | null;
+  timerEnabled: boolean | null;
+  timerActive: boolean | null;
+  serviceResult: string | null;
+  serviceExitStatus: number | null;
+  buildFreezerState: string | null;
+  agentFreezerState: string | null;
+  frozenMarker: string | null;
+  lastEvent: string | null;
+}
+
+export interface BuildResourceObservation {
+  cargoDefaults: string | null;
+  cargoHome: string | null;
+  workloadShell: string | null;
+  diskGuardian?: string | null;
+  systemd: readonly { path: string; content: string | null }[];
+  totalMemoryBytes: number;
+  logicalCpus: number;
+  windowsLogicalCpus?: number | null;
+  wslConfig?: string | null;
+  windowsPhysicalMemoryBytes?: number | null;
+  hostDiskGuard?: HostDiskGuardObservation;
+}
+
+function guardianEventSummary(value: string | null): string {
+  if (value === null || value.trim() === "") return "none";
+  return value.trim().split(/\s+/)
+    .filter((part) => !part.startsWith("at=") && !part.startsWith("free_kib="))
+    .join(" ");
+}
+
+function assessHostDiskGuard(observed: HostDiskGuardObservation | undefined): BuildResourceFinding {
+  if (observed === undefined) {
+    return {
+      name: "host disk guard",
+      status: "drift",
+      detail: "disk guardian state is unavailable",
+      fix: "red-dev install core",
+    };
+  }
+  if (observed.timerEnabled !== true || observed.timerActive !== true) {
+    return {
+      name: "host disk guard",
+      status: "drift",
+      detail: "disk guardian timer is disabled/inactive",
+      fix: "red-dev install core",
+    };
+  }
+  if (observed.serviceResult !== "success" || observed.serviceExitStatus !== 0) {
+    return {
+      name: "host disk guard",
+      status: "drift",
+      detail: `last guardian run failed (${observed.serviceResult ?? "unknown"}/` +
+        `${observed.serviceExitStatus ?? "unknown"})`,
+      fix: "systemctl --user status red-dev-disk-guardian.service",
+    };
+  }
+  if (observed.totalKiB === null || observed.freeKiB === null) {
+    return {
+      name: "host disk guard",
+      status: "drift",
+      detail: "Windows host disk capacity cannot be measured",
+      fix: "df -Pk /mnt/c",
+    };
+  }
+
+  const thresholds = hostDiskThresholds(observed.totalKiB);
+  const buildsFrozen = observed.buildFreezerState === "frozen";
+  const agentsFrozen = observed.agentFreezerState === "frozen";
+  const bothFrozen = buildsFrozen && agentsFrozen;
+  const bothRunning = observed.buildFreezerState === "running" &&
+    observed.agentFreezerState === "running";
+  const markedFrozen = observed.frozenMarker !== null;
+  const shouldBeFrozen = observed.freeKiB < thresholds.floorKiB ||
+    (observed.freeKiB < thresholds.resumeKiB && markedFrozen);
+  if (
+    (shouldBeFrozen && (!markedFrozen || !bothFrozen)) ||
+    (!shouldBeFrozen && (markedFrozen || !bothRunning))
+  ) {
+    return {
+      name: "host disk guard",
+      status: "drift",
+      detail: "guardian marker, disk threshold and cgroup freezer state disagree",
+      fix: "systemctl --user start red-dev-disk-guardian.service",
+    };
+  }
+
+  const gib = (kib: number): number => Math.floor(kib / 1024 ** 2);
+  const admission = observed.freeKiB < thresholds.reserveKiB
+    ? "admission blocked"
+    : "admission open";
+  return {
+    name: "host disk guard",
+    status: "ok",
+    detail: `${gib(observed.freeKiB)} GiB free; ${gib(thresholds.reserveKiB)} GiB build reserve ` +
+      `(${admission}); ${gib(thresholds.floorKiB)} GiB freeze / ` +
+      `${gib(thresholds.resumeKiB)} GiB resume; timer enabled/active; ` +
+      `workloads ${bothFrozen ? "frozen" : "running"}; last event ` +
+      guardianEventSummary(observed.lastEvent),
+  };
+}
+
+/** Turn file observations into the two operator-facing resource verdicts. PURE. */
+export function assessBuildResources(
+  p: Platform,
+  policy: BuildResourcePolicy,
+  observed: BuildResourceObservation,
+): BuildResourceFinding[] {
+  if (p.os !== "linux") {
+    return [{ name: "build resources", status: "n/a", detail: "owned by the Linux/WSL side" }];
+  }
+
+  const cargoCurrent =
+    observed.cargoDefaults === renderCargoDefaults(policy) &&
+    observed.cargoHome?.includes(CARGO_INCLUDE) === true;
+  const findings: BuildResourceFinding[] = [
+    cargoCurrent
+      ? {
+          name: "Cargo resources",
+          status: "ok",
+          detail: `${policy.cargoJobs} compiler job(s), ${policy.rustTestThreads} libtest thread(s)`,
+        }
+      : {
+          name: "Cargo resources",
+          status: "drift",
+          detail: "the low-priority Cargo resource layer is absent or stale",
+          fix: "red-dev install core",
+        },
+  ];
+
+  if (!p.caps.systemd) {
+    findings.push({
+      name: "heavy workload slice",
+      status: "n/a",
+      detail: "this Linux host has no systemd user manager",
+    });
+    return findings;
+  }
+
+  const isolation = workloadPolicy({
+    totalMemoryBytes: observed.totalMemoryBytes,
+    logicalCpus: observed.logicalCpus,
+  });
+  const sliceCurrent =
+    observed.workloadShell === isolation.shell &&
+    observed.diskGuardian === isolation.diskGuardian &&
+    Object.entries(isolation.systemd).every(([path, content]) =>
+      observed.systemd.some((entry) => entry.path === path && entry.content === content)
+    );
+  findings.push(
+    sliceCurrent
+      ? {
+          name: "workload isolation",
+          status: "ok",
+          detail:
+            `dynamic 80% wall (${isolation.capacity.memoryMax} memory, ` +
+            `${isolation.capacity.cpuQuota} CPU); protected Zellij and bounded panes, agents and builds`,
+        }
+      : {
+          name: "workload isolation",
+          status: "drift",
+          detail: "the aggregate cgroup or one of its workload attachments is absent or stale",
+          fix: "red-dev install core",
+        },
+  );
+  if (p.env === "wsl") {
+    findings.push(assessHostDiskGuard(observed.hostDiskGuard));
+    const hostPlan = wslHostConfigPlan(
+      observed.wslConfig ?? null,
+      observed.windowsLogicalCpus ?? observed.logicalCpus,
+      observed.windowsPhysicalMemoryBytes ?? undefined,
+    );
+    findings.push(
+      hostPlan.action === "current"
+        ? {
+            name: "WSL host resources",
+            status: "ok",
+            detail: "60% host RAM, CPU headroom, 4 GiB swap, one retained crash dump, cache reclaim",
+          }
+        : {
+            name: "WSL host resources",
+            status: "drift",
+            detail: hostPlan.action === "blocked" ? hostPlan.reason : ".wslconfig is missing safe resource defaults",
+            fix: "red-dev install core, then from PowerShell: wsl --shutdown",
+          },
+    );
+  }
+  return findings;
+}
+
+async function resourceObservation(home: string, p: Platform): Promise<BuildResourceObservation> {
+  const read = async (path: string): Promise<string | null> =>
+    existsSync(path) ? await file(path).text() : null;
+  const systemd = `${home}/.config/systemd/user`;
+  const totalMemoryBytes = totalmem();
+  const logicalCpus = workloadLogicalCpuCount();
+  const isolation = workloadPolicy({ totalMemoryBytes, logicalCpus });
+  const systemdFiles = await Promise.all(
+    Object.keys(isolation.systemd).map(async (path) => ({
+      path,
+      content: await read(`${systemd}/${path}`),
+    })),
+  );
+  let wslConfig: string | null | undefined;
+  let physicalMemoryBytes: number | null | undefined;
+  let windowsLogicalCpus: number | null | undefined;
+  let hostDiskGuard: HostDiskGuardObservation | undefined;
+  if (p.env === "wsl") {
+    try {
+      wslConfig = await read(`${localPath(await windowsUserProfile(), "wsl")}/.wslconfig`);
+    } catch {
+      wslConfig = null;
+    }
+    try {
+      physicalMemoryBytes = await windowsPhysicalMemoryBytes();
+    } catch {
+      physicalMemoryBytes = null;
+    }
+    try {
+      windowsLogicalCpus = await windowsLogicalCpuCount();
+    } catch {
+      windowsLogicalCpus = null;
+    }
+    const [
+      disk,
+      timerEnabled,
+      timerActive,
+      serviceResult,
+      serviceExitStatus,
+      buildFreezerState,
+      agentFreezerState,
+    ] = await Promise.all([
+      commandOutput(["df", "-Pk", "/mnt/c"]),
+      commandOutput(["systemctl", "--user", "is-enabled", "red-dev-disk-guardian.timer"]),
+      commandOutput(["systemctl", "--user", "is-active", "red-dev-disk-guardian.timer"]),
+      commandOutput(["systemctl", "--user", "show", "red-dev-disk-guardian.service", "-p", "Result", "--value"]),
+      commandOutput(["systemctl", "--user", "show", "red-dev-disk-guardian.service", "-p", "ExecMainStatus", "--value"]),
+      commandOutput(["systemctl", "--user", "show", "red-dev-heavy-builds.slice", "-p", "FreezerState", "--value"]),
+      commandOutput(["systemctl", "--user", "show", "red-dev-heavy-agents.slice", "-p", "FreezerState", "--value"]),
+    ]);
+    const diskUsage = disk?.code === 0 ? parseHostDiskDf(disk.output) : null;
+    const exitStatus = serviceExitStatus?.output ?? "";
+    hostDiskGuard = {
+      totalKiB: diskUsage?.totalKiB ?? null,
+      freeKiB: diskUsage?.freeKiB ?? null,
+      timerEnabled: timerEnabled === null ? null : timerEnabled.output === "enabled",
+      timerActive: timerActive === null ? null : timerActive.output === "active",
+      serviceResult: serviceResult?.output || null,
+      serviceExitStatus: /^\d+$/.test(exitStatus) ? Number(exitStatus) : null,
+      buildFreezerState: buildFreezerState?.output || null,
+      agentFreezerState: agentFreezerState?.output || null,
+      frozenMarker: await read(`${home}/.local/state/red-dev/disk-guardian-frozen`),
+      lastEvent: await read(`${home}/.local/state/red-dev/disk-guardian-last`),
+    };
+  }
+  return {
+    cargoDefaults: await read(`${home}/.config/red-dev/cargo.toml`),
+    cargoHome: await read(`${home}/.cargo/config.toml`),
+    workloadShell: await read(`${home}/.local/share/red-dev/config/bash/build-resources.sh`),
+    diskGuardian: await read(`${home}/.local/share/red-dev/bin/disk-guardian.sh`),
+    systemd: systemdFiles,
+    totalMemoryBytes,
+    logicalCpus,
+    ...(windowsLogicalCpus === undefined ? {} : { windowsLogicalCpus }),
+    ...(wslConfig === undefined ? {} : { wslConfig }),
+    ...(physicalMemoryBytes === undefined ? {} : { windowsPhysicalMemoryBytes: physicalMemoryBytes }),
+    ...(hostDiskGuard === undefined ? {} : { hostDiskGuard }),
+  };
+}
+
+/** Read-only posture used by doctor. */
+export async function inspectBuildResources(p: Platform): Promise<BuildResourceFinding[]> {
+  const policy = buildResourcePolicy({
+    totalMemoryBytes: totalmem(),
+    logicalCpus: workloadLogicalCpuCount(),
+  });
+  return assessBuildResources(p, policy, await resourceObservation(userHome(), p));
+}
+
+async function convergeWslHostResources(p: Platform, logicalCpus: number): Promise<void> {
+  if (p.env !== "wsl") return;
+  let windowsHome: string;
+  try {
+    windowsHome = localPath(await windowsUserProfile(), "wsl");
+  } catch {
+    log.warn("could not locate the Windows profile; .wslconfig resource defaults were not changed");
+    return;
+  }
+  const path = `${windowsHome}/.wslconfig`;
+  const existing = existsSync(path) ? await file(path).text() : null;
+  const physicalMemoryBytes = await windowsPhysicalMemoryBytes();
+  const windowsCpus = await windowsLogicalCpuCount();
+  if (physicalMemoryBytes === null) {
+    log.warn("could not read Windows physical memory; the WSL memory cap was not changed");
+  }
+  const plan = wslHostConfigPlan(
+    existing,
+    windowsCpus ?? logicalCpus,
+    physicalMemoryBytes ?? undefined,
+  );
+  if (plan.action === "blocked") {
+    log.warn(plan.reason);
+    return;
+  }
+  if (plan.action === "current") {
+    log.skip("WSL host resource defaults already current");
+    return;
+  }
+  if (existing !== null) {
+    const backup = `${path}.red-dev-backup`;
+    if (!existsSync(backup)) await write(backup, existing);
+  }
+  await write(path, plan.content);
+  log.ok(`WSL host defaults added: ${plan.added.join(", ")}`);
+  log.plain("       they take effect after the next `wsl --shutdown`; red-dev does not stop live sessions");
+}
+
+async function reloadUserUnits(): Promise<boolean> {
+  const child = spawn(["systemctl", "--user", "daemon-reload"], {
+    stdin: "ignore",
+    stdout: "ignore",
+    stderr: "ignore",
+  });
+  return (await child.exited) === 0;
+}
+
+async function enableDiskGuardianTimer(): Promise<boolean> {
+  const child = spawn([
+    "systemctl", "--user", "enable", "--now", "red-dev-disk-guardian.timer",
+  ], {
+    stdin: "ignore",
+    stdout: "ignore",
+    stderr: "ignore",
+  });
+  return (await child.exited) === 0;
+}
+
+/**
+ * Converge the host's safe build defaults and Linux cgroup hierarchy.
+ *
+ * Existing workloads are deliberately not restarted or moved. New shells use
+ * the shipped wrappers, and new redskilled Workers match the prefix drop-in.
+ */
+export async function convergeBuildResources(
+  p: Platform,
+  facts: { totalMemoryBytes?: number; logicalCpus?: number } = {},
+): Promise<void> {
+  if (p.os !== "linux") {
+    log.skip("build resources are managed inside Linux/WSL");
+    return;
+  }
+
+  const home = userHome();
+  const totalMemoryBytes = facts.totalMemoryBytes ?? totalmem();
+  const logicalCpus = facts.logicalCpus ?? workloadLogicalCpuCount();
+  const policy = buildResourcePolicy({
+    totalMemoryBytes,
+    logicalCpus,
+  });
+  const isolation = workloadPolicy({ totalMemoryBytes, logicalCpus });
+  const managedDir = `${home}/.config/red-dev`;
+  const cargoDir = `${home}/.cargo`;
+  mkdirSync(managedDir, { recursive: true });
+  mkdirSync(cargoDir, { recursive: true });
+
+  const managedCargo = `${managedDir}/cargo.toml`;
+  const cargoChanged = await writeIfChanged(managedCargo, renderCargoDefaults(policy));
+  const cargoHome = `${cargoDir}/config.toml`;
+  const existing = existsSync(cargoHome) ? await file(cargoHome).text() : null;
+  const cargoPlan = cargoHomeConfigPlan(existing);
+  if (cargoPlan.action === "blocked") {
+    log.warn(cargoPlan.reason);
+    log.plain(`       managed defaults are ready at ${managedCargo}`);
+  } else if (cargoPlan.action === "write") {
+    if (existing !== null) {
+      const backup = `${cargoHome}.red-dev-backup`;
+      if (!existsSync(backup)) await write(backup, existing);
+    }
+    await write(cargoHome, cargoPlan.content);
+    log.ok(`Cargo bounded to ${policy.cargoJobs} compiler job(s), ${policy.rustTestThreads} libtest thread(s)`);
+  } else if (cargoChanged) {
+    log.ok(`Cargo defaults updated: ${policy.cargoJobs} compiler job(s), ${policy.rustTestThreads} libtest thread(s)`);
+  } else {
+    log.skip(`Cargo resources already bounded (${policy.cargoJobs} build / ${policy.rustTestThreads} test)`);
+  }
+
+  await convergeWslHostResources(p, logicalCpus);
+
+  if (!p.caps.systemd) {
+    log.warn("aggregate memory containment unavailable: this Linux host has no systemd user manager");
+    return;
+  }
+
+  const systemd = `${home}/.config/systemd/user`;
+  const units = Object.entries(isolation.systemd).map(([path, content]) =>
+    [`${systemd}/${path}`, content] as const
+  );
+  const guardianDir = `${home}/.local/share/red-dev/bin`;
+  const guardianPath = `${guardianDir}/disk-guardian.sh`;
+  mkdirSync(guardianDir, { recursive: true });
+  const guardianChanged = await writeIfChanged(guardianPath, isolation.diskGuardian);
+  chmodSync(guardianPath, 0o755);
+
+  let changed = guardianChanged ? 1 : 0;
+  for (const [path, content] of units) {
+    mkdirSync(path.slice(0, path.lastIndexOf("/")), { recursive: true });
+    if (await writeIfChanged(path, content)) changed++;
+  }
+  if (!(await reloadUserUnits())) {
+    log.warn("build resource files were written, but the systemd user manager did not reload them");
+    return;
+  }
+  if (!(await enableDiskGuardianTimer())) {
+    log.warn("disk guardian was installed, but its timer could not be enabled");
+    return;
+  }
+  if (changed > 0) {
+    log.ok("Zellij, panes, agents and builds now use separate cgroup budgets");
+    log.plain(
+      `       red-dev is capped at 80%: ${isolation.capacity.memoryMax} memory and ` +
+        `${isolation.capacity.cpuQuota} CPU`,
+    );
+  } else {
+    log.skip("heavy workload slice already current");
+  }
+}

--- a/src/dotfiles.ts
+++ b/src/dotfiles.ts
@@ -36,6 +36,7 @@ import redSkillsWatchSh from "../config/bash/red-skills-watch.sh" with { type: "
 import windowsClipboardSh from "../config/bash/windows-clipboard.sh" with { type: "text" };
 import inputrc from "../config/bash/inputrc.conf" with { type: "text" };
 import zellijBase from "../config/zellij/config.kdl" with { type: "text" };
+import { workloadPolicy } from "./workload-policy.ts";
 
 /** Exported so `doctor` can compare what is deployed against what this
  * binary would deploy — an upgraded red-dev with stale files on disk is
@@ -46,6 +47,7 @@ export const FILES: Record<string, string> = {
   "init.sh": initSh,
   "aliases.sh": aliasesSh,
   "functions.sh": functionsSh,
+  "build-resources.sh": workloadPolicy().shell,
   "prompt.sh": promptSh,
   "shared.sh": sharedSh,
   "zellij.sh": zellijSh,

--- a/src/drift.ts
+++ b/src/drift.ts
@@ -579,6 +579,8 @@ export async function collectDrift(p: Platform): Promise<DriftCheck[]> {
   checks.push(await checkDocker(p));
   checks.push(await checkToolchainParity(p));
   checks.push(await checkBlesh());
+  const { inspectBuildResources } = await import("./build-resources.ts");
+  checks.push(...(await inspectBuildResources(p)));
   checks.push(await checkSharedRoot(p));
   checks.push(await checkHotkeys(p));
   checks.push(await checkPrivilegedWork(p));

--- a/src/local-overrides.test.ts
+++ b/src/local-overrides.test.ts
@@ -23,7 +23,7 @@ describe("rc.sh sources the override files", () => {
     // Sourced before them, every alias here would be replaced by the
     // generated aliases.sh a moment later — present in the file and
     // absent from the shell, which is the worst of both.
-    const loop = rc.indexOf("for _red_part in path shared zellij");
+    const loop = rc.indexOf("for _red_part in path shared build-resources zellij");
     const mine = rc.indexOf("for _red_mine in");
     expect(loop).toBeGreaterThan(-1);
     expect(mine).toBeGreaterThan(loop);

--- a/src/main.ts
+++ b/src/main.ts
@@ -2196,7 +2196,7 @@ async function cmdAgentsRun(p: Platform, passthrough: string[]): Promise<number>
   }
 
   try {
-    return await runLaunchTarget(decision.target);
+    return await runLaunchTarget(decision.target, p);
   } catch {
     log.err(`${decision.target.label} could not be started: ${decision.target.executable}`);
     return 1;

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -179,6 +179,7 @@ type ProviderSpec =
         | "wsl-interop"
         | "wsl-runtime-dir"
         | "blesh"
+        | "build-resources"
         | "runtimes"
         | "shared-root"
         | "hotkeys"
@@ -409,6 +410,7 @@ const builtin = (
     | "wsl-runtime-dir"
     | "wsl-sync"
     | "blesh"
+    | "build-resources"
     | "runtimes"
     | "shared-root"
     | "hotkeys"
@@ -836,6 +838,13 @@ export const TOOLS: Tool[] = [
     managed: true,
     u24: builtin("runtimes"),
     win: builtin("runtimes"),
+  },
+  {
+    name: "build-resources",
+    scope: "core",
+    managed: true,
+    u24: builtin("build-resources"),
+    win: skip("build resource containment is managed inside Linux/WSL"),
   },
   {
     // On by default; RED_BLE=0 opts out. See the note in src/blesh.ts

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -1686,6 +1686,7 @@ const BUILTIN_INTENT: Partial<Record<BuiltinName, string>> = {
   "wsl-interop": "checking that Windows binaries are reachable from inside the distro",
   "wsl-runtime-dir": "making sure XDG_RUNTIME_DIR exists and is owned by this user",
   blesh: "building and installing ble.sh, the bash line editor",
+  "build-resources": "bounding Cargo/Rust parallelism and heavy-workload memory",
   runtimes: "installing language runtimes through mise",
   "shared-root": "creating the shared workspace root and its permissions",
   hotkeys: "registering the Windows hotkeys",
@@ -1766,6 +1767,11 @@ export async function applyProvider(pr: Provider, ctx: ApplyContext): Promise<vo
       if (pr.name === "runtimes") {
         const { installRuntimes } = await import("./runtimes.ts");
         await installRuntimes(ctx.platform);
+        return;
+      }
+      if (pr.name === "build-resources") {
+        const { convergeBuildResources } = await import("./build-resources.ts");
+        await convergeBuildResources(ctx.platform);
         return;
       }
       if (pr.name === "alacritty") {

--- a/src/workload-policy.test.ts
+++ b/src/workload-policy.test.ts
@@ -1,0 +1,533 @@
+import { describe, expect, test } from "bun:test";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { FILES } from "./dotfiles.ts";
+import type { Platform } from "./platform.ts";
+import { workloadPolicy } from "./workload-policy.ts";
+
+const LINUX_SYSTEMD: Platform = {
+  os: "linux",
+  distro: "ubuntu",
+  version: "24.04",
+  codename: "noble",
+  env: "wsl",
+  arch: "x64",
+  caps: { apt: true, gui: false, systemd: true, winget: true, flatpak: false },
+};
+const WORKSTATION = { totalMemoryBytes: 20 * 1024 ** 3, logicalCpus: 10 };
+
+describe("workload policy", () => {
+  test("keeps Zellij protected while every ordinary pane enters the bounded work plane", async () => {
+    const policy = workloadPolicy(WORKSTATION);
+
+    expect(policy.systemd["red-dev-interactive.slice"]).toContain("MemoryLow=2G");
+    expect(policy.systemd["red-dev-heavy-panes.slice"]).toContain("MemoryMax=6G");
+    const paneLaunch = policy.launch("pane", ["bash"], LINUX_SYSTEMD);
+    expect(paneLaunch.slice(0, 6)).toEqual([
+      "systemd-run", "--user", "--scope", "--quiet", "--collect",
+      "--slice=red-dev-heavy-panes.slice",
+    ]);
+    expect(paneLaunch).toContain("--property=MemoryMax=3G");
+    expect(paneLaunch.slice(-3)).toEqual(["red-dev-heavy-panes.slice", "pane", "bash"]);
+    expect(paneLaunch[paneLaunch.indexOf("-c") + 1]).toContain("cat /proc/self/cgroup");
+    if (process.platform === "win32") return;
+
+    const dir = mkdtempSync(`${tmpdir()}/red-dev-workload-policy-`);
+    const runtime = `${dir}/run`;
+    const bin = `${dir}/bin`;
+    mkdirSync(`${runtime}/systemd`, { recursive: true });
+    mkdirSync(bin);
+    const manager = Bun.listen({
+      unix: `${runtime}/systemd/private`,
+      socket: { data() {} },
+    });
+    try {
+      const systemdRun = `${bin}/systemd-run`;
+      writeFileSync(systemdRun, '#!/bin/sh\nprintf "SCOPE %s\\n" "$*"\nexit 73\n');
+      chmodSync(systemdRun, 0o755);
+      const shell = `${dir}/workload.sh`;
+      writeFileSync(shell, policy.shell);
+      const proc = Bun.spawn(["bash", "--noprofile", "--norc", "-c", `source "${shell}"; echo CONTINUED`], {
+        env: {
+          ...process.env,
+          PATH: `${bin}:${process.env.PATH ?? ""}`,
+          RED_ENV: "wsl",
+          ZELLIJ: "0",
+          RED_DEV_PANE_SCOPED: "",
+          XDG_RUNTIME_DIR: runtime,
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exit] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+        proc.exited,
+      ]);
+      expect(exit).toBe(73);
+      expect(stdout).toContain("--slice=red-dev-heavy-panes.slice");
+      expect(stdout).toContain("red-dev-workload-guard red-dev-heavy-panes.slice pane bash");
+      expect(stdout).not.toContain("CONTINUED");
+      expect(stderr).toContain("pane resource guard failed");
+    } finally {
+      manager.stop(true);
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("routes agents and builds through the same aggregate work budget", () => {
+    const policy = workloadPolicy(WORKSTATION);
+
+    expect(policy.systemd["red-dev-heavy-agents.slice"]).toContain("MemoryMax=8G");
+    expect(policy.systemd["red-dev-heavy-builds.slice"]).toContain("CPUWeight=50");
+    const agentLaunch = policy.launch("agent", ["redcode", "--yolo"], LINUX_SYSTEMD);
+    expect(agentLaunch).toContain("--slice=red-dev-heavy-agents.slice");
+    expect(agentLaunch).toContain("--property=MemoryMax=5G");
+    expect(agentLaunch.slice(-4)).toEqual([
+      "red-dev-heavy-agents.slice", "agent", "redcode", "--yolo",
+    ]);
+    const buildLaunch = policy.launch("build", ["cargo", "test"], LINUX_SYSTEMD);
+    expect(buildLaunch).toContain("--slice=red-dev-heavy-builds.slice");
+    expect(buildLaunch).toContain("--property=MemoryMax=8G");
+    expect(buildLaunch.slice(-7)).toEqual([
+      "red-dev-heavy-builds.slice", "build", "nice", "-n", "10", "cargo", "test",
+    ]);
+  });
+
+  test("scales every domain under an 80 percent host wall", () => {
+    const small = workloadPolicy({ totalMemoryBytes: 20 * 1024 ** 3, logicalCpus: 10 });
+    expect(small.systemd["red-dev.slice"]).toContain("MemoryMax=16G");
+    expect(small.systemd["red-dev.slice"]).toContain("CPUQuota=800%");
+    expect(small.systemd["red-dev-heavy.slice"]).toContain("MemoryMax=13G");
+    expect(small.launch("pane", ["bash"], LINUX_SYSTEMD)).toContain(
+      "--property=MemoryMax=3G",
+    );
+
+    const large = workloadPolicy({ totalMemoryBytes: 40 * 1024 ** 3, logicalCpus: 20 });
+    expect(large.systemd["red-dev.slice"]).toContain("MemoryMax=32G");
+    expect(large.systemd["red-dev.slice"]).toContain("CPUQuota=1600%");
+    expect(large.launch("agent", ["redcode"], LINUX_SYSTEMD)).toContain(
+      "--property=MemoryMax=10G",
+    );
+    expect(large.launch("build", ["cargo"], LINUX_SYSTEMD)).toContain(
+      "--property=MemoryMax=16G",
+    );
+  });
+
+  test("attaches the control daemon and every Worker to the generated domains", () => {
+    const policy = workloadPolicy(WORKSTATION);
+
+    expect(policy.systemd["redskilled.service.d/50-red-dev-heavy-slice.conf"]).toBe(
+      "# Managed by red-dev.\n[Service]\nSlice=red-dev-interactive.slice\n",
+    );
+    expect(policy.systemd["red-worker-.service.d/50-red-dev-heavy-slice.conf"]).toContain(
+      "Slice=red-dev-heavy-agents.slice\nCPUQuota=250%",
+    );
+    expect(policy.systemd["red-worker-.service.d/50-red-dev-heavy-slice.conf"]).toContain(
+      "MemoryMax=5G",
+    );
+    expect(policy.systemd["red-fleet-.scope.d/50-red-dev-heavy-slice.conf"]).toBe(
+      "# Managed by red-dev.\n[Scope]\nSlice=red-dev-heavy-agents.slice\n",
+    );
+  });
+
+  test("freezes only agent and build domains when the Windows host disk reaches the critical floor", async () => {
+    if (process.platform === "win32") return;
+    const policy = workloadPolicy(WORKSTATION);
+    const dir = mkdtempSync(`${tmpdir()}/red-dev-disk-guardian-`);
+    const bin = `${dir}/bin`;
+    const calls = `${dir}/systemctl.calls`;
+    mkdirSync(bin);
+    try {
+      writeFileSync(
+        `${bin}/df`,
+        "#!/bin/sh\nprintf 'Filesystem 1024-blocks Used Available Capacity Mounted on\\n'\nprintf 'C: 1000000000 985000000 15000000 99%% /mnt/c\\n'\n",
+      );
+      writeFileSync(
+        `${bin}/systemctl`,
+        `#!/bin/sh\nprintf '%s\\n' "$*" >>"${calls}"\n`,
+      );
+      chmodSync(`${bin}/df`, 0o755);
+      chmodSync(`${bin}/systemctl`, 0o755);
+      const guardian = `${dir}/disk-guardian.sh`;
+      writeFileSync(guardian, policy.diskGuardian);
+
+      const proc = Bun.spawn(["/bin/sh", guardian], {
+        env: {
+          ...process.env,
+          PATH: `${bin}:${process.env.PATH ?? ""}`,
+          XDG_STATE_HOME: `${dir}/state`,
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      expect(await proc.exited).toBe(0);
+      const invocation = await Bun.file(calls).text();
+      expect(invocation).toContain(
+        "--user freeze red-dev-heavy-builds.slice red-dev-heavy-agents.slice",
+      );
+      expect(invocation).not.toContain("freeze red-dev-heavy.slice");
+      expect(await Bun.file(`${dir}/state/red-dev/disk-guardian-last`).text()).toContain(
+        "action=frozen reason=host-disk-critical",
+      );
+      expect(await Bun.file(`${dir}/state/red-dev/workloads.log`).text()).toContain(
+        "kind=disk-guardian result=frozen reason=host-disk-critical",
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("freezes fail closed when the Windows host disk cannot be measured", async () => {
+    if (process.platform === "win32") return;
+    const dir = mkdtempSync(`${tmpdir()}/red-dev-disk-guardian-unknown-`);
+    const bin = `${dir}/bin`;
+    const calls = `${dir}/systemctl.calls`;
+    mkdirSync(bin);
+    try {
+      writeFileSync(`${bin}/df`, "#!/bin/sh\nexit 1\n");
+      writeFileSync(`${bin}/systemctl`, `#!/bin/sh\nprintf '%s\\n' "$*" >>"${calls}"\n`);
+      chmodSync(`${bin}/df`, 0o755);
+      chmodSync(`${bin}/systemctl`, 0o755);
+      const guardian = `${dir}/disk-guardian.sh`;
+      writeFileSync(guardian, workloadPolicy(WORKSTATION).diskGuardian);
+
+      const proc = Bun.spawn(["/bin/sh", guardian], {
+        env: {
+          ...process.env,
+          PATH: `${bin}:${process.env.PATH ?? ""}`,
+          XDG_STATE_HOME: `${dir}/state`,
+        },
+      });
+      expect(await proc.exited).toBe(0);
+      expect(await Bun.file(calls).text()).toContain(
+        "--user freeze red-dev-heavy-builds.slice red-dev-heavy-agents.slice",
+      );
+      expect(await Bun.file(`${dir}/state/red-dev/disk-guardian-frozen`).text()).toContain(
+        "reason=host-disk-unavailable",
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("returns 125 instead of claiming success when cgroups cannot be frozen", async () => {
+    if (process.platform === "win32") return;
+    const dir = mkdtempSync(`${tmpdir()}/red-dev-disk-guardian-freeze-failure-`);
+    const bin = `${dir}/bin`;
+    mkdirSync(bin);
+    try {
+      writeFileSync(
+        `${bin}/df`,
+        "#!/bin/sh\nprintf 'Filesystem 1024-blocks Used Available Capacity Mounted on\\n'\nprintf 'C: 1000000000 985000000 15000000 99%% /mnt/c\\n'\n",
+      );
+      writeFileSync(`${bin}/systemctl`, "#!/bin/sh\nexit 1\n");
+      chmodSync(`${bin}/df`, 0o755);
+      chmodSync(`${bin}/systemctl`, 0o755);
+      const guardian = `${dir}/disk-guardian.sh`;
+      writeFileSync(guardian, workloadPolicy(WORKSTATION).diskGuardian);
+
+      const proc = Bun.spawn(["/bin/sh", guardian], {
+        env: {
+          ...process.env,
+          PATH: `${bin}:${process.env.PATH ?? ""}`,
+          XDG_STATE_HOME: `${dir}/state`,
+        },
+      });
+      expect(await proc.exited).toBe(125);
+      expect(await Bun.file(`${dir}/state/red-dev/disk-guardian-frozen`).exists()).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("thaws guarded workloads after the Windows host disk recovers", async () => {
+    if (process.platform === "win32") return;
+    const policy = workloadPolicy(WORKSTATION);
+    const dir = mkdtempSync(`${tmpdir()}/red-dev-disk-guardian-recovery-`);
+    const bin = `${dir}/bin`;
+    const state = `${dir}/state/red-dev`;
+    const calls = `${dir}/systemctl.calls`;
+    mkdirSync(bin, { recursive: true });
+    mkdirSync(state, { recursive: true });
+    writeFileSync(`${state}/disk-guardian-frozen`, "frozen\n");
+    try {
+      writeFileSync(
+        `${bin}/df`,
+        "#!/bin/sh\nprintf 'Filesystem 1024-blocks Used Available Capacity Mounted on\\n'\nprintf 'C: 1000000000 900000000 100000000 90%% /mnt/c\\n'\n",
+      );
+      writeFileSync(
+        `${bin}/systemctl`,
+        `#!/bin/sh\nprintf '%s\\n' "$*" >>"${calls}"\n`,
+      );
+      chmodSync(`${bin}/df`, 0o755);
+      chmodSync(`${bin}/systemctl`, 0o755);
+      const guardian = `${dir}/disk-guardian.sh`;
+      writeFileSync(guardian, policy.diskGuardian);
+
+      const proc = Bun.spawn(["/bin/sh", guardian], {
+        env: {
+          ...process.env,
+          PATH: `${bin}:${process.env.PATH ?? ""}`,
+          XDG_STATE_HOME: `${dir}/state`,
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      expect(await proc.exited).toBe(0);
+      expect(await Bun.file(calls).exists()).toBe(true);
+      expect(await Bun.file(calls).text()).toContain(
+        "--user thaw red-dev-heavy-builds.slice red-dev-heavy-agents.slice",
+      );
+      expect(await Bun.file(`${state}/disk-guardian-frozen`).exists()).toBe(false);
+      expect(await Bun.file(`${state}/disk-guardian-last`).text()).toContain(
+        "action=thawed reason=host-disk-recovered",
+      );
+      expect(await Bun.file(`${state}/workloads.log`).text()).toContain(
+        "kind=disk-guardian result=thawed reason=host-disk-recovered",
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("installs shell launchers from that same policy", async () => {
+    if (process.platform === "win32") return;
+    const policy = workloadPolicy(WORKSTATION);
+    const dir = mkdtempSync(`${tmpdir()}/red-dev-workload-shell-`);
+    const runtime = `${dir}/run`;
+    const bin = `${dir}/bin`;
+    mkdirSync(`${runtime}/systemd`, { recursive: true });
+    mkdirSync(bin);
+    const manager = Bun.listen({
+      unix: `${runtime}/systemd/private`,
+      socket: { data() {} },
+    });
+    try {
+      for (const command of ["cargo", "redcode"]) {
+        writeFileSync(`${bin}/${command}`, "#!/bin/sh\nexit 0\n");
+        chmodSync(`${bin}/${command}`, 0o755);
+      }
+      writeFileSync(
+        `${bin}/df`,
+        "#!/bin/sh\nprintf 'Filesystem 1024-blocks Used Available Capacity Mounted on\\n'\nprintf 'C: 1000000000 800000000 200000000 80%% /mnt/c\\n'\n",
+      );
+      chmodSync(`${bin}/df`, 0o755);
+      writeFileSync(`${bin}/systemd-run`, '#!/bin/sh\nprintf "SCOPE %s\\n" "$*"\n');
+      chmodSync(`${bin}/systemd-run`, 0o755);
+      const shell = `${dir}/workload.sh`;
+      writeFileSync(shell, policy.shell);
+      const proc = Bun.spawn([
+        "bash",
+        "--noprofile",
+        "--norc",
+        "-c",
+        `source "${shell}"; redcode ask; cargo test`,
+      ], {
+        env: {
+          ...process.env,
+          PATH: `${bin}:${process.env.PATH ?? ""}`,
+          RED_ENV: "wsl",
+          ZELLIJ: "",
+          XDG_RUNTIME_DIR: runtime,
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exit] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+        proc.exited,
+      ]);
+      expect(exit).toBe(0);
+      expect(stderr).toBe("");
+      expect(stdout).toContain("--slice=red-dev-heavy-agents.slice");
+      expect(stdout).toContain("--property=MemoryMax=5G --property=MemorySwapMax=128M");
+      expect(stdout).toContain("red-dev-heavy-agents.slice agent redcode ask");
+      expect(stdout).toContain("--slice=red-dev-heavy-builds.slice");
+      expect(stdout).toContain("--property=MemoryMax=8G --property=MemorySwapMax=128M");
+      expect(stdout).toContain("red-dev-heavy-builds.slice build nice -n 10 cargo test");
+    } finally {
+      manager.stop(true);
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("preserves spaces and glob characters in wrapped command arguments", async () => {
+    if (process.platform === "win32") return;
+    const dir = mkdtempSync(`${tmpdir()}/red-dev-workload-argv-`);
+    const bin = `${dir}/bin`;
+    mkdirSync(bin);
+    writeFileSync(`${bin}/cargo`, '#!/bin/sh\nprintf "ARG=<%s>\\n" "$@"\n');
+    chmodSync(`${bin}/cargo`, 0o755);
+    const shell = `${dir}/workload.sh`;
+    writeFileSync(shell, workloadPolicy(WORKSTATION).shell);
+    try {
+      const proc = Bun.spawn([
+        "bash",
+        "--noprofile",
+        "--norc",
+        "-c",
+        `source "${shell}"; cargo "two words" "*.ts"`,
+      ], {
+        env: { ...process.env, PATH: `${bin}:${process.env.PATH ?? ""}`, RED_ENV: "windows" },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exit] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+        proc.exited,
+      ]);
+      expect(exit).toBe(0);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("ARG=<two words>\nARG=<*.ts>\n");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("refuses a WSL build before the Windows host disk crosses its reserve", async () => {
+    if (process.platform === "win32") return;
+    const dir = mkdtempSync(`${tmpdir()}/red-dev-workload-disk-`);
+    const runtime = `${dir}/run`;
+    const bin = `${dir}/bin`;
+    const marker = `${dir}/executed`;
+    mkdirSync(`${runtime}/systemd`, { recursive: true });
+    mkdirSync(bin);
+    const manager = Bun.listen({
+      unix: `${runtime}/systemd/private`,
+      socket: { data() {} },
+    });
+    try {
+      writeFileSync(
+        `${bin}/df`,
+        "#!/bin/sh\nprintf 'Filesystem 1024-blocks Used Available Capacity Mounted on\\n'\nprintf 'C: 1000000000 970000000 30000000 97%% /mnt/c\\n'\n",
+      );
+      writeFileSync(`${bin}/cargo`, `#!/bin/sh\ntouch "${marker}"\n`);
+      writeFileSync(
+        `${bin}/systemd-run`,
+        '#!/bin/sh\nwhile [ "$1" != "--" ]; do shift; done\nshift\nexec "$@"\n',
+      );
+      for (const command of ["df", "cargo", "systemd-run"]) {
+        chmodSync(`${bin}/${command}`, 0o755);
+      }
+      const shell = `${dir}/workload.sh`;
+      writeFileSync(shell, workloadPolicy(WORKSTATION).shell);
+
+      const proc = Bun.spawn([
+        "/bin/bash", "--noprofile", "--norc", "-c", `source "${shell}"; cargo test`,
+      ], {
+        env: {
+          ...process.env,
+          HOME: dir,
+          PATH: `${bin}:${process.env.PATH ?? ""}`,
+          RED_ENV: "wsl",
+          XDG_RUNTIME_DIR: runtime,
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      expect(await proc.exited).toBe(125);
+      expect(await new Response(proc.stderr).text()).toContain(
+        "Windows host disk reserve",
+      );
+      expect(await Bun.file(marker).exists()).toBe(false);
+    } finally {
+      manager.stop(true);
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("refuses Linux workloads when containment is unavailable or cannot be proven", async () => {
+    if (process.platform === "win32") return;
+    const dir = mkdtempSync(`${tmpdir()}/red-dev-workload-refusal-`);
+    const runtime = `${dir}/run`;
+    const bin = `${dir}/bin`;
+    const state = `${dir}/state`;
+    mkdirSync(`${runtime}/systemd`, { recursive: true });
+    mkdirSync(bin);
+    const marker = `${dir}/executed`;
+    const shell = `${dir}/workload.sh`;
+    writeFileSync(shell, workloadPolicy(WORKSTATION).shell);
+    writeFileSync(`${bin}/cargo`, `#!/bin/sh\ntouch "${marker}"\n`);
+    chmodSync(`${bin}/cargo`, 0o755);
+
+    try {
+      const unavailable = Bun.spawn([
+        "/bin/bash", "--noprofile", "--norc", "-c", `source "${shell}"; cargo test`,
+      ], {
+        env: {
+          HOME: dir,
+          PATH: bin,
+          RED_ENV: "server",
+          XDG_RUNTIME_DIR: `${dir}/missing`,
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      expect(await unavailable.exited).toBe(125);
+      expect(await new Response(unavailable.stderr).text()).toContain(
+        "refusing uncontained build workload",
+      );
+      expect(await Bun.file(marker).exists()).toBe(false);
+
+      const manager = Bun.listen({
+        unix: `${runtime}/systemd/private`,
+        socket: { data() {} },
+      });
+      try {
+        writeFileSync(
+          `${bin}/systemd-run`,
+          '#!/bin/sh\nwhile [ "$1" != "--" ]; do shift; done\nshift\nexec "$@"\n',
+        );
+        chmodSync(`${bin}/systemd-run`, 0o755);
+        const wrongGroup = Bun.spawn([
+          "/bin/bash", "--noprofile", "--norc", "-c", `source "${shell}"; cargo test`,
+        ], {
+          env: {
+            ...process.env,
+            HOME: dir,
+            PATH: `${bin}:${process.env.PATH ?? ""}`,
+            RED_ENV: "server",
+            XDG_RUNTIME_DIR: runtime,
+            XDG_STATE_HOME: state,
+          },
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        expect(await wrongGroup.exited).toBe(125);
+        expect(await new Response(wrongGroup.stderr).text()).toContain(
+          "entered the wrong cgroup",
+        );
+        expect(await Bun.file(marker).exists()).toBe(false);
+        expect(await Bun.file(`${state}/red-dev/workloads.log`).text()).toContain(
+          "result=refused",
+        );
+      } finally {
+        manager.stop(true);
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("deploys the policy before Zellij and uses it to launch the protected server", () => {
+    const policy = workloadPolicy();
+
+    expect(FILES["build-resources.sh"]).toBe(policy.shell);
+    expect(FILES["rc.sh"]).toContain(
+      "for _red_part in path shared build-resources zellij init aliases functions prompt red-skills-watch",
+    );
+    expect(FILES["zellij.sh"]).toContain("_red_dev_run_control zellij");
+    expect(FILES["zellij.sh"]).toContain("refusing uncontained zellij");
+    expect(FILES["zellij.sh"]).not.toContain("--slice=red-dev-interactive.slice");
+    expect(policy.diskGuardian).toContain("systemctl --user freeze");
+    expect(policy.systemd["red-dev-disk-guardian.service"]).toContain(
+      "Slice=red-dev-interactive.slice",
+    );
+    expect(policy.systemd["red-dev-disk-guardian.timer"]).toContain(
+      "OnUnitActiveSec=10s",
+    );
+  });
+});

--- a/src/workload-policy.ts
+++ b/src/workload-policy.ts
@@ -1,0 +1,568 @@
+import { readFileSync } from "node:fs";
+import { totalmem } from "node:os";
+import type { Platform } from "./platform.ts";
+
+const GIB = 1024 ** 3;
+const MIB = 1024 ** 2;
+const GIB_KIB = 1024 ** 2;
+const DOCUMENTATION = "https://github.com/reddb-io/red-dev";
+const HOST_DISK_RESERVE_GIB = 60;
+const HOST_DISK_RESERVE_PERCENT = 8;
+const HOST_DISK_FLOOR_GIB = 20;
+const HOST_DISK_FLOOR_PERCENT = 2;
+const HOST_DISK_RESUME_GIB = 30;
+const HOST_DISK_RESUME_PERCENT = 3;
+
+export type WorkloadKind = "control" | "pane" | "agent" | "build";
+
+export interface WorkloadPolicyFacts {
+  totalMemoryBytes: number;
+  logicalCpus: number;
+}
+export interface HostDiskThresholds {
+  reserveKiB: number;
+  floorKiB: number;
+  resumeKiB: number;
+}
+
+/** Build admission and circuit-breaker thresholds derived from the same policy. PURE. */
+export function hostDiskThresholds(totalKiB: number): HostDiskThresholds {
+  const total = Number.isFinite(totalKiB) && totalKiB > 0 ? Math.floor(totalKiB) : 0;
+  return {
+    reserveKiB: Math.max(
+      HOST_DISK_RESERVE_GIB * GIB_KIB,
+      Math.floor(total * HOST_DISK_RESERVE_PERCENT / 100),
+    ),
+    floorKiB: Math.max(
+      HOST_DISK_FLOOR_GIB * GIB_KIB,
+      Math.floor(total * HOST_DISK_FLOOR_PERCENT / 100),
+    ),
+    resumeKiB: Math.max(
+      HOST_DISK_RESUME_GIB * GIB_KIB,
+      Math.floor(total * HOST_DISK_RESUME_PERCENT / 100),
+    ),
+  };
+}
+
+interface ResourceDomain {
+  slice: string;
+  description: string;
+  aggregate: Readonly<Record<string, string>>;
+  scope?: Readonly<Record<string, string>>;
+  commandPrefix?: readonly string[];
+}
+
+interface ResourceDomains {
+  root: ResourceDomain;
+  control: ResourceDomain;
+  work: ResourceDomain;
+  pane: ResourceDomain;
+  agent: ResourceDomain;
+  build: ResourceDomain;
+}
+
+const AGENT_COMMANDS = "claude codex opencode redcode gemini pi hermes muse";
+const BUILD_COMMANDS = "cargo rustc cmake ctest make ninja gcc g++ clang clang++ bun pnpm npm";
+
+export function workloadLogicalCpuCount(): number {
+  try {
+    let count = 0;
+    for (const line of readFileSync("/proc/cpuinfo", "utf8").split("\n")) {
+      if (/^processor\s*:/.test(line)) count++;
+    }
+    if (count > 0) return count;
+  } catch {
+    // Native Windows has no /proc; its process environment carries this.
+  }
+  const reported = Number(process.env["NUMBER_OF_PROCESSORS"] ?? "1");
+  return Number.isFinite(reported) && reported > 0 ? Math.floor(reported) : 1;
+}
+
+function formatMiB(value: number): string {
+  return value % 1024 === 0 ? `${value / 1024}G` : `${value}M`;
+}
+
+function resourceDomains(facts: WorkloadPolicyFacts): ResourceDomains {
+  const totalMiB = Math.max(1024, Math.floor(facts.totalMemoryBytes / MIB));
+  const nominalGiB = Math.max(1, Math.round(facts.totalMemoryBytes / GIB));
+  const cpus = Math.max(1, Math.floor(facts.logicalCpus));
+  const rootMemory = (fraction: number): string =>
+    formatMiB(Math.max(512, Math.floor(totalMiB * fraction)));
+  const memory = (fraction: number, rounding: "ceil" | "floor" = "ceil"): string => {
+    const amount = rounding === "ceil"
+      ? Math.ceil(nominalGiB * fraction)
+      : Math.floor(nominalGiB * fraction);
+    return `${Math.max(1, amount)}G`;
+  };
+  const cpu = (fraction: number): string =>
+    `${Math.max(1, Math.floor(cpus * 100 * fraction))}%`;
+
+  return {
+    root: {
+      slice: "red-dev.slice",
+      description: "red-dev global workstation budget",
+      aggregate: {
+        MemoryHigh: rootMemory(0.7),
+        MemoryMax: rootMemory(0.8),
+        MemorySwapMax: "512M",
+        TasksMax: "12288",
+        CPUQuota: cpu(0.8),
+        CPUWeight: "100",
+        IOWeight: "100",
+      },
+    },
+    control: {
+      slice: "red-dev-interactive.slice",
+      description: "red-dev protected interactive control plane",
+      aggregate: {
+        MemoryLow: memory(0.1),
+        MemoryHigh: memory(0.15),
+        MemoryMax: memory(0.2),
+        MemorySwapMax: "0",
+        TasksMax: "2048",
+        CPUWeight: "1000",
+        IOWeight: "1000",
+      },
+    },
+    work: {
+      slice: "red-dev-heavy.slice",
+      description: "red-dev bounded development work plane",
+      aggregate: {
+        MemoryHigh: memory(0.55, "floor"),
+        MemoryMax: memory(0.65, "floor"),
+        MemorySwapMax: "512M",
+        TasksMax: "8192",
+        CPUQuota: cpu(0.7),
+        CPUWeight: "50",
+        IOWeight: "50",
+      },
+    },
+    pane: {
+      slice: "red-dev-heavy-panes.slice",
+      description: "red-dev interactive pane workloads",
+      aggregate: {
+        MemoryHigh: memory(0.2),
+        MemoryMax: memory(0.3),
+        MemorySwapMax: "0",
+        TasksMax: "4096",
+        CPUQuota: cpu(0.5),
+        CPUWeight: "100",
+        IOWeight: "100",
+      },
+      scope: {
+        CPUQuota: cpu(0.3),
+        CPUWeight: "100",
+        IOWeight: "100",
+        MemoryHigh: memory(0.1),
+        MemoryMax: memory(0.15),
+        MemorySwapMax: "0",
+        TasksMax: "2048",
+        OOMPolicy: "continue",
+      },
+    },
+    agent: {
+      slice: "red-dev-heavy-agents.slice",
+      description: "red-dev coding agents",
+      aggregate: {
+        MemoryHigh: memory(0.3),
+        MemoryMax: memory(0.4),
+        MemorySwapMax: "256M",
+        TasksMax: "4096",
+        CPUQuota: cpu(0.5),
+        CPUWeight: "200",
+        IOWeight: "100",
+      },
+      scope: {
+        CPUQuota: cpu(0.25),
+        CPUWeight: "200",
+        IOWeight: "100",
+        MemoryHigh: memory(0.2),
+        MemoryMax: memory(0.25),
+        MemorySwapMax: "128M",
+        TasksMax: "2048",
+        OOMPolicy: "continue",
+      },
+    },
+    build: {
+      slice: "red-dev-heavy-builds.slice",
+      description: "red-dev builds and tests",
+      aggregate: {
+        MemoryHigh: memory(0.3),
+        MemoryMax: memory(0.4),
+        MemorySwapMax: "256M",
+        TasksMax: "4096",
+        CPUQuota: cpu(0.5),
+        CPUWeight: "50",
+        IOWeight: "25",
+      },
+      scope: {
+        CPUQuota: cpu(0.5),
+        CPUWeight: "50",
+        IOWeight: "25",
+        MemoryHigh: memory(0.25),
+        MemoryMax: memory(0.4),
+        MemorySwapMax: "128M",
+        TasksMax: "2048",
+        OOMPolicy: "continue",
+      },
+      commandPrefix: ["nice", "-n", "10"],
+    },
+  };
+}
+
+function renderSlice(domain: ResourceDomain): string {
+  const properties = Object.entries(domain.aggregate).map(([key, value]) => `${key}=${value}`);
+  return `[Unit]
+Description=${domain.description}
+Documentation=${DOCUMENTATION}
+
+[Slice]
+${properties.join("\n")}
+`;
+}
+
+function renderAttachment(
+  section: "Service" | "Scope",
+  domain: ResourceDomain,
+  includeScopeLimits: boolean,
+): string {
+  const limits = includeScopeLimits
+    ? Object.entries(domain.scope ?? {}).map(([key, value]) => `${key}=${value}`)
+    : [];
+  return `# Managed by red-dev.
+[${section}]
+Slice=${domain.slice}
+${limits.length > 0 ? `${limits.join("\n")}\n` : ""}`;
+}
+
+const SCOPE_GUARD = `expected_slice=$1
+kind=$2
+shift 2
+if ! red_dev_cgroup=$(cat /proc/self/cgroup 2>/dev/null); then
+  printf 'red-dev: cannot verify %s workload cgroup; refusing launch\n' "$kind" >&2
+  exit 125
+fi
+case "$red_dev_cgroup" in
+  *"/$expected_slice/"*|*"/$expected_slice") red_dev_result=accepted ;;
+  *)
+    printf 'red-dev: %s workload entered the wrong cgroup; expected %s, got %s\n' \
+      "$kind" "$expected_slice" "$red_dev_cgroup" >&2
+    red_dev_result=refused
+    ;;
+esac
+red_dev_path=\${red_dev_cgroup#*::}
+red_dev_unit=\${red_dev_path##*/}
+red_dev_workload_id=\${red_dev_unit%.scope}
+red_dev_state=\${XDG_STATE_HOME:-$HOME/.local/state}/red-dev
+if mkdir -p "$red_dev_state" 2>/dev/null; then
+  printf 'at=%s workload_id=%s pid=%s kind=%s unit=%s result=%s cgroup=%s\n' \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$red_dev_workload_id" "$$" "$kind" \
+    "$red_dev_unit" "$red_dev_result" "$red_dev_cgroup" \
+    >>"$red_dev_state/workloads.log" 2>/dev/null || true
+fi
+if [ "$red_dev_result" != accepted ]; then exit 125; fi
+exec "$@"`;
+
+function shellQuote(value: string): string {
+  return /^[A-Za-z0-9_./:=+%@,-]+$/.test(value)
+    ? value
+    : `'${value.split("'").join(`'"'"'`)}'`;
+}
+
+function scopeArgv(kind: WorkloadKind, domain: ResourceDomain, argv: readonly string[]): string[] {
+  const properties = Object.entries(domain.scope ?? {}).map(([key, value]) =>
+    `--property=${key}=${value}`
+  );
+  return [
+    "systemd-run", "--user", "--scope", "--quiet", "--collect",
+    `--slice=${domain.slice}`,
+    ...properties,
+    "--",
+    "sh",
+    "-c",
+    SCOPE_GUARD,
+    "red-dev-workload-guard",
+    domain.slice,
+    kind,
+    ...(domain.commandPrefix ?? []),
+    ...argv,
+  ];
+}
+
+function renderShell(domains: ResourceDomains): string {
+  const command = (kind: WorkloadKind, domain: ResourceDomain): string =>
+    scopeArgv(kind, domain, []).map(shellQuote).join(" ");
+  return `# Managed by red-dev. Generated from the Workload Policy.
+# Zellij, ordinary panes, agents and builds each enter the resource domain
+# declared in one policy. Workloads do not run when containment cannot be proven.
+
+_red_dev_systemd_ready() {
+  [ "\${RED_ENV:-server}" != "windows" ] &&
+    command -v systemd-run >/dev/null 2>&1 &&
+    { [ -S "/run/user/$(id -u)/systemd/private" ] ||
+      { [ -n "\${XDG_RUNTIME_DIR:-}" ] && [ -S "$XDG_RUNTIME_DIR/systemd/private" ]; }; }
+}
+
+_red_dev_guard_unavailable() {
+  printf 'red-dev: user systemd is unavailable; refusing uncontained %s workload\n' "$1" >&2
+  return 125
+}
+
+_red_dev_host_disk_ready() {
+  [ "\${RED_ENV:-server}" = "wsl" ] || return 0
+  _red_dev_disk_line=$(command df -Pk /mnt/c 2>/dev/null | command tail -n 1) ||
+    _red_dev_disk_line=
+  set -- $_red_dev_disk_line
+  _red_dev_disk_total_kib=\${2:-}
+  _red_dev_disk_free_kib=\${4:-}
+  case "$_red_dev_disk_total_kib:$_red_dev_disk_free_kib" in
+    *[!0-9:]*|:*|*:)
+      printf 'red-dev: cannot verify Windows host disk reserve; refusing build\n' >&2
+      return 125
+      ;;
+  esac
+  _red_dev_disk_reserve_kib=$((${HOST_DISK_RESERVE_GIB} * 1024 * 1024))
+  _red_dev_disk_percent_kib=$((_red_dev_disk_total_kib * ${HOST_DISK_RESERVE_PERCENT} / 100))
+  if [ "$_red_dev_disk_percent_kib" -gt "$_red_dev_disk_reserve_kib" ]; then
+    _red_dev_disk_reserve_kib=$_red_dev_disk_percent_kib
+  fi
+  if [ "$_red_dev_disk_free_kib" -lt "$_red_dev_disk_reserve_kib" ]; then
+    printf 'red-dev: Windows host disk reserve reached: %s GiB free, %s GiB required; refusing build\n' \
+      "$((_red_dev_disk_free_kib / 1024 / 1024))" \
+      "$((_red_dev_disk_reserve_kib / 1024 / 1024))" >&2
+    return 125
+  fi
+  unset _red_dev_disk_line _red_dev_disk_total_kib _red_dev_disk_free_kib
+  unset _red_dev_disk_reserve_kib _red_dev_disk_percent_kib
+}
+
+_red_dev_run_control() {
+  if [ "\${RED_ENV:-server}" = "windows" ]; then
+    command "$@"
+    return $?
+  fi
+  if ! _red_dev_systemd_ready; then
+    _red_dev_guard_unavailable control
+    return 125
+  fi
+  ${command("control", domains.control)} "$@"
+}
+
+_red_dev_run_agent() {
+  if [ "\${RED_ENV:-server}" = "windows" ] || [ "\${RED_DEV_HEAVY_SCOPE:-1}" != "1" ]; then
+    command "$@"
+    return $?
+  fi
+  if ! _red_dev_systemd_ready; then
+    _red_dev_guard_unavailable agent
+    return 125
+  fi
+  ${command("agent", domains.agent)} "$@"
+}
+
+_red_dev_run_build() {
+  _red_dev_host_disk_ready || return $?
+  if [ "\${RED_ENV:-server}" = "windows" ] || [ "\${RED_DEV_HEAVY_SCOPE:-1}" != "1" ]; then
+    command "$@"
+    return $?
+  fi
+  if ! _red_dev_systemd_ready; then
+    _red_dev_guard_unavailable build
+    return 125
+  fi
+  ${command("build", domains.build)} "$@"
+}
+
+if [ -n "\${ZELLIJ:-}" ] &&
+  [ "\${RED_DEV_PANE_SCOPED:-0}" != "1" ] &&
+  [ "\${RED_DEV_PANE_SCOPE:-1}" = "1" ]; then
+  if ! _red_dev_systemd_ready; then
+    _red_dev_guard_unavailable pane
+    exit 125
+  fi
+  RED_DEV_PANE_SCOPED=1 ${command("pane", domains.pane)} bash
+  _red_dev_pane_status=$?
+  if [ "$_red_dev_pane_status" -ne 0 ]; then
+    printf 'red-dev: pane resource guard failed (%s) — closing this pane\n' \
+      "$_red_dev_pane_status" >&2
+  fi
+  exit "$_red_dev_pane_status"
+fi
+
+_red_dev_define_workload_command() {
+  declare -F "$1" >/dev/null 2>&1 && return 0
+  alias "$1" >/dev/null 2>&1 && return 0
+  command -v "$1" >/dev/null 2>&1 || return 0
+  eval "function $1 { _red_dev_run_$2 '$1' \\\"\\$@\\\"; }"
+}
+
+for _red_dev_workload_command in ${AGENT_COMMANDS}; do
+  _red_dev_define_workload_command "$_red_dev_workload_command" agent
+done
+for _red_dev_workload_command in ${BUILD_COMMANDS}; do
+  _red_dev_define_workload_command "$_red_dev_workload_command" build
+done
+unset _red_dev_workload_command
+unset -f _red_dev_define_workload_command
+`;
+}
+
+function renderDiskGuardian(): string {
+  return `#!/bin/sh
+# Managed by red-dev. Keeps the Windows host away from disk exhaustion while
+# preserving the interactive Zellij control plane and ordinary pane shells.
+state_dir=\${XDG_STATE_HOME:-$HOME/.local/state}/red-dev
+state_file=$state_dir/disk-guardian-frozen
+last_file=$state_dir/disk-guardian-last
+workload_log=$state_dir/workloads.log
+mkdir -p "$state_dir" 2>/dev/null || exit 125
+
+disk_line=$(command df -Pk /mnt/c 2>/dev/null | command tail -n 1) || disk_line=
+set -- $disk_line
+disk_total_kib=\${2:-}
+disk_free_kib=\${4:-}
+case "$disk_total_kib:$disk_free_kib" in
+  *[!0-9:]*|:*|*:)
+    disk_action=freeze
+    disk_reason=host-disk-unavailable
+    ;;
+  *)
+    disk_floor_kib=$((${HOST_DISK_FLOOR_GIB} * 1024 * 1024))
+    disk_floor_percent_kib=$((disk_total_kib * ${HOST_DISK_FLOOR_PERCENT} / 100))
+    [ "$disk_floor_percent_kib" -le "$disk_floor_kib" ] ||
+      disk_floor_kib=$disk_floor_percent_kib
+    disk_resume_kib=$((${HOST_DISK_RESUME_GIB} * 1024 * 1024))
+    disk_resume_percent_kib=$((disk_total_kib * ${HOST_DISK_RESUME_PERCENT} / 100))
+    [ "$disk_resume_percent_kib" -le "$disk_resume_kib" ] ||
+      disk_resume_kib=$disk_resume_percent_kib
+    if [ "$disk_free_kib" -lt "$disk_floor_kib" ]; then
+      disk_action=freeze
+      disk_reason=host-disk-critical
+    elif [ "$disk_free_kib" -ge "$disk_resume_kib" ]; then
+      disk_action=thaw
+      disk_reason=host-disk-recovered
+    else
+      disk_action=hold
+    fi
+    ;;
+esac
+
+case "$disk_action" in
+  freeze)
+    command systemctl --user freeze \
+      red-dev-heavy-builds.slice red-dev-heavy-agents.slice >/dev/null 2>&1 || exit 125
+    if [ ! -e "$state_file" ]; then
+      event_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+      printf 'at=%s free_kib=%s action=frozen reason=%s\n' \
+        "$event_at" "\${disk_free_kib:-unknown}" "$disk_reason" >"$state_file" || exit 125
+      printf 'at=%s free_kib=%s action=frozen reason=%s\n' \
+        "$event_at" "\${disk_free_kib:-unknown}" "$disk_reason" >"$last_file" || exit 125
+      printf 'at=%s kind=disk-guardian result=frozen reason=%s free_kib=%s\n' \
+        "$event_at" "$disk_reason" "\${disk_free_kib:-unknown}" >>"$workload_log" 2>/dev/null || true
+    fi
+    ;;
+  hold)
+    if [ -e "$state_file" ]; then
+      command systemctl --user freeze \
+        red-dev-heavy-builds.slice red-dev-heavy-agents.slice >/dev/null 2>&1 || exit 125
+    fi
+    ;;
+  thaw)
+    command systemctl --user thaw \
+      red-dev-heavy-builds.slice red-dev-heavy-agents.slice >/dev/null 2>&1 || exit 125
+    if [ -e "$state_file" ]; then
+      event_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+      printf 'at=%s free_kib=%s action=thawed reason=%s\n' \
+        "$event_at" "\${disk_free_kib:-unknown}" "$disk_reason" >"$last_file" || exit 125
+      printf 'at=%s kind=disk-guardian result=thawed reason=%s free_kib=%s\n' \
+        "$event_at" "$disk_reason" "\${disk_free_kib:-unknown}" >>"$workload_log" 2>/dev/null || true
+      rm -f "$state_file"
+    fi
+    ;;
+esac
+`;
+}
+
+export interface WorkloadPolicy {
+  /** Exact systemd bytes owned by red-dev, keyed below the user unit directory. */
+  systemd: Readonly<Record<string, string>>;
+  /** Shell adapter installed before Zellij and expensive tool activation. */
+  shell: string;
+  /** Periodic host-disk circuit breaker run from the protected control plane. */
+  diskGuardian: string;
+  /** The global wall shown by doctor and status surfaces. */
+  capacity: { memoryMax: string; cpuQuota: string };
+  /** Launch a workload through its cgroup adapter when the platform supports it. */
+  launch(kind: WorkloadKind, argv: readonly string[], p: Platform): string[];
+}
+
+/**
+ * The workstation's single workload-isolation policy.
+ *
+ * The Interface is rendered files and launch argv. All cgroup names and limits
+ * remain private so shell, systemd, agents, convergence and doctor cannot drift.
+ */
+export function workloadPolicy(
+  facts: WorkloadPolicyFacts = {
+    totalMemoryBytes: totalmem(),
+    logicalCpus: workloadLogicalCpuCount(),
+  },
+): WorkloadPolicy {
+  const domains = resourceDomains(facts);
+  return {
+    systemd: {
+      [domains.root.slice]: renderSlice(domains.root),
+      [domains.work.slice]: renderSlice(domains.work),
+      [domains.control.slice]: renderSlice(domains.control),
+      [domains.pane.slice]: renderSlice(domains.pane),
+      [domains.agent.slice]: renderSlice(domains.agent),
+      [domains.build.slice]: renderSlice(domains.build),
+      "redskilled.service.d/50-red-dev-heavy-slice.conf":
+        renderAttachment("Service", domains.control, false),
+      "red-worker-.service.d/50-red-dev-heavy-slice.conf":
+        renderAttachment("Service", domains.agent, true),
+      "red-fleet-.scope.d/50-red-dev-heavy-slice.conf":
+        renderAttachment("Scope", domains.agent, false),
+      "red-dev-disk-guardian.service": `# Managed by red-dev.
+[Unit]
+Description=red-dev Windows host disk guardian
+Documentation=${DOCUMENTATION}
+
+[Service]
+Type=oneshot
+Slice=${domains.control.slice}
+ExecStart=%h/.local/share/red-dev/bin/disk-guardian.sh
+`,
+      "red-dev-disk-guardian.timer": `# Managed by red-dev.
+[Unit]
+Description=Poll the Windows host disk before builds can exhaust it
+Documentation=${DOCUMENTATION}
+
+[Timer]
+OnBootSec=15s
+OnUnitActiveSec=10s
+AccuracySec=1s
+Unit=red-dev-disk-guardian.service
+
+[Install]
+WantedBy=timers.target
+`,
+    },
+    shell: renderShell(domains),
+    diskGuardian: renderDiskGuardian(),
+    capacity: {
+      memoryMax: domains.root.aggregate["MemoryMax"] ?? "unknown",
+      cpuQuota: domains.root.aggregate["CPUQuota"] ?? "unknown",
+    },
+    launch(kind, argv, p) {
+      if (p.os !== "linux" || !p.caps.systemd) return [...argv];
+      const domain = {
+        control: domains.control,
+        pane: domains.pane,
+        agent: domains.agent,
+        build: domains.build,
+      }[kind];
+      return scopeArgv(kind, domain, argv);
+    },
+  };
+}

--- a/src/zellij-autostart.test.ts
+++ b/src/zellij-autostart.test.ts
@@ -67,7 +67,9 @@ function run(env: Record<string, string>, interactive: boolean): Run {
   const dir = stubDir();
   // Somewhere to leave a crash log that is not the real one under $HOME.
   const stateHome = mkdtempSync(`${tmpdir()}/red-zellij-state-`);
-  const body = `source ${SOURCE}; echo FELLTHROUGH`;
+  // The workload-policy adapter is sourced immediately before zellij.sh
+  // in the managed rc. These tests isolate Zellij's terminal behavior.
+  const body = `_red_dev_run_control() { command "$@"; }; source ${SOURCE}; echo FELLTHROUGH`;
   const argv = interactive
     ? ["script", "-qec", `bash --norc -i -c '${body}'`, "/dev/null"]
     : ["bash", "--norc", "-c", body];


### PR DESCRIPTION
## Summary

- bound WSL, Cargo, agents, panes and builds with fail-closed systemd scopes
- refuse builds before `/mnt/c` crosses its Windows host reserve
- install a periodic disk guardian with freeze/thaw hysteresis
- expose Cargo, WSL, isolation and host-disk state in `red-dev doctor`
- load the policy before Zellij and route agent launches through containment

## Validation

- `bun run typecheck`
- `bun test` — 2529 pass, 0 fail
- compiled Linux and Windows release binaries

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/234"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790296655&installation_model_id=20659&pr_number=234&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F234&signature=3cefa51ceb98e9643344fd5711db8dd78af8036e3f36135764b97b231a1b608f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->