### PR TITLE
fix: preserve tty when resuming zellij

### DIFF
--- a/config/bash/zellij.sh
+++ b/config/bash/zellij.sh
@@ -131,7 +131,11 @@ if declare -F _red_zellij_launch >/dev/null 2>&1; then
   )"
 
   _red_zellij_status=1
-  while IFS= read -r _red_zellij_session; do
+  # Read candidates on fd 9 so an interactive attach keeps the terminal on
+  # stdin. Feeding this loop with a plain here-document replaces fd 0 with a
+  # pipe for every command in the body. Zellij's stdin threads then spin on
+  # EOF while its output still targets the tty, freezing the terminal client.
+  while IFS= read -r _red_zellij_session <&9; do
     [ -n "$_red_zellij_session" ] || continue
     printf '%s\n' "$_red_zellij_session" >"$_red_zellij_last.tmp-$$" 2>/dev/null &&
       mv -f "$_red_zellij_last.tmp-$$" "$_red_zellij_last" 2>/dev/null
@@ -139,7 +143,7 @@ if declare -F _red_zellij_launch >/dev/null 2>&1; then
       2>>"$_red_zellij_log"
     _red_zellij_status=$?
     [ "$_red_zellij_status" -eq 0 ] && break
-  done <<EOF
+  done 9<<EOF
 $_red_zellij_candidates
 EOF
 

--- a/src/zellij-autostart.test.ts
+++ b/src/zellij-autostart.test.ts
@@ -49,7 +49,9 @@ if [ "\${1:-}" = "attach" ]; then
     create=1
     shift
   fi
-  echo "STUB RED_IN_ZELLIJ=$RED_IN_ZELLIJ ATTACH=\${1:-} CREATE=$create"
+  stdin_tty=0
+  [ -t 0 ] && stdin_tty=1
+  echo "STUB RED_IN_ZELLIJ=$RED_IN_ZELLIJ ATTACH=\${1:-} CREATE=$create STDIN_TTY=$stdin_tty"
   if [ "\${1:-}" = "\${STUB_BAD_SESSION:-}" ]; then
     echo "invalid saved session: \${1:-}" >&2
     exit 7
@@ -162,6 +164,14 @@ describe("zellij autostart", () => {
   });
 
   describe("resumes the last valid session", () => {
+    test("keeps the terminal on stdin while reading session candidates", () => {
+      const r = run({
+        STUB_SESSIONS: "live [Created 2h ago]",
+      }, true);
+
+      expect(r.out).toContain("ATTACH=live CREATE=0 STDIN_TTY=1");
+    });
+
     test("prefers the newest live session over serialized exited sessions", () => {
       const r = run({
         STUB_SESSIONS:


### PR DESCRIPTION
Preserve the interactive TTY while iterating resumable Zellij sessions, preventing the client stdin threads from spinning on a heredoc pipe. Adds a pseudo-terminal regression test. Validated with 30 focused tests and typecheck.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-dev/pr/235"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790801270&installation_model_id=20659&pr_number=235&repository=reddb-io%2Fred-dev&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-dev%2Fpull%2F235&signature=a85582f077701e024878ce36303990eac96b4a8be1eecd0518825d86552f7ce6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->